### PR TITLE
Add baseaccount update in forced navigation

### DIFF
--- a/src/Lotgd/ForcedNavigation.php
+++ b/src/Lotgd/ForcedNavigation.php
@@ -17,6 +17,8 @@ class ForcedNavigation
             $result = db_query($sql);
             if (db_num_rows($result) == 1) {
                 $session['user'] = db_fetch_assoc($result);
+                global $baseaccount;
+                $baseaccount = $session['user'];
                 self::$baseAccount = $session['user'];
                 $session['bufflist'] = unserialize($session['user']['bufflist']);
                 if (!is_array($session['bufflist'])) $session['bufflist'] = [];


### PR DESCRIPTION
## Summary
- ensure `$baseaccount` is updated when refreshing user data during forced navigation

## Testing
- `php -l src/Lotgd/ForcedNavigation.php`

------
https://chatgpt.com/codex/tasks/task_e_6867724902e08329a5dd4cf72872015d