### PR TITLE
Fix installer directory check

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -722,7 +722,7 @@ class Installer
         	."$DB_DATACACHEPATH = \"{$session['dbinfo']['DB_DATACACHEPATH']}\";\n"
         	."?>\n";
                 $failure=false;
-                $dir = __DIR__;
+                $dir = dirname('dbconnect.php');
                 if (is_writable($dir)) {
                         error_clear_last();
                         $fp = fopen('dbconnect.php', 'w+');


### PR DESCRIPTION
## Summary
- use `dirname('dbconnect.php')` when checking if dbconnect.php can be written

## Testing
- `php -l install/lib/Installer.php`

------
https://chatgpt.com/codex/tasks/task_e_68643d3804848329831113644c85e674