### PR TITLE
Pass connection instance to createDb

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1199,11 +1199,7 @@ class Installer
         output("`n`2Attempting to create your database...`n");
         $sql = "CREATE DATABASE `$dbname`";
         if ($connection->query($sql) === TRUE) {
-            if (method_exists($connection, 'select_db')) {
-                $selected = $connection->select_db($dbname);
-            } else {
-                $selected = $connection->selectDb($dbname);
-            }
+            $selected = $this->selectDatabase($connection, $dbname);
             if ($selected) {
                 output("`@Success!`2  I was able to create the database and connect to it!`n");
             } else {


### PR DESCRIPTION
## Summary
- pass database instance to `createDb()` during installer stage 4
- allow `createDb()` to handle the wrapper connection

## Testing
- `php -l install/lib/Installer.php`


------
https://chatgpt.com/codex/tasks/task_e_6862f3263e78832986cc559149bd7681