### PR TITLE
Fix IS_INSTALLER checks

### DIFF
--- a/common.php
+++ b/common.php
@@ -151,7 +151,7 @@ ob_start();
 if (file_exists("dbconnect.php")){
 	require_once("dbconnect.php");
 }else{
-	if (!defined("IS_INSTALLER")){
+if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
 		if (!defined("DB_NODB")) define("DB_NODB",true);
                 PageParts::pageHeader("The game has not yet been installed");
 		output("`#Welcome to `@Legend of the Green Dragon`#, a game by Eric Stevens & JT Traub.`n`n");
@@ -195,7 +195,7 @@ if (!defined("DB_NODB")) {
 }
 
 if ($link===false){
-	if (!defined("IS_INSTALLER")){
+if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
 		// Ignore this bit.  It's only really for Eric's server
 		//I won't, because all people can use it //Oliver
 		//Yet made a bit more interesting text than just the naughty normal "Unable to connect to database - sorry it didn't work out" stuff
@@ -233,7 +233,7 @@ if ($link===false){
 
 if (!defined("DB_NODB")) {
 if (!DB_CONNECTED || !@Database::selectDb($DB_NAME)){
-		if (!defined("IS_INSTALLER") && DB_CONNECTED){
+                if ((!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) && DB_CONNECTED){
 			// Ignore this bit.  It's only really for Eric's server or people that want to trigger something when the database is jerky
 			if (file_exists("lib/smsnotify.php")) {
                                 $smsmessage = "Cant Attach to DB: " . Database::error();
@@ -269,7 +269,9 @@ if (!DB_CONNECTED || !@Database::selectDb($DB_NAME)){
 }
 
 //Generate our settings object
-if (!defined("IS_INSTALLER")) $settings=new Settings("settings");
+if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
+    $settings = new Settings('settings');
+}
 
 if (isset($settings) && $logd_version == $settings->getSetting("installer_version","-1")) {
 	define("IS_INSTALLER", false);
@@ -300,7 +302,7 @@ PhpGenericEnvironment::setup();
 ForcedNavigation::doForcedNav(ALLOW_ANONYMOUS,OVERRIDE_FORCED_NAV);
 
 $script = substr($SCRIPT_NAME,0,strrpos($SCRIPT_NAME,"."));
-if (!defined("IS_INSTALLER")) {
+if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
 	mass_module_prepare(array(
 				'template-header','template-footer','template-statstart','template-stathead','template-statrow','template-statbuff','template-statend',
 				'template-navhead','template-navitem','template-petitioncount','template-adwrapper','template-login','template-loginfull','everyhit',
@@ -326,7 +328,7 @@ if (!isset($nokeeprestore[$SCRIPT_NAME]) || !$nokeeprestore[$SCRIPT_NAME]) {
 
 }
 
-if (isset($settings) && $logd_version != $settings->getSetting("installer_version","-1") && !defined("IS_INSTALLER")){
+if (isset($settings) && $logd_version != $settings->getSetting('installer_version', '-1') && (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER))) {
         PageParts::pageHeader("Upgrade Needed");
 	output("`#The game is temporarily unavailable while a game upgrade is applied, please be patient, the upgrade will be completed soon.");
 	output("In order to perform the upgrade, an admin will have to run through the installer.");
@@ -442,7 +444,7 @@ if ($session['user']['superuser']==0){
 
 Template::prepareTemplate();
 
-if(!defined("IS_INSTALLER")) {
+if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
 	if (!isset($session['user']['hashorse'])) $session['user']['hashorse']=0;
         $playermount = Mounts::getmount($session['user']['hashorse']);
 	$temp_comp = @unserialize($session['user']['companions']);
@@ -485,7 +487,7 @@ if(!defined("IS_INSTALLER")) {
 
 }
 
-if (!defined("IS_INSTALLER") && $settings->getSetting('debug',0)) {
+if ((!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) && $settings->getSetting('debug', 0)) {
 	//Server runs in Debug mode, tell the superuser about it
 	if (($session['user']['superuser']&SU_EDIT_CONFIG)==SU_EDIT_CONFIG) {
 		tlschema("debug");
@@ -514,5 +516,7 @@ $output->setNestedTagEval($nestedeval);
 // This however is the only context where blockmodule can be called safely!
 // You should do as LITTLE as possible here and consider if you can hook on
 // a page header instead.
-if (!defined("IS_INSTALLER")) modulehook("everyhit");
+if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
+    modulehook('everyhit');
+}
 ?>

--- a/ext/lotgd_common.php
+++ b/ext/lotgd_common.php
@@ -121,7 +121,7 @@ ob_start();
 if (file_exists("dbconnect.php")){
 	require_once("dbconnect.php");
 }else{
-	if (!defined("IS_INSTALLER")){
+       if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
 	 	if (!defined("DB_NODB")) define("DB_NODB",true);
                 PageParts::pageHeader("The game has not yet been installed");
 		output("`#Welcome to `@Legend of the Green Dragon`#, a game by Eric Stevens & JT Traub.`n`n");
@@ -156,7 +156,7 @@ unset($DB_USER);
 unset($DB_PASS);
 
 if ($link===false){
- 	if (!defined("IS_INSTALLER")){
+if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
 		// Ignore this bit.  It's only really for Eric's server
 		//I won't, because all people can use it //Oliver
 		//Yet made a bit more interesting text than just the naughty normal "Unable to connect to database - sorry it didn't work out" stuff
@@ -193,7 +193,7 @@ if ($link===false){
 }
 
 if (!DB_CONNECTED || !Database::selectDb($DB_NAME)){
-	if (!defined("IS_INSTALLER") && DB_CONNECTED){
+       if ((!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) && DB_CONNECTED){
 		// Ignore this bit.  It's only really for Eric's server
 		if (file_exists("lib/smsnotify.php")) {
                         $smsmessage = "Cant Attach to DB: " . Database::error();
@@ -278,7 +278,7 @@ if (!isset($nokeeprestore[$SCRIPT_NAME]) || !$nokeeprestore[$SCRIPT_NAME]) {
 
 }
 
-if ($logd_version != $settings->getSetting("installer_version","-1") && !defined("IS_INSTALLER")){
+if ($logd_version != $settings->getSetting('installer_version', '-1') && (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER))) {
         PageParts::pageHeader("Upgrade Needed");
 	output("`#The game is temporarily unavailable while a game upgrade is applied, please be patient, the upgrade will be completed soon.");
 	output("In order to perform the upgrade, an admin will have to run through the installer.");

--- a/src/Lotgd/HolidayText.php
+++ b/src/Lotgd/HolidayText.php
@@ -25,7 +25,7 @@ class HolidayText
             }
         }
         $args = ['text' => $text, 'type' => $type];
-        if (!defined('IS_INSTALLER')) {
+        if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
             $args = modulehook('holiday', $args);
         }
         $text = $args['text'];

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -354,7 +354,7 @@ class Modules
         global $navsection, $mostrecentmodule;
         global $output, $session, $currenthook;
 
-        if (defined('IS_INSTALLER')) {
+        if (defined('IS_INSTALLER') && IS_INSTALLER) {
             return $args;
         }
 

--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -50,7 +50,7 @@ class Database
      */
     public static function query(string $sql, bool $die = true): array|bool|\mysqli_result
     {
-        if (defined('DB_NODB') && !defined('LINK')) {
+        if ((defined('DB_NODB') && DB_NODB) && !defined('LINK')) {
             return [];
         }
         global $session, $dbinfo;
@@ -117,7 +117,7 @@ class Database
     public static function error(): string
     {
         $r = self::getInstance()->error();
-        if ($r == '' && defined('DB_NODB') && !defined('DB_INSTALLER_STAGE4')) {
+        if ($r == '' && (defined('DB_NODB') && DB_NODB) && !defined('DB_INSTALLER_STAGE4')) {
             return 'The database connection was never established';
         }
         return $r;
@@ -145,7 +145,7 @@ class Database
      */
     public static function insertId(): int|string
     {
-        if (defined('DB_NODB') && !defined('LINK')) {
+        if ((defined('DB_NODB') && DB_NODB) && !defined('LINK')) {
             return -1;
         }
         return self::getInstance()->insertId();
@@ -161,7 +161,7 @@ class Database
         if (is_array($result)) {
             return count($result);
         }
-        if (defined('DB_NODB') && !defined('LINK')) {
+        if ((defined('DB_NODB') && DB_NODB) && !defined('LINK')) {
             return 0;
         }
         return self::getInstance()->numRows($result);
@@ -176,7 +176,7 @@ class Database
         if (isset($dbinfo['affected_rows'])) {
             return $dbinfo['affected_rows'];
         }
-        if (defined('DB_NODB') && !defined('LINK')) {
+        if ((defined('DB_NODB') && DB_NODB) && !defined('LINK')) {
             return 0;
         }
         return self::getInstance()->affectedRows();
@@ -232,7 +232,7 @@ class Database
         if (is_array($result)) {
             return true;
         }
-        if (defined('DB_NODB') && !defined('LINK')) {
+        if ((defined('DB_NODB') && DB_NODB) && !defined('LINK')) {
             return false;
         }
         self::getInstance()->freeResult($result);
@@ -244,7 +244,7 @@ class Database
      */
     public static function tableExists(string $tablename): bool
     {
-        if (defined('DB_NODB') && !defined('LINK')) {
+        if ((defined('DB_NODB') && DB_NODB) && !defined('LINK')) {
             return false;
         }
         return self::getInstance()->tableExists($tablename);

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -72,9 +72,13 @@ public static function pageHeader(...$args): void {
                         if (!array_key_exists($script,self::$runHeaders))
                                 self::$runHeaders[$script] = false;
                         if (!self::$runHeaders[$script]) {
-                                if (!defined("IS_INSTALLER")) modulehook("everyheader", array('script'=>$script));
+                                if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
+                                    modulehook('everyheader', ['script' => $script]);
+                                }
                                 self::$runHeaders[$script] = true;
-                                if (!defined("IS_INSTALLER")) modulehook("header-$script");
+                                if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
+                                    modulehook("header-$script");
+                                }
                         }
                 }
 	}
@@ -163,7 +167,7 @@ public static function pageFooter(bool $saveuser=true){
 
     Buffs::restoreBuffFields();
 
-	if (!defined("IS_INSTALLER")) { 
+        if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
 		$sql = "SELECT motddate FROM " . db_prefix("motd") . " ORDER BY motditem DESC LIMIT 1";
 		$result = db_query($sql);
 		$row = db_fetch_assoc($result);

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -150,8 +150,9 @@ class Template
 		    $fieldname=substr($val,0,strpos($val,"-->"));
 		    if ($fieldname!=""){
 			    $template[$fieldname]=substr($val,strpos($val,"-->")+3);
-			    if (!defined("IS_INSTALLER")) modulehook("template-{$fieldname}",
-					    array("content"=>$template[$fieldname]));
+                            if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
+                                modulehook("template-{$fieldname}", ['content' => $template[$fieldname]]);
+                            }
 		    }
 	    }
 	    return $template;


### PR DESCRIPTION
## Summary
- fix `IS_INSTALLER` condition checks to ensure value is checked
- check value of `DB_NODB` before skipping DB operations

## Testing
- `composer validate --no-check-publish`
- `php -l common.php`
- `php -l ext/lotgd_common.php`
- `php -l src/Lotgd/PageParts.php`
- `php -l src/Lotgd/Template.php`
- `php -l src/Lotgd/Modules.php`
- `php -l src/Lotgd/HolidayText.php`
- `php -l src/Lotgd/MySQL/Database.php`
- `php -l src/Lotgd/MySQL/DbMysqli.php`
- `composer install`


------
https://chatgpt.com/codex/tasks/task_e_686bf919a59883298ce8ed9cd23d56b5