### PR TITLE
Simplify Puritanic AI CSS for Bootstrap

### DIFF
--- a/templates/puritanic_ai/puritanic_ai.css
+++ b/templates/puritanic_ai/puritanic_ai.css
@@ -25,19 +25,17 @@ td {
 
 /* Navigation Table */
 table.nav {
-	border: 1px solid #000000;
-	height: auto;
-	width: 182px;
+        border: 1px solid #000000;
+        height: auto;
 }
 
 .navhead {
-	text-decoration: none;
-	width: 180px;
-	height: auto;
-	padding: 1px;
-	float: left;
-	line-height: 33px;
-	clear: none;
+        text-decoration: none;
+        height: auto;
+        padding: 1px;
+        float: left;
+        line-height: 33px;
+        clear: none;
 	color: #FFFFFF;
 	cursor: default;
 	text-align: center;
@@ -62,15 +60,9 @@ a {
 	background-color: #2B2B2B;
 }
 
-.sidebar-content {
-	padding-left: 3px;
-	padding-right: 3px;
-}
-
 .pageheader-center,.pageheader-left,.pageheader-right {
-	width: 33.3%;
-	padding: 3px;
-	text-align: center;
+        padding: 3px;
+        text-align: center;
 }
 
 .pageheader-left {
@@ -86,23 +78,21 @@ a {
 
 /* Navigation Link */
 a.nav {
-	color: #FFFFFF;
-	text-decoration: none;
-	width: 181px;
-	height: auto;
-	float: left;
-	padding: 1px;
-	clear: none;
-	text-align: center;
+        color: #FFFFFF;
+        text-decoration: none;
+        height: auto;
+        float: left;
+        padding: 1px;
+        clear: none;
+        text-align: center;
 }
 
 .navhelp {
-	text-decoration: none;
-	width: 181px;
-	height: auto;
-	padding: 1px;
-	float: left;
-	clear: none;
+        text-decoration: none;
+        height: auto;
+        padding: 1px;
+        float: left;
+        clear: none;
 }
 
 /* Translations and others */
@@ -113,9 +103,8 @@ select {
 	color: #CCCCCC;
 }
 table.vitalinfo {
-	background-color: #333333;
-	border: 1px solid #000000;
-	width: 182px;
+        background-color: #333333;
+        border: 1px solid #000000;
 }
 a.motd {
 	text-decoration: none;
@@ -154,10 +143,9 @@ td.nav a.t {
 }
 
 a.t {
-	width: 7px;
-	height: 7px;
-	border: 1px dotted #FFFFFF;
-	background-color: #999;
+        height: 7px;
+        border: 1px dotted #FFFFFF;
+        background-color: #999;
 	color: #FFF;
 	font-size: 7px;
 	text-decoration: none;
@@ -166,9 +154,8 @@ a.t {
 }
 
 a.thot {
-	width: 7px;
-	height: 7px;
-	border: 1px dotted #FFFFFF;
+        height: 7px;
+        border: 1px dotted #FFFFFF;
 	background-color: #666666;
 	color: #FFFFFF;
 	font-size: 7px;
@@ -201,10 +188,9 @@ td.charhead {
 }
 
 table.charinfo {
-	width: 182px;
-	color: #FFFFFF;
-	border: none;
-	border-spacing: 0px;
+        color: #FFFFFF;
+        border: none;
+        border-spacing: 0px;
 }
 
 td.charinfo {

--- a/templates_twig/puritanic_ai/assets/style.css
+++ b/templates_twig/puritanic_ai/assets/style.css
@@ -58,13 +58,7 @@ a {
     background-color: #1e1e1e;
 }
 
-.sidebar-content {
-    padding-left: 3px;
-    padding-right: 3px;
-}
-
 .pageheader-center, .pageheader-left, .pageheader-right {
-    width: 33.3%;
     padding: 3px;
     text-align: center;
 }
@@ -152,7 +146,6 @@ td.nav a.t {
 }
 
 a.t {
-    width: 7px;
     height: 7px;
     border: 1px dotted #FFFFFF;
     background-color: #999;
@@ -164,7 +157,6 @@ a.t {
 }
 
 a.thot {
-    width: 7px;
     height: 7px;
     border: 1px dotted #FFFFFF;
     background-color: #666666;
@@ -237,7 +229,6 @@ td[class*="page-bottom"] {
 
 .form-control {
     display: block;
-    width: 100%;
     padding: 2px 4px;
     border: 1px solid #ced4da;
     background-color: #000;
@@ -332,23 +323,32 @@ table.petition-count {
     position: relative;
     top: -15px;
     text-align: center;
+    margin-bottom: .5rem;
 }
 
 .verticalad-wrapper {
     float: right;
+    margin-left: 1rem;
 }
 
 .nav-container {
     text-align: center;
 }
 
-.layout-table {
-    width: 100%;
-    border-collapse: collapse;
-    border-spacing: 0;
-}
 
 .clear {
     clear: both;
     display: block;
+}
+
+@media (max-width: 992px) {
+    .navad-wrapper {
+        top: 0;
+        margin-bottom: 1rem;
+    }
+    .verticalad-wrapper {
+        float: none;
+        margin: 1rem 0;
+        text-align: center;
+    }
 }

--- a/templates_twig/puritanic_ai/page.twig
+++ b/templates_twig/puritanic_ai/page.twig
@@ -13,14 +13,14 @@
     <div class="container-fluid">
         <div class="row">
             <div class="col-12">
-                <table class="layout-table noborder" width="100%">
+                <table class="noborder">
                     <tr class="page-header">
                         <td class="noborder pageheader-left align-center">
                             <button class="btn btn-secondary d-lg-none me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNav" aria-controls="offcanvasNav" aria-label="Open navigation menu">&#9776;</button>
                             <table>
                                 <tr>
-                                    <td class="noborder motd align-left valign-bottom" width="50%">&nbsp;&nbsp;<strong>{{ motd|raw }}</strong></td>
-                                    <td class="noborder align-right valign-bottom" width="50%"><strong>{{ petition|raw }}</strong></td>
+                                    <td class="noborder motd align-left valign-bottom">&nbsp;&nbsp;<strong>{{ motd|raw }}</strong></td>
+                                    <td class="noborder align-right valign-bottom"><strong>{{ petition|raw }}</strong></td>
                                 </tr>
                             </table>
                         </td>
@@ -35,7 +35,7 @@
             </div>
         </div>
         <div class="row">
-            <nav class="col-lg-2 sidebar-content valign-top d-none d-lg-block">
+            <nav class="col-lg-2 valign-top d-none d-lg-block">
                 <div class="navad-wrapper">{{ navad|raw }}</div>
                 <div class="nav-container" role="navigation">{{ nav|raw }}</div>
             </nav>
@@ -44,7 +44,7 @@
                 {{ bodyad|raw }}
                 {{ content|raw }}
             </main>
-            <aside class="col-lg-2 sidebar-content valign-top d-none d-lg-block">
+            <aside class="col-lg-2 valign-top d-none d-lg-block">
                 {{ stats|raw }}
                 <br>
                 {{ paypal|raw }}
@@ -52,7 +52,7 @@
         </div>
         <div class="row">
             <div class="col-12">
-                <table class="layout-table" width="100%" height="20">
+                <table class="w-100" height="20">
                     <tr>
                         <td class="align-center"></td>
                     </tr>
@@ -61,21 +61,21 @@
         </div>
         <div class="row">
             <div class="col-12">
-                <table class="layout-table" width="100%">
+                <table class="w-100">
                     <tr>
                         <td colspan="3" height="10" class="align-center"></td>
                     </tr>
                     <tr>
-                        <td width="12"></td>
+                        <td></td>
                         <td class="valign-top">
-                            <table class="layout-table colOtWhite" width="100%">
+                            <table class="colOtWhite w-100">
                                 <tr>
                                     <td class="valign-top">{{ copyright|raw }}<br/>Design: Puritanic AI theme <a href="https://shinobilegends.com">shinobilegends.com</a></td>
                                     <td class="valign-top align-right">{{ source|raw }}<br />{{ version }}<br />({{ pagegen|raw }})</td>
                                 </tr>
                             </table>
                         </td>
-                        <td width="12"></td>
+                        <td></td>
                     </tr>
                     <tr>
                         <td colspan="3" height="10" class="align-center"></td>

--- a/templates_twig/puritanic_ai/popup.twig
+++ b/templates_twig/puritanic_ai/popup.twig
@@ -8,10 +8,10 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5/dist/css/bootstrap.min.css">
 </head>
 <body class="popup-body">
-    <table class="layout-table" cellpadding="5" width="100%">
+    <table class="w-100" cellpadding="5">
         <tr>
             <td colspan="2" class="pageheader popup-header">
-                <table class="layout-table noborder" width="100%">
+                <table class="noborder w-100">
                     <tr>
                         <td class="noborder"><strong>{{ title }}</strong><div class="verticalad-wrapper"></div></td>
                     </tr>
@@ -19,7 +19,7 @@
             </td>
         </tr>
         <tr>
-            <td width="100%" class="main-content valign-top">
+            <td class="main-content valign-top">
                 {{ content|raw }}
             </td>
         </tr>


### PR DESCRIPTION
## Summary
- drop unused layout-table and sidebar-content classes
- rely on Bootstrap width utilities
- add responsive tweaks for ads

## Testing
- `composer validate --no-check-all --strict`

------
https://chatgpt.com/codex/tasks/task_e_686d6832aed88329947c9444773dfb73