### PR TITLE
Update puritanic header alignment

### DIFF
--- a/templates_twig/puritanic_ai/page.twig
+++ b/templates_twig/puritanic_ai/page.twig
@@ -15,7 +15,7 @@
             <div class="col-12">
                 <table class="noborder w-100">
                     <tr class="page-header">
-                        <td class="noborder pageheader-left align-center">
+                        <td class="noborder pageheader-left align-center valign-top">
                             <button class="btn btn-secondary d-lg-none me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNav" aria-controls="offcanvasNav" aria-label="Open navigation menu">&#9776;</button>
                             <table>
                                 <tr>
@@ -25,7 +25,7 @@
                             </table>
                         </td>
                         <td class="noborder pageheader-center align-center">{{ title }}</td>
-                        <td class="noborder pageheader-right">
+                        <td class="noborder pageheader-right valign-top">
                             <button class="btn btn-secondary d-lg-none me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasStats" aria-controls="offcanvasStats">&#128202;</button>
                             <img src="{{ template_path }}/assets/mail.gif" width="24" height="19" alt="Mail"><strong>{{ mail|raw }}</strong>&nbsp;&nbsp;
                             {{ petitiondisplay|raw }}


### PR DESCRIPTION
## Summary
- align navigation and stats header cells at top of their container

## Testing
- `composer validate --no-check-all --strict`

------
https://chatgpt.com/codex/tasks/task_e_686d7dbb34c4832995f02772cba44973