### PR TITLE
Refactor common code paths

### DIFF
--- a/common.php
+++ b/common.php
@@ -8,6 +8,15 @@ use Lotgd\HolidayText;
 use Lotgd\Output;
 use Lotgd\Accounts;
 use Lotgd\Settings;
+use Lotgd\Translator;
+use Lotgd\PhpGenericEnvironment;
+use Lotgd\ForcedNavigation;
+use Lotgd\Nav;
+use Lotgd\LocalConfig;
+use Lotgd\PageParts;
+use Lotgd\Redirect;
+use Lotgd\Template;
+use Lotgd\MySQL\Database;
 // translator ready
 // addnews ready
 // mail ready
@@ -47,29 +56,13 @@ $license = "\n<!-- Creative Commons License -->\n<a rel='license' href='http://c
 
 $logd_version = "2.0.0 +nb Edition";
 
-
 // Include some commonly needed and useful routines
 require_once("lib/output.php");
 $output = new Output();
-require_once("lib/nav.php");
-require_once("lib/local_config.php");
-require_once("lib/dbwrapper.php");
+LocalConfig::apply();
 require_once("config/constants.php");
-require_once("lib/datacache.php");
+require_once("lib/dbwrapper.php");
 require_once("lib/modules.php");
-require_once("lib/http.php");
-require_once("lib/e_rand.php");
-require_once("lib/pageparts.php");
-require_once("lib/sanitize.php");
-require_once("lib/tempstat.php");
-require_once("lib/datetime.php");
-require_once("lib/translator.php");
-require_once("lib/playerfunctions.php");
-require_once("lib/serialization.php");
-
-// Legacy, because modules may rely on that, but those files are already migrated to namespace structure
-require_once("lib/buffs.php");
-require_once("lib/addnews.php");
 
 
 //start the gzip compression
@@ -85,15 +78,7 @@ if(!defined("ALLOW_ANONYMOUS")) define("ALLOW_ANONYMOUS",false);
 
 //Initialize variables required for this page
 
-require_once("lib/template.php");
-require_once("lib/settings.php");
-require_once("lib/redirect.php");
-require_once("lib/censor.php");
-require_once("lib/arrayutil.php");
-require_once("lib/sql.php");
-require_once("lib/debuglog.php");
-require_once("lib/forcednavigation.php");
-require_once("lib/php_generic_environment.php");
+// wrappers no longer required for these helpers
 
 //session_register("session");
 //deprecated
@@ -135,15 +120,15 @@ if (file_exists("dbconnect.php")){
 }else{
 	if (!defined("IS_INSTALLER")){
 		if (!defined("DB_NODB")) define("DB_NODB",true);
-		page_header("The game has not yet been installed");
+                PageParts::pageHeader("The game has not yet been installed");
 		output("`#Welcome to `@Legend of the Green Dragon`#, a game by Eric Stevens & JT Traub.`n`n");
         output("You must run the game's installer, and follow its instructions in order to set up LoGD.  You can go to the installer <a href='installer.php'>here</a>.",true);
 		output("`n`nIf you're not sure why you're seeing this message, it's because this game is not properly configured right now. ");
 		output("If you've previously been running the game here, chances are that you lost a file called '`%dbconnect.php`#' from your site.");
 		output("If that's the case, no worries, we can get you back up and running in no time, and the installer can help!");
-        addnav("Game Installer","installer.php");
+        Nav::add("Game Installer","installer.php");
 		$session = array(); // reset the session so that it doesn't have any old data in it
-		page_footer();
+                PageParts::pageFooter();
 	}
 }
 
