### PR TITLE
Fix mysqli extension message

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -30,7 +30,9 @@ if (!$requirements_met) {
 	//we have NO output object possibly :( hence no nice formatting
     echo "<h1>Requirements not sufficient<br/><br/>";
     if (!$php_met) echo sprintf("You need PHP 7.4 or higher to install this version. Please upgrade from your existing PHP version %s.<br/>",PHP_VERSION);
-    if (!$mysqli_extension_met) echo "The mysqli extension is missing. You need to enable the mysqli extension to install this version.<br/>";
+    if (!$mysql_met && extension_loaded('mysqli') === false) {
+        echo "The mysqli extension is missing. You need to enable the mysqli extension to install this version.<br/>";
+    }
     if (!$mysql_met && function_exists('mysqli_get_client_info')) echo sprintf("You need MySQL 5.0 or higher to install this version. Your current MySQL client version is %s.<br/>",mysqli_get_client_info());
 	exit(1);
 }


### PR DESCRIPTION
## Summary
- fix logic for displaying the mysqli extension requirement

## Testing
- `php -l install/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6862e70b62f083298dc0192df9f5d0a2