### PR TITLE
Enable Twig template caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ continue to work as before.
 Twig views receive variables for common placeholders like `nav`, `stats`, and
 `paypal`, allowing flexible layouts.
 Compiled Twig templates are cached under the directory defined by the
-`datacachepath` setting. Ensure this location is writable by the web server;
-a `twig` subfolder will be created automatically.
+`datacachepath` setting. The engine attempts to create a `twig` subdirectory
+and only enables caching when it is writable. If the path cannot be created
+or written to, templates are rendered without caching.
 
 ## Install from Release Archive
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ matching folder is found, pages are rendered with Twig; classic `.htm` templates
 continue to work as before.
 Twig views receive variables for common placeholders like `nav`, `stats`, and
 `paypal`, allowing flexible layouts.
+Compiled Twig templates are cached under the directory defined by the
+`datacachepath` setting. Ensure this location is writable by the web server;
+a `twig` subfolder will be created automatically.
 
 ## Install from Release Archive
 

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -96,7 +96,7 @@ class Template
 
         if ($templateType === 'twig' || is_dir("templates_twig/$templatename")) {
             // Initialize Twig environment for modern templates
-            TwigTemplate::init($templatename);
+            TwigTemplate::init($templatename, $settings instanceof Settings ? $settings : null);
             $template = [];
         } else {
             $template = self::loadTemplate($templatename);

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -96,7 +96,11 @@ class Template
 
         if ($templateType === 'twig' || is_dir("templates_twig/$templatename")) {
             // Initialize Twig environment for modern templates
-            TwigTemplate::init($templatename, $settings instanceof Settings ? $settings : null);
+            $cachePath = null;
+            if ($settings instanceof Settings) {
+                $cachePath = $settings->getSetting('datacachepath', '/tmp');
+            }
+            TwigTemplate::init($templatename, $cachePath);
             $template = [];
         } else {
             $template = self::loadTemplate($templatename);

--- a/src/Lotgd/TwigTemplate.php
+++ b/src/Lotgd/TwigTemplate.php
@@ -10,22 +10,22 @@ class TwigTemplate extends Template
 {
     private static ?Environment $env = null;
     private static string $templateDir = '';
+    /** Path used for caching compiled templates */
+    private static string $cacheDir = '/tmp';
 
-    public static function init(string $templateName, ?Settings $settings = null): void
+    public static function init(string $templateName, ?string $datacachePath = null): void
     {
         self::$templateDir = __DIR__ . '/../../templates_twig/' . $templateName;
         $loader = new FilesystemLoader(self::$templateDir);
 
-        $baseDir = $settings?->getSetting('datacachepath', '/tmp') ?? '/tmp';
-        $cacheDir = rtrim($baseDir, '/\\') . '/twig';
-        $cacheEnabled = false;
-        if (is_dir($cacheDir) || mkdir($cacheDir, 0755, true)) {
-            $cacheEnabled = is_writable($cacheDir);
-        }
-
         $options = ['auto_reload' => true];
-        if ($cacheEnabled) {
-            $options['cache'] = $cacheDir;
+
+        if ($datacachePath !== null && $datacachePath !== '') {
+            self::$cacheDir = $datacachePath;
+            $cacheDir = rtrim($datacachePath, '/\\') . '/twig';
+            if ((is_dir($cacheDir) || mkdir($cacheDir, 0755, true)) && is_writable($cacheDir)) {
+                $options['cache'] = $cacheDir;
+            }
         }
 
         self::$env = new Environment($loader, $options);

--- a/src/Lotgd/TwigTemplate.php
+++ b/src/Lotgd/TwigTemplate.php
@@ -12,6 +12,8 @@ class TwigTemplate extends Template
     private static string $templateDir = '';
     /** Path used for caching compiled templates */
     private static string $cacheDir = '/tmp';
+    /** Subdirectory within datacachepath for Twig cache */
+    private const CACHE_SUBDIR = 'twig';
 
     public static function init(string $templateName, ?string $datacachePath = null): void
     {
@@ -22,7 +24,7 @@ class TwigTemplate extends Template
 
         if ($datacachePath !== null && $datacachePath !== '') {
             self::$cacheDir = $datacachePath;
-            $cacheDir = rtrim($datacachePath, '/\\') . '/twig';
+            $cacheDir = rtrim($datacachePath, '/\\') . '/' . self::CACHE_SUBDIR;
             if ((is_dir($cacheDir) || mkdir($cacheDir, 0755, true)) && is_writable($cacheDir)) {
                 $options['cache'] = $cacheDir;
             }

--- a/src/Lotgd/TwigTemplate.php
+++ b/src/Lotgd/TwigTemplate.php
@@ -13,9 +13,23 @@ class TwigTemplate extends Template
 
     public static function init(string $templateName): void
     {
+        global $settings;
+
         self::$templateDir = __DIR__ . '/../../templates_twig/' . $templateName;
         $loader = new FilesystemLoader(self::$templateDir);
-        self::$env = new Environment($loader);
+
+        $baseDir = ($settings instanceof Settings)
+            ? $settings->getSetting('datacachepath', '/tmp')
+            : '/tmp';
+        $cacheDir = rtrim($baseDir, '/\\') . '/twig';
+        if (!is_dir($cacheDir)) {
+            mkdir($cacheDir, 0777, true);
+        }
+
+        self::$env = new Environment($loader, [
+            'cache' => $cacheDir,
+            'auto_reload' => true,
+        ]);
         define('TEMPLATE_IS_TWIG', true);
     }
 


### PR DESCRIPTION
## Summary
- enable caching for Twig by reading `datacachepath`
- create a `twig` cache directory if needed
- mention writable cache requirement in README

## Testing
- `php -l src/Lotgd/TwigTemplate.php`
- `php -r '$start=microtime(true);require "/workspace/lotgd/autoload.php";\Lotgd\TwigTemplate::init("puritanic_ai");\Lotgd\TwigTemplate::render("page.twig",["title"=>"t","template_path"=>"","headscript"=>"","script"=>""]);$t1=microtime(true)-$start;$start=microtime(true);\Lotgd\TwigTemplate::render("page.twig",["title"=>"t","template_path"=>"","headscript"=>"","script"=>""]);$t2=microtime(true)-$start;echo "first:$t1 second:$t2\n";'`

------
https://chatgpt.com/codex/tasks/task_e_686b8561b6f08329a932728540e95ea4