### PR TITLE
Update timeout clearing

### DIFF
--- a/ext/js/ajax_polling.js
+++ b/ext/js/ajax_polling.js
@@ -122,6 +122,9 @@ function set_poll_ajax() {
  * background polling when the user navigates away.
  */
 function clear_ajax() {
+    if (typeof jaxon_timeout_status === 'function') {
+        jaxon_timeout_status(1);   // ensure final timeout message
+    }
     window.clearInterval(active_timeout_interval);
     window.clearInterval(active_mail_interval);
     window.clearInterval(active_comment_interval);


### PR DESCRIPTION
## Summary
- request a final timeout update before stopping AJAX polling

## Testing
- `php -l ext/ajax_settings.php`
- `php -l ext/js/ajax_polling.js`
- `node --check ext/js/ajax_polling.js`


------
https://chatgpt.com/codex/tasks/task_e_686d417609bc8329894d7764a896536a