### PR TITLE
Add viewport and Bootstrap to Puritanic AI theme

### DIFF
--- a/templates_twig/puritanic_ai/page.twig
+++ b/templates_twig/puritanic_ai/page.twig
@@ -2,8 +2,10 @@
 <html>
 <head>
     <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ title }}</title>
     <link rel="stylesheet" href="{{ template_path }}/assets/style.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="/templates/common/colors.css"/>
     {{ headscript|raw }}{{ script|raw }}
 </head>
@@ -86,5 +88,6 @@
             </td>
         </tr>
     </table>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/templates_twig/puritanic_ai/popup.twig
+++ b/templates_twig/puritanic_ai/popup.twig
@@ -2,8 +2,10 @@
 <html>
 <head>
     <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ title }}</title>
     <link rel="stylesheet" href="{{ template_path }}/assets/style.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5/dist/css/bootstrap.min.css">
 </head>
 <body class="popup-body">
     <table class="layout-table" cellpadding="5" width="100%">
@@ -25,5 +27,6 @@
             <td class="trhead align-left">{{ copyright|raw }}</td>
         </tr>
     </table>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enhance Puritanic AI templates with responsive viewport
- include Bootstrap CSS and JS bundles for layout improvements

## Testing
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_686d50350f908329a4c8ecde035c79a7