### PR TITLE
Refactor puritanic_ai template styles

### DIFF
--- a/templates_twig/puritanic_ai/assets/style.css
+++ b/templates_twig/puritanic_ai/assets/style.css
@@ -286,3 +286,51 @@ table.petition-count {
 }
 
 /* Additional styles as needed based on your layout and design requirements */
+
+/* Layout helper classes */
+.align-center {
+    text-align: center;
+}
+
+.align-left {
+    text-align: left;
+}
+
+.align-right {
+    text-align: right;
+}
+
+.valign-top {
+    vertical-align: top;
+}
+
+.valign-bottom {
+    vertical-align: bottom;
+}
+
+.noborder {
+    border: 0;
+}
+
+.navad-wrapper {
+    position: relative;
+    top: -15px;
+    text-align: center;
+}
+
+.verticalad-wrapper {
+    float: right;
+}
+
+.nav-container {
+    text-align: center;
+}
+
+.layout-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.clear {
+    clear: both;
+}

--- a/templates_twig/puritanic_ai/navhead.twig
+++ b/templates_twig/puritanic_ai/navhead.twig
@@ -1,1 +1,1 @@
-<span class="navhead">&#151;{{ title|raw }}&mdash;</span><br clear='all'>
+<span class="navhead">&#151;{{ title|raw }}&mdash;</span><br class="clear">

--- a/templates_twig/puritanic_ai/navhelp.twig
+++ b/templates_twig/puritanic_ai/navhelp.twig
@@ -1,1 +1,1 @@
-<span class="navhelp">{{ text|raw }}</span><br clear='all'>
+<span class="navhelp">{{ text|raw }}</span><br class="clear">

--- a/templates_twig/puritanic_ai/navitem.twig
+++ b/templates_twig/puritanic_ai/navitem.twig
@@ -1,1 +1,1 @@
-<a href="{{ link }}" {{ accesskey }} class='nav' {{ popup }}>{{ text|raw }}</a><br clear='all'>
+<a href="{{ link }}" {{ accesskey }} class='nav' {{ popup }}>{{ text|raw }}</a><br class="clear">

--- a/templates_twig/puritanic_ai/page.twig
+++ b/templates_twig/puritanic_ai/page.twig
@@ -8,22 +8,22 @@
     {{ headscript|raw }}{{ script|raw }}
 </head>
 <body class="main-body">
-    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+    <table class="layout-table" width="100%">
         <tr>
             <td>
-                <table border="0" cellpadding="0" cellspacing="0" width="100%" class="noborder">
+                <table class="layout-table noborder" width="100%">
                     <tr class="page-header">
-                        <td class="noborder pageheader-left" align="center">
+                        <td class="noborder pageheader-left align-center">
                             <table>
                                 <tr>
-                                    <td class="noborder motd" align="left" valign="bottom" width="50%">&nbsp;&nbsp;<b>{{ motd|raw }}</b></td>
-                                    <td class="noborder" align="right" width="50%" valign="bottom"><b>{{ petition|raw }}</b></td>
+                                    <td class="noborder motd align-left valign-bottom" width="50%">&nbsp;&nbsp;<strong>{{ motd|raw }}</strong></td>
+                                    <td class="noborder align-right valign-bottom" width="50%"><strong>{{ petition|raw }}</strong></td>
                                 </tr>
                             </table>
                         </td>
-                        <td align="center" class="noborder pageheader-center">{{ title }}</td>
+                        <td class="noborder pageheader-center align-center">{{ title }}</td>
                         <td class="noborder pageheader-right">
-                            <img src="{{ template_path }}/assets/mail.gif" width="24" height="19"><b>{{ mail|raw }}</b>&nbsp;&nbsp;
+                            <img src="{{ template_path }}/assets/mail.gif" width="24" height="19" alt="Mail"><strong>{{ mail|raw }}</strong>&nbsp;&nbsp;
                             {{ petitiondisplay|raw }}
                         </td>
                     </tr>
@@ -32,18 +32,18 @@
         </tr>
         <tr>
             <td>
-                <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                <table class="layout-table" width="100%">
                     <tr>
-                        <td valign="top" width="200" class="sidebar-content">
-                            <div style="position: relative; top: -15;" align="center">{{ navad|raw }}</div>
-                            <div align="center" role="navigation">{{ nav|raw }}</div>
+                        <td width="200" class="sidebar-content valign-top">
+                            <div class="navad-wrapper">{{ navad|raw }}</div>
+                            <div class="nav-container" role="navigation">{{ nav|raw }}</div>
                         </td>
-                        <td valign="top" width="100%" class="main-content">
-                            <div style="float: right">{{ verticalad|raw }}</div>
+                        <td width="100%" class="main-content valign-top">
+                            <div class="verticalad-wrapper">{{ verticalad|raw }}</div>
                             {{ bodyad|raw }}
                             {{ content|raw }}
                         </td>
