### PR TITLE
Fix stack trace in error handler

### DIFF
--- a/lib/errorhandler.php
+++ b/lib/errorhandler.php
@@ -153,7 +153,7 @@ set_error_handler("logd_error_handler");
  */
 function lotgd_exception_handler($exception): void
 {
-    $trace = Backtrace::show();
+    $trace = Backtrace::show($exception->getTrace());
     lotgd_render_error($exception->getMessage(), $exception->getFile(), $exception->getLine(), $trace);
 }
 set_exception_handler('lotgd_exception_handler');


### PR DESCRIPTION
## Summary
- display full exception traces instead of just the handler
- allow `Backtrace::show()` to accept an explicit trace

## Testing
- `php -l src/Lotgd/Backtrace.php`
- `php -l lib/errorhandler.php`


------
https://chatgpt.com/codex/tasks/task_e_68690daff20883298086e606ae4eda42