### PR TITLE
Add strict typing to Lotgd utilities

### DIFF
--- a/src/Lotgd/ModuleManager.php
+++ b/src/Lotgd/ModuleManager.php
@@ -1,8 +1,18 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 class ModuleManager
 {
+    /**
+     * Return list of installed modules optionally filtered by category.
+     *
+     * @param string|null $category  Filter results by category
+     * @param string      $sortBy    Column to sort by
+     * @param bool        $ascending Sort order
+     *
+     * @return array<string,mixed>[] List of installed modules
+     */
     public static function listInstalled(?string $category = null, string $sortBy = 'installdate', bool $ascending = false): array
     {
         $sql = 'SELECT * FROM ' . db_prefix('modules');
@@ -20,18 +30,33 @@ class ModuleManager
         return $modules;
     }
 
+    /**
+     * Retrieve all uninstalled modules.
+     *
+     * @return array<string> List of module names
+     */
     public static function listUninstalled(): array
     {
         $status = get_module_install_status();
         return $status['uninstalledmodules'] ?? [];
     }
 
+    /**
+     * Get the categories of installed modules.
+     *
+     * @return array<string,int> Mapping of category name to count
+     */
     public static function getInstalledCategories(): array
     {
         $status = get_module_install_status();
         return $status['installedcategories'] ?? [];
     }
 
+    /**
+     * Install a module.
+     *
+     * @return bool True on success
+     */
     public static function install(string $module): bool
     {
         if (install_module($module)) {
@@ -42,6 +67,11 @@ class ModuleManager
         return false;
     }
 
+    /**
+     * Uninstall a module.
+     *
+     * @return bool True on success
+     */
     public static function uninstall(string $module): bool
     {
         if (uninstall_module($module)) {
@@ -53,6 +83,9 @@ class ModuleManager
         return false;
     }
 
+    /**
+     * Activate a module.
+     */
     public static function activate(string $module): bool
     {
         $res = activate_module($module);
@@ -63,6 +96,9 @@ class ModuleManager
         return $res;
     }
 
+    /**
+     * Deactivate a module.
+     */
     public static function deactivate(string $module): bool
     {
         $res = deactivate_module($module);
@@ -71,6 +107,9 @@ class ModuleManager
         return $res;
     }
 
+    /**
+     * Force a module to reinstall.
+     */
     public static function reinstall(string $module): bool
     {
         $sql = 'UPDATE ' . db_prefix('modules') . " SET filemoddate='" . DATETIME_DATEMIN . "' WHERE modulename='" . $module . "'";

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 use Lotgd\Backtrace;
 use Lotgd\Translator;
@@ -142,7 +143,13 @@ class Modules
     /**
      * Return status bitfield for a module.
      */
-    public static function getStatus(string $moduleName, $version = false): int
+    /**
+     * Return status bitfield for a module.
+     *
+     * @param string $moduleName Module short name
+     * @param string|false $version Optional version check
+     */
+    public static function getStatus(string $moduleName, string|false $version = false): int
     {
         
 
@@ -189,6 +196,9 @@ class Modules
     /**
      * Determine if a module is active.
      */
+    /**
+     * Check if a module is active.
+     */
     public static function isActive(string $moduleName): bool
     {
         return (bool) (self::getStatus($moduleName) & MODULE_ACTIVE);
@@ -197,13 +207,22 @@ class Modules
     /**
      * Determine if a module is installed optionally checking version.
      */
-    public static function isInstalled(string $moduleName, $version = false): bool
+    /**
+     * Determine if a module is installed and optionally verify version.
+     *
+     * @param string      $moduleName Module short name
+     * @param string|false $version    Required version or false
+     */
+    public static function isInstalled(string $moduleName, string|false $version = false): bool
     {
         return (bool) (self::getStatus($moduleName, $version) & (MODULE_INSTALLED | MODULE_VERSION_OK));
     }
 
     /**
      * Validate module requirements and optionally inject dependencies.
+     *
+     * @param array $reqs        Module requirements
+     * @param bool  $forceinject Inject missing modules if true
      */
     public static function checkRequirements(array $reqs, bool $forceinject = false): bool
     {
@@ -235,6 +254,8 @@ class Modules
 
     /**
      * Block a module from participating in hooks during the current request.
+     *
+     * @param string $moduleName Module short name
      */
     public static function block(string $moduleName): void
     {
@@ -243,6 +264,8 @@ class Modules
 
     /**
      * Allow a previously blocked module to participate in hooks again.
+     *
+     * @param string $moduleName Module short name
      */
     public static function unblock(string $moduleName): void
     {
@@ -255,6 +278,8 @@ class Modules
 
     /**
      * Check if a module is currently blocked.
+     *
+     * @param string $moduleName Module short name
      */
     public static function isModuleBlocked(string $moduleName): bool
     {
@@ -264,6 +289,8 @@ class Modules
 
     /**
      * Prefetch hook information for a set of hooks.
+     *
+     * @param array $hookNames List of hook names
      */
     public static function massPrepare(array $hookNames): bool
     {

--- a/src/Lotgd/Motd.php
+++ b/src/Lotgd/Motd.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\Forms;
@@ -7,7 +8,13 @@ use Lotgd\Forms;
  */
 class Motd
 {
-    public static function motdAdmin($id, $poll = false)
+    /**
+     * Display MOTD administration interface.
+     *
+     * @param int  $id   MOTD identifier
+     * @param bool $poll Whether the MOTD is a poll
+     */
+    public static function motdAdmin(int $id, bool $poll = false): void
     {
         global $session;
         $id = (int)$id;
@@ -30,7 +37,10 @@ class Motd
         }
     }
 
-    public static function motdItem($subject, $body, $author, $date, $id)
+    /**
+     * Render a MOTD item.
+     */
+    public static function motdItem(string $subject, string $body, string $author, string $date, int $id): void
     {
         rawoutput('<div class="motditem" style="margin-bottom: 15px;">');
         rawoutput('<h4>' . htmlentities($subject, ENT_COMPAT, getsetting('charset', 'ISO-8859-1')) . '</h4>');
@@ -40,7 +50,10 @@ class Motd
         rawoutput('</div>');
     }
 
-    public static function pollItem($id, $subject, $body, $author, $date, $showpoll = true)
+    /**
+     * Render a poll entry.
+     */
+    public static function pollItem(int $id, string $subject, string $body, string $author, string $date, bool $showpoll = true): void
     {
         rawoutput('<div class="pollitem">');
         rawoutput('<h4>' . htmlentities($subject, ENT_COMPAT, getsetting('charset', 'ISO-8859-1')) . '</h4>');
@@ -52,7 +65,10 @@ class Motd
         rawoutput('</div>');
     }
 
-    public static function motdForm($id)
+    /**
+     * Display edit form for a MOTD record.
+     */
+    public static function motdForm(int $id): void
     {
         require_once 'lib/showform.php';
         $sql = 'SELECT motdtitle,motdbody,motdtype FROM ' . db_prefix('motd') . " WHERE motditem='$id'";
@@ -78,7 +94,10 @@ class Motd
         rawoutput('</form>');
     }
 
-    public static function motdPollForm()
+    /**
+     * Show form to create a new poll entry.
+     */
+    public static function motdPollForm(): void
     {
         require_once 'lib/showform.php';
         $form = array(
@@ -92,7 +111,10 @@ class Motd
         rawoutput('</form>');
     }
 
-    public static function motdDel($id)
+    /**
+     * Delete a MOTD record.
+     */
+    public static function motdDel(int $id): void
     {
         $sql = 'DELETE FROM ' . db_prefix('motd') . " WHERE motditem='$id'";
         db_query($sql);

--- a/src/Lotgd/MountName.php
+++ b/src/Lotgd/MountName.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 /**
@@ -8,6 +9,8 @@ class MountName
 {
     /**
      * Return the mount display name and a lowercase variant.
+     *
+     * @return array{0:string,1:string}
      */
     public static function getmountname(): array
     {

--- a/src/Lotgd/Mounts.php
+++ b/src/Lotgd/Mounts.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 /**
@@ -8,6 +9,10 @@ class Mounts
 {
     /**
      * Retrieve mount information from the database.
+     *
+     * @param int $horse Mount id
+     *
+     * @return array<string,mixed>
      */
     public static function getmount(int $horse = 0): array
     {

--- a/src/Lotgd/Names.php
+++ b/src/Lotgd/Names.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 /**
@@ -6,7 +7,12 @@ namespace Lotgd;
  */
 class Names
 {
-    public static function getPlayerTitle($old = false)
+    /**
+     * Retrieve a player's title string.
+     *
+     * @param array|false $old Optional player row to inspect
+     */
+    public static function getPlayerTitle(array|false $old = false)
     {
         global $session;
         $title = '';
@@ -24,7 +30,12 @@ class Names
         return $title;
     }
 
-    public static function getPlayerBasename($old = false)
+    /**
+     * Get a player's base name without title codes.
+     *
+     * @param array|false $old Optional player row
+     */
+    public static function getPlayerBasename(array|false $old = false)
     {
         global $session;
         $name = '';
@@ -49,7 +60,10 @@ class Names
         return $pname;
     }
 
-    public static function changePlayerName($newname, $old = false)
+    /**
+     * Apply the player's title to a base name.
+     */
+    public static function changePlayerName(string $newname, array|false $old = false): string
     {
         if ($newname == '') {
             $newname = self::getPlayerBasename($old);
@@ -62,7 +76,10 @@ class Names
         return $newname;
     }
 
-    public static function changePlayerCtitle($nctitle, $old = false)
+    /**
+     * Replace the player's custom title.
+     */
+    public static function changePlayerCtitle(string $nctitle, array|false $old = false): string
     {
         global $session;
         if ($nctitle == '') {
@@ -79,7 +96,10 @@ class Names
         return $newname;
     }
 
-    public static function changePlayerTitle($ntitle, $old = false)
+    /**
+     * Replace a standard title while respecting custom titles.
+     */
+    public static function changePlayerTitle(string $ntitle, array|false $old = false): string
     {
         global $session;
         if ($old === false) {

--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\HolidayText;

--- a/src/Lotgd/Nav/SuperuserNav.php
+++ b/src/Lotgd/Nav/SuperuserNav.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd\Nav;
 
 /**

--- a/src/Lotgd/Nav/VillageNav.php
+++ b/src/Lotgd/Nav/VillageNav.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd\Nav;
 
 /**

--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\GameLog;

--- a/src/Lotgd/Nltoappon.php
+++ b/src/Lotgd/Nltoappon.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 /**

--- a/src/Lotgd/Output.php
+++ b/src/Lotgd/Output.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\DumpItem;

--- a/src/Lotgd/OutputArray.php
+++ b/src/Lotgd/OutputArray.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 /**

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\Buffs;

--- a/src/Lotgd/Partner.php
+++ b/src/Lotgd/Partner.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 /**

--- a/src/Lotgd/PhpGenericEnvironment.php
+++ b/src/Lotgd/PhpGenericEnvironment.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 /**

--- a/src/Lotgd/PlayerFunctions.php
+++ b/src/Lotgd/PlayerFunctions.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 /**

--- a/src/Lotgd/PullUrl.php
+++ b/src/Lotgd/PullUrl.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\Settings;

--- a/src/Lotgd/Pvp.php
+++ b/src/Lotgd/Pvp.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\DateTime;


### PR DESCRIPTION
## Summary
- enforce strict_types across numerous Lotgd utility classes
- begin documenting helper methods with phpdoc
- update some parameter types to use unions

## Testing
- `php -l src/Lotgd/ModuleManager.php`
- `php -l src/Lotgd/Motd.php`
- `php -l src/Lotgd/MountName.php`
- `php -l src/Lotgd/Mounts.php`
- `php -l src/Lotgd/Names.php`
- `php -l src/Lotgd/Nav.php`
- `php -l src/Lotgd/Nav/SuperuserNav.php`
- `php -l src/Lotgd/Nav/VillageNav.php`
- `php -l src/Lotgd/Newday.php`
- `php -l src/Lotgd/Nltoappon.php`
- `php -l src/Lotgd/Output.php`
- `php -l src/Lotgd/OutputArray.php`
- `php -l src/Lotgd/PageParts.php`
- `php -l src/Lotgd/Partner.php`
- `php -l src/Lotgd/PhpGenericEnvironment.php`
- `php -l src/Lotgd/PlayerFunctions.php`
- `php -l src/Lotgd/PullUrl.php`
- `php -l src/Lotgd/Pvp.php`


------
https://chatgpt.com/codex/tasks/task_e_686976bffc2083299a42daf8589999f3