### PR TITLE
Fix PayPal donation markup

### DIFF
--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -771,7 +771,7 @@ public static function mailLinkTabText(){
             $paypalstr .= '<form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">'
                 ."<input type='hidden' name='cmd' value='_xclick'>"
                 ."<input type='hidden' name='business' value='$paysite'>"
-                ."<input type='hidden' name='item_name' value='".(isset($settings) ? $settings->getSetting('paypaltext','Legend of the Green Dragon Site Donation from') : 'Legend of the Gren Dragon Site Donation From')." ".full_Sanitize::sanitize($session['user']['name'])."'>"
+                ."<input type='hidden' name='item_name' value='".(isset($settings) ? $settings->getSetting('paypaltext','Legend of the Green Dragon Site Donation from') : 'Legend of the Gren Dragon Site Donation From')." ".Sanitize::fullSanitize($session['user']['name'])."'>"
                 ."<input type='hidden' name='item_number' value='".htmlentities($session['user']['login'], ENT_COMPAT, isset($settings) ? $settings->getSetting('charset', 'ISO-8859-1') : 'UTF-8').":".$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI']."'>"
                 ."<input type='hidden' name='no_shipping' value='1'>";
             if (file_exists('payment.php')) {


### PR DESCRIPTION
## Summary
- use `Sanitize::fullSanitize()` when building PayPal donation form

## Testing
- `php -l src/Lotgd/PageParts.php`

------
https://chatgpt.com/codex/tasks/task_e_686a8194ec708329b0e4e4439c438e51