### PR TITLE
Update README chat instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Features of this fork include:
 - compatibility with PHP 8
 - PHPMailer replacing the sendmail system
 - mail notifications that auto-refresh via Ajax
+- incremental chat updates via `commentary_refresh` to load new messages without reloading the page
 - Composer integration for third-party modules
   - after modifying Composer settings, run `composer dump-autoload` to recognize new namespaces
   - after running `composer install` or `composer dump-autoload`, include `autoload.php` to load all dependencies
@@ -31,7 +32,6 @@ So, it should work on every modern PHP environment.
 If somebody really has time, there are still things to do:
 - replace the template system with a state-of-the-art system such as Smarty
 - Twig template support for modern theming
-- integrate refreshing chats (tests with Jaxon worked but were slow)
 - convert arrays into objects to avoid extensive `isset()` checks
 - configure the `datacachepath` setting in `dbconnect.php` to a writable directory so errors can be cached for email notifications
 


### PR DESCRIPTION
## Summary
- document incremental chat refresh via `commentary_refresh`
- remove outdated to-do item about integrating refreshing chats

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_686cc0637ad48329bf521ddfd50b008e