### PR TITLE
Add installer logger

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -712,7 +712,7 @@ class Installer
                                         $failure=true;
                                         $err = error_get_last();
                                         if ($err) {
-                                                error_log($err['message']);
+                                                \Lotgd\Installer\InstallerLogger::log($err['message']);
                                                 output("`n`$Failed to write to dbconnect.php:`2 %s", $err['message']);
                                         }
                                 }
@@ -721,7 +721,7 @@ class Installer
                                 $failure=true;
                                 $err = error_get_last();
                                 if ($err) {
-                                        error_log($err['message']);
+                                        \Lotgd\Installer\InstallerLogger::log($err['message']);
                                         output("`n`$Failed to create dbconnect.php:`2 %s", $err['message']);
                                 }
                         }
@@ -780,7 +780,7 @@ class Installer
                                                 $failure=true;
                                                 $err = error_get_last();
                                                 if ($err) {
-                                                        error_log($err['message']);
+                                                        \Lotgd\Installer\InstallerLogger::log($err['message']);
                                                         output("`n`$Failed to write to dbconnect.php:`2 %s", $err['message']);
                                                 }
                                         }
@@ -789,7 +789,7 @@ class Installer
                                         $failure=true;
                                         $err = error_get_last();
                                         if ($err) {
-                                                error_log($err['message']);
+                                                \Lotgd\Installer\InstallerLogger::log($err['message']);
                                                 output("`n`$Failed to create dbconnect.php:`2 %s", $err['message']);
                                         }
                                 }

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -712,8 +712,8 @@ class Installer
                                         $failure=true;
                                         $err = error_get_last();
                                         if ($err) {
-                                                \Lotgd\Installer\InstallerLogger::log($err['message']);
-                                                output("`n`$Failed to write to dbconnect.php:`2 %s", $err['message']);
+                                                \Lotgd\Installer\InstallerLogger::log(sprintf("Error: %s in %s on line %d", $err['message'], $err['file'], $err['line']));
+                                                output("`n`$Failed to write to dbconnect.php:`2 %s in %s on line %d", $err['message'], $err['file'], $err['line']);
                                         }
                                 }
                                 fclose($fp);

--- a/install/lib/InstallerLogger.php
+++ b/install/lib/InstallerLogger.php
@@ -16,6 +16,6 @@ class InstallerLogger
         $logFile = $logDir . '/install.log';
         $date = date('Y-m-d H:i:s');
         $entry = sprintf("[%s] %s\n", $date, $message);
-        error_log($entry, 3, $logFile);
+        file_put_contents($logFile, $entry, FILE_APPEND | LOCK_EX);
     }
 }

--- a/install/lib/InstallerLogger.php
+++ b/install/lib/InstallerLogger.php
@@ -10,7 +10,7 @@ class InstallerLogger
         $logDir = __DIR__ . '/../../errors';
         if (!is_dir($logDir)) {
             if (!mkdir($logDir, 0755, true) && !is_dir($logDir)) {
-                throw new \RuntimeException(sprintf('Directory "%s" was not created', $logDir));
+                throw new RuntimeException(sprintf('Directory "%s" was not created', $logDir));
             }
         }
         $logFile = $logDir . '/install.log';

--- a/install/lib/InstallerLogger.php
+++ b/install/lib/InstallerLogger.php
@@ -1,13 +1,17 @@
 <?php
 namespace Lotgd\Installer;
 
+use RuntimeException;
+
 class InstallerLogger
 {
     public static function log(string $message): void
     {
         $logDir = __DIR__ . '/../../errors';
         if (!is_dir($logDir)) {
-            @mkdir($logDir, 0777, true);
+            if (!mkdir($logDir, 0777, true) && !is_dir($logDir)) {
+                throw new \RuntimeException(sprintf('Directory "%s" was not created', $logDir));
+            }
         }
         $logFile = $logDir . '/install.log';
         $date = date('Y-m-d H:i:s');

--- a/install/lib/InstallerLogger.php
+++ b/install/lib/InstallerLogger.php
@@ -9,7 +9,7 @@ class InstallerLogger
     {
         $logDir = __DIR__ . '/../../errors';
         if (!is_dir($logDir)) {
-            if (!mkdir($logDir, 0777, true) && !is_dir($logDir)) {
+            if (!mkdir($logDir, 0755, true) && !is_dir($logDir)) {
                 throw new \RuntimeException(sprintf('Directory "%s" was not created', $logDir));
             }
         }

--- a/install/lib/InstallerLogger.php
+++ b/install/lib/InstallerLogger.php
@@ -1,0 +1,17 @@
+<?php
+namespace Lotgd\Installer;
+
+class InstallerLogger
+{
+    public static function log(string $message): void
+    {
+        $logDir = __DIR__ . '/../../errors';
+        if (!is_dir($logDir)) {
+            @mkdir($logDir, 0777, true);
+        }
+        $logFile = $logDir . '/install.log';
+        $date = date('Y-m-d H:i:s');
+        $entry = sprintf("[%s] %s\n", $date, $message);
+        error_log($entry, 3, $logFile);
+    }
+}


### PR DESCRIPTION
## Summary
- add `InstallerLogger` that writes to `errors/install.log`
- log installer file write errors with `InstallerLogger`
- restore vendor autoload files that were removed by mistake

## Testing
- `php -l install/lib/InstallerLogger.php`
- `php -l install/lib/Installer.php`


------
https://chatgpt.com/codex/tasks/task_e_68642f054f848329b9974148ddc581b0