### PR TITLE
Add AJAX commentary refresh

### DIFF
--- a/ext/ajax_common.php
+++ b/ext/ajax_common.php
@@ -21,3 +21,4 @@ $jaxon->setOption('core.request.uri', 'ext/ajax_process.php');
 $jaxon->register(Jaxon::CALLABLE_FUNCTION, 'mail_status');
 $jaxon->register(Jaxon::CALLABLE_FUNCTION, 'commentary_text');
 $jaxon->register(Jaxon::CALLABLE_FUNCTION, 'timeout_status');
+$jaxon->register(Jaxon::CALLABLE_FUNCTION, 'commentary_refresh');

--- a/ext/ajax_maillink.php
+++ b/ext/ajax_maillink.php
@@ -1,21 +1,30 @@
 <?php
 $maillink_add_pre=$s_js.$s_script;
 $maillink_add_after="<script type='text/javascript'>
+var lotgd_comment_section = '".($session['last_comment_section'] ?? '')."';
+var lotgd_lastCommentId = " . (int)($session['lastcommentid'] ?? 0) . ";
 $(window).ready(function(){
-		set_mail_ajax();
-		window.setTimeout('set_timeout_ajax()','".((getsetting("LOGINTIMEOUT",900)-$start_timeout_show_seconds)*1000)."');
+                set_mail_ajax();
+                if(lotgd_comment_section){
+                        set_comment_ajax();
+                }
+                window.setTimeout('set_timeout_ajax()','".((getsetting("LOGINTIMEOUT",900)-$start_timeout_show_seconds)*1000)."');
 
-		window.setTimeout('clear_ajax()','".((getsetting("LOGINTIMEOUT",900)-$clear_script_execution_seconds)*1000)."');
-		});
+                window.setTimeout('clear_ajax()','".((getsetting("LOGINTIMEOUT",900)-$clear_script_execution_seconds)*1000)."');
+                });
 function set_mail_ajax() {
-	active_mail_interval=window.setInterval('jaxon_mail_status(1)',".($check_mail_timeout_seconds*1000).");
+        active_mail_interval=window.setInterval('jaxon_mail_status(1)',".($check_mail_timeout_seconds*1000).");
+}
+function set_comment_ajax() {
+        active_comment_interval=window.setInterval(function(){jaxon_commentary_refresh(lotgd_comment_section, lotgd_lastCommentId);},10000);
 }
 function set_timeout_ajax() {
-	active_timeout_interval=window.setInterval('jaxon_timeout_status(1)',".($check_timeout_seconds*1000).");
+        active_timeout_interval=window.setInterval('jaxon_timeout_status(1)',".($check_timeout_seconds*1000).");
 }
 function clear_ajax() {
-	window.clearInterval(active_timeout_interval);
-	window.clearInterval(active_mail_interval);
+        window.clearInterval(active_timeout_interval);
+        window.clearInterval(active_mail_interval);
+        window.clearInterval(active_comment_interval);
 }
 </script>";
 


### PR DESCRIPTION
## Summary
- add `commentary_refresh` Jaxon callable to serve new comments
- register the new callable
- update mail ajax script to poll for new commentary and update `lastCommentId`

## Testing
- `php -l ext/ajax_server.php`
- `php -l ext/ajax_maillink.php`
- `php -l ext/ajax_common.php`


------
https://chatgpt.com/codex/tasks/task_e_686cb18cfcf48329b10aa92a5705fcd8