### PR TITLE
Log mysqli connection errors during install

### DIFF
--- a/lib/dbmysqli.php
+++ b/lib/dbmysqli.php
@@ -8,12 +8,30 @@ class DbMysqli {
     protected $link;
 
     public function connect($host, $user, $pass) {
-        $this->link = @mysqli_connect($host, $user, $pass);
+        $this->link = mysqli_connect($host, $user, $pass);
+
+        if (!$this->link) {
+            $error = mysqli_connect_error();
+            if (defined('IS_INSTALLER') && IS_INSTALLER && class_exists('Lotgd\\Installer\\InstallerLogger')) {
+                \Lotgd\Installer\InstallerLogger::log($error);
+            }
+            echo $error;
+        }
+
         return $this->link ? true : false;
     }
 
     public function pconnect($host, $user, $pass) {
-        $this->link = @mysqli_connect($host, $user, $pass);
+        $this->link = mysqli_connect($host, $user, $pass);
+
+        if (!$this->link) {
+            $error = mysqli_connect_error();
+            if (defined('IS_INSTALLER') && IS_INSTALLER && class_exists('Lotgd\\Installer\\InstallerLogger')) {
+                \Lotgd\Installer\InstallerLogger::log($error);
+            }
+            echo $error;
+        }
+
         return $this->link ? true : false;
     }
 


### PR DESCRIPTION
## Summary
- remove suppression from mysqli connect calls
- log connection errors during install and display message

## Testing
- `php -l lib/dbmysqli.php`


------
https://chatgpt.com/codex/tasks/task_e_68645bbc5c788329aa82b6e0d07e8c29