### PR TITLE
Style offcanvas panels with dark background

### DIFF
--- a/templates_twig/puritanic_ai/assets/style.css
+++ b/templates_twig/puritanic_ai/assets/style.css
@@ -352,3 +352,9 @@ table.petition-count {
         text-align: center;
     }
 }
+
+.offcanvas-header,
+.offcanvas-body {
+    background-color: #000;
+    color: #ccc;
+}


### PR DESCRIPTION
## Summary
- style puritanic AI offcanvas header and body with dark color scheme

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686d792db0248329862377d498cdfbf9