### PR TITLE
Convert Puritanic AI login pages to Bootstrap

### DIFF
--- a/templates_twig/puritanic_ai/assets/style.css
+++ b/templates_twig/puritanic_ai/assets/style.css
@@ -231,8 +231,28 @@ td[class*="page-bottom"] {
     border-color: #000000 #888846 #888846 #000000;
 }
 
-.login-submit {
+.text-center {
     text-align: center;
+}
+
+.form-control {
+    display: block;
+    width: 100%;
+    padding: 2px 4px;
+    border: 1px solid #ced4da;
+    background-color: #000;
+    color: #CCCCCC;
+}
+
+.btn {
+    background-color: #222222;
+    color: #000000;
+    font-family: verdana, arial, helvetica, sans-serif;
+    font-size: 12px;
+    background-image: url(/templates/images/input.gif);
+    border: 1px solid;
+    border-color: #000000 #888846 #888846 #000000;
+    cursor: pointer;
 }
 
 /* Other Styles */

--- a/templates_twig/puritanic_ai/login.twig
+++ b/templates_twig/puritanic_ai/login.twig
@@ -1,19 +1,13 @@
-<table class="login-table" role='form'>
-    <tr>
-        <td class="noborder">
-            <table class="login-inner">
-                <tr>
-                    <td class="login-label">{{ username|raw }}:</td>
-                    <td class="login-label">{{ password|raw }}:</td>
-                </tr>
-                <tr>
-                    <td><input name='name' id='name' accesskey='u' size='10'></td>
-                    <td><input name='password' id='password' accesskey='p' type='password' size='10'></td>
-                </tr>
-                <tr>
-                    <td colspan='2' class="login-submit"><input type='submit' value='{{ button|raw }}' class='button'></td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-</table>
+<form class="row g-2" role="form" action="/login" method="post">
+    <div class="col-12 col-sm">
+        <label for="name" class="visually-hidden">{{ username|raw }}</label>
+        <input name="name" id="name" accesskey="u" size="10" class="form-control" placeholder="{{ username|raw }}" />
+    </div>
+    <div class="col-12 col-sm">
+        <label for="password" class="visually-hidden">{{ password|raw }}</label>
+        <input name="password" id="password" accesskey="p" type="password" size="10" class="form-control" placeholder="{{ password|raw }}" />
+    </div>
+    <div class="col-12 text-center">
+        <input type="submit" value="{{ button|raw }}" class="btn" />
+    </div>
+</form>

--- a/templates_twig/puritanic_ai/loginfull.twig
+++ b/templates_twig/puritanic_ai/loginfull.twig
@@ -1,11 +1,3 @@
-<table class="loginfull-table">
-    <tr>
-        <td class="noborder">
-            <table class="loginfull-inner">
-                <tr>
-                    <td class="server-full-message">Server Full!</td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-</table>
+<div class="alert alert-danger text-center" role="alert">
+    Server Full!
+</div>


### PR DESCRIPTION
## Summary
- style Puritanic AI login form using Bootstrap-like markup
- replace server-full table with alert markup
- add helper classes in the theme stylesheet

## Testing
- `composer validate --no-check-all --strict`
- `composer install`

------
https://chatgpt.com/codex/tasks/task_e_686d657f41c08329bb1ff1043111c55f