### PR TITLE
Bump PHP requirement to 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Legend of the Green Dragon Fork
 
-![PHP Version](https://img.shields.io/badge/PHP-7.4%2B-blue)
+![PHP Version](https://img.shields.io/badge/PHP-8.0%2B-blue)
 ![License](https://img.shields.io/badge/license-CC%20BY--SA-lightgrey)
 This is a fork of the original Legend of the Green Dragon game by Eric "MightyE" Stevens (http://www.mightye.org) and JT "Kendaer" Traub (http://www.dragoncat.net)
 
@@ -64,7 +64,7 @@ See `CHANGELOG.txt` for a list of changes.
 To run Legend of the Green Dragon on a typical web host you will need:
 
 - **Web server:** Apache 2 (or another server capable of running PHP)
-- **PHP:** version 8.0 or newer (7.4 is the minimum supported)
+- **PHP:** version 8.0 or newer
 - **Database:** MySQL 5.0 or later. MariaDB is a compatible alternative.
 - The database user must have the `LOCK TABLES` privilege.
 

--- a/installer.php
+++ b/installer.php
@@ -9,13 +9,13 @@ define("OVERRIDE_FORCED_NAV",true);
 define("IS_INSTALLER",true);
 
 
-//PHP 7.4 or higher is required for this version
+//PHP 8.0 or higher is required for this version
 //MySQL 5.0.3 and the mysqli extension are required for this version
 $requirements_met=true;
 $php_met=true;
 $mysql_met=true;
 
-if (version_compare(PHP_VERSION, '7.4.0') < 0) {
+if (version_compare(PHP_VERSION, '8.0.0') < 0) {
         $requirements_met=false;
         $php_met=false;
 } elseif (!extension_loaded('mysqli')) {
@@ -29,7 +29,7 @@ if (version_compare(PHP_VERSION, '7.4.0') < 0) {
 if (!$requirements_met) {
 	//we have NO output object possibly :( hence no nice formatting
     echo "<h1>Requirements not sufficient<br/><br/>";
-    if (!$php_met) echo sprintf("You need PHP 7.4 or higher to install this version. Please upgrade from your existing PHP version %s.<br/>",PHP_VERSION);
+    if (!$php_met) echo sprintf("You need PHP 8.0 or higher to install this version. Please upgrade from your existing PHP version %s.<br/>",PHP_VERSION);
     if (!$mysql_met && extension_loaded('mysqli') === false) {
         echo "The mysqli extension is missing. You need to enable the mysqli extension to install this version.<br/>";
     }


### PR DESCRIPTION
## Summary
- require PHP 8.0 or newer in installer
- update README badge and system requirements

## Testing
- `php -l installer.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_6868d66cbbcc8329bc6fa5454fa3b4c8