### PR TITLE
Document modern template as default skin

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,10 @@ Want to have this running in no time?
 
 Twig templates reside in the `templates_twig/` directory. Each template should
 have its own folder containing a `config.json`, `page.twig`, and `popup.twig`.
-Set the template name via the `defaultskin` setting or a `template` cookie. If a
-matching folder is found, pages are rendered with Twig; classic `.htm` templates
-continue to work as before.
+The distribution includes the **modern** template and uses it as the default
+skin. You can switch to another template by changing the `defaultskin` setting
+or by setting a `template` cookie. If a matching folder is found, pages are
+rendered with Twig; classic `.htm` templates continue to work as before.
 Twig views receive variables for common placeholders like `nav`, `stats`, and
 `paypal`, allowing flexible layouts.
 Compiled Twig templates are cached under the directory defined by the

--- a/config/configuration.php
+++ b/config/configuration.php
@@ -11,7 +11,7 @@ $setup = array(
 	"This is a comma separated list the petitionsender can choose one point from. Use as many as you like - without colors,note",
 	"Enter languages here like this: `i(shortname 2 chars) comma (readable name of the language)`i and continue as long as you wish,note",
 	"serverlanguages"=>"Languages available on this server",
-	"defaultlanguage"=>"Default Language,enum,".getsetting("serverlanguages","en,English,fr,Français,dk,Danish,de,Deutsch,es,Español,it,Italian"),
+	"defaultlanguage"=>"Default Language,enum,".getsetting("serverlanguages","en,English,fr,FranÃ§ais,dk,Danish,de,Deutsch,es,EspaÃ±ol,it,Italian"),
 	"corenewspath"=>"Path and file to fetch the Core News for +nb Editions",
 	"edittitles"=>"Should DK titles be editable in user editor,bool",
 	"forcedmotdpopup"=>"Force a MOTD popup if an unseen motd is there?,bool",
@@ -45,7 +45,7 @@ $setup = array(
 	"homecurtime"=>"Should the current realm time be shown?,bool",
 	"homenewdaytime"=>"Should the time till newday be shown?,bool",
 	"homenewestplayer"=>"Should the newest player be shown?,bool",
-	"defaultskin"=>"What skin should be the default?,theme",
+	"defaultskin"=>"Which template should be the default? (ships with modern.htm),theme",
 	"listonlyonline"=>"Show Warriors List with only online folks (prevent paging)?,bool",
 	"impressum"=>"Tell the world something about the person running this server. (e.g. name and address),textarea",
 

--- a/settings.php
+++ b/settings.php
@@ -16,10 +16,9 @@ zlib.output_compression_level = 7
 for instance. And then do an "apache2 -k graceful" and check with phpinfo() to see if it worked.
 */
 
-/* The default skin which gets selected if you have NO skin accessible / configured or the database simply does not exist to select a default skin.
-
-This will also be used in cases of database outages and so forth
-
+/* The bundled **modern** template is used when no skin is configured or the
+database is unavailable. Change the template by adjusting the `defaultskin`
+setting in your game configuration.
 */
 $_defaultskin="modern.htm";
 

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -83,10 +83,11 @@ class Template
         }
         if ($templatename == '' || (!file_exists("templates/$templatename") && !is_dir("templates_twig/$templatename"))) {
             if (isset($settings) && $settings instanceof Settings) {
-                // If the settings object is available, use it to get the default skin
+                // Pull the skin from settings (the distribution ships with modern.htm).
+                // Administrators can change this via the 'defaultskin' setting.
                 $templatename = $settings->getSetting('defaultskin', 'modern.htm');
             } else {
-                // Fallback to a hardcoded default skin if settings are not available
+                // Use modern.htm when settings are unavailable
                 $templatename = 'modern.htm';
             }
             if (strpos($templatename, ':') !== false) {
@@ -137,7 +138,7 @@ class Template
      * Load a template file and split it into sections.
      *
      * If the template doesn't exist, uses the admin-defined default template
-     * and then falls back to modern.htm.
+     * (modern.htm by default) and then falls back to modern.htm.
      *
      * @param string $templatename Template file name
      *


### PR DESCRIPTION
## Summary
- mention in README that the distribution ships with the modern template enabled by default
- clarify how to change the default skin in `settings.php`
- update configuration description for `defaultskin`
- note modern template default in Template.php comments

## Testing
- `composer validate --no-check-publish`

------
https://chatgpt.com/codex/tasks/task_e_686d42ff343c8329851997c1b2f1a630