### PR TITLE
Switch to modern legacy theme

### DIFF
--- a/home.php
+++ b/home.php
@@ -155,7 +155,7 @@ if (getsetting("homeskinselect", 1)) {
         if (isset($_COOKIE['template'])) {
                 $prefs['template'] = Template::addTypePrefix($_COOKIE['template']);
         } else {
-                $prefs['template'] = Template::addTypePrefix(getsetting("defaultskin", "yarbrough.htm"));
+                $prefs['template'] = Template::addTypePrefix(getsetting("defaultskin", "modern.htm"));
         }
         Forms::showForm($form, $prefs, true);
 	$submit = translate_inline("Choose");

--- a/prefs.php
+++ b/prefs.php
@@ -308,7 +308,7 @@ if ($op=="suicide" && getsetting("selfdelete",0)!=0) {
                 $prefs['template'] = Template::addTypePrefix($_COOKIE['template']);
         }
         if (!isset($prefs['template']) || $prefs['template'] == "") {
-                $prefs['template'] = Template::addTypePrefix(getsetting("defaultskin", "yarbrough.htm"));
+                $prefs['template'] = Template::addTypePrefix(getsetting("defaultskin", "modern.htm"));
         }
 	if (!isset($prefs['sexuality']) || $prefs['sexuality'] == "") {
 		$prefs['sexuality'] = !$session['user']['sex'];

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -84,14 +84,20 @@ class Template
         if ($templatename == '' || (!file_exists("templates/$templatename") && !is_dir("templates_twig/$templatename"))) {
             if (isset($settings) && $settings instanceof Settings) {
                 // If the settings object is available, use it to get the default skin
-                $templatename = $settings->getSetting('defaultskin', 'jade.htm');
+                $templatename = $settings->getSetting('defaultskin', 'modern.htm');
             } else {
                 // Fallback to a hardcoded default skin if settings are not available
-                $templatename = 'jade.htm';
+                $templatename = 'modern.htm';
+            }
+            if (strpos($templatename, ':') !== false) {
+                [$templateType, $templatename] = explode(':', $templatename, 2);
             }
         }
         if ($templatename == '' || (!file_exists("templates/$templatename") && !is_dir("templates_twig/$templatename"))) {
             $templatename = $_defaultskin;
+            if (strpos($templatename, ':') !== false) {
+                [$templateType, $templatename] = explode(':', $templatename, 2);
+            }
         }
 
         if ($templateType === 'twig' || is_dir("templates_twig/$templatename")) {
@@ -131,7 +137,7 @@ class Template
      * Load a template file and split it into sections.
      *
      * If the template doesn't exist, uses the admin-defined default template
-     * and then falls back to jade.htm.
+     * and then falls back to modern.htm.
      *
      * @param string $templatename Template file name
      *


### PR DESCRIPTION
## Summary
- default to the `modern` skin for legacy compatibility
- load the modern theme when no skin is configured
- update home and prefs fallbacks to use `modern` skin

## Testing
- `php -l settings.php`
- `php -l home.php`
- `php -l prefs.php`
- `php -l src/Lotgd/Template.php`


------
https://chatgpt.com/codex/tasks/task_e_686d398074f083299715899e3e5fabf2