### PR TITLE
Remove debug statement from mail link assembly

### DIFF
--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -875,7 +875,6 @@ public static function mailLinkTabText(){
 
         $mailHtml = '';
         if (isset($session['user']['acctid']) && $session['user']['acctid'] > 0 && $session['user']['loggedin']) {
-            debug($session);
             if (getsetting('ajax', 0) == 1 && isset($session['user']['prefs']['ajax']) && $session['user']['prefs']['ajax']) {
                 if (file_exists('ext/ajax_maillink.php')) {
                     require 'ext/ajax_maillink.php';


### PR DESCRIPTION
## Summary
- remove debugging line from `assembleMailLink`

## Testing
- `grep -n "debug($session)" -n src/Lotgd/PageParts.php`

------
https://chatgpt.com/codex/tasks/task_e_686d2f05f3a08329909ce94929c86658