### PR TITLE
Add repository link post-install

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -241,6 +241,7 @@ class Installer
         output("Your install of Legend of the Green Dragon has been completed!`n");
         output("`nRemember us when you have hundreds of users on your server, enjoying the game.");
         output("Eric, JT, and a lot of others put a lot of work into this world, so please don't disrespect that by violating the license.`n`n");
+        output("For further information see the <a href='https://github.com/NB-Core/lotgd' target='_blank'>project README</a> on GitHub. Issues and discussions can be filed there.`n", true);
         if ($session['user']['loggedin']){
             addnav("Continue",$session['user']['restorepage']);
         }else{


### PR DESCRIPTION
## Summary
- mention the GitHub repository README once installation is complete
- tell users to file issues and discussions there

## Testing
- `php -l install/lib/Installer.php`
- `composer validate --no-interaction`

------
https://chatgpt.com/codex/tasks/task_e_6868d89873f8832981ae8f2420c2321f