### PR TITLE
Apply strict types and type hints to MySQL layer

### DIFF
--- a/src/Lotgd/MySQL/DbMysqli.php
+++ b/src/Lotgd/MySQL/DbMysqli.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Lotgd\MySQL;
 
 use Lotgd\DataCache;
@@ -8,9 +10,13 @@ use Lotgd\DataCache;
  */
 class DbMysqli
 {
-    protected $link;
+    /** @var \mysqli|null */
+    protected ?\mysqli $link = null;
 
-    public function connect($host, $user, $pass)
+    /**
+     * Open a connection to the database server.
+     */
+    public function connect(string $host, string $user, string $pass): bool
     {
         $this->link = mysqli_connect($host, $user, $pass);
 
@@ -25,7 +31,10 @@ class DbMysqli
         return $this->link ? true : false;
     }
 
-    public function pconnect($host, $user, $pass)
+    /**
+     * Open a persistent connection to the database server.
+     */
+    public function pconnect(string $host, string $user, string $pass): bool
     {
         $this->link = mysqli_connect($host, $user, $pass);
 
@@ -40,63 +49,99 @@ class DbMysqli
         return $this->link ? true : false;
     }
 
-    public function selectDb($dbname)
+    /**
+     * Select a database.
+     */
+    public function selectDb(string $dbname): bool
     {
         return mysqli_select_db($this->link, $dbname);
     }
 
-    public function setCharset($charset)
+    /**
+     * Set the client character set.
+     */
+    public function setCharset(string $charset): bool
     {
         return mysqli_set_charset($this->link, $charset);
     }
 
-    public function query($sql)
+    /**
+     * Execute a query on the current connection.
+     */
+    public function query(string $sql): \mysqli_result|bool
     {
         return mysqli_query($this->link, $sql);
     }
 
-    public function fetchAssoc($result)
+    /**
+     * Fetch an associative row from a result set.
+     */
+    public function fetchAssoc(\mysqli_result $result): array|null|false
     {
         return mysqli_fetch_assoc($result);
     }
 
-    public function insertId()
+    /**
+     * Get the last inserted ID for this connection.
+     */
+    public function insertId(): int|string
     {
         return mysqli_insert_id($this->link);
     }
 
-    public function numRows($result)
+    /**
+     * Count rows from a result set.
+     */
+    public function numRows(\mysqli_result $result): int
     {
         return mysqli_num_rows($result);
     }
 
-    public function affectedRows()
+    /**
+     * Get the number of rows affected by the previous query.
+     */
+    public function affectedRows(): int
     {
         return mysqli_affected_rows($this->link);
     }
 
-    public function error()
+    /**
+     * Retrieve the last error message.
+     */
+    public function error(): string
     {
         return mysqli_error($this->link);
     }
 
-    public function escape($string)
+    /**
+     * Escape a string for use in a query.
+     */
+    public function escape(string $string): string
     {
         return mysqli_real_escape_string($this->link, $string);
     }
 
-    public function freeResult($result)
+    /**
+     * Free a result set.
+     */
+    public function freeResult(\mysqli_result $result): bool
     {
         return mysqli_free_result($result);
     }
 
-    public function tableExists($tablename)
+    /**
+     * Check whether the given table exists.
+     */
+    public function tableExists(string $tablename): bool
     {
         $result = $this->query("SHOW TABLES LIKE '$tablename'");
         return ($result && mysqli_num_rows($result) > 0);
     }
 
-    public function getServerVersion()
+    /**
+     * Get the server version string.
+     */
+    public function getServerVersion(): string
     {
         return mysqli_get_server_info($this->link);
     }

--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Lotgd\MySQL;
 
 class TableDescriptor
@@ -17,7 +19,11 @@ class TableDescriptor
 //
 // There's no support for foreign keys that INNODB offers.  Sorry.
 
-    public static function synctable($tablename,$descriptor,$nodrop=false){
+    /**
+     * Synchronise a table with the provided descriptor.
+     */
+    public static function synctable(string $tablename, array $descriptor, bool $nodrop = false): ?int
+    {
 	//table names should be db_prefix'd before they get in to
 	//this function.
 	if (!db_table_exists($tablename)){
@@ -114,7 +120,11 @@ class TableDescriptor
 	}//end if
 }//end function
 
-    public static function tableCreateFromDescriptor($tablename,$descriptor){
+    /**
+     * Generate SQL to create a table from the given descriptor.
+     */
+    public static function tableCreateFromDescriptor(string $tablename, array $descriptor): string
+    {
 	$sql = "CREATE TABLE $tablename (\n";
 	$type = "INNODB";
 	reset($descriptor);
@@ -160,7 +170,11 @@ class TableDescriptor
 	return $sql;
 }
 
-    public static function tableCreateDescriptor($tablename){
+    /**
+     * Build a descriptor array from an existing table.
+     */
+    public static function tableCreateDescriptor(string $tablename): array
+    {
 	//this function assumes that $tablename is already passed
 	//through db_prefix.
 	$descriptor = array();
@@ -216,7 +230,11 @@ class TableDescriptor
 	return $descriptor;
 }
 
-    public static function descriptorCreateSql($input){
+    /**
+     * Convert a descriptor element to SQL.
+     */
+    public static function descriptorCreateSql(array $input): string
+    {
 	$input['type'] = descriptor_sanitize_type($input['type']);
 	if ($input['type']=="key" || $input['type']=='unique key'){
 		//this is a standard index
@@ -256,7 +274,11 @@ class TableDescriptor
 	return $return;
 }
 
-    public static function descriptorSanitizeType($type){
+    /**
+     * Normalise a descriptor type value.
+     */
+    public static function descriptorSanitizeType(string $type): string
+    {
 	$type = strtolower($type);
 	$changes = array(
 		"primary index"=>"primary key",


### PR DESCRIPTION
## Summary
- enable strict types in MySQL classes
- add proper type hints and PHPDoc

## Testing
- `php -l src/Lotgd/MySQL/Database.php`
- `php -l src/Lotgd/MySQL/DbMysqli.php`
- `php -l src/Lotgd/MySQL/TableDescriptor.php`


------
https://chatgpt.com/codex/tasks/task_e_68697dd9ad5083299aac9a19ff7695c9