### PR TITLE
Fix datacache permission test

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -520,11 +520,12 @@ class Installer
         		} else {
         			$fp = @fopen($session['dbinfo']['DB_DATACACHEPATH']."/dummy.php","w+");
         			if ($fp){
-        				if (fwrite($fp,	$dbconnect)!==false){
+				$dummyContent = "<?php //test ?>";
+        				if (fwrite($fp, $dummyContent)!==false){
         					output("`2Result: `@Pass`n");
         				}else{
         					output("`2Result: `$Fail`n");
-        					rawoutput("<blockquote>");
+        					rawoutput("<blockquote></blockquote>");
         					array_push($issues,"`^I was not able to write to your datacache directory!`n");
         				}
         				fclose($fp);


### PR DESCRIPTION
## Summary
- improve datacache permission check in installer

## Testing
- `composer validate --no-check-all --strict`

------
https://chatgpt.com/codex/tasks/task_e_6862f713b5e88329a45e90e42f9ab344