### PR TITLE
Remove verbose dumps and log sanitized payment errors

### DIFF
--- a/payment.php
+++ b/payment.php
@@ -184,7 +184,7 @@ if ($payment_errors>"") {
         mail($adminEmail,$subj,$payment_errors."\n".$sanitizedInfo,"From: " . getsetting("gameadminemail", "postmaster@localhost.com"));
 }
 $output = ob_get_contents();
-if ($output > ""){
+if (!empty($output)){
         error_log("Unexpected payment output: " . $output);
         $sanitizedInfo = sprintf(
                 "Txn ID: %s\nStatus: %s\nAmount: %s %s\nPayer: %s\nReceiver: %s",

--- a/payment.php
+++ b/payment.php
@@ -179,7 +179,7 @@ $adminEmail = getsetting("gameadminemail", "postmaster@localhost.com");
 if ($payment_errors>"") {
 	$subj = translate_mail("Payment Error",0);
 	// $payment_errors not translated
-        $sanitizedInfo = sprintf("Txn ID: %s\nStatus: %s\nAmount: %s %s\nPayer: %s\nReceiver: %s", $txn_id, $payment_status, $payment_amount, $payment_currency, $payer_email, $receiver_email);
+        $sanitizedInfo = sprintf("Txn ID: %s\nStatus: %s\nAmount: %0.2f %s\nPayer: %s\nReceiver: %s", $txn_id, $payment_status, (float)$payment_amount, $payment_currency, $payer_email, $receiver_email);
         error_log($payment_errors . "\n" . $sanitizedInfo);
         mail($adminEmail,$subj,$payment_errors."\n".$sanitizedInfo,"From: " . getsetting("gameadminemail", "postmaster@localhost.com"));
 }


### PR DESCRIPTION
## Summary
- clean up payment handler
- log issues with `error_log()`
- send sanitized payment info in emails
- log details if admin email is missing

## Testing
- `php -l payment.php`


------
https://chatgpt.com/codex/tasks/task_e_686645b5b8a8832997898bd17c112685