### PR TITLE
Remove installer file after completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ you do this by typing
    chmod -w dbconnect.php
 This is to keep you from making unintentional changes to this file.
 
+The installer also attempts to remove `install/index.php` once installation
+finishes. If this file remains, delete it manually to prevent accidental
+reinstallation.
+
 The installer will have installed, but not activated, some common modules
 which we feel make for a good baseline of the game.
 

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -30,5 +30,6 @@ class Installer
     public function stage8(): void { $this->includeStage(8); }
     public function stage9(): void { $this->includeStage(9); }
     public function stage10(): void { $this->includeStage(10); }
+    public function stage11(): void { $this->includeStage(11); }
     public function stageDefault(): void { $this->includeStage('default'); }
 }

--- a/install/lib/installer_stage_11.php
+++ b/install/lib/installer_stage_11.php
@@ -1,0 +1,21 @@
+<?php
+output("`@`c`bAll Done!`b`c");
+output("Your install of Legend of the Green Dragon has been completed!`n");
+output("`nRemember us when you have hundreds of users on your server, enjoying the game.");
+output("Eric, JT, and a lot of others put a lot of work into this world, so please don't disrespect that by violating the license.");
+if ($session['user']['loggedin']){
+	addnav("Continue",$session['user']['restorepage']);
+}else{
+	addnav("Login Screen","./");
+}
+savesetting("installer_version",$logd_version);
+$file = __DIR__ . '/../index.php';
+	if (file_exists($file)) {
+		if (@unlink($file)) {
+			output("`2Installer file install/index.php removed.`n");
+		} else {
+			output("`\$Unable to delete install/index.php. Please remove it manually.`n");
+		}
+	}
+$noinstallnavs=true;
+?>

--- a/install/lib/installer_stage_default.php
+++ b/install/lib/installer_stage_default.php
@@ -1,13 +1,5 @@
 <?php
-output("`@`c`bAll Done!`b`c");
-output("Your install of Legend of the Green Dragon has been completed!`n");
-output("`nRemember us when you have hundreds of users on your server, enjoying the game.");
-output("Eric, JT, and a lot of others put a lot of work into this world, so please don't disrespect that by violating the license.");
-if ($session['user']['loggedin']){
-	addnav("Continue",$session['user']['restorepage']);
-}else{
-	addnav("Login Screen","./");
-}
-savesetting("installer_version",$logd_version);
-$noinstallnavs=true;
+output("`\$Requested installer step not found.`n");
+output("`2Restarting at stage 1...`n");
+redirect("install/index.php?stage=1");
 ?>


### PR DESCRIPTION
## Summary
- remove `install/index.php` after running the last installer stage
- warn admins if the file can't be deleted
- document installer file removal in README
- rename final stage to `installer_stage_11.php`
- default stage now informs the admin when an unknown stage is requested and restarts at stage 1

## Testing
- `php -l install/lib/installer_stage_default.php`
- `php -l install/lib/installer_stage_11.php`
- `php -l install/lib/Installer.php`


------
https://chatgpt.com/codex/tasks/task_e_6861afbcee7c8329b4bc5fde88b4288d