### PR TITLE
Clean placeholders in login form

### DIFF
--- a/templates_twig/puritanic_ai/login.twig
+++ b/templates_twig/puritanic_ai/login.twig
@@ -1,11 +1,11 @@
 <form class="row g-2" role="form" action="/login" method="post">
     <div class="col-12 col-sm">
-        <label for="name" class="visually-hidden">{{ username|raw }}</label>
-        <input name="name" id="name" accesskey="u" size="10" class="form-control" placeholder="{{ username|raw }}" />
+    <label for="name" class="visually-hidden">{{ username|raw }}</label>
+    <input name="name" id="name" accesskey="u" size="10" class="form-control" placeholder="{{ username|striptags }}" autocomplete="username" />
     </div>
     <div class="col-12 col-sm">
-        <label for="password" class="visually-hidden">{{ password|raw }}</label>
-        <input name="password" id="password" accesskey="p" type="password" size="10" class="form-control" placeholder="{{ password|raw }}" />
+    <label for="password" class="visually-hidden">{{ password|raw }}</label>
+    <input name="password" id="password" accesskey="p" type="password" size="10" class="form-control" placeholder="{{ password|striptags }}" autocomplete="password" />
     </div>
     <div class="col-12 text-center">
         <button type="submit" class="btn">{{ button|raw }}</button>


### PR DESCRIPTION
## Summary
- sanitize placeholders in Puritanic login form
- add autocomplete attributes for better browser autocompletion

## Testing
- `composer validate --no-check-all --strict`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d7b2cfbc88329935f9bc291357394