### PR TITLE
Fix trailing comment parenthesis

### DIFF
--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -104,7 +104,7 @@ class Template
 	    $fulltemplate = file_get_contents("templates/$templatename");
 	    $fulltemplate = explode("<!--!",$fulltemplate);
 	    foreach ($fulltemplate as $val) {
-            if ($val == "") continue; // Skip empty sections)
+           if ($val == "") continue; // Skip empty sections
 		    $fieldname=substr($val,0,strpos($val,"-->"));
 		    if ($fieldname!=""){
 			    $template[$fieldname]=substr($val,strpos($val,"-->")+3);


### PR DESCRIPTION
## Summary
- remove stray parenthesis in Template.php comment

## Testing
- `php -l src/Lotgd/Template.php`

------
https://chatgpt.com/codex/tasks/task_e_686a51fd6d888329bee6b05210309c4e