### PR TITLE
Update installer references

### DIFF
--- a/QUICKINSTALL.TXT
+++ b/QUICKINSTALL.TXT
@@ -11,7 +11,7 @@ All ok?
 Then:
 ->Upload this and all folders including all files (directory structure must remain intact!) to your web host directory via i.e. FTP.
 ->READ INSTALL.TXT for necessary steps or modifications
-->enter in your browser "http://mydomain.mytld/myfolder/installer.php", where mydomain.mytld is your domain+top level domain, i.e. "google.com" and myfolder if you have located the game in a subfolder.
+->enter in your browser "http://mydomain.mytld/myfolder/install/index.php", where mydomain.mytld is your domain+top level domain, i.e. "google.com" and myfolder if you have located the game in a subfolder.
 ->Run the installer which will guide you through the rest of the setup process. If you are unsure about features, leave them out, you can activate them later on.
 
 For questions regarding this version, you may use http://nb-core.org to report bugs and other issues. This version needs to be run by halfway experienced people, so basic support is not provided.

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ subdirectories.
 
 As of 0.9.8-prerelease.11, the only way to install or upgrade the game is
 via the included installer.   To access the installer, log out of the game and
-then access installer.php (for instance, if your game was installed at
+then access install/index.php (for instance, if your game was installed at
 http://logd.dragoncat.net, you would access the installer at
-http://logd.dragoncat.net/installer.php)
+http://logd.dragoncat.net/install/index.php)
 
 From here, it should be a simple matter of walking through the steps!
 Choose upgrade as the type of install (it defaults to *new* install, so
@@ -123,9 +123,9 @@ an account to access the database on behalf of the site; this account
 should have full permissions on the database.
 
 After you have the database created, point your browser at the location you
-have the logd files installed at and load up installer.php (for instance,
+have the logd files installed at and load up install/index.php (for instance,
 if the files are accessible as http://logd.dragoncat.net, you will want to
-load http://logd.dragoncat.net/installer.php in the browser).  The installer
+load http://logd.dragoncat.net/install/index.php in the browser).  The installer
 will walk you through a complete setup from the ground up.  Make sure to
 follow all instructions!
 


### PR DESCRIPTION
## Summary
- replace outdated `installer.php` references with `install/index.php` in documentation
- search repo to ensure no other uses of the old installer name

## Testing
- `grep -r "installer.php" -n --exclude-dir=.git`


------
https://chatgpt.com/codex/tasks/task_e_68624c948b4483299fb09e44a5903897