### PR TITLE
Fix jQuery path for Jaxon scripts

### DIFF
--- a/ext/ajax_base_setup.php
+++ b/ext/ajax_base_setup.php
@@ -8,7 +8,7 @@ $s_css=$jaxon->getCss();
 $s_js=($jaxon->getJs());
 $s_script=($jaxon->getScript());
 if (isset($pre_headscript)) {
-	$pre_headscript.=$s_css."<script src=\"/ext/js/jquery-3.3.1.min.js\"></script>";
+    $pre_headscript.=$s_css."<script src=\"/ext/js/jquery-3.6.3.min.js\"></script>";
 } else {
 	$pre_headscript = "";
 }


### PR DESCRIPTION
## Summary
- update ajax Jaxon bootstrap to load jQuery 3.6.3

## Testing
- `php -l ext/ajax_base_setup.php`

------
https://chatgpt.com/codex/tasks/task_e_686cc010931c8329bc5d72eecbe4bb8c