### PR TITLE
Display installer log location

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,11 @@ The root `.htaccess` file configures custom error pages, disables directory list
   - The installer writes to `install/errors/install.log`. If you see a warning
     that the log could not be written, ensure this path is writable.
 
+### Where to find installer logs
+
+Installer errors are saved to `install/errors/install.log`. Check this file if
+the installer fails or reports problems.
+
 ---
 
 ## Contributing & Support

--- a/install/lib/InstallerLogger.php
+++ b/install/lib/InstallerLogger.php
@@ -35,6 +35,10 @@ class InstallerLogger
             return false;
         }
 
+        if (function_exists('output')) {
+            output("`n`^See %s for a detailed error log.`n", self::getLogFilePath());
+        }
+
         return true;
     }
 }


### PR DESCRIPTION
## Summary
- show a note pointing to the installer log after any logged error
- document where to find installer logs in README

## Testing
- `composer validate --no-check-all --strict`
- `php -l install/lib/InstallerLogger.php`


------
https://chatgpt.com/codex/tasks/task_e_6868d98de5bc8329adee1d97bd261bd1