### PR TITLE
Add project autoloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Mostly, technical stuff is now new:
 - the sendmail-system was replaced by phpmailer()
 - the mail notification feature an auto-refresh via ajax now
 - composer was integrated for sensible (see above) third party modules
+- After modifying Composer settings, run `composer dump-autoload` so new namespaces are recognized.
 - mysqli is now standard, so it's used primarily, the old ones won't be tested (and really, most things didn't work when you switched the db provider in lotgd)
 
 So, it should work on every modern PHP enviroment.

--- a/autoload.php
+++ b/autoload.php
@@ -1,4 +1,8 @@
 <?php
-$loader = require __DIR__.'/ext/vendor/autoload.php';
+$autoloadPath = __DIR__.'/ext/vendor/autoload.php';
+if (!file_exists($autoloadPath)) {
+    throw new RuntimeException("The vendor autoload file was not found at: {$autoloadPath}");
+}
+$loader = require $autoloadPath;
 $loader->addPsr4('Lotgd\\', __DIR__.'/src/');
 

--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,4 @@
+<?php
+$loader = require __DIR__.'/ext/vendor/autoload.php';
+$loader->addPsr4('Lotgd\\', __DIR__.'/src/');
+

--- a/ext/lotgd_common.php
+++ b/ext/lotgd_common.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__."/../autoload.php";
 // translator ready
 // addnews ready
 // mail ready


### PR DESCRIPTION
## Summary
- add root `autoload.php` to register Lotgd namespace
- include new autoloader early in `ext/lotgd_common.php`
- document running `composer dump-autoload`

## Testing
- `composer dump-autoload` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fde50cd5083299783abff332f3671