### PR TITLE
Document AJAX helpers and rename JS polling script

### DIFF
--- a/ext/ajax_base_setup.php
+++ b/ext/ajax_base_setup.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Base setup for AJAX requests, including the Jaxon library and
+ * initial JavaScript dependencies. This file prepares the page for
+ * asynchronous features like mail and commentary updates.
+ */
 require_once(__DIR__ . '/ajax_common.php');
 
 global $jaxon;

--- a/ext/ajax_common.php
+++ b/ext/ajax_common.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Common bootstrap for AJAX operations. This file configures the
+ * Jaxon library and registers callable functions used by the client
+ * side scripts.
+ */
 require_once __DIR__ . '/../autoload.php'; // Start autoload
 
 use Jaxon\Jaxon;                      // Use the jaxon core class

--- a/ext/ajax_maillink.php
+++ b/ext/ajax_maillink.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Prepares the mail link JavaScript code snippets used by the
+ * interface. It injects Jaxon scripts and variables required by the
+ * asynchronous mail and commentary polling.
+ */
 global $jaxon;
 $s_js=($jaxon->getJs());
 $s_script=($jaxon->getScript());
@@ -14,6 +20,6 @@ $maillink_add_after .= "var lotgd_timeout_interval_ms = " . ($check_timeout_seco
 $maillink_add_after .= "var lotgd_timeout_delay_ms = " . ((getsetting('LOGINTIMEOUT', 900) - $start_timeout_show_seconds) * 1000) . ";";
 $maillink_add_after .= "var lotgd_clear_delay_ms = " . ((getsetting('LOGINTIMEOUT', 900) - $clear_script_execution_seconds) * 1000) . ";";
 $maillink_add_after .= "</script>";
-$maillink_add_after .= "<script src='/ext/js/mail_ajax.js'></script>";
+$maillink_add_after .= "<script src='/ext/js/ajax_polling.js'></script>";
 $maillink_add_after .= "<div id='notify'></div>";
 

--- a/ext/ajax_maillink.php
+++ b/ext/ajax_maillink.php
@@ -6,8 +6,8 @@ declare(strict_types=1);
  * asynchronous mail and commentary polling.
  */
 global $jaxon;
-$s_js=($jaxon->getJs());
-$s_script=($jaxon->getScript());
+$s_js = $jaxon->getJs();
+$s_script = $jaxon->getScript();
 
 require __DIR__ . '/ajax_settings.php';
 $maillink_add_pre = $s_js . $s_script;

--- a/ext/ajax_process.php
+++ b/ext/ajax_process.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Entry point for processing Jaxon AJAX requests. Loads the
+ * lightweight environment, common settings and server callbacks,
+ * then passes control to the Jaxon engine.
+ */
 // File ajax_process.php
 define("OVERRIDE_FORCED_NAV",true);
 

--- a/ext/ajax_server.php
+++ b/ext/ajax_server.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Collection of server-side Jaxon callbacks used by the AJAX
+ * interface. Handles mail notifications, timeout warnings and
+ * commentary updates.
+ */
 /* you need to check if somebody timed out.
    if you call common.php and we have a timeout, he will the redirect to index.php?op=timeout, resulting in a full page
    which will (called in 1s intervals) download a lot of useless traffic to him and from your server
@@ -15,6 +21,12 @@ use Jaxon\Response\Response;          // and the Response class
 use Lotgd\Commentary;
 use function Jaxon\jaxon;
 
+/**
+ * Respond when a user's session has expired.
+ *
+ * @param bool $args Trigger flag from the client
+ * @return Response
+ */
 function mail_expired($args=false) {
 	if ($args===false) return;
 	chdir("..");
@@ -32,6 +44,12 @@ function mail_expired($args=false) {
 	return $objResponse;
 }
 
+/**
+ * Return mail and timeout status information for the active user.
+ *
+ * @param bool $args Trigger flag from the client
+ * @return Response
+ */
 function mail_status($args=false) {
 	global $start_timeout_show_seconds;
 	chdir("..");
@@ -72,6 +90,12 @@ function mail_status($args=false) {
 	return $objResponse;
 }
 
+/**
+ * Update last activity time and report remaining session timeout.
+ *
+ * @param bool $args Trigger flag from the client
+ * @return Response
+ */
 function timeout_status($args=false) {
 	global $start_timeout_show_seconds, $never_timeout_if_browser_open;
 	chdir("..");
@@ -96,6 +120,12 @@ function timeout_status($args=false) {
 }
 
 
+/**
+ * Retrieve a block of commentary for a given section.
+ *
+ * @param array|bool $args Parameter array from the client
+ * @return Response
+ */
 function commentary_text($args=false) {
 	global $session;
 	if ($args===false || !is_array($args)) return;
@@ -111,6 +141,13 @@ function commentary_text($args=false) {
        return $objResponse;
 }
 
+/**
+ * Return new commentary posts after a given comment ID.
+ *
+ * @param string $section The commentary section name
+ * @param int $lastId ID of the last comment already displayed
+ * @return Response
+ */
 function commentary_refresh(string $section, int $lastId) {
         global $session;
         $comments = [];

--- a/ext/ajax_server.php
+++ b/ext/ajax_server.php
@@ -27,7 +27,7 @@ use function Jaxon\jaxon;
  * @param bool $args Trigger flag from the client
  * @return Response
  */
-function mail_expired($args=false) {
+function mail_expired($args=false): Response {
 	if ($args===false) return;
 	chdir("..");
 	$new="Expired";

--- a/ext/ajax_settings.php
+++ b/ext/ajax_settings.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Configuration values controlling the AJAX polling behaviour for
+ * mail checks, timeouts and intervals. Adjust these values to tune
+ * the client-side update frequency.
+ */
 
 $mail_debug=0; //debug
 $never_timeout_if_browser_open=0;

--- a/ext/js/ajax_polling.js
+++ b/ext/js/ajax_polling.js
@@ -1,9 +1,23 @@
-// JavaScript used for AJAX mail and timeout checks
-// This file was extracted from ext/ajax_maillink.php
-var active_mail_interval;
-var active_comment_interval;
-var active_timeout_interval;
+"use strict";
 
+/**
+ * AJAX polling helpers.
+ *
+ * This module schedules periodic checks for new mail, commentary updates
+ * and session timeout status using Jaxon callbacks defined on the server.
+ * Timing values are injected by {@code ext/ajax_maillink.php} as global
+ * variables.
+ */
+
+var active_mail_interval;     // ID of the mail polling interval
+var active_comment_interval;  // ID of the commentary polling interval
+var active_timeout_interval;  // ID of the timeout polling interval
+
+/**
+ * Start periodic mail polling if the interval is configured.
+ * Invokes the {@code jaxon_mail_status} callback every
+ * {@code lotgd_mail_interval_ms} milliseconds.
+ */
 function set_mail_ajax() {
     if (typeof lotgd_mail_interval_ms === 'undefined') return;
     active_mail_interval = window.setInterval(function() {
@@ -13,6 +27,11 @@ function set_mail_ajax() {
     }, lotgd_mail_interval_ms);
 }
 
+/**
+ * Start periodic commentary refresh if the interval is configured.
+ * Calls the {@code jaxon_commentary_refresh} callback with the
+ * last known comment ID so only new posts are fetched.
+ */
 function set_comment_ajax() {
     if (typeof lotgd_comment_interval_ms === 'undefined') return;
     active_comment_interval = window.setInterval(function() {
@@ -22,6 +41,11 @@ function set_comment_ajax() {
     }, lotgd_comment_interval_ms);
 }
 
+/**
+ * Start periodic session timeout checks if the interval is configured.
+ * Calls the {@code jaxon_timeout_status} callback to determine how
+ * much time the user has left before being logged out.
+ */
 function set_timeout_ajax() {
     if (typeof lotgd_timeout_interval_ms === 'undefined') return;
     active_timeout_interval = window.setInterval(function() {
@@ -31,12 +55,19 @@ function set_timeout_ajax() {
     }, lotgd_timeout_interval_ms);
 }
 
+/**
+ * Stop all polling intervals. Used after the page unloads to avoid
+ * background polling when the user navigates away.
+ */
 function clear_ajax() {
     window.clearInterval(active_timeout_interval);
     window.clearInterval(active_mail_interval);
     window.clearInterval(active_comment_interval);
 }
 
+// Start polling once the DOM is ready using configuration variables
+// supplied by the server. Commentary and timeout checks only run
+// if the corresponding variables are present.
 $(function() {
     set_mail_ajax();
     if (typeof lotgd_comment_section !== 'undefined' && lotgd_comment_section) {

--- a/ext/lotgd_common.php
+++ b/ext/lotgd_common.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Lightweight loader for AJAX requests. It includes the standard
+ * game bootstrap and ensures allowed navigation is reloaded for
+ * asynchronous calls.
+ */
 // Lightweight loader for AJAX requests
 if (!defined('AJAX_MODE')) {
     define('AJAX_MODE', true);


### PR DESCRIPTION
## Summary
- enable strict typing in AJAX PHP scripts
- add file-level documentation comments
- document functions in ajax_server.php
- describe JavaScript module for mail AJAX handling
- rename mail_ajax.js to ajax_polling.js and document its helpers

## Testing
- `composer validate --no-interaction`


------
https://chatgpt.com/codex/tasks/task_e_686cf3167994832984cf2923da5735b7