### PR TITLE
Improve installer logging resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,9 @@ The root `.htaccess` file configures custom error pages, disables directory list
 - **Code Changes Not Reflected:**
   - Ensure you have rebuilt the container after making changes to the Dockerfile.
   - Clear your application's cache or your browser's cache if necessary.
+- **Installer Log Location:**
+  - The installer writes to `install/errors/install.log`. If you see a warning
+    that the log could not be written, ensure this path is writable.
 
 ---
 

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -556,12 +556,14 @@ class Installer
                                                         output("`2Result: `\$Fail`n");
                                                         $err = error_get_last();
                                                         if ($err) {
-                                                                \Lotgd\Installer\InstallerLogger::log(sprintf(
-                                                                    "Error: %s in %s on line %d",
-                                                                    $err['message'],
-                                                                    $err['file'],
-                                                                    $err['line']
-                                                                ));
+                                                        if (!\Lotgd\Installer\InstallerLogger::log(sprintf(
+                                                            "Error: %s in %s on line %d",
+                                                            $err['message'],
+                                                            $err['file'],
+                                                            $err['line']
+                                                        ))) {
+                                                            output("`^Could not write install log (`2%s`^)`n", \Lotgd\Installer\InstallerLogger::getLogFilePath());
+                                                        }
                                                                 rawoutput("<blockquote>" . htmlentities($err['message'], ENT_COMPAT, getsetting('charset', 'ISO-8859-1')) . "</blockquote>");
                                                         }
                                                         array_push($issues, "`^I was not able to write to your datacache directory!`n");
@@ -573,12 +575,14 @@ class Installer
                                                     if (!unlink($dummyFile)) {
                                                         $err = error_get_last();
                                                         if ($err) {
-                                                            \Lotgd\Installer\InstallerLogger::log(sprintf(
+                                                            if (!\Lotgd\Installer\InstallerLogger::log(sprintf(
                                                                 "Error: %s in %s on line %d",
                                                                 $err['message'],
                                                                 $err['file'],
                                                                 $err['line']
-                                                            ));
+                                                            ))) {
+                                                                output("`^Could not write install log (`2%s`^)`n", \Lotgd\Installer\InstallerLogger::getLogFilePath());
+                                                            }
                                                             rawoutput("<blockquote>" . htmlentities($err['message'], ENT_COMPAT, getsetting('charset', 'ISO-8859-1')) . "</blockquote>");
                                                         } else {
                                                             rawoutput("<blockquote>`^Failed to delete the dummy file.`</blockquote>");
@@ -589,12 +593,14 @@ class Installer
                                                 output("`2Result: `\$Fail`n");
                                                 $err = error_get_last();
                                                 if ($err) {
-                                                        \Lotgd\Installer\InstallerLogger::log(sprintf(
+                                                        if (!\Lotgd\Installer\InstallerLogger::log(sprintf(
                                                             "Error: %s in %s on line %d",
                                                             $err['message'],
                                                             $err['file'],
                                                             $err['line']
-                                                        ));
+                                                        ))) {
+                                                            output("`^Could not write install log (`2%s`^)`n", \Lotgd\Installer\InstallerLogger::getLogFilePath());
+                                                        }
                                                         rawoutput("<blockquote>" . htmlentities($err['message'], ENT_COMPAT, getsetting('charset', 'ISO-8859-1')) . "</blockquote>");
                                                 }
                                                 array_push($issues, "`^I was not able to write to your datacache directory! Check your permissions there!`n");
@@ -767,7 +773,9 @@ class Installer
                                         $failure=true;
                                         $err = error_get_last();
                                         if ($err) {
-                                                \Lotgd\Installer\InstallerLogger::log(sprintf("Error: %s in %s on line %d", $err['message'], $err['file'], $err['line']));
+                                                if (!\Lotgd\Installer\InstallerLogger::log(sprintf("Error: %s in %s on line %d", $err['message'], $err['file'], $err['line']))) {
+                                                    output("`^Could not write install log (`2%s`^)`n", \Lotgd\Installer\InstallerLogger::getLogFilePath());
+                                                }
                                                 output("`n`\$Failed to write to dbconnect.php:`2 %s in %s on line %d", $err['message'], $err['file'], $err['line']);
                                         }
                                 }
@@ -776,7 +784,9 @@ class Installer
                                 $failure=true;
                                 $err = error_get_last();
                                 if ($err) {
-                                        \Lotgd\Installer\InstallerLogger::log($err['message']);
+                                        if (!\Lotgd\Installer\InstallerLogger::log($err['message'])) {
+                                            output("`^Could not write install log (`2%s`^)`n", \Lotgd\Installer\InstallerLogger::getLogFilePath());
+                                        }
                                         output("`n`\$Failed to create dbconnect.php:`2 %s", $err['message']);
                                 }
                         }
@@ -835,7 +845,9 @@ class Installer
                                                 $failure=true;
                                                 $err = error_get_last();
                                                 if ($err) {
-                                                        \Lotgd\Installer\InstallerLogger::log($err['message']);
+                                                        if (!\Lotgd\Installer\InstallerLogger::log($err['message'])) {
+                                                            output("`^Could not write install log (`2%s`^)`n", \Lotgd\Installer\InstallerLogger::getLogFilePath());
+                                                        }
                                                         output("`n`\$Failed to write to dbconnect.php:`2 %s", $err['message']);
                                                 }
                                         }
@@ -844,7 +856,9 @@ class Installer
                                         $failure=true;
                                         $err = error_get_last();
                                         if ($err) {
-                                                \Lotgd\Installer\InstallerLogger::log($err['message']);
+                                                if (!\Lotgd\Installer\InstallerLogger::log($err['message'])) {
+                                                    output("`^Could not write install log (`2%s`^)`n", \Lotgd\Installer\InstallerLogger::getLogFilePath());
+                                                }
                                                 output("`n`\$Failed to create dbconnect.php:`2 %s", $err['message']);
                                         }
                                 }

--- a/install/lib/InstallerLogger.php
+++ b/install/lib/InstallerLogger.php
@@ -5,17 +5,36 @@ use RuntimeException;
 
 class InstallerLogger
 {
-    public static function log(string $message): void
+    /**
+     * Return the install log file path.
+     */
+    public static function getLogFilePath(): string
     {
-        $logDir = __DIR__ . '/../errors';
+        return __DIR__ . '/../errors/install.log';
+    }
+
+    public static function log(string $message): bool
+    {
+        $logDir = dirname(self::getLogFilePath());
         if (!is_dir($logDir)) {
             if (!mkdir($logDir, 0755, true) && !is_dir($logDir)) {
-                throw new RuntimeException(sprintf('Directory "%s" was not created', $logDir));
+                return false;
             }
         }
-        $logFile = $logDir . '/install.log';
-        $date = date('Y-m-d H:i:s');
+
+        $date  = date('Y-m-d H:i:s');
         $entry = sprintf("[%s] %s\n", $date, $message);
-        file_put_contents($logFile, $entry, FILE_APPEND | LOCK_EX);
+
+        try {
+            $written = file_put_contents(self::getLogFilePath(), $entry, FILE_APPEND | LOCK_EX);
+        } catch (\Throwable $th) {
+            return false;
+        }
+
+        if ($written === false) {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
- prevent `InstallerLogger` from throwing when log directory creation fails
- warn during installation if log can't be written
- mention the installer log location in README troubleshooting

## Testing
- `php -l install/lib/InstallerLogger.php`
- `php -l install/lib/Installer.php`


------
https://chatgpt.com/codex/tasks/task_e_6868cf583b6883299c6bce61e370fc9a