### PR TITLE
Add Ajax rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Features of this fork include:
 - PHPMailer replacing the sendmail system
 - mail notifications that auto-refresh via Ajax
 - incremental chat updates via `commentary_refresh` to load new messages without reloading the page
+- Ajax requests are rate limited to roughly one per second; faster requests
+  receive an HTTP 429 response. Adjust `\$ajax_rate_limit_seconds` in
+  `ext/ajax_settings.php` to change the threshold
 - Composer integration for third-party modules
   - after modifying Composer settings, run `composer dump-autoload` to recognize new namespaces
   - after running `composer install` or `composer dump-autoload`, include `autoload.php` to load all dependencies

--- a/ext/ajax_process.php
+++ b/ext/ajax_process.php
@@ -12,7 +12,20 @@ require_once(__DIR__ . '/lotgd_common.php');
 require_once(__DIR__ . '/ajax_common.php');
 require_once(__DIR__ . '/ajax_server.php');
 
-// Call the Jaxon processing engine
-if($jaxon->canProcessRequest()) {
+// Simple rate limiting for Jaxon requests.  If an Ajax request arrives less
+// than the configured threshold after the previous one, we respond with HTTP 429 and skip
+// executing the handler.  The timestamp is only updated when the request is
+// accepted to avoid locking out legitimate retries.
+if ($jaxon->canProcessRequest()) {
+    $now       = microtime(true);
+    $threshold = $ajax_rate_limit_seconds; // from ajax_settings.php
+
+    if (isset($_SESSION['lastrequest']) && ($now - $_SESSION['lastrequest']) < $threshold) {
+        http_response_code(429);
+        echo 'Too Many Requests';
+        return;
+    }
+
+    $_SESSION['lastrequest'] = $now;
     $jaxon->processRequest();
 }

--- a/ext/ajax_settings.php
+++ b/ext/ajax_settings.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 $mail_debug=0; //debug
 $never_timeout_if_browser_open=0;
 
+// Minimum time in seconds between Ajax requests from the same session.
+$ajax_rate_limit_seconds = 1.0; // adjust to allow faster or slower polling
+
 if ($mail_debug==0) {
 	$check_mail_timeout_seconds = 10; 	// how often check for new mail
 	$check_timeout_seconds = 5;  		// how often checking for timeout


### PR DESCRIPTION
## Summary
- prevent spamming of `ext/ajax_process.php` by tracking last request time
- document the one-second Ajax rate limit in the README
- make Ajax rate limit configurable

## Testing
- `php -l ext/ajax_process.php`
- `composer validate --no-check-all --no-check-lock`


------
https://chatgpt.com/codex/tasks/task_e_686d2f1b503c83298a1f9916c9d756c8