### PR TITLE
Refactor select classes to use namespaces

### DIFF
--- a/src/Lotgd/Censor.php
+++ b/src/Lotgd/Censor.php
@@ -1,14 +1,15 @@
 <?php
 namespace Lotgd;
 
+use Lotgd\Sanitize;
+
 class Censor
 {
     public static function soap($input, $debug = false, $skiphook = false)
     {
         global $session;
-        require_once('lib/sanitize.php');
         $final_output = $input;
-        $output = full_sanitize($input);
+        $output = Sanitize::fullSanitize($input);
         $mix_mask = str_pad('', strlen($output), 'X');
         if (getsetting('soap', 1)) {
             $search = self::nasty_word_list();
@@ -37,7 +38,7 @@ class Censor
                             }
                         } else {
                             if ($debug) {
-                                output("`7This word is not ok: \"`%%s`7\"; it blocks on the pattern `i%s`i at \"`\$%s`7\".`n", sanitize_mb($longword), $word, $shortword);
+                                output("`7This word is not ok: \"`%%s`7\"; it blocks on the pattern `i%s`i at \"`\$%s`7\".`n", Sanitize::sanitizeMb($longword), $word, $shortword);
                             }
                             $len = strlen($shortword);
                             $pad = str_pad('', $len, '_');

--- a/src/Lotgd/ExpireChars.php
+++ b/src/Lotgd/ExpireChars.php
@@ -6,83 +6,163 @@ use Lotgd\PlayerFunctions;
 use Lotgd\Mail;
 use Lotgd\GameLog;
 
+/**
+ * Maintenance tasks for deleting inactive characters and notifying players
+ * about impending account expiration.
+ */
 class ExpireChars
 {
+    /** Execute the full expiration routine. */
     public static function expire(): void
     {
         global $settings_extended;
         $settings_extended = new Settings('settings_extended');
 
-        $lastexpire = strtotime(getsetting('last_char_expire', DATETIME_DATEMIN));
-        $needtoexpire = strtotime('-23 hours');
-        if ($lastexpire < $needtoexpire) {
-            savesetting('last_char_expire', date('Y-m-d H:i:s'));
-            $old = getsetting('expireoldacct', 45);
-            $new = getsetting('expirenewacct', 10);
-            $trash = getsetting('expiretrashacct', 1);
+        if (!self::needsExpiration()) {
+            return;
+        }
 
-            $sql1 = 'SELECT login,acctid,dragonkills,level FROM ' . db_prefix('accounts') .
-                ' WHERE (superuser&' . NO_ACCOUNT_EXPIRATION . ')=0 AND (1=0'
-                . ($old > 0 ? " OR (laston < '" . date('Y-m-d H:i:s', strtotime("-$old days")) . "')" : '')
-                . ($new > 0 ? " OR (laston < '" . date('Y-m-d H:i:s', strtotime("-$new days")) . "' AND level=1 AND dragonkills=0)" : '')
-                . ($trash > 0 ? " OR (laston < '" . date('Y-m-d H:i:s', strtotime('-' . ($trash + 1) . ' days')) . "' AND level=1 AND experience < 10 AND dragonkills=0)" : '')
-                . ')';
-            $result1 = db_query($sql1);
-            $acctids = [];
-            $pinfo = [];
-            $dk0lvl = 0;
-            $dk0ct = 0;
-            $dk1lvl = 0;
-            $dk1ct = 0;
-            $dks = 0;
-            while ($row1 = db_fetch_assoc($result1)) {
-                PlayerFunctions::charCleanup($row1['acctid'], CHAR_DELETE_AUTO);
-                $acctids[] = $row1['acctid'];
-                $pinfo[] = "{$row1['login']}:dk{$row1['dragonkills']}-lv{$row1['level']}";
-                if ($row1['dragonkills'] == 0) {
-                    $dk0lvl += $row1['level'];
-                    $dk0ct++;
-                } elseif ($row1['dragonkills'] == 1) {
-                    $dk1lvl += $row1['level'];
-                    $dk1ct++;
-                }
-                $dks += $row1['dragonkills'];
+        self::cleanupExpiredAccounts();
+        self::notifyUpcomingExpirations();
+    }
+
+    /**
+     * Determine whether the expiration routine should run.
+     * If the last run was more than 23 hours ago, update the timestamp
+     * and return true.
+     */
+    private static function needsExpiration(): bool
+    {
+        $lastExpire = strtotime(getsetting('last_char_expire', DATETIME_DATEMIN));
+        if ($lastExpire >= strtotime('-23 hours')) {
+            return false;
+        }
+        savesetting('last_char_expire', date('Y-m-d H:i:s'));
+        return true;
+    }
+
+    /**
+     * Remove accounts that have passed the configured inactivity thresholds
+     * and log statistics on the removed characters.
+     */
+    private static function cleanupExpiredAccounts(): void
+    {
+        $old = getsetting('expireoldacct', 45);
+        $new = getsetting('expirenewacct', 10);
+        $trash = getsetting('expiretrashacct', 1);
+
+        $rows = self::fetchAccountsToExpire($old, $new, $trash);
+        if (empty($rows)) {
+            return;
+        }
+
+        $acctIds = [];
+        foreach ($rows as $row) {
+            PlayerFunctions::charCleanup($row['acctid'], CHAR_DELETE_AUTO);
+            $acctIds[] = $row['acctid'];
+        }
+
+        self::logExpiredAccountStats($rows);
+        self::deleteAccounts($acctIds);
+    }
+
+    /**
+     * Select accounts eligible for deletion.
+     *
+     * @return array<int,array{acctid:int,login:string,dragonkills:int,level:int}>
+     */
+    private static function fetchAccountsToExpire(int $old, int $new, int $trash): array
+    {
+        $sql = 'SELECT login,acctid,dragonkills,level FROM ' . db_prefix('accounts') .
+            ' WHERE (superuser&' . NO_ACCOUNT_EXPIRATION . ')=0 AND (1=0'
+            . ($old > 0 ? " OR (laston < '" . date('Y-m-d H:i:s', strtotime("-$old days")) . "')" : '')
+            . ($new > 0 ? " OR (laston < '" . date('Y-m-d H:i:s', strtotime("-$new days")) . "' AND level=1 AND dragonkills=0)" : '')
+            . ($trash > 0 ? " OR (laston < '" . date('Y-m-d H:i:s', strtotime('-' . ($trash + 1) . ' days')) . "' AND level=1 AND experience < 10 AND dragonkills=0)" : '')
+            . ')';
+
+        $result = db_query($sql);
+        $rows = [];
+        while ($row = db_fetch_assoc($result)) {
+            $rows[] = $row;
+        }
+        return $rows;
+    }
+
+    /**
+     * Write summary information about deleted accounts to the gamelog.
+     */
+    private static function logExpiredAccountStats(array $rows): void
+    {
+        $acctCount = count($rows);
+        if ($acctCount === 0) {
+            return;
+        }
+
+        $dk0lvl = $dk0ct = $dk1lvl = $dk1ct = $dks = 0;
+        $info = [];
+        foreach ($rows as $row) {
+            $info[] = "{$row['login']}:dk{$row['dragonkills']}-lv{$row['level']}";
+            if ($row['dragonkills'] == 0) {
+                $dk0lvl += $row['level'];
+                $dk0ct++;
+            } elseif ($row['dragonkills'] == 1) {
+                $dk1lvl += $row['level'];
+                $dk1ct++;
             }
+            $dks += $row['dragonkills'];
+        }
 
-            $msg = "[{$dk0ct}] with 0 dk avg lvl [" . round($dk0lvl / max(1, $dk0ct), 2) . "]\n";
-            $msg .= "[{$dk1ct}] with 1 dk avg lvl [" . round($dk1lvl / max(1, $dk1ct), 2) . "]\n";
-            $msg .= 'Avg DK: [' . round($dks / max(1, count($acctids)), 2) . "]\n";
-            $msg .= 'Accounts: ' . implode(', ', $pinfo);
-            GameLog::log('Deleted ' . count($acctids) . " accounts:\n$msg", 'char expiration');
+        $msg = "[{$dk0ct}] with 0 dk avg lvl [" . round($dk0lvl / max(1, $dk0ct), 2) . "]\n";
+        $msg .= "[{$dk1ct}] with 1 dk avg lvl [" . round($dk1lvl / max(1, $dk1ct), 2) . "]\n";
+        $msg .= 'Avg DK: [' . round($dks / max(1, $acctCount), 2) . "]\n";
+        $msg .= 'Accounts: ' . implode(', ', $info);
 
-            if (count($acctids)) {
-                $sql = 'DELETE FROM ' . db_prefix('accounts') .
-                    ' WHERE acctid IN (' . implode(',', $acctids) . ')';
-                db_query($sql);
-            }
+        GameLog::log('Deleted ' . $acctCount . " accounts:\n$msg", 'char expiration');
+    }
 
-            $old = max(1, $old - getsetting('notifydaysbeforedeletion', 5));
-            $sql = 'SELECT login,acctid,emailaddress FROM ' . db_prefix('accounts') .
-                " WHERE 1=0 " . ($old > 0 ? "OR (laston < '" . date('Y-m-d H:i:s', strtotime("-$old days")) . "')" : '') .
-                " AND emailaddress!='' AND sentnotice=0 AND (superuser&" . NO_ACCOUNT_EXPIRATION . ')=0';
-            $result = db_query($sql);
-            $subject = translate_inline($settings_extended->getSetting('expirationnoticesubject'));
-            $message = translate_inline($settings_extended->getSetting('expirationnoticetext'));
-            $message = str_replace('{server}', getsetting('serverurl', 'http://nodomain.notd'), $message);
+    /**
+     * Delete the supplied account ids from the database.
+     */
+    private static function deleteAccounts(array $acctIds): void
+    {
+        if (empty($acctIds)) {
+            return;
+        }
 
-            $collector = [];
-            $from_array = [getsetting('gameadminemail', 'postmaster@localhost') => getsetting('gameadminemail', 'postmaster@localhost')];
-            $cc_array = [];
-            while ($row = db_fetch_assoc($result)) {
-                $to_array = [$row['emailaddress'] => $row['emailaddress']];
-                $body = str_replace('{charname}', $row['login'], $message);
-                Mail::send($to_array, $body, $subject, $from_array, $cc_array, 'text/html');
-                $collector[] = $row['acctid'];
-            }
-            if (!empty($collector)) {
-                $sql = 'UPDATE ' . db_prefix('accounts') . ' SET sentnotice=1 WHERE acctid IN (' . implode(',', $collector) . ');';
-                db_query($sql);
-            }
+        $sql = 'DELETE FROM ' . db_prefix('accounts') . ' WHERE acctid IN (' . implode(',', $acctIds) . ')';
+        db_query($sql);
+    }
+
+    /**
+     * Send expiration warning emails to players nearing deletion.
+     */
+    private static function notifyUpcomingExpirations(): void
+    {
+        global $settings_extended;
+
+        $old = max(1, getsetting('expireoldacct', 45) - getsetting('notifydaysbeforedeletion', 5));
+        $sql = 'SELECT login,acctid,emailaddress FROM ' . db_prefix('accounts') .
+            " WHERE 1=0 " . ($old > 0 ? "OR (laston < '" . date('Y-m-d H:i:s', strtotime("-$old days")) . "')" : '') .
+            " AND emailaddress!='' AND sentnotice=0 AND (superuser&" . NO_ACCOUNT_EXPIRATION . ')=0';
+        $result = db_query($sql);
+
+        $subject = translate_inline($settings_extended->getSetting('expirationnoticesubject'));
+        $message = translate_inline($settings_extended->getSetting('expirationnoticetext'));
+        $message = str_replace('{server}', getsetting('serverurl', 'http://nodomain.notd'), $message);
+
+        $collector = [];
+        $from = [getsetting('gameadminemail', 'postmaster@localhost') => getsetting('gameadminemail', 'postmaster@localhost')];
+        $cc = [];
+        while ($row = db_fetch_assoc($result)) {
+            $to = [$row['emailaddress'] => $row['emailaddress']];
+            $body = str_replace('{charname}', $row['login'], $message);
+            Mail::send($to, $body, $subject, $from, $cc, 'text/html');
+            $collector[] = $row['acctid'];
+        }
+
+        if (!empty($collector)) {
+            $sql = 'UPDATE ' . db_prefix('accounts') . ' SET sentnotice=1 WHERE acctid IN (' . implode(',', $collector) . ');';
+            db_query($sql);
         }
     }
 }

--- a/src/Lotgd/ExpireChars.php
+++ b/src/Lotgd/ExpireChars.php
@@ -1,0 +1,88 @@
+<?php
+namespace Lotgd;
+
+use Lotgd\Settings;
+use Lotgd\PlayerFunctions;
+use Lotgd\Mail;
+use Lotgd\GameLog;
+
+class ExpireChars
+{
+    public static function expire(): void
+    {
+        global $settings_extended;
+        $settings_extended = new Settings('settings_extended');
+
+        $lastexpire = strtotime(getsetting('last_char_expire', DATETIME_DATEMIN));
+        $needtoexpire = strtotime('-23 hours');
+        if ($lastexpire < $needtoexpire) {
+            savesetting('last_char_expire', date('Y-m-d H:i:s'));
+            $old = getsetting('expireoldacct', 45);
+            $new = getsetting('expirenewacct', 10);
+            $trash = getsetting('expiretrashacct', 1);
+
+            $sql1 = 'SELECT login,acctid,dragonkills,level FROM ' . db_prefix('accounts') .
+                ' WHERE (superuser&' . NO_ACCOUNT_EXPIRATION . ')=0 AND (1=0'
+                . ($old > 0 ? " OR (laston < '" . date('Y-m-d H:i:s', strtotime("-$old days")) . "')" : '')
+                . ($new > 0 ? " OR (laston < '" . date('Y-m-d H:i:s', strtotime("-$new days")) . "' AND level=1 AND dragonkills=0)" : '')
+                . ($trash > 0 ? " OR (laston < '" . date('Y-m-d H:i:s', strtotime('-' . ($trash + 1) . ' days')) . "' AND level=1 AND experience < 10 AND dragonkills=0)" : '')
+                . ')';
+            $result1 = db_query($sql1);
+            $acctids = [];
+            $pinfo = [];
+            $dk0lvl = 0;
+            $dk0ct = 0;
+            $dk1lvl = 0;
+            $dk1ct = 0;
+            $dks = 0;
+            while ($row1 = db_fetch_assoc($result1)) {
+                PlayerFunctions::charCleanup($row1['acctid'], CHAR_DELETE_AUTO);
+                $acctids[] = $row1['acctid'];
+                $pinfo[] = "{$row1['login']}:dk{$row1['dragonkills']}-lv{$row1['level']}";
+                if ($row1['dragonkills'] == 0) {
+                    $dk0lvl += $row1['level'];
+                    $dk0ct++;
+                } elseif ($row1['dragonkills'] == 1) {
+                    $dk1lvl += $row1['level'];
+                    $dk1ct++;
+                }
+                $dks += $row1['dragonkills'];
+            }
+
+            $msg = "[{$dk0ct}] with 0 dk avg lvl [" . round($dk0lvl / max(1, $dk0ct), 2) . "]\n";
+            $msg .= "[{$dk1ct}] with 1 dk avg lvl [" . round($dk1lvl / max(1, $dk1ct), 2) . "]\n";
+            $msg .= 'Avg DK: [' . round($dks / max(1, count($acctids)), 2) . "]\n";
+            $msg .= 'Accounts: ' . implode(', ', $pinfo);
+            GameLog::log('Deleted ' . count($acctids) . " accounts:\n$msg", 'char expiration');
+
+            if (count($acctids)) {
+                $sql = 'DELETE FROM ' . db_prefix('accounts') .
+                    ' WHERE acctid IN (' . implode(',', $acctids) . ')';
+                db_query($sql);
+            }
+
+            $old = max(1, $old - getsetting('notifydaysbeforedeletion', 5));
+            $sql = 'SELECT login,acctid,emailaddress FROM ' . db_prefix('accounts') .
+                " WHERE 1=0 " . ($old > 0 ? "OR (laston < '" . date('Y-m-d H:i:s', strtotime("-$old days")) . "')" : '') .
+                " AND emailaddress!='' AND sentnotice=0 AND (superuser&" . NO_ACCOUNT_EXPIRATION . ')=0';
+            $result = db_query($sql);
+            $subject = translate_inline($settings_extended->getSetting('expirationnoticesubject'));
+            $message = translate_inline($settings_extended->getSetting('expirationnoticetext'));
+            $message = str_replace('{server}', getsetting('serverurl', 'http://nodomain.notd'), $message);
+
+            $collector = [];
+            $from_array = [getsetting('gameadminemail', 'postmaster@localhost') => getsetting('gameadminemail', 'postmaster@localhost')];
+            $cc_array = [];
+            while ($row = db_fetch_assoc($result)) {
+                $to_array = [$row['emailaddress'] => $row['emailaddress']];
+                $body = str_replace('{charname}', $row['login'], $message);
+                Mail::send($to_array, $body, $subject, $from_array, $cc_array, 'text/html');
+                $collector[] = $row['acctid'];
+            }
+            if (!empty($collector)) {
+                $sql = 'UPDATE ' . db_prefix('accounts') . ' SET sentnotice=1 WHERE acctid IN (' . implode(',', $collector) . ');';
+                db_query($sql);
+            }
+        }
+    }
+}

--- a/src/Lotgd/Mail.php
+++ b/src/Lotgd/Mail.php
@@ -4,6 +4,7 @@ namespace Lotgd;
 /**
  * Placeholder class for future mail handling refactoring.
  */
+use Lotgd\Settings;
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
 
@@ -85,7 +86,7 @@ class Mail
             $body = preg_replace("'[`]n'", "\n", $body);
             $body = full_sanitize($body);
             $subject = htmlentities(full_sanitize($subject), ENT_COMPAT, getsetting('charset', 'ISO-8859-1'));
-            require 'lib/settings_extended.php';
+            $settings_extended = new Settings('settings_extended');
             $subj = translate_mail($settings_extended->getSetting('notificationmailsubject'), $to);
             $msg = translate_mail($settings_extended->getSetting('notificationmailtext'), $to);
             $replace = [

--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -1,6 +1,9 @@
 <?php
 namespace Lotgd;
 
+use Lotgd\GameLog;
+use Lotgd\ExpireChars;
+
 class Newday
 {
     public static function dbCleanup(): void
@@ -16,16 +19,14 @@ class Newday
             }
         }
         $time = round(getmicrotime() - $start, 2);
-        require_once('lib/gamelog.php');
-        gamelog('Optimized tables: ' . join(', ', $tables) . " in $time seconds.", 'maintenance');
+        GameLog::log('Optimized tables: ' . join(', ', $tables) . " in $time seconds.", 'maintenance');
     }
 
     public static function commentCleanup(): void
     {
-        require_once('lib/gamelog.php');
         $timestamp = self::calculateExpirationTimestamp('2 month');
         db_query('DELETE FROM ' . db_prefix('referers') . " WHERE last < '$timestamp'");
-        gamelog('Deleted ' . db_affected_rows() . ' records from ' . db_prefix('referers') . " older than $timestamp.", 'maintenance');
+        GameLog::log('Deleted ' . db_affected_rows() . ' records from ' . db_prefix('referers') . " older than $timestamp.", 'maintenance');
 
         $timestamp = date('Y-m-d H:i:s', strtotime('now'));
         $sql = 'INSERT IGNORE INTO ' . db_prefix('debuglog_archive') .
@@ -37,21 +38,21 @@ class Newday
             $timestamp = self::calculateExpirationTimestamp(round(getsetting('expiredebuglog', 18), 0) . ' days');
             $sql = 'DELETE FROM ' . db_prefix('debuglog_archive') . " WHERE date <'$timestamp'";
             if (getsetting('expiredebuglog', 18) > 0) db_query($sql);
-            gamelog('Moved ' . db_affected_rows() . ' from ' . db_prefix('debuglog') . ' to ' . db_prefix('debuglog_archive') . " older than $timestamp.", 'maintenance');
+            GameLog::log('Moved ' . db_affected_rows() . ' from ' . db_prefix('debuglog') . ' to ' . db_prefix('debuglog_archive') . " older than $timestamp.", 'maintenance');
         } else {
-            gamelog('ERROR, problems with moving the debuglog to the archive', 'maintenance');
+            GameLog::log('ERROR, problems with moving the debuglog to the archive', 'maintenance');
         }
 
         $timestamp = self::calculateExpirationTimestamp(round(getsetting('oldmail', 14), 0) . ' days');
         $sql = 'DELETE FROM ' . db_prefix('mail') . " WHERE sent<'$timestamp'";
         db_query($sql);
-        gamelog('Deleted ' . db_affected_rows() . ' records from ' . db_prefix('mails') . " older than $timestamp.", 'maintenance');
+        GameLog::log('Deleted ' . db_affected_rows() . ' records from ' . db_prefix('mails') . " older than $timestamp.", 'maintenance');
         massinvalidate('mail');
 
         if ((int) getsetting('expirecontent', 180) > 0) {
             $timestamp = self::calculateExpirationTimestamp(round(getsetting('expirecontent', 180), 0) . ' days');
             $sql = 'DELETE FROM ' . db_prefix('news') . " WHERE newsdate<'$timestamp'";
-            gamelog('Deleted ' . db_affected_rows() . ' records from ' . db_prefix('news') . " older than $timestamp.", 'comment expiration');
+            GameLog::log('Deleted ' . db_affected_rows() . ' records from ' . db_prefix('news') . " older than $timestamp.", 'comment expiration');
             db_query($sql);
         }
 
@@ -59,28 +60,28 @@ class Newday
         $sql = 'DELETE FROM ' . db_prefix('gamelog') . " WHERE date < '$timestamp' ";
         if (getsetting('expiregamelog', 30) > 0) {
             db_query($sql);
-            gamelog('Cleaned up ' . db_prefix('gamelog') . ' table removing ' . db_affected_rows() . " older than $timestamp.", 'maintenance');
+            GameLog::log('Cleaned up ' . db_prefix('gamelog') . ' table removing ' . db_affected_rows() . " older than $timestamp.", 'maintenance');
         }
 
         $sql = 'DELETE FROM ' . db_prefix('commentary') . " WHERE postdate<'" . self::calculateExpirationTimestamp(getsetting('expirecontent', 180) . ' days') . "'";
         if (getsetting('expirecontent', 180) > 0) {
             $timestamp = self::calculateExpirationTimestamp(round(getsetting('expirecontent', 180), 0) . ' days');
             db_query($sql);
-            gamelog('Deleted ' . db_affected_rows() . ' records from ' . db_prefix('commentary') . " older than $timestamp.", 'comment expiration');
+            GameLog::log('Deleted ' . db_affected_rows() . ' records from ' . db_prefix('commentary') . " older than $timestamp.", 'comment expiration');
         }
 
         $sql = 'DELETE FROM ' . db_prefix('moderatedcomments') . " WHERE moddate<'" . self::calculateExpirationTimestamp(getsetting('expirecontent', 180) . ' days') . "'";
         if (getsetting('expirecontent', 180) > 0) {
             $timestamp = self::calculateExpirationTimestamp(round(getsetting('expirecontent', 180), 0) . ' days');
             db_query($sql);
-            gamelog('Deleted ' . db_affected_rows() . ' records from ' . db_prefix('moderatedcomments') . " older than $timestamp.", 'comment expiration');
+            GameLog::log('Deleted ' . db_affected_rows() . ' records from ' . db_prefix('moderatedcomments') . " older than $timestamp.", 'comment expiration');
         }
 
         $sql = 'DELETE FROM ' . db_prefix('faillog') . " WHERE date<'" . self::calculateExpirationTimestamp(round(getsetting('expirefaillog', 1), 0) . ' days') . "'";
         if (getsetting('expirefaillog', 1) > 0) {
             db_query($sql);
             $timestamp = self::calculateExpirationTimestamp(round(getsetting('expirecontent', 180), 0) . ' days');
-            gamelog('Deleted ' . db_affected_rows() . ' records from ' . db_prefix('faillog') . " older than $timestamp.", 'maintenance');
+            GameLog::log('Deleted ' . db_affected_rows() . ' records from ' . db_prefix('faillog') . " older than $timestamp.", 'maintenance');
         }
     }
 
@@ -91,7 +92,7 @@ class Newday
 
     public static function charCleanup(): void
     {
-        require_once('lib/expire_chars.php');
+        ExpireChars::expire();
     }
 
     public static function runOnce(): void

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -646,10 +646,9 @@ public static function charStats(): string{
 		  $atk=$u['attack'];
 		  $def=$u['defense'];
 		 */
-		require_once("lib/playerfunctions.php");
-		$o_atk=$atk=get_player_attack();
-		$o_def=$def=get_player_defense();
-		$spd=get_player_speed();
+                $o_atk=$atk=PlayerFunctions::getPlayerAttack();
+                $o_def=$def=PlayerFunctions::getPlayerDefense();
+                $spd=PlayerFunctions::getPlayerSpeed();
 
 		$buffcount = 0;
 		$buffs = "";
@@ -723,8 +722,8 @@ public static function charStats(): string{
 			self::addCharStat("Intelligence", $u['intelligence'].check_temp_stat("intelligence",1));
 			self::addCharStat("Constitution", $u['constitution'].check_temp_stat("constitution",1));
 			self::addCharStat("Wisdom", $u['wisdom'].check_temp_stat("wisdom",1));
-			self::addCharStat("Attack", $atk."`\$<span title='".explained_get_player_attack()."'>(?)</span>`0".check_temp_stat("attack",1));
-			self::addCharStat("Defense", $def."`\$<span title='".explained_get_player_defense()."'>(?)</span>`0".check_temp_stat("defense",1));
+                        self::addCharStat("Attack", $atk."`\$<span title='".PlayerFunctions::explainedGetPlayerAttack()."'>(?)</span>`0".check_temp_stat("attack",1));
+                        self::addCharStat("Defense", $def."`\$<span title='".PlayerFunctions::explainedGetPlayerDefense()."'>(?)</span>`0".check_temp_stat("defense",1));
 			self::addCharStat("Speed", $spd.check_temp_stat("speed",1));
 		} else {
 			$maxsoul = 50 + 10 * $u['level']+$u['dragonkills']*2;

--- a/src/Lotgd/PullUrl.php
+++ b/src/Lotgd/PullUrl.php
@@ -1,6 +1,8 @@
 <?php
 namespace Lotgd;
 
+use Lotgd\Settings;
+
 /**
  * Helper methods to fetch remote URLs using different mechanisms.
  */
@@ -18,8 +20,10 @@ class PullUrl
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         $val = 5;
         if (defined('DB_CONNECTED') && DB_CONNECTED === true) {
-            require_once 'lib/settings.php';
-            $val = getsetting('curltimeout', 5);
+            global $settings;
+            if ($settings instanceof Settings) {
+                $val = $settings->getSetting('curltimeout', 5);
+            }
         }
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $val);
         curl_setopt($ch, CURLOPT_TIMEOUT, $val);

--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -1,6 +1,8 @@
 <?php
 namespace Lotgd;
 
+use Lotgd\Sanitize;
+
 // Old Global Variables
 global $translation_table;
 $translation_table = array();
@@ -224,10 +226,9 @@ class Translator
 				if (isset($seentlbuttons[$namespace][$indata])){
 					$link = "";
 				}else{
-					$seentlbuttons[$namespace][$indata] = true;
-					require_once("lib/sanitize.php");
-					$uri = cmd_sanitize($namespace);
-					$uri = comscroll_sanitize($uri);
+                                $seentlbuttons[$namespace][$indata] = true;
+                                        $uri = Sanitize::cmdSanitize($namespace);
+                                        $uri = Sanitize::comscrollSanitize($uri);
 					$link = "translatortool.php?u=".
 						rawurlencode($uri)."&t=".rawurlencode($indata);
 					$link = "<a href='$link' target='_blank' onClick=\"".


### PR DESCRIPTION
## Summary
- replace sanitize wrapper usage in `Censor` and `Translator`
- replace player function wrappers in `PageParts`
- use Settings object in `PullUrl` and `Mail`
- convert gamelog/expire chars calls in `Newday`
- implement new `ExpireChars` helper

## Testing
- `composer dump-autoload`
- `php -l src/Lotgd/ExpireChars.php`
- `php -l src/Lotgd/Censor.php`
- `php -l src/Lotgd/Translator.php`
- `php -l src/Lotgd/PageParts.php`
- `php -l src/Lotgd/PullUrl.php`
- `php -l src/Lotgd/Mail.php`
- `php -l src/Lotgd/Newday.php`


------
https://chatgpt.com/codex/tasks/task_e_6866fe270ae0832987f3ed51bd0e16a4