### PR TITLE
Use multi-stage Composer build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN composer install --no-dev --no-interaction --prefer-dist
 FROM php:apache
 
 # Install system packages and PHP extensions required by the game
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libpng-dev \
     libjpeg-dev \
     libonig-dev \


### PR DESCRIPTION
## Summary
- simplify Dockerfile with a multi-stage Composer build
- update docs for new Dockerfile and quick-start steps
- improve inline comments and restore PHP settings

## Testing
- `composer validate --no-check-all --strict`
- `docker compose build` *(fails: command not found)*
- `docker-compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869921fd2d08329b657cd0afed477eb