### PR TITLE
Move errorhandler and forestoutcomes to classes

### DIFF
--- a/common.php
+++ b/common.php
@@ -62,7 +62,8 @@ require_once("lib/output.php");
 $output = new Output();
 LocalConfig::apply();
 require_once("config/constants.php");
-require_once("lib/errorhandler.php");
+use Lotgd\ErrorHandler;
+ErrorHandler::register();
 
 // Legacy, because modules may rely on that, but those files are already migrated to namespace structure
 require_once("lib/dbwrapper.php");

--- a/ext/lotgd_common.php
+++ b/ext/lotgd_common.php
@@ -427,9 +427,10 @@ if ($session['user']['superuser'] & SU_MEGAUSER)
 		$session['user']['superuser'] | SU_EDIT_USERS;
 
 Translator::translatorSetup();
-//set up the error handler after the intial setup (since it does require a
+//set up the error handler after the initial setup (since it does require a
 //db call for notification)
-require_once("lib/errorhandler.php");
+use Lotgd\ErrorHandler;
+ErrorHandler::register();
 
 if ($settings->getSetting('debug',0)) {
 	//Server runs in Debug mode, tell the superuser about it

--- a/forest.php
+++ b/forest.php
@@ -5,6 +5,7 @@
 require_once("common.php");
 use Lotgd\Forest;
 use Lotgd\Buffs;
+use Lotgd\Forest\Outcomes;
 require_once("lib/http.php");
 require_once("lib/events.php");
 use Lotgd\Battle;
@@ -185,13 +186,13 @@ if ($op=="search"){
 				$badguy['creaturedefense']=$session['user']['defense'];
 				$stack[] = $badguy;
 			} else {
-				require_once("lib/forestoutcomes.php");
+                               
 				if ($packofmonsters == true) {
 					$initialbadguy = db_fetch_assoc($result);
 					$prefixs = array("Elite","Dangerous","Lethal","Savage","Deadly","Malevolent","Malignant");
 					for($i=0;$i<$multi;$i++) {
 						$initialbadguy['creaturelevel'] = e_rand($mintargetlevel, $targetlevel);
-						$badguy = buffbadguy($initialbadguy);
+                                               $badguy = Outcomes::buffBadguy($initialbadguy);
 						if ($type == "thrill") {
 							// 10% more experience
 							$badguy['creatureexp'] = round($badguy['creatureexp']*1.1, 0);
@@ -232,7 +233,7 @@ if ($op=="search"){
 							$badguy['creatureaiscript']="require('".$aiscriptfile."');";
 						}
 						//AI setup
-						$badguy = buffbadguy($badguy);
+                                               $badguy = Outcomes::buffBadguy($badguy);
 						// Okay, they are thrillseeking, let's give them a bit extra
 						// exp and gold.
 						if ($type == "thrill") {
@@ -292,17 +293,15 @@ if ($op=="fight" || $op=="run" || $op == "newtarget"){
 
 if ($battle){
 
-	require_once("battle.php");
+        require_once("battle.php");
 
-	if ($victory){
-		require_once("lib/forestoutcomes.php");
-		$op="";
-		httpset('op', "");
-		forestvictory($newenemies,isset($options['denyflawless'])?$options['denyflawless']:false);
-		$dontdisplayforestmessage=true;
-	}elseif($defeat){
-		require_once("lib/forestoutcomes.php");
-		forestdefeat($newenemies);
+        if ($victory){
+                $op="";
+                httpset('op', "");
+                Outcomes::victory($newenemies,isset($options['denyflawless'])?$options['denyflawless']:false);
+                $dontdisplayforestmessage=true;
+        }elseif($defeat){
+                Outcomes::defeat($newenemies);
 	}else{
 		Battle::fightnav();
 	}

--- a/lib/errorhandler.php
+++ b/lib/errorhandler.php
@@ -1,173 +1,33 @@
 <?php
-use Lotgd\Backtrace;
-use Lotgd\Sanitize;
-use Lotgd\Translator;
 
-/**
- * Render an error message using simple HTML styling.
- */
+// Legacy wrapper for Lotgd\ErrorHandler class
+use Lotgd\ErrorHandler;
+
 function lotgd_render_error(string $message, string $file, int $line, string $backtrace): void
 {
-    http_response_code(500);
-    echo "<!DOCTYPE html>\n";
-    echo "<html lang='en'><head>\n";
-    echo "<meta charset='UTF-8'>\n";
-    echo "<title>Application Error</title>\n";
-    echo "<style>body{background:#000;color:#fff;font-family:sans-serif;padding:20px;}a{color:#fff;}pre{background:#111;padding:10px;overflow:auto;}</style>\n";
-    echo "</head><body>\n";
-    echo "<h1>Application Error</h1>\n";
-    echo sprintf('<p>%s</p>', HTMLEntities($message, ENT_COMPAT));
-    echo sprintf('<p>in <b>%s</b> at <b>%s</b></p>', HTMLEntities($file, ENT_COMPAT), $line);
-    echo $backtrace;
-    echo "<p>If the problem persists, please <a href='/petition.php'>submit a petition</a>.</p>\n";
-    echo "</body></html>";
+    ErrorHandler::renderError($message, $file, $line, $backtrace);
 }
 
-
-function logd_error_handler($errno, $errstr, $errfile, $errline){
-	global $session, $settings;
-	static $in_error_handler = 0;
-	// If we have used the @ operator, just don't report anything!
-	if (!error_reporting()) return;
-	ini_set('display_errors', 1);
-	$in_error_handler++;
-	if ($in_error_handler > 1){//prevents the error handler from being re-called when we're already within a call of it.
-		if ($errno & (E_USER_WARNING | E_WARNING)){
-			echo "PHP Warning: \"$errstr\"<br>in <b>$errfile</b> at <b>$errline</b>.  Additionally this occurred while within logd_error_handler().<br>";
-		}elseif ($errno & (E_USER_ERROR | E_ERROR)){
-			echo "PHP ERROR: \"$errstr\"<br>in <b>$errfile</b> at <b>$errline</b>.  Additionally this occurred while within logd_error_handler().<br>";
-		}
-		$in_error_handler--;
-		return;
-	}
-	switch($errno){
-	case E_NOTICE:
-	case E_USER_NOTICE:
-		if (getsetting('show_notices', 0) &&
-				$session['user']['superuser'] & SU_SHOW_PHPNOTICE) {
-			debug("PHP Notice: \"$errstr\"<br>in <b>$errfile</b> at <b>$errline</b>.");
-		}
-		break;
-	case E_WARNING:
-	case E_USER_WARNING:
-		Translator::tlschema("errorhandler");
-		if ($session['user']['superuser'] & SU_DEBUG_OUTPUT == SU_DEBUG_OUTPUT) {
-			output("PHP Warning: \"%s\"`nin `b%s`b at `b%s`b.`n",$errstr,$errfile,$errline,true);
-			Translator::tlschema();
-			$backtrace = Backtrace::show();
-			rawoutput($backtrace);
-		} else $backtrace="";
-		if (isset($settings) && !empty($settings->getSetting("notify_on_warn",0))){
-			//$args = func_get_args();
-			//call_user_func_array("logd_error_notify",$args);
-			logd_error_notify($errno, $errstr, $errfile, $errline, $backtrace);
-		}
-		break;
-        case E_ERROR:
-        case E_USER_ERROR:
-                $backtrace = Backtrace::show();
-                lotgd_render_error($errstr, $errfile, $errline, $backtrace);
-                if (isset($settings) && !empty($settings->getSetting("notify_on_error",0)))
-				{
-                        logd_error_notify($errno, $errstr, $errfile, $errline, $backtrace);
-                }
-                die();
-                break;
-	}
-	$in_error_handler--;
+function logd_error_handler($errno, $errstr, $errfile, $errline): void
+{
+    ErrorHandler::handleError($errno, $errstr, $errfile, $errline);
 }
 
-function logd_error_notify($errno, $errstr, $errfile, $errline, $backtrace){
-	global $session;
-	$sendto = explode(";",getsetting("notify_address",""));
-	$howoften = getsetting("notify_every",30);
-	reset($sendto);
-       $data = datacache("error_notify",86400);
-       if (!is_array($data)){
-               $data = array('firstrun'=>false,'errors'=>array());
-               if (!updatedatacache("error_notify", $data)) {
-                       error_log('Unable to write datacache for error_notify');
-               }
-       } else {
-               if (!isset($data['errors']) || !is_array($data['errors'])){
-                       $data['errors'] = array();
-               }
-               if (!array_key_exists('firstrun',$data)){
-                       $data['firstrun'] = false;
-               }
-       }
-	$do_notice = false;
-	if (!array_key_exists($errstr,$data['errors'])){
-		$do_notice = true;
-	}elseif (strtotime("now") - ($data['errors'][$errstr]) > $howoften * 60) {
-		$do_notice = true;
-	}
-	if (!isset($data['firstrun']))
-		$data['firstrun']=false;
-	if ($data['firstrun']){
-		debug("First run, not notifying users.");
-	}else{
-		if ($do_notice){
-
-			/***
-			  * Set up the mime bits
-			 **/
-            $userstr = "";
-			if ($session && isset($session['user']['name']) && isset($session['user']['acctid'])) {
-				$userstr = "Error triggered by user " . $session['user']['name'] . " (" . $session['user']['acctid'] . ")\n";
-			}
-            $plain_text = "$userstr$errstr in $errfile ($errline)\n" . Sanitize::sanitizeHtml($backtrace);
-			$html_text = "<html><body>$errstr in $errfile ($errline)<hr>$backtrace</body></html>";
-
-			$semi_rand = md5(time());
-			$hostname = (isset($_SERVER['HTTP_HOST'])?$_SERVER['HTTP_HOST']:'not called from browser, no hostname');
-			$subject = "$hostname $errno";
-
-			$body = $html_text; //send as html
-			foreach ($sendto as $key=>$email) {
-				debug("Notifying $email of this error.");
-
-                                $from = array(getsetting("gameadminemail", "postmaster@localhost") => getsetting("gameadminemail", "postmaster@localhost"));
-                                \Lotgd\Mail::send(array($email => $email), $body, $subject, $from, false, "text/html");
-/*				mail($email, $subject, $body,
-					"From: " . $from . "\n" .
-					"MIME-Version: 1.0\n" .
-					"Content-Type: multipart/alternative;\n" .
-					"     boundary=" . $mime_boundary_header);
-*/			}
-			//mark the time that notice was last sent for this error.
-			$data['errors'][$errstr] = strtotime("now");
-		}else{
-			debug("Not notifying users for this error, it's only been ".round((strtotime("now") - $data['errors'][$errstr]) / 60,2)." minutes.");
-		}
-	}
-       if (!updatedatacache("error_notify", $data)) {
-               error_log('Unable to write datacache for error_notify');
-       }
-       debug($data);
+function logd_error_notify($errno, $errstr, $errfile, $errline, $backtrace): void
+{
+    ErrorHandler::errorNotify($errno, $errstr, $errfile, $errline, $backtrace);
 }
-set_error_handler("logd_error_handler");
 
-/**
- * Handle uncaught exceptions with formatted output.
- */
 function lotgd_exception_handler($exception): void
 {
-    $trace = Backtrace::show($exception->getTrace());
-    lotgd_render_error($exception->getMessage(), $exception->getFile(), $exception->getLine(), $trace);
+    ErrorHandler::handleException($exception);
 }
-set_exception_handler('lotgd_exception_handler');
 
-/**
- * Catch fatal errors that are not handled by set_error_handler.
- */
 function lotgd_fatal_shutdown(): void
 {
-    $error = error_get_last();
-    if ($error && in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR])) {
-        $trace = Backtrace::show();
-        lotgd_render_error($error['message'], $error['file'], $error['line'], $trace);
-    }
+    ErrorHandler::fatalShutdown();
 }
-register_shutdown_function('lotgd_fatal_shutdown');
+
+ErrorHandler::register();
+
 ?>

--- a/lib/forestoutcomes.php
+++ b/lib/forestoutcomes.php
@@ -1,214 +1,24 @@
 <?php
-// addnews ready
-// translator ready
-// mail ready
-use Lotgd\Battle;
-use Lotgd\DeathMessage;
-use Lotgd\PageParts;
+// Legacy wrapper for \Lotgd\Forest\Outcomes class
+
+use Lotgd\Forest\Outcomes;
+
 require_once("lib/output.php");
 require_once("lib/nav.php");
 require_once("lib/playerfunctions.php");
 
-function forestvictory($enemies,$denyflawless=false){
-	global $session, $options;
-	$diddamage = false;
-	$creaturelevel = 0;
-	$gold = 0;
-	$exp = 0;
-	$expbonus = 0;
-	$count = 0;
-	$totalbackup = 0;
-	foreach ($enemies as $badguy) {
-		if (getsetting("dropmingold",0)){
-			$badguy['creaturegold']= e_rand(round($badguy['creaturegold']/4), round(3*$badguy['creaturegold']/4));
-		}else{
-			$badguy['creaturegold']=e_rand(0,$badguy['creaturegold']);
-		}
-		$gold += $badguy['creaturegold'];
-		if (isset($badguy['creaturelose'])) {
-			$msg = translate_inline($badguy['creaturelose'],"battle");
-			output_notl("`b`&%s`0`b`n",$msg);
-		}
-		output("`b`\$You have slain %s!`0`b`n",$badguy['creaturename']);
-		$count++;
-		// If any creature did damage, we have no flawless fight. Easy as that.
-		if ($badguy['diddamage'] == 1) {
-			$diddamage = true;
-		}
-		$creaturelevel = max($creaturelevel, $badguy['creaturelevel']);
-		if (!$denyflawless && isset($badguy['denyflawless']) && $badguy['denyflawless']>"") {
-			$denyflawless = $badguy['denyflawless'];
-		}
-		$expbonus += round(($badguy['creatureexp'] * (1 + .25 * ($badguy['creaturelevel']-$session['user']['level']))) - $badguy['creatureexp'],0);
-	}
-	$multibonus = $count>1?1:0;
-	$expbonus += $session['user']['dragonkills'] * $session['user']['level'] * $multibonus;
-	$totalexp = 0;
-	foreach ($options['experience'] as $experience) {
-		$totalexp += $experience;
-	}
-	// We now have the total experience which should have been gained during the fight.
-	// Now we will calculate the average exp per enemy.
-	$exp = round($totalexp / $count);
-	$gold = e_rand(round($gold/$count),round($gold),0);
-	$expbonus = round ($expbonus/$count,0);
-
-	if ($gold) {
-		output("`#You receive `^%s`# gold!`n",$gold);
-		debuglog("received gold for slaying a monster.",false,false,"forestwin",$badguy['creaturegold']);
-	}
-	// No gem hunters allowed!
-	$args = modulehook("alter-gemchance", array("chance"=>getsetting("forestgemchance", 25)));
-	$gemchances = $args['chance'];
-	if ($session['user']['level'] < getsetting('maxlevel',15) && e_rand(1,$gemchances) == 1) {
-		output("`&You find A GEM!`n`#");
-		$session['user']['gems']++;
-		debuglog("found gem when slaying a monster.",false,false,"forestwingem",1);
-	}
-	if (getsetting("instantexp",false) == true) {
-		$expgained = 0;
-		foreach ($options['experiencegained'] as $experience) {
-			$expgained += $experience;
-		}
-
-		$diff = $expgained - $exp;
-		$expbonus += $diff;
-		if (floor($exp + $expbonus) < 0) {
-			$expbonus = -$exp+1;
-		}
-		if ($expbonus>0){
-			$expbonus = round($expbonus * pow(1+(getsetting("addexp", 5)/100), $count-1),0);
-			output("`#***Because of the difficult nature of this fight, you are awarded an additional `^%s`# experience! `n",$expbonus);
-		} elseif ($expbonus<0){
-			output("`#***Because of the simplistic nature of this fight, you are penalized `^%s`# experience! `n",abs($expbonus));
-		}
-		if (count($enemies) > 1) {
-			output("During this fight you received `^%s`# total experience!`n`0",$exp+$expbonus);
-		}
-		$session['user']['experience']+=$expbonus;
-	} else {
-		if (floor($exp + $expbonus) < 0) {
-			$expbonus = -$exp+1;
-		}
-		if ($expbonus>0){
-			$expbonus = round($expbonus * pow(1+(getsetting("addexp", 5)/100), $count-1),0);
-			output("`#***Because of the difficult nature of this fight, you are awarded an additional `^%s`# experience! `n(%s + %s = %s) ",$expbonus,$exp,abs($expbonus),$exp+$expbonus);
-		} elseif ($expbonus<0){
-			output("`#***Because of the simplistic nature of this fight, you are penalized `^%s`# experience! `n(%s - %s = %s) ",abs($expbonus),$exp,abs($expbonus),$exp+$expbonus);
-		}
-		output("You receive `^%s`# total experience!`n`0",$exp+$expbonus);
-		$session['user']['experience']+=($exp+$expbonus);
-	}
-	$session['user']['gold']+=$gold;
-	// Increase the level for each enemy by one half, so flawless fights can be achieved for
-	// fighting multiple low-level critters
-	if (!$creaturelevel)
-		$creaturelevel = $badguy['creaturelevel'];
-	else
-		$creaturelevel+=(0.5*($count-1));
-
-	if (!$diddamage) {
-		output("`c`b`&~~ Flawless Fight! ~~`0`b`c");
-		if ($denyflawless){
-			output("`c`\$%s`0`c", translate_inline($denyflawless));
-		}elseif ($session['user']['level']<=$creaturelevel){
-			output("`c`b`\$You receive an extra turn!`0`b`c`n");
-			$session['user']['turns']++;
-		}else{
-			output("`c`\$A more difficult fight would have yielded an extra turn.`0`c`n");
-		}
-	}
-	if ($session['user']['hitpoints'] <= 0) {
-		output("With your dying breath you spy a small stand of mushrooms off to the side.");
-		output("You recognize them as some of the ones that the healer had drying in the hut and taking a chance, cram a handful into your mouth.");
-		output("Even raw they have some restorative properties.`n");
-		$session['user']['hitpoints'] = 1;
-	}
+function forestvictory($enemies, $denyflawless = false): void
+{
+    Outcomes::victory($enemies, $denyflawless);
 }
 
-function forestdefeat($enemies,$where="in the forest"){
-	global $session;
-	$percent=getsetting('forestexploss',10);
-	addnav("Daily news","news.php");
-	$names = array();
-	$killer = false;
-	foreach ($enemies as $badguy) {
-		$names[] = $badguy['creaturename'];
-		if (isset($badguy['killedplayer']) && $badguy['killedplayer'] == true) $killer = $badguy['creaturename'];
-		if (isset($badguy['creaturewin']) && $badguy['creaturewin'] > "") {
-			$msg = translate_inline($badguy['creaturewin'],"battle");
-			output_notl("`b`&%s`0`b`n",$msg);
-		}
-	}
-	if (count($names) > 1) $lastname = array_pop($names);
-	$enemystring = join(", ", $names);
-	$and = translate_inline("and");
-	if (isset($lastname) && $lastname > "") $enemystring = "$enemystring $and $lastname";
-       $taunt = Battle::selectTauntArray();
-	//leave it for now, it's tricky 
-	/*if (is_array($where)) {
-		$where=sprintf_translate($where);
-	} else {
-		$where=translate_inline($where);
-	}*/
-	$deathmessage=DeathMessage::selectArray(true,array("{where}"),array($where));
-	if ($deathmessage['taunt']==1) {
-		AddNews::add("%s`n%s",$deathmessage['deathmessage'],$taunt);
-	} else {
-		AddNews::add("%s",$deathmessage['deathmessage']);
-	}
-	$session['user']['alive']=0;
-	debuglog("lost gold when they were slain $where",false,false,"forestlose",-$session['user']['gold']);
-	$session['user']['gold']=0;
-	$session['user']['hitpoints']=0;
-	$session['user']['experience']=round($session['user']['experience']*(1-($percent/100)),0);
-	output("`4All gold on hand has been lost!`n");
-	output("`4%s %% of experience has been lost!`b`n",$percent);
-	output("You may begin fighting again tomorrow.");
-	page_footer();
+function forestdefeat($enemies, $where = 'in the forest'): void
+{
+    Outcomes::defeat($enemies, $where);
 }
 
-function buffbadguy($badguy){
-	global $session;
-	static $dk = false;	// This will save us a lot of trouble when going through
-						// this function more than once...
-	if ($dk === false) {
-		//make badguys get harder as you advance in dragon kills.
-		$dk = get_player_dragonkillmod(true);
-		// How many of the dk points should actually be used.
-		// We want to add .05 for every 100 dragonkills.
-		// make it 0.1 +nb
-		$add = ($session['user']['dragonkills']/100)*.10;
-		$dk = round($dk * (.25 + $add));
-	}
-
-	$expflux = round($badguy['creatureexp']/10,0);
-	$expflux = e_rand(-$expflux,$expflux);
-	$badguy['creatureexp']+=$expflux;
-
-	$atkflux = e_rand(0, $dk);
-	$defflux = e_rand(0, ($dk-$atkflux));
-
-	$hpflux = ($dk - ($atkflux+$defflux)) * 5;
-	$badguy['creatureattack']+=$atkflux;
-	$badguy['creaturedefense']+=$defflux;
-	$badguy['creaturehealth']+=$hpflux;
-
-	if (getsetting("disablebonuses", 1)) {
-		//adapting flux as for people with many DKs they will just bathe in gold....
-		$base = 30 - min(20,round(sqrt($session['user']['dragonkills'])/2)); 
-		$base /=1000;
-		$bonus = 1 + $base*($atkflux+$defflux) + .001*$hpflux;
-		$badguy['creaturegold'] = round($badguy['creaturegold']*$bonus, 0);
-		$badguy['creatureexp'] = round($badguy['creatureexp']*$bonus, 0);
-	}
-
-	$badguy = modulehook("creatureencounter",$badguy);
-	debug("DEBUG: $dk modification points total.");
-	debug("DEBUG: +$atkflux allocated to attack.");
-	debug("DEBUG: +$defflux allocated to defense.");
-	debug("DEBUG: +".($hpflux/5)."*5 to hitpoints.");
-	return modulehook("buffbadguy",$badguy);
+function buffbadguy($badguy)
+{
+    return Outcomes::buffBadguy($badguy);
 }
-
 ?>

--- a/modules/cities/run.php
+++ b/modules/cities/run.php
@@ -1,5 +1,6 @@
 <?php
 use Lotgd\FightNav;
+use Lotgd\Forest\Outcomes;
         $op = httpget("op");
 	$city = urldecode(httpget("city"));
 	$continue = httpget("continue");
@@ -97,8 +98,7 @@ use Lotgd\FightNav;
 
 				$args = array("soberval"=>0.9,
 						"sobermsg"=>"`&Facing your bloodthirsty opponent, the adrenaline rush helps to sober you up slightly.", "schema"=>"module-cities");
-				modulehook("soberup", $args);
-				require_once("lib/forestoutcomes.php");
+                                modulehook("soberup", $args);
 				$sql = "SELECT * FROM " . db_prefix("creatures") . " WHERE creaturelevel = '{$session['user']['level']}' AND forest = 1 ORDER BY rand(".e_rand().") LIMIT 1";
 				$result = db_query($sql);
 				restore_buff_fields();
@@ -123,7 +123,7 @@ use Lotgd\FightNav;
 						//file there, get content and put it into the ai script field.
 						$badguy['creatureaiscript']="require('".$aiscriptfile."');";
 					}
-					$badguy = buffbadguy($badguy);
+                                        $badguy = Outcomes::buffBadguy($badguy);
 				}
 				calculate_buff_fields();
 				$badguy['playerstarthp']=$session['user']['hitpoints'];
@@ -172,15 +172,13 @@ use Lotgd\FightNav;
 	if ($battle){
 		page_header("You've been waylaid!");
 		require_once("battle.php");
-		if ($victory){
-			require_once("lib/forestoutcomes.php");
-			forestvictory($newenemies,"This fight would have yielded an extra turn except it was during travel.");
+                if ($victory){
+                        Outcomes::victory($newenemies,"This fight would have yielded an extra turn except it was during travel.");
 			addnav("Continue your journey","runmodule.php?module=cities&op=travel&city=".urlencode($city)."&continue=1&d=$danger");
 			module_display_events("travel",
 				"runmodule.php?module=cities&city=".urlencode($city)."&d=$danger&continue=1");
-		}elseif ($defeat){
-			require_once("lib/forestoutcomes.php");
-			forestdefeat($newenemies,array("travelling to %s",$city));
+                }elseif ($defeat){
+                        Outcomes::defeat($newenemies,array("travelling to %s",$city));
 		}else{
                         FightNav::fightnav(true,true,"runmodule.php?module=cities&city=".urlencode($city)."&d=$danger");
 		}

--- a/src/Lotgd/ErrorHandler.php
+++ b/src/Lotgd/ErrorHandler.php
@@ -1,0 +1,218 @@
+<?php
+namespace Lotgd;
+
+use Lotgd\Backtrace;
+use Lotgd\Sanitize;
+use Lotgd\Translator;
+use Lotgd\Settings;
+use Lotgd\DataCache;
+
+/**
+ * Centralized error handling utilities.
+ */
+class ErrorHandler
+{
+    /**
+     * Render a fatal error message in a simple HTML page.
+     *
+     * @param string $message   Error text to display
+     * @param string $file      Originating filename
+     * @param int    $line      Line number of the error
+     * @param string $backtrace HTML representation of the stack trace
+     */
+    public static function renderError(string $message, string $file, int $line, string $backtrace): void
+    {
+        http_response_code(500);
+        echo "<!DOCTYPE html>\n";
+        echo "<html lang='en'><head>\n";
+        echo "<meta charset='UTF-8'>\n";
+        echo "<title>Application Error</title>\n";
+        echo "<style>body{background:#000;color:#fff;font-family:sans-serif;padding:20px;}a{color:#fff;}pre{background:#111;padding:10px;overflow:auto;}</style>\n";
+        echo "</head><body>\n";
+        echo "<h1>Application Error</h1>\n";
+        echo sprintf('<p>%s</p>', htmlentities($message, ENT_COMPAT));
+        echo sprintf('<p>in <b>%s</b> at <b>%s</b></p>', htmlentities($file, ENT_COMPAT), $line);
+        echo $backtrace;
+        echo "<p>If the problem persists, please <a href='/petition.php'>submit a petition</a>.</p>\n";
+        echo "</body></html>";
+    }
+
+    /**
+     * Default PHP error handler that displays debug output and sends notifications.
+     *
+     * @param int    $errno     PHP error level constant
+     * @param string $errstr    Error message
+     * @param string $errfile   File the error originated from
+     * @param int    $errline   Line in the file the error originated from
+     * @return void
+     */
+    public static function handleError($errno, $errstr, $errfile, $errline): void
+    {
+        global $session, $settings;
+        static $inErrorHandler = 0;
+
+        if (!error_reporting()) {
+            return; // @ operator used
+        }
+        ini_set('display_errors', '1');
+        $inErrorHandler++;
+        if ($inErrorHandler > 1) {
+            if ($errno & (E_USER_WARNING | E_WARNING)) {
+                echo "PHP Warning: \"$errstr\"<br>in <b>$errfile</b> at <b>$errline</b>.  Additionally this occurred while within logd_error_handler().<br>";
+            } elseif ($errno & (E_USER_ERROR | E_ERROR)) {
+                echo "PHP ERROR: \"$errstr\"<br>in <b>$errfile</b> at <b>$errline</b>.  Additionally this occurred while within logd_error_handler().<br>";
+            }
+            $inErrorHandler--;
+            return;
+        }
+        switch ($errno) {
+            case E_NOTICE:
+            case E_USER_NOTICE:
+                $showNotices = isset($settings) && $settings instanceof Settings
+                    ? $settings->getSetting('show_notices', 0)
+                    : getsetting('show_notices', 0);
+                if ($showNotices && ($session['user']['superuser'] & SU_SHOW_PHPNOTICE)) {
+                    debug("PHP Notice: \"$errstr\"<br>in <b>$errfile</b> at <b>$errline</b>.");
+                }
+                break;
+            case E_WARNING:
+            case E_USER_WARNING:
+                Translator::tlschema('errorhandler');
+                if (($session['user']['superuser'] & SU_DEBUG_OUTPUT) == SU_DEBUG_OUTPUT) {
+                    output("PHP Warning: \"%s\"`nin `b%s`b at `b%s`b.`n", $errstr, $errfile, $errline, true);
+                    Translator::tlschema();
+                    $backtrace = Backtrace::show();
+                    rawoutput($backtrace);
+                } else {
+                    $backtrace = '';
+                }
+                if (isset($settings) && !empty($settings->getSetting('notify_on_warn', 0))) {
+                    self::errorNotify($errno, $errstr, $errfile, $errline, $backtrace);
+                }
+                break;
+            case E_ERROR:
+            case E_USER_ERROR:
+                $backtrace = Backtrace::show();
+                self::renderError($errstr, $errfile, $errline, $backtrace);
+                if (isset($settings) && !empty($settings->getSetting('notify_on_error', 0))) {
+                    self::errorNotify($errno, $errstr, $errfile, $errline, $backtrace);
+                }
+                die();
+                break;
+        }
+        $inErrorHandler--;
+    }
+
+    /**
+     * Send an e-mail notification about a PHP error.
+     *
+     * @param int    $errno     PHP error level
+     * @param string $errstr    Error message
+     * @param string $errfile   File in which the error occurred
+     * @param int    $errline   Line number of the error
+     * @param string $backtrace HTML stack trace
+     * @return void
+     */
+    public static function errorNotify($errno, $errstr, $errfile, $errline, $backtrace): void
+    {
+        global $session, $settings;
+        $sendto = explode(';', isset($settings) && $settings instanceof Settings
+            ? $settings->getSetting('notify_address', '')
+            : getsetting('notify_address', '')
+        );
+        $howoften = isset($settings) && $settings instanceof Settings
+            ? $settings->getSetting('notify_every', 30)
+            : getsetting('notify_every', 30);
+        $data = DataCache::datacache('error_notify', 86400);
+        if (!is_array($data)) {
+            $data = ['firstrun' => false, 'errors' => []];
+            if (!DataCache::updatedatacache('error_notify', $data)) {
+                error_log('Unable to write datacache for error_notify');
+            }
+        } else {
+            if (!isset($data['errors']) || !is_array($data['errors'])) {
+                $data['errors'] = [];
+            }
+            if (!array_key_exists('firstrun', $data)) {
+                $data['firstrun'] = false;
+            }
+        }
+        $doNotice = false;
+        if (!array_key_exists($errstr, $data['errors'])) {
+            $doNotice = true;
+        } elseif (strtotime('now') - ($data['errors'][$errstr]) > $howoften * 60) {
+            $doNotice = true;
+        }
+        if (!isset($data['firstrun'])) {
+            $data['firstrun'] = false;
+        }
+        if ($data['firstrun']) {
+            debug('First run, not notifying users.');
+        } else {
+            if ($doNotice) {
+                $userstr = '';
+                if ($session && isset($session['user']['name']) && isset($session['user']['acctid'])) {
+                    $userstr = 'Error triggered by user ' . $session['user']['name'] . ' (' . $session['user']['acctid'] . ")\n";
+                }
+                $plain_text = "$userstr$errstr in $errfile ($errline)\n" . Sanitize::sanitizeHtml($backtrace);
+                $html_text = "<html><body>$errstr in $errfile ($errline)<hr>$backtrace</body></html>";
+                $hostname = $_SERVER['HTTP_HOST'] ?? 'not called from browser, no hostname';
+                $subject = "$hostname $errno";
+                $body = $html_text;
+                foreach ($sendto as $email) {
+                    debug("Notifying $email of this error.");
+                    $admin = isset($settings) && $settings instanceof Settings
+                        ? $settings->getSetting('gameadminemail', 'postmaster@localhost')
+                        : getsetting('gameadminemail', 'postmaster@localhost');
+                    $from = [$admin => $admin];
+                    \Lotgd\Mail::send([$email => $email], $body, $subject, $from, false, 'text/html');
+                }
+                $data['errors'][$errstr] = strtotime('now');
+            } else {
+                debug('Not notifying users for this error, it\'s only been ' . round((strtotime('now') - $data['errors'][$errstr]) / 60, 2) . ' minutes.');
+            }
+        }
+        if (!DataCache::updatedatacache('error_notify', $data)) {
+            error_log('Unable to write datacache for error_notify');
+        }
+        debug($data);
+    }
+
+    /**
+     * Handle uncaught exceptions.
+     *
+     * @param \Throwable $exception Exception instance
+     * @return void
+     */
+    public static function handleException($exception): void
+    {
+        $trace = Backtrace::show($exception->getTrace());
+        self::renderError($exception->getMessage(), $exception->getFile(), $exception->getLine(), $trace);
+    }
+
+    /**
+     * Catch fatal errors on shutdown.
+     *
+     * @return void
+     */
+    public static function fatalShutdown(): void
+    {
+        $error = error_get_last();
+        if ($error && in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
+            $trace = Backtrace::show();
+            self::renderError($error['message'], $error['file'], $error['line'], $trace);
+        }
+    }
+
+    /**
+     * Register the handlers with PHP.
+     *
+     * @return void
+     */
+    public static function register(): void
+    {
+        set_error_handler([self::class, 'handleError']);
+        set_exception_handler([self::class, 'handleException']);
+        register_shutdown_function([self::class, 'fatalShutdown']);
+    }
+}

--- a/src/Lotgd/Forest/Outcomes.php
+++ b/src/Lotgd/Forest/Outcomes.php
@@ -1,0 +1,239 @@
+<?php
+namespace Lotgd\Forest;
+
+use Lotgd\AddNews;
+use Lotgd\Battle;
+use Lotgd\DeathMessage;
+use Lotgd\PageParts;
+use Lotgd\Translator;
+use Lotgd\Settings;
+use Lotgd\Nav;
+
+/**
+ * Helper methods for handling forest fight results and creature buffs.
+ */
+class Outcomes
+{
+    /**
+     * Apply rewards and penalties for winning a forest battle.
+     *
+     * @param array $enemies      List of encountered enemies
+     * @param mixed $denyflawless Custom text to deny flawless bonus
+     * @return void
+     */
+    public static function victory(array $enemies, $denyflawless = false): void
+    {
+        global $session, $options, $settings;
+        $diddamage = false;
+        $creaturelevel = 0;
+        $gold = 0;
+        $exp = 0;
+        $expbonus = 0;
+        $count = 0;
+        foreach ($enemies as $badguy) {
+            $dropMinGold = isset($settings) && $settings instanceof Settings
+                ? $settings->getSetting('dropmingold', 0)
+                : getsetting('dropmingold', 0);
+            if ($dropMinGold) {
+                $badguy['creaturegold'] = e_rand(round($badguy['creaturegold'] / 4), round(3 * $badguy['creaturegold'] / 4));
+            } else {
+                $badguy['creaturegold'] = e_rand(0, $badguy['creaturegold']);
+            }
+            $gold += $badguy['creaturegold'];
+            if (isset($badguy['creaturelose'])) {
+                $msg = translate_inline($badguy['creaturelose'], 'battle');
+                output_notl("`b`&%s`0`b`n", $msg);
+            }
+            output("`b`\$You have slain %s!`0`b`n", $badguy['creaturename']);
+            $count++;
+            if ($badguy['diddamage'] == 1) {
+                $diddamage = true;
+            }
+            $creaturelevel = max($creaturelevel, $badguy['creaturelevel']);
+            if (!$denyflawless && isset($badguy['denyflawless']) && $badguy['denyflawless'] > '') {
+                $denyflawless = $badguy['denyflawless'];
+            }
+            $expbonus += round(($badguy['creatureexp'] * (1 + .25 * ($badguy['creaturelevel'] - $session['user']['level']))) - $badguy['creatureexp'], 0);
+        }
+        $multibonus = $count > 1 ? 1 : 0;
+        $expbonus += $session['user']['dragonkills'] * $session['user']['level'] * $multibonus;
+        $totalexp = array_sum($options['experience']);
+        $exp = round($totalexp / $count);
+        $gold = e_rand(round($gold / $count), round($gold), 0);
+        $expbonus = round($expbonus / $count, 0);
+
+        if ($gold) {
+            output("`#You receive `^%s`# gold!`n", $gold);
+            debuglog('received gold for slaying a monster.', false, false, 'forestwin', $badguy['creaturegold']);
+        }
+        $gemChance = isset($settings) && $settings instanceof Settings
+            ? $settings->getSetting('forestgemchance', 25)
+            : getsetting('forestgemchance', 25);
+        $args = modulehook('alter-gemchance', ['chance' => $gemChance]);
+        $gemchances = $args['chance'];
+        $maxLevel = isset($settings) && $settings instanceof Settings
+            ? $settings->getSetting('maxlevel', 15)
+            : getsetting('maxlevel', 15);
+        if ($session['user']['level'] < $maxLevel && e_rand(1, $gemchances) == 1) {
+            output("`&You find A GEM!`n`#");
+            $session['user']['gems']++;
+            debuglog('found gem when slaying a monster.', false, false, 'forestwingem', 1);
+        }
+        $instantExp = isset($settings) && $settings instanceof Settings
+            ? $settings->getSetting('instantexp', false)
+            : getsetting('instantexp', false);
+        if ($instantExp == true) {
+            $expgained = array_sum($options['experiencegained']);
+            $diff = $expgained - $exp;
+            $expbonus += $diff;
+            if (floor($exp + $expbonus) < 0) {
+                $expbonus = -$exp + 1;
+            }
+            if ($expbonus > 0) {
+                $addExp = isset($settings) && $settings instanceof Settings
+                    ? $settings->getSetting('addexp', 5)
+                    : getsetting('addexp', 5);
+                $expbonus = round($expbonus * pow(1 + ($addExp / 100), $count - 1), 0);
+                output("`#***Because of the difficult nature of this fight, you are awarded an additional `^%s`# experience! `n", $expbonus);
+            } elseif ($expbonus < 0) {
+                output("`#***Because of the simplistic nature of this fight, you are penalized `^%s`# experience! `n", abs($expbonus));
+            }
+            if (count($enemies) > 1) {
+                output("During this fight you received `^%s`# total experience!`n`0", $exp + $expbonus);
+            }
+            $session['user']['experience'] += $expbonus;
+        } else {
+            if (floor($exp + $expbonus) < 0) {
+                $expbonus = -$exp + 1;
+            }
+            if ($expbonus > 0) {
+                $addExp = isset($settings) && $settings instanceof Settings
+                    ? $settings->getSetting('addexp', 5)
+                    : getsetting('addexp', 5);
+                $expbonus = round($expbonus * pow(1 + ($addExp / 100), $count - 1), 0);
+                output("`#***Because of the difficult nature of this fight, you are awarded an additional `^%s`# experience! `n(%s + %s = %s) ", $expbonus, $exp, abs($expbonus), $exp + $expbonus);
+            } elseif ($expbonus < 0) {
+                output("`#***Because of the simplistic nature of this fight, you are penalized `^%s`# experience! `n(%s - %s = %s) ", abs($expbonus), $exp, abs($expbonus), $exp + $expbonus);
+            }
+            output("You receive `^%s`# total experience!`n`0", $exp + $expbonus);
+            $session['user']['experience'] += ($exp + $expbonus);
+        }
+        $session['user']['gold'] += $gold;
+        if (!$creaturelevel) {
+            $creaturelevel = $badguy['creaturelevel'];
+        } else {
+            $creaturelevel += (0.5 * ($count - 1));
+        }
+        if (!$diddamage) {
+            output("`c`b`&~~ Flawless Fight! ~~`0`b`c");
+            if ($denyflawless) {
+                output("`c`\$%s`0`c", translate_inline($denyflawless));
+            } elseif ($session['user']['level'] <= $creaturelevel) {
+                output("`c`b`\$You receive an extra turn!`0`b`c`n");
+                $session['user']['turns']++;
+            } else {
+                output("`c`\$A more difficult fight would have yielded an extra turn.`0`c`n");
+            }
+        }
+        if ($session['user']['hitpoints'] <= 0) {
+            output("With your dying breath you spy a small stand of mushrooms off to the side.");
+            output("You recognize them as some of the ones that the healer had drying in the hut and taking a chance, cram a handful into your mouth.");
+            output("Even raw they have some restorative properties.`n");
+            $session['user']['hitpoints'] = 1;
+        }
+    }
+
+    /**
+     * Handle the player being defeated in the forest.
+     *
+     * @param array  $enemies List of enemies that defeated the player
+     * @param string $where   Description of where the defeat happened
+     * @return void
+     */
+    public static function defeat(array $enemies, $where = 'in the forest'): void
+    {
+        global $session, $settings;
+        $percent = isset($settings) && $settings instanceof Settings
+            ? $settings->getSetting('forestexploss', 10)
+            : getsetting('forestexploss', 10);
+        Nav::add('Daily news', 'news.php');
+        $names = [];
+        $killer = false;
+        foreach ($enemies as $badguy) {
+            $names[] = $badguy['creaturename'];
+            if (isset($badguy['killedplayer']) && $badguy['killedplayer'] == true) {
+                $killer = $badguy['creaturename'];
+            }
+            if (isset($badguy['creaturewin']) && $badguy['creaturewin'] > '') {
+                $msg = translate_inline($badguy['creaturewin'], 'battle');
+                output_notl("`b`&%s`0`b`n", $msg);
+            }
+        }
+        if (count($names) > 1) {
+            $lastname = array_pop($names);
+        }
+        $enemystring = join(', ', $names);
+        $and = translate_inline('and');
+        if (isset($lastname) && $lastname > '') {
+            $enemystring = "$enemystring $and $lastname";
+        }
+        $taunt = Battle::selectTauntArray();
+        $deathmessage = DeathMessage::selectArray(true, ['{where}'], [$where]);
+        if ($deathmessage['taunt'] == 1) {
+            AddNews::add("%s`n%s", $deathmessage['deathmessage'], $taunt);
+        } else {
+            AddNews::add("%s", $deathmessage['deathmessage']);
+        }
+        $session['user']['alive'] = 0;
+        debuglog("lost gold when they were slain $where", false, false, 'forestlose', -$session['user']['gold']);
+        $session['user']['gold'] = 0;
+        $session['user']['hitpoints'] = 0;
+        $session['user']['experience'] = round($session['user']['experience'] * (1 - ($percent / 100)), 0);
+        output("`4All gold on hand has been lost!`n");
+        output("`4%s %% of experience has been lost!`b`n", $percent);
+        output('You may begin fighting again tomorrow.');
+        page_footer();
+    }
+
+    /**
+     * Buff an enemy based on player dragon kills.
+     *
+     * @param array $badguy Enemy data to adjust
+     * @return array Modified enemy data
+     */
+    public static function buffBadguy(array $badguy): array
+    {
+        global $session, $settings;
+        static $dk = false;
+        if ($dk === false) {
+            $dk = get_player_dragonkillmod(true);
+            $add = ($session['user']['dragonkills'] / 100) * .10;
+            $dk = round($dk * (.25 + $add));
+        }
+        $expflux = round($badguy['creatureexp'] / 10, 0);
+        $expflux = e_rand(-$expflux, $expflux);
+        $badguy['creatureexp'] += $expflux;
+        $atkflux = e_rand(0, $dk);
+        $defflux = e_rand(0, ($dk - $atkflux));
+        $hpflux = ($dk - ($atkflux + $defflux)) * 5;
+        $badguy['creatureattack'] += $atkflux;
+        $badguy['creaturedefense'] += $defflux;
+        $badguy['creaturehealth'] += $hpflux;
+        $disableBonuses = isset($settings) && $settings instanceof Settings
+            ? $settings->getSetting('disablebonuses', 1)
+            : getsetting('disablebonuses', 1);
+        if ($disableBonuses) {
+            $base = 30 - min(20, round(sqrt($session['user']['dragonkills']) / 2));
+            $base /= 1000;
+            $bonus = 1 + $base * ($atkflux + $defflux) + .001 * $hpflux;
+            $badguy['creaturegold'] = round($badguy['creaturegold'] * $bonus, 0);
+            $badguy['creatureexp'] = round($badguy['creatureexp'] * $bonus, 0);
+        }
+        $badguy = modulehook('creatureencounter', $badguy);
+        debug("DEBUG: $dk modification points total.");
+        debug("DEBUG: +$atkflux allocated to attack.");
+        debug("DEBUG: +$defflux allocated to defense.");
+        debug("DEBUG: +" . ($hpflux / 5) . "*5 to hitpoints.");
+        return modulehook('buffbadguy', $badguy);
+    }
+}


### PR DESCRIPTION
## Summary
- move error handling functions to `Lotgd\ErrorHandler`
- move forest outcome helpers to `Lotgd\Forest\Outcomes`
- update legacy wrappers
- replace old `require_once` calls with new class usage
- regenerate composer autoload files
- use `$settings->getSetting()` in the new classes
- switch datacache calls to `DataCache`
- replace `addnav()` with `Nav::add()`
- document parameters in new classes

## Testing
- `composer dump-autoload`
- `php -l src/Lotgd/ErrorHandler.php`
- `php -l src/Lotgd/Forest/Outcomes.php`
- `php -l lib/errorhandler.php`
- `php -l lib/forestoutcomes.php`
- `php -l common.php`
- `php -l ext/lotgd_common.php`
- `php -l forest.php`
- `php -l modules/cities/run.php`


------
https://chatgpt.com/codex/tasks/task_e_68695205b220832997255f9c252f8ecb