### PR TITLE
Remove old magic quotes

### DIFF
--- a/bios.php
+++ b/bios.php
@@ -15,16 +15,16 @@ tlschema("bio");
 check_su_access(SU_EDIT_COMMENTS);
 
 $op = httpget('op');
-$userid = httpget('userid');
+$userid = (int)httpget('userid');
 if ($op=="block"){
-	$sql = "UPDATE " . db_prefix("accounts") . " SET bio='`iBlocked for inappropriate usage`i',biotime='9999-12-31 23:59:59' WHERE acctid='$userid'";
+       $sql = "UPDATE " . db_prefix("accounts") . " SET bio='`iBlocked for inappropriate usage`i',biotime='9999-12-31 23:59:59' WHERE acctid=$userid";
 	$subj = array("Your bio has been blocked");
 	$msg = array("The system administrators have decided that your bio entry is inappropriate, so it has been blocked.`n`nIf you wish to appeal this decision, you may do so with the petition link.");
 	systemmail($userid, $subj, $msg);
 	db_query($sql);
 }
 if ($op=="unblock"){
-	$sql = "UPDATE " . db_prefix("accounts") . " SET bio='',biotime='".DATETIME_DATEMIN."' WHERE acctid='$userid'";
+       $sql = "UPDATE " . db_prefix("accounts") . " SET bio='',biotime='".DATETIME_DATEMIN."' WHERE acctid=$userid";
 	$subj = array("Your bio has been unblocked");
 	$msg = array("The system administrators have decided to unblock your bio.  You can once again enter a bio entry.");
 	systemmail($userid,$subj,$msg);

--- a/lib/errorhandling.php
+++ b/lib/errorhandling.php
@@ -6,30 +6,5 @@
 error_reporting (E_ALL ^ E_NOTICE);
 #error_reporting (E_ALL);
 
-function set_magic_quotes(&$vars) {
-	if (is_array($vars)) {
-		reset($vars);
-		foreach ($vars as $key=>$val)
-			set_magic_quotes($vars[$key]);
-	}else{
-		if (isset($vars))$vars = addslashes($vars);
-	}
-}
-
-
-//do some cleanup here to make sure magic_quotes_gpc is ON
-//magic quotes are always false since php5.4
-//if (!get_magic_quotes_gpc()){
-if (1) {
-	set_magic_quotes($_GET);
-	set_magic_quotes($_POST);
-	set_magic_quotes($_SESSION);
-	set_magic_quotes($_COOKIE);
-	set_magic_quotes($HTTP_GET_VARS);
-	set_magic_quotes($HTTP_POST_VARS);
-	set_magic_quotes($HTTP_COOKIE_VARS);
-	ini_set("magic_quotes_gpc",1);
-}
-
-// magic_quotes_runtime is OFF
-//set_magic_quotes_runtime(0);
+// Legacy magic quotes handling removed.  Inputs must now be
+// properly escaped or validated at the point of use.

--- a/logdnet.php
+++ b/logdnet.php
@@ -72,12 +72,12 @@ function lotgdsort($a, $b)
 
 $op = httpget('op');
 if ($op==""){
-	$addy = httpget('addy');
-	$desc = httpget('desc');
-	$vers = httpget('version');
-	$admin = httpget('admin');
-	$count = (int)httpget('c');
-	$lang = httpget('l');
+       $addy  = httpget('addy');
+       $desc  = httpget('desc');
+       $vers  = httpget('version');
+       $admin = httpget('admin');
+       $count = (int)httpget('c');
+       $lang  = httpget('l');
 
 	if ($vers == "") $vers = "Unknown";
 	if ($admin == "" || $admin=="postmaster@localhost.com")
@@ -118,14 +118,27 @@ if ($op==""){
 			// Only one update per minute allowed.
 			if (strtotime($row['lastping'])<strtotime("-1 minutes")){
 				// Increase the popularity of this server
-				$sql = "UPDATE " . db_prefix("logdnet") . " SET lang='$lang',count='$count',recentips='$ips',priority=priority+1,description='$desc',version='$vers',admin='$admin',lastupdate='$date',lastping='$date' WHERE serverid={$row['serverid']}";
-				db_query($sql);
+                               $sql = "UPDATE " . db_prefix("logdnet") .
+                                       " SET lang='" . db_real_escape_string($lang) .
+                                       "',count='$count',recentips='" . db_real_escape_string($ips) .
+                                       "',priority=priority+1,description='" . db_real_escape_string($desc) .
+                                       "',version='" . db_real_escape_string($vers) .
+                                       "',admin='" . db_real_escape_string($admin) .
+                                       "',lastupdate='$date',lastping='$date' WHERE serverid=" . (int)$row['serverid'];
+                               db_query($sql);
 			}
 	//	}
 	}else{
 		// This is a new server, so add it and give it a small priority boost.
-		$sql = "INSERT INTO " . db_prefix("logdnet") . " (address,description,version,admin,priority,lastupdate,lastping,count,recentips,lang) VALUES ('$addy','$desc','$vers','$admin',10,'$date','$date','$count','{$_SERVER['REMOTE_ADDR']}','$lang')";
-		$result = db_query($sql);
+               $sql = "INSERT INTO " . db_prefix("logdnet") .
+                       " (address,description,version,admin,priority,lastupdate,lastping,count,recentips,lang) VALUES ('" .
+                       db_real_escape_string($addy) . "','" .
+                       db_real_escape_string($desc) . "','" .
+                       db_real_escape_string($vers) . "','" .
+                       db_real_escape_string($admin) . "',10,'$date','$date','$count','" .
+                       db_real_escape_string($_SERVER['REMOTE_ADDR']) . "','" .
+                       db_real_escape_string($lang) . "')";
+               $result = db_query($sql);
 	}
 
 	// Do these next two things whether we've added a new server or

--- a/logdnet.php
+++ b/logdnet.php
@@ -120,7 +120,7 @@ if ($op==""){
 				// Increase the popularity of this server
                                $sql = "UPDATE " . db_prefix("logdnet") .
                                        " SET lang='" . db_real_escape_string($lang) .
-                                       "',count='$count',recentips='" . db_real_escape_string($ips) .
+                                       "',count='" . (int)$count . "',recentips='" . db_real_escape_string($ips) .
                                        "',priority=priority+1,description='" . db_real_escape_string($desc) .
                                        "',version='" . db_real_escape_string($vers) .
                                        "',admin='" . db_real_escape_string($admin) .

--- a/pages/bans/case_setupban.php
+++ b/pages/bans/case_setupban.php
@@ -1,5 +1,5 @@
 <?php
-$sql = "SELECT name,lastip,uniqueid FROM " . db_prefix("accounts") . " WHERE acctid=\"$userid\"";
+$sql = "SELECT name,lastip,uniqueid FROM " . db_prefix("accounts") . " WHERE acctid=" . (int)$userid;
 $result = db_query($sql);
 $row = db_fetch_assoc($result);
 if ($row['name']!="")

--- a/pages/user/user_edit.php
+++ b/pages/user/user_edit.php
@@ -1,5 +1,5 @@
 <?php
-$result = db_query("SELECT * FROM " . db_prefix("accounts") . " WHERE acctid='$userid'");
+$result = db_query("SELECT * FROM " . db_prefix("accounts") . " WHERE acctid=" . (int)$userid);
 $row = db_fetch_assoc($result);
 $petition=httpget("returnpetition");
 if ($petition != "")
@@ -87,7 +87,7 @@ if (httpget("subop")==""){
 			// Set up the defaults as well.
 			if (isset($x[1])) $data[$key] = $x[1];
 		}
-		$sql = "SELECT * FROM " . db_prefix("module_userprefs") ." WHERE modulename='$module' AND userid='$userid'";
+               $sql = "SELECT * FROM " . db_prefix("module_userprefs") ." WHERE modulename='" . db_real_escape_string($module) . "' AND userid=" . (int)$userid;
 		$result = db_query($sql);
 		while ($row = db_fetch_assoc($result)){
 			$data[$row['setting']] = $row['value'];

--- a/pages/user/user_lasthit.php
+++ b/pages/user/user_lasthit.php
@@ -1,6 +1,6 @@
 <?php
 $output="";
-$sql = "SELECT output FROM " . db_prefix("accounts_output") . " WHERE acctid='$userid'";
+$sql = "SELECT output FROM " . db_prefix("accounts_output") . " WHERE acctid=" . (int)$userid;
 $result = db_query($sql);
 $row = db_fetch_assoc($result);
 if ($row['output']=='') {

--- a/pages/user/user_savemodule.php
+++ b/pages/user/user_savemodule.php
@@ -13,7 +13,7 @@ if (isset($post['validation_error']) && $post['validation_error']) {
 } else {
 	output_notl("`n");
 	foreach ($post as $key=>$val) {
-		output("`\$Setting '`2%s`\$' to '`2%s`\$'`n", $key, stripslashes($val));
+		output("`\$Setting '`2%s`\$' to '`2%s`\$'`n", $key, htmlspecialchars($val, ENT_QUOTES, 'UTF-8'));
                $sql = "REPLACE INTO " . db_prefix("module_userprefs") .
                        " (modulename,userid,setting,value) VALUES ('" .
                        db_real_escape_string($module) . "',$userid,'" .

--- a/pages/user/user_savemodule.php
+++ b/pages/user/user_savemodule.php
@@ -1,6 +1,6 @@
 <?php
 //save module settings.
-$userid = httpget('userid');
+$userid = (int)httpget('userid');
 $module = httpget('module');
 $post = httpallpost();
 $post = modulehook("validateprefs", $post, true, $module);
@@ -14,7 +14,11 @@ if (isset($post['validation_error']) && $post['validation_error']) {
 	output_notl("`n");
 	foreach ($post as $key=>$val) {
 		output("`\$Setting '`2%s`\$' to '`2%s`\$'`n", $key, stripslashes($val));
-		$sql = "REPLACE INTO " . db_prefix("module_userprefs") . " (modulename,userid,setting,value) VALUES ('$module','$userid','$key','$val')";
+               $sql = "REPLACE INTO " . db_prefix("module_userprefs") .
+                       " (modulename,userid,setting,value) VALUES ('" .
+                       db_real_escape_string($module) . "',$userid,'" .
+                       db_real_escape_string($key) . "','" .
+                       db_real_escape_string($val) . "')";
 		db_query($sql);
 	}
 	output("`^Preferences for module %s saved.`n", $module);

--- a/pages/user/user_special.php
+++ b/pages/user/user_special.php
@@ -3,15 +3,15 @@ if (httppost("newday") !=""){
 #	$offset = "-".(24 / (int)getsetting("daysperday",4))." hours";
 #	$newdate = date("Y-m-d H:i:s",strtotime($offset));
 #	$sql = "UPDATE " . db_prefix("accounts") . " SET lasthit='$newdate' WHERE acctid='$userid'";
-	$sql = "UPDATE " . db_prefix("accounts") . " SET lasthit='".DATETIME_DATEMIN."' WHERE acctid='$userid'";
+       $sql = "UPDATE " . db_prefix("accounts") . " SET lasthit='".DATETIME_DATEMIN."' WHERE acctid=" . (int)$userid;
 	db_query($sql);
 }elseif(httppost("fixnavs")!=""){
-	$sql = "UPDATE " . db_prefix("accounts") . " SET allowednavs='', restorepage='', specialinc='' WHERE acctid='$userid'";
+       $sql = "UPDATE " . db_prefix("accounts") . " SET allowednavs='', restorepage='', specialinc='' WHERE acctid=" . (int)$userid;
 	db_query($sql);
-	$sql = "DELETE FROM ".db_prefix("accounts_output")." WHERE acctid='$userid';";
+       $sql = "DELETE FROM ".db_prefix("accounts_output")." WHERE acctid=" . (int)$userid . ";";
 	db_query($sql);
 } elseif(httppost("clearvalidation")!=""){
-	$sql = "UPDATE " . db_prefix("accounts") . " SET emailvalidation='' WHERE acctid='$userid'";
+       $sql = "UPDATE " . db_prefix("accounts") . " SET emailvalidation='' WHERE acctid=" . (int)$userid;
 	db_query($sql);
 }
 $op = "edit";

--- a/prefs.php
+++ b/prefs.php
@@ -26,10 +26,10 @@ $op = httpget('op');
 
 addnav("Navigation");
 if ($op=="suicide" && getsetting("selfdelete",0)!=0) {
-	$userid = httpget('userid');
+       $userid = (int)httpget('userid');
 	require_once("lib/charcleanup.php");
 	char_cleanup($userid, CHAR_DELETE_SUICIDE);
-	$sql = "DELETE FROM " . db_prefix("accounts") . " WHERE acctid='$userid'";
+       $sql = "DELETE FROM " . db_prefix("accounts") . " WHERE acctid=$userid";
 	db_query($sql);
 	output("Your character has been deleted!");
 	AddNews::add("`#%s quietly passed from this world.",$session['user']['name']);

--- a/user.php
+++ b/user.php
@@ -12,7 +12,7 @@ tlschema("user");
 check_su_access(SU_EDIT_USERS);
 
 $op = httpget('op');
-$userid=httpget("userid");
+$userid=(int)httpget("userid");
 
 if ($op == "lasthit") {
 	// Try and keep user editor and captcha from breaking each other.


### PR DESCRIPTION
## Summary
- remove `set_magic_quotes` from `lib/errorhandling.php`
- escape user IDs and other inputs properly
- sanitize module preference updates
- escape logdnet registration values

## Testing
- `php -l lib/errorhandling.php`
- `php -l bios.php`
- `php -l prefs.php`
- `php -l logdnet.php`
- `php -l user.php`
- `php -l pages/user/user_edit.php`
- `php -l pages/user/user_special.php`
- `php -l pages/user/user_lasthit.php`
- `php -l pages/user/user_savemodule.php`
- `php -l pages/bans/case_setupban.php`


------
https://chatgpt.com/codex/tasks/task_e_6865554e338883299c3d4199234c346b