### PR TITLE
Fix error_notify datacache defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If somebody really has time, there are still things to do:
 - replace the template system with a state-of-the-art system such as Smarty
 - integrate refreshing chats (tests with Jaxon worked but were slow)
 - convert arrays into objects to avoid extensive `isset()` checks
-- the error sending via mail has an issue with the datacache+firstrun key in the array. Not sure why. Also outputting PHP warnings to a user should not be done, but those should be logged somewhere in a real log
+- configure the `datacachepath` setting in `dbconnect.php` to a writable directory so errors can be cached for email notifications
 
 Contact me on github via issue if you like https://github.com/NB-Core/lotgd
 

--- a/lib/errorhandler.php
+++ b/lib/errorhandler.php
@@ -62,12 +62,20 @@ function logd_error_notify($errno, $errstr, $errfile, $errline, $backtrace){
 	$sendto = explode(";",getsetting("notify_address",""));
 	$howoften = getsetting("notify_every",30);
 	reset($sendto);
-	$data = datacache("error_notify",86400);
-	if (!is_array($data)){
-		$data = array('firstrun'=>true,'errors'=>array());
-	}else{
-		$data['firstrun'] = false;
-	}
+       $data = datacache("error_notify",86400);
+       if (!is_array($data)){
+               $data = array('firstrun'=>false,'errors'=>array());
+               if (!updatedatacache("error_notify", $data)) {
+                       error_log('Unable to write datacache for error_notify');
+               }
+       } else {
+               if (!array_key_exists('errors',$data) || !is_array($data['errors'])){
+                       $data['errors'] = array();
+               }
+               if (!array_key_exists('firstrun',$data)){
+                       $data['firstrun'] = false;
+               }
+       }
 	$do_notice = false;
 	if (!array_key_exists($errstr,$data['errors'])){
 		$do_notice = true;
@@ -115,8 +123,10 @@ function logd_error_notify($errno, $errstr, $errfile, $errline, $backtrace){
 			debug("Not notifying users for this error, it's only been ".round((strtotime("now") - $data['errors'][$errstr]) / 60,2)." minutes.");
 		}
 	}
-	updatedatacache("error_notify",$data);
-	debug($data);
+       if (!updatedatacache("error_notify", $data)) {
+               error_log('Unable to write datacache for error_notify');
+       }
+       debug($data);
 }
 set_error_handler("logd_error_handler");
 ?>

--- a/lib/errorhandler.php
+++ b/lib/errorhandler.php
@@ -69,7 +69,7 @@ function logd_error_notify($errno, $errstr, $errfile, $errline, $backtrace){
                        error_log('Unable to write datacache for error_notify');
                }
        } else {
-               if (!array_key_exists('errors',$data) || !is_array($data['errors'])){
+               if (!isset($data['errors']) || !is_array($data['errors'])){
                        $data['errors'] = array();
                }
                if (!array_key_exists('firstrun',$data)){


### PR DESCRIPTION
## Summary
- ensure `error_notify` cache defaults to `['firstrun'=>false,'errors'=>[]]`
- stop overwriting `firstrun` when saving

## Testing
- `php -l lib/errorhandler.php`


------
https://chatgpt.com/codex/tasks/task_e_686555551a888329912435b9307a4c82