### PR TITLE
Integrate autoload.php across code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Mostly, technical stuff is now new:
 - the mail notification feature an auto-refresh via ajax now
 - composer was integrated for sensible (see above) third party modules
 - After modifying Composer settings, run `composer dump-autoload` so new namespaces are recognized.
+- After running `composer install` or `composer dump-autoload`, include `autoload.php` to load all dependencies.
+- `autoload.php` automatically loads `ext/vendor/autoload.php` and registers the project namespace.
 - mysqli is now standard, so it's used primarily, the old ones won't be tested (and really, most things didn't work when you switched the db provider in lotgd)
 
 So, it should work on every modern PHP enviroment.

--- a/common.php
+++ b/common.php
@@ -1,5 +1,5 @@
 <?php
-require_once(__DIR__ . '/autoload.php');
+require_once __DIR__ . '/autoload.php';
 // translator ready
 // addnews ready
 // mail ready

--- a/common.php
+++ b/common.php
@@ -1,4 +1,5 @@
 <?php
+require_once(__DIR__ . '/autoload.php');
 // translator ready
 // addnews ready
 // mail ready

--- a/ext/ajax_common.php
+++ b/ext/ajax_common.php
@@ -1,5 +1,5 @@
 <?php
-require_once(__DIR__ . '/vendor/autoload.php'); // Start autoload 
+require_once __DIR__ . '/../autoload.php'; // Start autoload
 
 use Jaxon\Jaxon;                      // Use the jaxon core class
 use Jaxon\Response\Response;          // and the Response class

--- a/lib/sendmail.php
+++ b/lib/sendmail.php
@@ -7,7 +7,7 @@
  */
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
-require_once('ext/vendor/autoload.php');
+require_once __DIR__ . '/../autoload.php';
 
 function send_email($to, $body, $subject, $from, $cc=false,$contenttype="text/plain") {
 	/**


### PR DESCRIPTION
## Summary
- include `autoload.php` in `common.php`
- use central autoloader in `sendmail.php` and `ajax_common.php`
- document how autoload.php loads vendor dependencies

## Testing
- `composer validate --no-check-all --strict`
- `php -l common.php`
- `php -l lib/sendmail.php`
- `php -l ext/ajax_common.php`


------
https://chatgpt.com/codex/tasks/task_e_686122fa2d088329a8562c1783396628