### PR TITLE
Fix autoload order in prefs.php

### DIFF
--- a/prefs.php
+++ b/prefs.php
@@ -4,6 +4,7 @@ use Lotgd\Forms;
 // mail ready
 // translator ready
 
+require_once("common.php");
 require_once("lib/http.php");
 
 $skin = httppost('template');
@@ -13,7 +14,6 @@ if ($skin > "") {
 }
 
 require_once("lib/villagenav.php");
-require_once("common.php");
 
 tlschema("prefs");
 


### PR DESCRIPTION
## Summary
- include `common.php` before using `lib/http.php`

`prefs.php` included `lib/http.php` before the Composer autoloader was loaded. This caused a `Class "Lotgd\Http" not found` error. Loading `common.php` first ensures the autoloader is registered before `Lotgd\Http` is referenced.

## Testing
- `php` was not available in the environment, so runtime tests were not executed.

------
https://chatgpt.com/codex/tasks/task_e_686c254644448329b52dfc62e6c01da4