@@ -159,13 +144,13 @@ if (file_exists("dbconnect.php")){
 //	$link = db_pconnect($DB_HOST, $DB_USER, $DB_PASS);
 $link = false;
 if (!defined("DB_NODB")) {
-	$link = db_connect($DB_HOST, $DB_USER, $DB_PASS);
+        $link = Database::connect($DB_HOST, $DB_USER, $DB_PASS);
 
-	//set charset to utf8 (table default, don't change that!)
-	if (!db_set_charset("utf8mb4")) {
-		echo "Error setting db connection charset to utf8...please check your db connection!";
-		exit(0);
-	}
+        //set charset to utf8 (table default, don't change that!)
+        if (!Database::setCharset("utf8mb4")) {
+                echo "Error setting db connection charset to utf8...please check your db connection!";
+                exit(0);
+        }
 }
 
 $out = ob_get_contents();
@@ -183,14 +168,14 @@ if ($link===false){
 		//Yet made a bit more interesting text than just the naughty normal "Unable to connect to database - sorry it didn't work out" stuff
 		$notified=false;
 		if (file_exists("lib/smsnotify.php")) {
-			$smsmessage = "No DB Server: " . db_error();
+                        $smsmessage = "No DB Server: " . Database::error();
 			require_once("lib/smsnotify.php");
 			$notified=true;
 		}
 		// And tell the user it died.  No translation here, we need the DB for
 		// translation.
 		if (!defined("DB_NODB")) define("DB_NODB",true);
-		page_header("Database Connection Error");
+                PageParts::pageHeader("Database Connection Error");
 		output("`c`\$Database Connection Error`0`c`n`n");
 		output("`xDue to technical problems the game is unable to connect to the database server.`n`n");
 		if (!$notified) {
@@ -205,8 +190,8 @@ if ($link===false){
 		}
 		output("Sorry for the inconvenience,`n");
 		output("Staff of %s",$_SERVER['SERVER_NAME']);
-		addnav("Home","index.php");
-		page_footer();
+                Nav::add("Home","index.php");
+                PageParts::pageFooter();
 	}
 	define("DB_CONNECTED",false);
 }else{
@@ -214,18 +199,18 @@ if ($link===false){
 }
 
 if (!defined("DB_NODB")) {
-	if (!DB_CONNECTED || !@db_select_db ($DB_NAME)){
+if (!DB_CONNECTED || !@Database::selectDb($DB_NAME)){
 		if (!defined("IS_INSTALLER") && DB_CONNECTED){
 			// Ignore this bit.  It's only really for Eric's server or people that want to trigger something when the database is jerky
 			if (file_exists("lib/smsnotify.php")) {
-				$smsmessage = "Cant Attach to DB: " . db_error();
+                                $smsmessage = "Cant Attach to DB: " . Database::error();
 				require_once("lib/smsnotify.php");
 				$notified=true;
 			}
 			// And tell the user it died.  No translation here, we need the DB for
 			// translation.
 			if (!defined("DB_NODB")) define("DB_NODB",true);
-			page_header("Database Connection Error");
+                        PageParts::pageHeader("Database Connection Error");
 			output("`c`\$Database Connection Error`0`c`n`n");
 			output("`xDue to technical problems the game is unable to connect to the database server.`n`n");
 			if (!$notified) {
@@ -240,8 +225,8 @@ if (!defined("DB_NODB")) {
 			}
 			output("Sorry for the inconvenience,`n");
 			output("Staff of %s",$_SERVER['SERVER_NAME']);
-			addnav("Home","index.php");
-			page_footer();
+                        Nav::add("Home","index.php");
+                        PageParts::pageFooter();
 		}
 		define("DB_CHOSEN",false);
 	}else{
@@ -265,16 +250,16 @@ if (isset($session['lasthit']) && isset($session['loggedin']) && strtotime("-".g
 	// technically we should be able to translate this, but for now,
 	// ignore it.
 	// 1.1.1 now should be a good time to get it on with it, added tl-inline
-	translator_setup();
-	$session['message'].=translate_inline("`nYour session has expired!`n","common");
+	Translator::translatorSetup();
+        $session['message'] .= Translator::translateInline("`nYour session has expired!`n", "common");
 }
 $session['lasthit']=strtotime("now");
 
 $cp = $copyright;
 $l = $license;
 
-php_generic_environment();
-do_forced_nav(ALLOW_ANONYMOUS,OVERRIDE_FORCED_NAV);
+PhpGenericEnvironment::setup();
+ForcedNavigation::doForcedNav(ALLOW_ANONYMOUS,OVERRIDE_FORCED_NAV);
 
 $script = substr($SCRIPT_NAME,0,strrpos($SCRIPT_NAME,"."));
 if (!defined("IS_INSTALLER")) {
@@ -290,7 +275,7 @@ $revertsession=$session;
 if (!isset($session['user']['loggedin'])) $session['user']['loggedin']=false;
 
 if ($session['user']['loggedin']!=true && !ALLOW_ANONYMOUS){
-	redirect("login.php?op=logout");
+    Redirect::redirect("login.php?op=logout");
 }
 
 if (!isset($session['counter'])) $session['counter']=0;
@@ -304,21 +289,21 @@ if (!isset($nokeeprestore[$SCRIPT_NAME]) || !$nokeeprestore[$SCRIPT_NAME]) {
 }
 
 if ($logd_version != getsetting("installer_version","-1") && !defined("IS_INSTALLER")){
-	page_header("Upgrade Needed");
+        PageParts::pageHeader("Upgrade Needed");
 	output("`#The game is temporarily unavailable while a game upgrade is applied, please be patient, the upgrade will be completed soon.");
 	output("In order to perform the upgrade, an admin will have to run through the installer.");
        output("If you are an admin, please <a href='installer.php'>visit the Installer</a> and complete the upgrade process.`n`n",true);
 	output("`@If you don't know what this all means, just sit tight, we're doing an upgrade and will be done soon, you will be automatically returned to the game when the upgrade is complete.");
 	rawoutput("<meta http-equiv='refresh' content='30; url={$session['user']['restorepage']}'>");
-       addnav("Installer (Admins only!)","installer.php");
+       Nav::add("Installer (Admins only!)","installer.php");
 	define("NO_SAVE_USER",true);
-	page_footer();
+        PageParts::pageFooter();
 } elseif ($logd_version == getsetting("installer_version","-1")  && file_exists('installer.php') && substr($_SERVER['SCRIPT_NAME'],-13)!="installer.php") {
 	// here we have a nasty situation. The installer file exists (ready to be used to get out of any bad situation like being defeated etc and it is no upgrade or new installation. It MUST be deleted
-	page_header("Major Security Risk");
+        PageParts::pageHeader("Major Security Risk");
        output("`\$Remove the file named 'installer.php' from your main game directory! You need to comply in order to get the game up and running.");
-	addnav("Home","index.php");
-	page_footer();
+        Nav::add("Home","index.php");
+        PageParts::pageFooter();
 }
 
 
@@ -375,16 +360,16 @@ if (
 	$host = str_replace(":80","",$_SERVER['HTTP_HOST']);
 
 	if ($site != $host){
-		$sql = "SELECT * FROM " . db_prefix("referers") . " WHERE uri='{$_SERVER['HTTP_REFERER']}'";
-		$result = db_query($sql);
-		$row = db_fetch_assoc($result);
-		db_free_result($result);
-		if (isset($row['refererid']) && $row['refererid']>""){
-			$sql = "UPDATE " . db_prefix("referers") . " SET count=count+1,last='".date("Y-m-d H:i:s")."',site='".addslashes($site)."',dest='".addslashes($host)."/".addslashes($REQUEST_URI)."',ip='{$_SERVER['REMOTE_ADDR']}' WHERE refererid='{$row['refererid']}'";
-		}else{
-			$sql = "INSERT INTO " . db_prefix("referers") . " (uri,count,last,site,dest,ip) VALUES ('{$_SERVER['HTTP_REFERER']}',1,'".date("Y-m-d H:i:s")."','".addslashes($site)."','".addslashes($host)."/".addslashes($REQUEST_URI)."','{$_SERVER['REMOTE_ADDR']}')";
-		}
-		db_query($sql);
+                $sql = "SELECT * FROM " . Database::prefix("referers") . " WHERE uri='{$_SERVER['HTTP_REFERER']}'";
+                $result = Database::query($sql);
+                $row = Database::fetchAssoc($result);
+                Database::freeResult($result);
+                if (isset($row['refererid']) && $row['refererid']>""){
+                        $sql = "UPDATE " . Database::prefix("referers") . " SET count=count+1,last='".date("Y-m-d H:i:s")."',site='".addslashes($site)."',dest='".addslashes($host)."/".addslashes($REQUEST_URI)."',ip='{$_SERVER['REMOTE_ADDR']}' WHERE refererid='{$row['refererid']}'";
+                }else{
+                        $sql = "INSERT INTO " . Database::prefix("referers") . " (uri,count,last,site,dest,ip) VALUES ('{$_SERVER['HTTP_REFERER']}',1,'".date("Y-m-d H:i:s")."','".addslashes($site)."','".addslashes($host)."/".addslashes($REQUEST_URI)."','{$_SERVER['REMOTE_ADDR']}')";
+                }
+                Database::query($sql);
 	}
 }
 
@@ -417,7 +402,7 @@ if ($session['user']['superuser']==0){
 	$lc = $l;
 }
 
-prepare_template();
+Template::prepareTemplate();
 
 if(!defined("IS_INSTALLER")) {
 	if (!isset($session['user']['hashorse'])) $session['user']['hashorse']=0;
@@ -439,10 +424,10 @@ if(!defined("IS_INSTALLER")) {
 		else $beta=0;
 
 	if (isset($session['user']['clanid'])) {
-		$sql = "SELECT * FROM " . db_prefix("clans") . " WHERE clanid='{$session['user']['clanid']}'";
-		$result = db_query_cached($sql, "clandata-{$session['user']['clanid']}", 3600);
-		if (db_num_rows($result)>0){
-			$claninfo = db_fetch_assoc($result);
+            $sql = "SELECT * FROM " . Database::prefix("clans") . " WHERE clanid='{$session['user']['clanid']}'";
+            $result = Database::queryCached($sql, "clandata-{$session['user']['clanid']}", 3600);
+            if (Database::numRows($result)>0){
+                    $claninfo = Database::fetchAssoc($result);
 		}else{
 			$claninfo = array();
 			$session['user']['clanid']=0;
@@ -458,7 +443,7 @@ if(!defined("IS_INSTALLER")) {
 		$session['user']['superuser'] =
 			$session['user']['superuser'] | SU_EDIT_USERS;
 
-	translator_setup();
+	Translator::translatorSetup();
 
 }
 

--- a/create.php
+++ b/create.php
@@ -8,9 +8,10 @@ define("ALLOW_ANONYMOUS",true);
 use Lotgd\Mail;
 use Lotgd\CheckBan;
 use Lotgd\Settings;
+use Lotgd\Sanitize;
+use Lotgd\DebugLog;
 require_once("common.php");
 require_once("lib/is_email.php");
-require_once("lib/sanitize.php");
 // legacy wrapper removed, instantiate settings directly
 $settings_extended = new Settings('settings_extended');
 use Lotgd\ServerFunctions;
@@ -85,8 +86,7 @@ if ($op=="forgotval"){
 			$sql="UPDATE ".db_prefix("accounts")." SET emailaddress='".$replaceemail."', replaceemail='',forgottenpassword='' WHERE emailvalidation='$id';";
 			db_query($sql);
 			output("`#`c Email changed successfully!`c`0`n");
-			require_once("lib/debuglog.php");
-			debuglog("Email change request validated by link from ".$row['emailaddress']." to ".$replaceemail,$row['acctid'],$row['acctid'],"Email");
+                        DebugLog::add("Email change request validated by link from ".$row['emailaddress']." to ".$replaceemail,$row['acctid'],$row['acctid'],"Email");
 			//If a superuser changes email, we want to know about it... at least those who can ee it anyway, the user editors...
 			if ($row['superuser']>0) {
 				// 5 failed attempts for superuser, 10 for regular user
@@ -196,7 +196,7 @@ if (getsetting("allowcreation",1)==0){
 }else{
 	if ($op=="create"){
 		$emailverification="";
-		$shortname = sanitize_name(getsetting("spaceinname", 0), httppost('name'));
+                $shortname = Sanitize::sanitizeName(getsetting("spaceinname", 0), httppost('name'));
 
 		if (soap($shortname)!=$shortname){
 			output("`\$Error`^: Bad language was found in your name, please consider revising it.`n");
@@ -254,7 +254,7 @@ if (getsetting("allowcreation",1)==0){
 				$sql = "SELECT playername FROM " . db_prefix("accounts") ;
 				$result = db_query($sql);
 				while ($row=db_fetch_assoc($result)) {
-					if (sanitize($row['playername'])==$shortname) {
+                                        if (Sanitize::sanitize($row['playername'])==$shortname) {
 						$count++;
 						break;
 					}

--- a/ext/lotgd_common.php
+++ b/ext/lotgd_common.php
@@ -7,6 +7,14 @@ use Lotgd\Mounts;
 use Lotgd\HolidayText;
 use Lotgd\Output;
 use Lotgd\Accounts;
+use Lotgd\Translator;
+use Lotgd\PhpGenericEnvironment;
+use Lotgd\ForcedNavigation;
+use Lotgd\Nav;
+use Lotgd\LocalConfig;
+use Lotgd\PageParts;
+use Lotgd\MySQL\Database;
+use Lotgd\Template;
 // translator ready
 // addnews ready
 // mail ready
@@ -49,20 +57,10 @@ $logd_version = "2.0.0 +nb Edition";
 // Include some commonly needed and useful routines
 require_once("lib/output.php");
 $output = new Output();
-require_once("lib/nav.php");
-require_once("lib/local_config.php");
+LocalConfig::apply();
 require_once("lib/dbwrapper.php");
 require_once("config/constants.php");
-require_once("lib/datacache.php");
 require_once("lib/modules.php");
-require_once("lib/http.php");
-require_once("lib/e_rand.php");
-require_once("lib/pageparts.php");
-require_once("lib/sanitize.php");
-require_once("lib/tempstat.php");
-require_once("lib/datetime.php");
-require_once("lib/translator.php");
-require_once("lib/playerfunctions.php");
 
 
 //start the gzip compression
@@ -78,15 +76,11 @@ if(!defined("ALLOW_ANONYMOUS")) define("ALLOW_ANONYMOUS",false);
 
 //Initialize variables required for this page
 
-require_once("lib/template.php");
-require_once("lib/settings.php");
-require_once("lib/redirect.php");
+// wrappers no longer required for these helpers
 require_once("lib/censor.php");
 require_once("lib/arrayutil.php");
 require_once("lib/sql.php");
 require_once("lib/debuglog.php");
-require_once("ext/ajax_forcednavigation.php");
-require_once("lib/php_generic_environment.php");
 
 //session_register("session");
 //deprecated
@@ -128,14 +122,14 @@ if (file_exists("dbconnect.php")){
 }else{
 	if (!defined("IS_INSTALLER")){
 	 	if (!defined("DB_NODB")) define("DB_NODB",true);
-	 	page_header("The game has not yet been installed");
+                PageParts::pageHeader("The game has not yet been installed");
 		output("`#Welcome to `@Legend of the Green Dragon`#, a game by Eric Stevens & JT Traub.`n`n");
                output("You must run the game's installer, and follow its instructions in order to set up LoGD.  You can go to the installer <a href='installer.php'>here</a>.",true);
 		output("`n`nIf you're not sure why you're seeing this message, it's because this game is not properly configured right now. ");
 		output("If you've previously been running the game here, chances are that you lost a file called '`%dbconnect.php`#' from your site.");
 		output("If that's the case, no worries, we can get you back up and running in no time, and the installer can help!");
-               addnav("Game Installer","installer.php");
-		page_footer();
+               Nav::add("Game Installer","installer.php");
+                PageParts::pageFooter();
 	}
 }
 
@@ -147,9 +141,9 @@ if (file_exists("dbconnect.php")){
 // http://php.net/manual/en/features.persistent-connections.php
 //
 //$link = db_pconnect($DB_HOST, $DB_USER, $DB_PASS);
-$link = db_connect($DB_HOST, $DB_USER, $DB_PASS);
+$link = Database::connect($DB_HOST, $DB_USER, $DB_PASS);
 //set charset to utf8 (table default, don't change that!)
-if (!db_set_charset("utf8")) {
+if (!Database::setCharset("utf8")) {
 	echo "Error setting db connection charset to utf8...please check your db connection!";
 	exit(0);
 }
@@ -167,14 +161,14 @@ if ($link===false){
 		//Yet made a bit more interesting text than just the naughty normal "Unable to connect to database - sorry it didn't work out" stuff
 		$notified=false;
 		if (file_exists("lib/smsnotify.php")) {
-			$smsmessage = "No DB Server: " . db_error();
+                        $smsmessage = "No DB Server: " . Database::error();
 			require_once("lib/smsnotify.php");
 			$notified=true;
 		}
 		// And tell the user it died.  No translation here, we need the DB for
 		// translation.
 	 	if (!defined("DB_NODB")) define("DB_NODB",true);
-		page_header("Database Connection Error");
+                PageParts::pageHeader("Database Connection Error");
 		output("`c`\$Database Connection Error`0`c`n`n");
 		output("`xDue to technical problems the game is unable to connect to the database server.`n`n");
 		if (!$notified) {
@@ -189,26 +183,26 @@ if ($link===false){
 		}
 		output("Sorry for the inconvenience,`n");
 		output("Staff of %s",$_SERVER['SERVER_NAME']);
-		addnav("Home","index.php");
-		page_footer();
+                Nav::add("Home","index.php");
+                PageParts::pageFooter();
 	}
 	define("DB_CONNECTED",false);
 }else{
 	define("DB_CONNECTED",true);
 }
 
-if (!DB_CONNECTED || !db_select_db ($DB_NAME)){
+if (!DB_CONNECTED || !Database::selectDb($DB_NAME)){
 	if (!defined("IS_INSTALLER") && DB_CONNECTED){
 		// Ignore this bit.  It's only really for Eric's server
 		if (file_exists("lib/smsnotify.php")) {
-			$smsmessage = "Cant Attach to DB: " . db_error();
+                        $smsmessage = "Cant Attach to DB: " . Database::error();
 			require_once("lib/smsnotify.php");
 			$notified=true;
 		}
 		// And tell the user it died.  No translation here, we need the DB for
 		// translation.
 	 	if (!defined("DB_NODB")) define("DB_NODB",true);
-		page_header("Database Connection Error");
+                PageParts::pageHeader("Database Connection Error");
 		output("`c`\$Database Connection Error`0`c`n`n");
 		output("`xDue to technical problems the game is unable to connect to the database server.`n`n");
 		if (!$notified) {
@@ -223,8 +217,8 @@ if (!DB_CONNECTED || !db_select_db ($DB_NAME)){
 		}
 		output("Sorry for the inconvenience,`n");
 		output("Staff of %s",$_SERVER['SERVER_NAME']);
-		addnav("Home","index.php");
-		page_footer();
+                Nav::add("Home","index.php");
+                PageParts::pageFooter();
 	}
 	define("DB_CHOSEN",false);
 }else{
@@ -246,16 +240,16 @@ if (isset($session['lasthit']) && isset($session['loggedin']) && strtotime("-".g
 	// technically we should be able to translate this, but for now,
 	// ignore it.
 	// 1.1.1 now should be a good time to get it on with it, added tl-inline
-	translator_setup();
-	$session['message'].=translate_inline("`nYour session has expired!`n","common");
+	Translator::translatorSetup();
+        $session['message'] .= Translator::translateInline("`nYour session has expired!`n", "common");
 }
 $session['lasthit']=strtotime("now");
 
 $cp = $copyright;
 $l = $license;
 
-php_generic_environment();
-do_forced_nav(ALLOW_ANONYMOUS,OVERRIDE_FORCED_NAV);
+PhpGenericEnvironment::setup();
+ForcedNavigation::doForcedNav(ALLOW_ANONYMOUS,OVERRIDE_FORCED_NAV);
 
 $script = substr($SCRIPT_NAME,0,strrpos($SCRIPT_NAME,"."));
 mass_module_prepare(array(
@@ -284,21 +278,21 @@ if (!isset($nokeeprestore[$SCRIPT_NAME]) || !$nokeeprestore[$SCRIPT_NAME]) {
 }
 
 if ($logd_version != getsetting("installer_version","-1") && !defined("IS_INSTALLER")){
-	page_header("Upgrade Needed");
+        PageParts::pageHeader("Upgrade Needed");
 	output("`#The game is temporarily unavailable while a game upgrade is applied, please be patient, the upgrade will be completed soon.");
 	output("In order to perform the upgrade, an admin will have to run through the installer.");
     output("If you are an admin, please <a href='installer.php'>visit the Installer</a> and complete the upgrade process.`n`n",true);
 	output("`@If you don't know what this all means, just sit tight, we're doing an upgrade and will be done soon, you will be automatically returned to the game when the upgrade is complete.");
 	rawoutput("<meta http-equiv='refresh' content='30; url={$session['user']['restorepage']}'>");
-    addnav("Installer (Admins only!)","installer.php");
+    Nav::add("Installer (Admins only!)","installer.php");
 	define("NO_SAVE_USER",true);
-	page_footer();
+        PageParts::pageFooter();
 } elseif ($logd_version == getsetting("installer_version","-1")  && file_exists('installer.php') && substr($_SERVER['SCRIPT_NAME'],-13)!="installer.php") {
 // here we have a nasty situation. The installer file exists (ready to be used to get out of any bad situation like being defeated etc and it is no upgrade or new installation. It MUST be deleted
-	page_header("Major Security Risk");
+        PageParts::pageHeader("Major Security Risk");
     output("`\$Remove the file named 'installer.php' from your main game directory! You need to comply in order to get the game up and running.");
-	addnav("Home","index.php");
-	page_footer();
+        Nav::add("Home","index.php");
+        PageParts::pageFooter();
 }
 
 
@@ -349,16 +343,16 @@ if (
 	$host = str_replace(":80","",$_SERVER['HTTP_HOST']);
 
 	if ($site != $host){
-		$sql = "SELECT * FROM " . db_prefix("referers") . " WHERE uri='{$_SERVER['HTTP_REFERER']}'";
-		$result = db_query($sql);
-		$row = db_fetch_assoc($result);
-		db_free_result($result);
-		if ($row['refererid']>""){
-			$sql = "UPDATE " . db_prefix("referers") . " SET count=count+1,last='".date("Y-m-d H:i:s")."',site='".addslashes($site)."',dest='".addslashes($host)."/".addslashes($REQUEST_URI)."',ip='{$_SERVER['REMOTE_ADDR']}' WHERE refererid='{$row['refererid']}'";
-		}else{
-			$sql = "INSERT INTO " . db_prefix("referers") . " (uri,count,last,site,dest,ip) VALUES ('{$_SERVER['HTTP_REFERER']}',1,'".date("Y-m-d H:i:s")."','".addslashes($site)."','".addslashes($host)."/".addslashes($REQUEST_URI)."','{$_SERVER['REMOTE_ADDR']}')";
-		}
-		db_query($sql);
+                $sql = "SELECT * FROM " . Database::prefix("referers") . " WHERE uri='{$_SERVER['HTTP_REFERER']}'";
+                $result = Database::query($sql);
+                $row = Database::fetchAssoc($result);
+                Database::freeResult($result);
+                if ($row['refererid']>""){
+                        $sql = "UPDATE " . Database::prefix("referers") . " SET count=count+1,last='".date("Y-m-d H:i:s")."',site='".addslashes($site)."',dest='".addslashes($host)."/".addslashes($REQUEST_URI)."',ip='{$_SERVER['REMOTE_ADDR']}' WHERE refererid='{$row['refererid']}'";
+                }else{
+                        $sql = "INSERT INTO " . Database::prefix("referers") . " (uri,count,last,site,dest,ip) VALUES ('{$_SERVER['HTTP_REFERER']}',1,'".date("Y-m-d H:i:s")."','".addslashes($site)."','".addslashes($host)."/".addslashes($REQUEST_URI)."','{$_SERVER['REMOTE_ADDR']}')";
+                }
+                Database::query($sql);
 	}
 }
 
@@ -391,7 +385,7 @@ if ($session['user']['superuser']==0){
 	$lc = $l;
 }
 
-prepare_template();
+Template::prepareTemplate();
 
 if (!isset($session['user']['hashorse'])) $session['user']['hashorse']=0;
 $playermount = Mounts::getmount($session['user']['hashorse']);
@@ -412,10 +406,10 @@ if (!$beta && getsetting("betaperplayer", 1) == 1)
 		else $beta=0;
 
 if (isset($session['user']['clanid'])) {
-	$sql = "SELECT * FROM " . db_prefix("clans") . " WHERE clanid='{$session['user']['clanid']}'";
-	$result = db_query_cached($sql, "clandata-{$session['user']['clanid']}", 3600);
-	if (db_num_rows($result)>0){
-		$claninfo = db_fetch_assoc($result);
+    $sql = "SELECT * FROM " . Database::prefix("clans") . " WHERE clanid='{$session['user']['clanid']}'";
+    $result = Database::queryCached($sql, "clandata-{$session['user']['clanid']}", 3600);
+    if (Database::numRows($result)>0){
+            $claninfo = Database::fetchAssoc($result);
 	}else{
 		$claninfo = array();
 		$session['user']['clanid']=0;
@@ -431,7 +425,7 @@ if ($session['user']['superuser'] & SU_MEGAUSER)
 	$session['user']['superuser'] =
 		$session['user']['superuser'] | SU_EDIT_USERS;
 
-translator_setup();
+Translator::translatorSetup();
 //set up the error handler after the intial setup (since it does require a
 //db call for notification)
 require_once("lib/errorhandler.php");


### PR DESCRIPTION
## Summary
- import Template class directly in both common loaders
- drop unnecessary wrapper includes
- call `Template::prepareTemplate` instead of wrapper function
- sanitize names and log debug info via namespaced classes in `create.php`

## Testing
- `php -l common.php`
- `php -l ext/lotgd_common.php`
- `php -l create.php`


------
https://chatgpt.com/codex/tasks/task_e_6868e4a796188329aa75a317769573d3