### PR TITLE
Fix return type in charstats docblock

### DIFF
--- a/lib/pageparts.php
+++ b/lib/pageparts.php
@@ -648,7 +648,7 @@ function getcharstat_value($section,$title){
  * Hooks provided:
  *		charstats
  *
- * @return array The current stats for this character or the list of online players
+ * @return string The current stats for this character or the list of online players
  */
 function charstats(){
 	global $session, $playermount, $companions;


### PR DESCRIPTION
## Summary
- correct the `@return` annotation above `charstats()` to reflect that a string is returned

## Testing
- `php -l lib/pageparts.php`

------
https://chatgpt.com/codex/tasks/task_e_685fde5c839883298e7ab78acd772918