### PR TITLE
Refactor runmodule

### DIFF
--- a/runmodule.php
+++ b/runmodule.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // translator ready
 // addnews ready
 // mail ready
@@ -6,16 +7,20 @@
 define("ALLOW_ANONYMOUS",true);
 define("OVERRIDE_FORCED_NAV",true);
 
-use Lotgd\DumpItem;
-require_once("lib/http.php");
+use Lotgd\Http;
+use Lotgd\Modules;
+use Lotgd\Nav\VillageNav;
+use Lotgd\ForcedNavigation;
+use Lotgd\DateTime;
 
 require_once("common.php");
-require_once("lib/modules.php");
-require_once("lib/villagenav.php");
-require_once("lib/forcednavigation.php");
 
-if (injectmodule(httpget('module'), (httpget('admin')?true:false))){
-	$info = get_module_info(httpget('module'));
+// Determine which module should be executed
+$module = (string) Http::get('module');
+
+// Load and execute the requested module if it exists and is active
+if (Modules::inject($module, Http::get('admin') ? true : false)){
+        $info = Modules::getModuleInfo($module);
 	if (!isset($info['allowanonymous'])){
 		$allowanonymous=false;
 	}else{
@@ -26,13 +31,15 @@ if (injectmodule(httpget('module'), (httpget('admin')?true:false))){
 	}else{
 		$override_forced_nav=$info['override_forced_nav'];
 	}
-	do_forced_nav($allowanonymous,$override_forced_nav);
+        // Check for any navigation overrides or login requirements
+        ForcedNavigation::doForcedNav($allowanonymous, $override_forced_nav);
 
-	$starttime = getmicrotime();
+        // Execute the module run function and measure execution time
+        $starttime = DateTime::getMicroTime();
 	$fname = $mostrecentmodule."_run";
 	tlschema("module-$mostrecentmodule");
 	$fname();
-	$endtime = getmicrotime();
+        $endtime = DateTime::getMicroTime();
 	if (($endtime - $starttime >= 1.00 && ($session['user']['superuser'] & SU_DEBUG_OUTPUT))){
 		//On a side note, you won't ever see this text. A normal module calls page_footer(), which ends execution here....
 		debug("Slow Module (".round($endtime-$starttime,2)."s): $mostrecentmodule`n");
@@ -42,21 +49,22 @@ if (injectmodule(httpget('module'), (httpget('admin')?true:false))){
 			"duration"=>round($endtime-$starttime,5),
 			);
 		//remember, this gets only called if you're a user with debug output triggering this!
-		modulehook("modules_slowmodule",$stats);
+                Modules::hook("modules_slowmodule", $stats);
 	}
 	tlschema();
 }else{
-	do_forced_nav(false,false);
+        // The requested module was not found; redirect appropriately
+        ForcedNavigation::doForcedNav(false, false);
 
-	tlschema("badnav");
+        tlschema("badnav");
 
-	page_header("Error");
-	if ($session['user']['loggedin']){
-		villagenav();
+        page_header("Error");
+        if ($session['user']['loggedin']){
+                VillageNav::render();
 	}else{
 		addnav("L?Return to the Login","index.php");
 	}
 	output("You are attempting to use a module which is no longer active, or has been uninstalled.");
-	page_footer();
+        page_footer();
 }
-?>
+


### PR DESCRIPTION
## Summary
- modernize `runmodule.php`
- replace legacy `lib/` function calls with new namespaces
- document the runtime flow and enable strict types
- remove trailing PHP closing tag

## Testing
- `php -l runmodule.php`


------
https://chatgpt.com/codex/tasks/task_e_687023cc613c83299f6cfdc01889f369