### PR TITLE
Use Bootstrap grid for Puritanic AI layout

### DIFF
--- a/templates_twig/puritanic_ai/assets/style.css
+++ b/templates_twig/puritanic_ai/assets/style.css
@@ -23,14 +23,12 @@ td {
 
 /* Navigation Table */
 table.nav {
-    border: 1px solid #000000;
+    border: 1px solid #444;
     height: auto;
-    width: 182px;
 }
 
 .navhead {
     text-decoration: none;
-    width: 180px;
     height: auto;
     padding: 1px;
     float: left;
@@ -57,7 +55,7 @@ a {
 
 .main-content {
     border-style: dotted;
-    background-color: #2B2B2B;
+    background-color: #1e1e1e;
 }
 
 .sidebar-content {
@@ -86,7 +84,6 @@ a {
 a.nav {
     color: #FFFFFF;
     text-decoration: none;
-    width: 181px;
     height: auto;
     float: left;
     padding: 1px;
@@ -96,7 +93,6 @@ a.nav {
 
 .navhelp {
     text-decoration: none;
-    width: 181px;
     height: auto;
     padding: 1px;
     float: left;
@@ -114,7 +110,6 @@ select {
 table.vitalinfo {
     background-color: #333333;
     border: 1px solid #000000;
-    width: 182px;
 }
 
 a.motd {
@@ -204,7 +199,6 @@ td.charhead {
 }
 
 table.charinfo {
-    width: 182px;
     color: #FFFFFF;
     border: none;
     border-spacing: 0px;

--- a/templates_twig/puritanic_ai/page.twig
+++ b/templates_twig/puritanic_ai/page.twig
@@ -10,9 +10,9 @@
     {{ headscript|raw }}{{ script|raw }}
 </head>
 <body class="main-body">
-    <table class="layout-table" width="100%">
-        <tr>
-            <td>
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
                 <table class="layout-table noborder" width="100%">
                     <tr class="page-header">
                         <td class="noborder pageheader-left align-center">
@@ -30,41 +30,35 @@
                         </td>
                     </tr>
                 </table>
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <table class="layout-table" width="100%">
-                    <tr>
-                        <td width="200" class="sidebar-content valign-top">
-                            <div class="navad-wrapper">{{ navad|raw }}</div>
-                            <div class="nav-container" role="navigation">{{ nav|raw }}</div>
-                        </td>
-                        <td width="100%" class="main-content valign-top">
-                            <div class="verticalad-wrapper">{{ verticalad|raw }}</div>
-                            {{ bodyad|raw }}
-                            {{ content|raw }}
-                        </td>
-                        <td width="132" class="sidebar-content valign-top">
-                            {{ stats|raw }}
-                            <br>
-                            {{ paypal|raw }}
-                        </td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="3">
+            </div>
+        </div>
+        <div class="row">
+            <nav class="col-lg-2 sidebar-content valign-top">
+                <div class="navad-wrapper">{{ navad|raw }}</div>
+                <div class="nav-container" role="navigation">{{ nav|raw }}</div>
+            </nav>
+            <main class="col-12 col-lg-8 main-content valign-top">
+                <div class="verticalad-wrapper">{{ verticalad|raw }}</div>
+                {{ bodyad|raw }}
+                {{ content|raw }}
+            </main>
+            <aside class="col-lg-2 sidebar-content valign-top">
+                {{ stats|raw }}
+                <br>
+                {{ paypal|raw }}
+            </aside>
+        </div>
+        <div class="row">
+            <div class="col-12">
                 <table class="layout-table" width="100%" height="20">
                     <tr>
                         <td class="align-center"></td>
                     </tr>
                 </table>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="3">
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-12">
                 <table class="layout-table" width="100%">
                     <tr>
                         <td colspan="3" height="10" class="align-center"></td>
@@ -85,9 +79,9 @@
                         <td colspan="3" height="10" class="align-center"></td>
                     </tr>
                 </table>
-            </td>
-        </tr>
-    </table>
+            </div>
+        </div>
+    </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refactor Puritanic AI page layout to use Bootstrap grid
- drop fixed widths in the Puritanic AI stylesheet
- tweak theme colours

## Testing
- `composer install`

------
https://chatgpt.com/codex/tasks/task_e_686d56ce9f2c83298cdba1eab7de9b0b