### PR TITLE
Add example AI companion scripts

### DIFF
--- a/scripts/fighter_rage.php
+++ b/scripts/fighter_rage.php
@@ -1,0 +1,25 @@
+<?php
+
+// Example fighter companion A.I. script.
+// Grants an attack bonus when the player's health drops below 50% once per fight.
+
+global $badguy, $session;
+
+if (!isset($badguy['rage_used'])) {
+    $badguy['rage_used'] = false;
+}
+
+if (!$badguy['rage_used'] && $session['user']['hitpoints'] < $session['user']['maxhitpoints'] * 0.5) {
+    apply_buff('companion_fighter_rage', [
+        'name' => '`&Battle Frenzy',
+        'startmsg' => '`&Your fighter companion enters a frenzy!',
+        'roundmsg' => '`&Frenzied strikes empower you.',
+        'wearoff' => '`&The frenzy subsides.',
+        'atkmod' => 1.2,
+        'rounds' => 5,
+        'schema' => 'battle',
+    ]);
+    $badguy['rage_used'] = true;
+}
+
+?>

--- a/scripts/mage_burst.php
+++ b/scripts/mage_burst.php
@@ -1,0 +1,28 @@
+<?php
+
+// Example mage companion A.I. script.
+// Casts a damaging burst a few times per battle when the foe is wounded.
+
+global $badguy;
+
+if (!isset($badguy['burst_charges'])) {
+    $badguy['burst_charges'] = 3;
+    if (!isset($badguy['maxhealth'])) {
+        $badguy['maxhealth'] = $badguy['creaturehealth'];
+    }
+}
+
+if ($badguy['burst_charges'] > 0 && $badguy['creaturehealth'] <= $badguy['maxhealth'] * 0.8) {
+    apply_buff('companion_mage_burst', [
+        'name' => '`!Arcane Burst',
+        'rounds' => 1,
+        'minioncount' => 1,
+        'minbadguydamage' => 5,
+        'maxbadguydamage' => 10,
+        'effectmsg' => '`!A burst of arcane energy hits the enemy for {damage} damage!',
+        'schema' => 'battle',
+    ]);
+    $badguy['burst_charges']--;
+}
+
+?>

--- a/scripts/support_shield.php
+++ b/scripts/support_shield.php
@@ -1,0 +1,22 @@
+<?php
+
+// Example support companion A.I. script.
+// Provides a short-lived damage shield at the start of battle.
+
+global $badguy;
+
+if (!isset($badguy['shield_given'])) {
+    apply_buff('companion_support_shield', [
+        'name' => '`@Protective Aura',
+        'startmsg' => '`@Your companion surrounds you with a shimmering shield.',
+        'wearoff' => '`@The protective aura fades away.',
+        'damageshield' => 0.3,
+        'effectmsg' => '`@The shield reflects {damage} damage back at the attacker!',
+        'effectnodmgmsg' => '`@The shield absorbs the blow.',
+        'rounds' => 3,
+        'schema' => 'battle',
+    ]);
+    $badguy['shield_given'] = true;
+}
+
+?>


### PR DESCRIPTION
## Summary
- add new fighter, mage, and support companion AI examples using the buff engine

## Testing
- `php -l scripts/fighter_rage.php`
- `php -l scripts/mage_burst.php`
- `php -l scripts/support_shield.php`
- `php -l scripts/medic_nin.php`

------
https://chatgpt.com/codex/tasks/task_e_68650603a8bc8329bcc605750c9158bb