### PR TITLE
Use namespaced commentary functions

### DIFF
--- a/account.php
+++ b/account.php
@@ -10,7 +10,7 @@ require_once("common.php");
 tlschema("account");
 
 page_header("Account Information");
-addcommentary();
+Commentary::addcommentary();
 checkday();
 
 output("`\$Some stats concerning your account. Note that this in the timezone of the server.`0`n`n.");

--- a/clan.php
+++ b/clan.php
@@ -24,7 +24,7 @@ addnav("Village");
 villagenav();
 addnav("Clan Options");
 addnav("C?List Clans","clan.php?op=list");
-addcommentary();
+Commentary::addcommentary();
 $gold = getsetting("goldtostartclan",10000);
 $gems = getsetting("gemstostartclan",15);
 $ranks = array(CLAN_APPLICANT=>"`!Applicant`0",CLAN_MEMBER=>"`#Member`0",CLAN_OFFICER=>"`^Officer`0",CLAN_ADMINISTRATIVE=>"`\$Administrative`0",CLAN_LEADER=>"`&Leader`0", CLAN_FOUNDER=>"`\$Founder");

--- a/ext/ajax_server.php
+++ b/ext/ajax_server.php
@@ -12,6 +12,7 @@
 #	file_put_contents("/var/www/html/naruto/debug.txt",$s, FILE_APPEND);
 //}
 use Jaxon\Response\Response;          // and the Response class
+use Lotgd\Commentary;
 use function Jaxon\jaxon;
 
 function mail_expired($args=false) {
@@ -104,7 +105,7 @@ function commentary_text($args=false) {
 	$talkline="says";
 	$schema=$args['schema'];
 	$viewonly=$args['viewonly'];	
-	$new=viewcommentary($section, $message, $limit, $talkline, $schema,$viewonly,1);
+	$new=Commentary::viewcommentary($section, $message, $limit, $talkline, $schema,$viewonly,1);
 	$new=maillink();
 	$objResponse = jaxon()->newResponse();
 	$objResponse->assign($section,"innerHTML", $new);

--- a/gypsy.php
+++ b/gypsy.php
@@ -9,7 +9,7 @@ require_once("lib/villagenav.php");
 
 tlschema("gypsy");
 
-addcommentary();
+Commentary::addcommentary();
 
 $cost = $session['user']['level']*20;
 $op = httpget('op');

--- a/inn.php
+++ b/inn.php
@@ -13,7 +13,7 @@ require_once("lib/villagenav.php");
 
 tlschema("inn");
 
-addcommentary();
+Commentary::addcommentary();
 $iname = getsetting("innname", LOCATION_INN);
 $vname = getsetting("villagename", LOCATION_FIELDS);
 $barkeep = getsetting('barkeep','`tCedrik');

--- a/mailinfo_server.php
+++ b/mailinfo_server.php
@@ -13,6 +13,7 @@ This will just make our mailinfo return a small string in case of a timeout, not
 #	$s=print_r($_POST,true);
 #	$s=$_SERVER['REMOTE_ADDR'].$s;
 #	file_put_contents("/var/www/html/naruto/debug.txt",$s, FILE_APPEND);
+use Lotgd\Commentary;
 //}
 
 function mail_expired($args=false) {
@@ -101,7 +102,7 @@ function commentary_text($args=false) {
 	$talkline="says";
 	$schema=$args['schema'];
 	$viewonly=$args['viewonly'];	
-	$new=viewcommentary($section, $message, $limit, $talkline, $schema,$viewonly,1);
+	$new=Commentary::viewcommentary($section, $message, $limit, $talkline, $schema,$viewonly,1);
 	$new=maillink();
 	$objResponse = new xajaxResponse();
 	$objResponse->assign($section,"innerHTML", $new);

--- a/moderate.php
+++ b/moderate.php
@@ -1,6 +1,7 @@
 <?php
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
+use Lotgd\Commentary;
 // translator ready
 // addnews ready
 // mail ready
@@ -11,7 +12,7 @@ use Lotgd\Moderate;
 
 tlschema("moderate");
 
-addcommentary();
+Commentary::addcommentary();
 
 SuAccess::check(SU_EDIT_COMMENTS);
 

--- a/modules/darkhorse.php
+++ b/modules/darkhorse.php
@@ -352,7 +352,7 @@ function darkhorse_runevent(string $type, string $link): void{
 		}
 		break;
 	case "tables":
-		addcommentary();
+		Commentary::addcommentary();
 		commentdisplay("You examine the etchings in the table:`n`n",
 				"darkhorse","Add your own etching:");
 		addnav("Navigation");

--- a/motd.php
+++ b/motd.php
@@ -15,7 +15,7 @@ tlschema("motd");
 $op = httpget('op');
 $id = httpget('id');
 
-addcommentary();
+Commentary::addcommentary();
 popup_header("LoGD Message of the Day (MoTD)");
 
 if ($session['user']['superuser'] & SU_POST_MOTD) {

--- a/rock.php
+++ b/rock.php
@@ -11,7 +11,7 @@ tlschema("rock");
 // This idea is Imusade's from lotgd.net
 if ($session['user']['dragonkills']>0 ||
 		$session['user']['superuser'] & SU_EDIT_COMMENTS){
-	addcommentary();
+	Commentary::addcommentary();
 }
 
 checkday();

--- a/shades.php
+++ b/shades.php
@@ -9,7 +9,7 @@ require_once("common.php");
 tlschema("shades");
 
 page_header("Land of the Shades");
-addcommentary();
+Commentary::addcommentary();
 checkday();
 
 if ($session['user']['alive']) redirect("village.php");

--- a/superuser.php
+++ b/superuser.php
@@ -10,7 +10,7 @@ require_once("lib/sanitize.php");
 require_once("lib/http.php");
 
 SuAccess::check(0xFFFFFFFF &~ SU_DOESNT_GIVE_GROTTO);
-addcommentary();
+Commentary::addcommentary();
 tlschema("superuser");
 
 SuperuserNav::render();

--- a/translatorlounge.php
+++ b/translatorlounge.php
@@ -10,7 +10,7 @@ require_once("lib/sanitize.php");
 require_once("lib/http.php");
 
 SuAccess::check(SU_IS_TRANSLATOR);
-addcommentary();
+Commentary::addcommentary();
 tlschema("translatorlounge");
 
 SuperuserNav::render();

--- a/viewpetition.php
+++ b/viewpetition.php
@@ -13,7 +13,7 @@ tlschema("petition");
 
 SuAccess::check(SU_EDIT_PETITIONS);
 
-addcommentary();
+Commentary::addcommentary();
 
 SuperuserNav::render();
 


### PR DESCRIPTION
## Summary
- swap legacy `addcommentary()`/`viewcommentary()` calls to `Lotgd\Commentary`
- import `Lotgd\Commentary` where needed

## Testing
- `php -l ext/ajax_server.php`
- `php -l mailinfo_server.php`
- `php -l superuser.php`


------
https://chatgpt.com/codex/tasks/task_e_6866d4c23250832984c46dfb3e9d8fe0