### PR TITLE
Fix commentary AJAX response

### DIFF
--- a/ext/ajax_server.php
+++ b/ext/ajax_server.php
@@ -105,8 +105,8 @@ function commentary_text($args=false) {
 	$talkline="says";
 	$schema=$args['schema'];
 	$viewonly=$args['viewonly'];	
-	$new=Commentary::viewcommentary($section, $message, $limit, $talkline, $schema,$viewonly,1);
-	$new=maillink();
-	$objResponse = jaxon()->newResponse();
-	$objResponse->assign($section,"innerHTML", $new);
+       $new=Commentary::viewcommentary($section, $message, $limit, $talkline, $schema,$viewonly,1);
+       $objResponse = jaxon()->newResponse();
+       $objResponse->assign($section, "innerHTML", $new);
+       return $objResponse;
 }


### PR DESCRIPTION
## Summary
- remove stray `maillink()` call in `commentary_text()`
- return the Jaxon response object

## Testing
- `php -l ext/ajax_server.php`

------
https://chatgpt.com/codex/tasks/task_e_686ca83f133483299db3976f7bd8c1c4