### PR TITLE
Fix AJAX session check

### DIFF
--- a/common.php
+++ b/common.php
@@ -323,8 +323,11 @@ if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
 $revertsession=$session;
 if (!isset($session['user']['loggedin'])) $session['user']['loggedin']=false;
 
-if ($session['user']['loggedin']!=true && !ALLOW_ANONYMOUS){
-    Redirect::redirect("login.php?op=logout");
+if ($session['user']['loggedin'] != true && !ALLOW_ANONYMOUS) {
+    if (!AJAX_MODE) {
+        Redirect::redirect('login.php?op=logout');
+    }
+    // For AJAX_MODE, allow the caller to handle a timed-out session.
 }
 
 if (!isset($session['counter'])) $session['counter']=0;


### PR DESCRIPTION
## Summary
- modify session login check to allow AJAX handlers to manage a missing or expired session

## Testing
- `composer validate --no-interaction`

------
https://chatgpt.com/codex/tasks/task_e_686ce59236488329b757ed61a626fb3c