-                        <td valign="top" width="132" class="sidebar-content">
+                        <td width="132" class="sidebar-content valign-top">
                             {{ stats|raw }}
                             <br>
                             {{ paypal|raw }}
@@ -54,33 +54,33 @@
         </tr>
         <tr>
             <td colspan="3">
-                <table width="100%" height="20">
+                <table class="layout-table" width="100%" height="20">
                     <tr>
-                        <td align="center"></td>
+                        <td class="align-center"></td>
                     </tr>
                 </table>
             </td>
         </tr>
         <tr>
             <td colspan="3">
-                <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                <table class="layout-table" width="100%">
                     <tr>
-                        <td colspan="3" height="10" align="center"></td>
+                        <td colspan="3" height="10" class="align-center"></td>
                     </tr>
                     <tr>
                         <td width="12"></td>
-                        <td valign="top">
-                            <table width="100%" class="colOtWhite">
+                        <td class="valign-top">
+                            <table class="layout-table colOtWhite" width="100%">
                                 <tr>
-                                    <td valign="top">{{ copyright|raw }}<br/>Design: Puritanic AI theme <a href="https://shinobilegends.com">shinobilegends.com</a></td>
-                                    <td valign="top" align="right">{{ source|raw }}<br />{{ version }}<br />({{ pagegen|raw }})</td>
+                                    <td class="valign-top">{{ copyright|raw }}<br/>Design: Puritanic AI theme <a href="https://shinobilegends.com">shinobilegends.com</a></td>
+                                    <td class="valign-top align-right">{{ source|raw }}<br />{{ version }}<br />({{ pagegen|raw }})</td>
                                 </tr>
                             </table>
                         </td>
                         <td width="12"></td>
                     </tr>
                     <tr>
-                        <td colspan="3" height="10" align="center"></td>
+                        <td colspan="3" height="10" class="align-center"></td>
                     </tr>
                 </table>
             </td>

--- a/templates_twig/puritanic_ai/popup.twig
+++ b/templates_twig/puritanic_ai/popup.twig
@@ -6,23 +6,23 @@
     <link rel="stylesheet" href="{{ template_path }}/assets/style.css"/>
 </head>
 <body class="popup-body">
-    <table border="0" cellpadding="5" cellspacing="0" width="100%">
+    <table class="layout-table" cellpadding="5" width="100%">
         <tr>
-            <td colspan="2" bgcolor="#222222" class="pageheader">
-                <table border="0" cellpadding="0" cellspacing="0" width="100%" class="noborder">
+            <td colspan="2" class="pageheader popup-header">
+                <table class="layout-table noborder" width="100%">
                     <tr>
-                        <td width="100%" class="noborder"><b>{{ title }}</b><div style="float: right;"></div></td>
+                        <td class="noborder"><strong>{{ title }}</strong><div class="verticalad-wrapper"></div></td>
                     </tr>
                 </table>
             </td>
         </tr>
         <tr>
-            <td valign="top" width="100%" class="main-content">
+            <td width="100%" class="main-content valign-top">
                 {{ content|raw }}
             </td>
         </tr>
         <tr>
-            <td align="left" class="trhead">{{ copyright|raw }}</td>
+            <td class="trhead align-left">{{ copyright|raw }}</td>
         </tr>
     </table>
 </body>

--- a/templates_twig/puritanic_ai/statbuff.twig
+++ b/templates_twig/puritanic_ai/statbuff.twig
@@ -1,2 +1,2 @@
-<tr><td class='charhead' colspan='2'><b>{{ title|raw }}:</b></td></tr>
+<tr><td class='charhead' colspan='2'><strong>{{ title|raw }}:</strong></td></tr>
 <tr><td class='charinfo' colspan='2'>{{ value|raw }}</td></tr>

--- a/templates_twig/puritanic_ai/stathead.twig
+++ b/templates_twig/puritanic_ai/stathead.twig
@@ -1,1 +1,1 @@
-<tr><td class='charhead' colspan='2'><b>{{ title|raw }}</b></td></tr>
+<tr><td class='charhead' colspan='2'><strong>{{ title|raw }}</strong></td></tr>

--- a/templates_twig/puritanic_ai/statrow.twig
+++ b/templates_twig/puritanic_ai/statrow.twig
@@ -1,1 +1,1 @@
-<tr><td class='charinfo'><b>{{ title|raw }}</b></td><td class='charinfo'>{{ value|raw }}</td></tr>
+<tr><td class='charinfo'><strong>{{ title|raw }}</strong></td><td class='charinfo'>{{ value|raw }}</td></tr>


### PR DESCRIPTION
## Summary
- clean up puritanic_ai HTML templates
- move inline styles to CSS
- add helper CSS classes

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ca6c5e37c83299fa50bf8d2f48fd2