### PR TITLE
Fix mail inbox

### DIFF
--- a/pages/mail/case_default.php
+++ b/pages/mail/case_default.php
@@ -33,9 +33,8 @@ if ($db_num_rows>0){
 	rawoutput("<td>".($sortorder=='name'?"<img src='images/shapes/$arrow' alt='$arrow'":"")."<a href='mail.php?sortorder=name&direction=".($sortorder=='name'?$newdirection:$sorting_direction)."'>$from</a></td>");
 	rawoutput("<td>".($sortorder=='date'?"<img src='images/shapes/$arrow' alt='$arrow'":"")."<a href='mail.php?sortorder=date&direction=".($sortorder=='date'?$newdirection:$sorting_direction)."'>$date</a></td>");
 	rawoutput("</tr>");
-	$from_list=array();
-	$rows=array();
-	$userlist=array();
+       $from_list=array();
+       $userlist=array();
 
         foreach ($rows as $row) {
                 if ($row['acctid']) {


### PR DESCRIPTION
## Summary
- remove the line that emptied `$rows` in `case_default.php`
- keep inbox messages available for rendering

## Testing
- `php -l pages/mail/case_default.php`


------
https://chatgpt.com/codex/tasks/task_e_686d363cf3748329810cb06bdf0662c8