### PR TITLE
Sanitize template cookie handling

### DIFF
--- a/home.php
+++ b/home.php
@@ -9,11 +9,10 @@ use Lotgd\TwigTemplate;
 // mail ready
 
 if (isset($_POST['template'])){
-	$skin = $_POST['template'];
-	if ($skin > "") {
-		setcookie("template",$skin ,strtotime("+45 days"));
-		$_COOKIE['template']=$skin;
-	}
+        $skin = $_POST['template'];
+        if ($skin > "") {
+                Template::setTemplateCookie($skin);
+        }
 }
 
 define("ALLOW_ANONYMOUS",true);
@@ -151,9 +150,10 @@ output("`c`2Game server running version: `@%s`0`c", $logd_version);
 if (getsetting("homeskinselect", 1)) {
 	rawoutput("<form action='home.php' method='POST'>");
 	rawoutput("<table align='center'><tr><td>");
-	$form = array("template"=>"Choose a different display skin:,theme");
-        if (isset($_COOKIE['template'])) {
-                $prefs['template'] = Template::addTypePrefix($_COOKIE['template']);
+        $form = array("template"=>"Choose a different display skin:,theme");
+        $cookieTemplate = Template::getTemplateCookie();
+        if ($cookieTemplate !== '') {
+                $prefs['template'] = Template::addTypePrefix($cookieTemplate);
         } else {
                 $prefs['template'] = Template::addTypePrefix(getsetting("defaultskin", DEFAULT_TEMPLATE));
         }

--- a/prefs.php
+++ b/prefs.php
@@ -10,8 +10,7 @@ require_once("lib/http.php");
 
 $skin = httppost('template');
 if ($skin > "") {
-	setcookie("template",$skin,strtotime("+45 days"));
-	$_COOKIE['template']=$skin;
+        Template::setTemplateCookie($skin);
 }
 
 require_once("lib/villagenav.php");
@@ -304,8 +303,9 @@ if ($op=="suicide" && getsetting("selfdelete",0)!=0) {
 	//
 	$prefs = $session['user']['prefs'];
 	$prefs['bio'] = $session['user']['bio'];
-        if (isset($_COOKIE['template'])) {
-                $prefs['template'] = Template::addTypePrefix($_COOKIE['template']);
+        $cookieTemplate = Template::getTemplateCookie();
+        if ($cookieTemplate !== '') {
+                $prefs['template'] = Template::addTypePrefix($cookieTemplate);
         }
         if (!isset($prefs['template']) || $prefs['template'] == "") {
                 $prefs['template'] = Template::addTypePrefix(getsetting("defaultskin", DEFAULT_TEMPLATE));

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -141,7 +141,7 @@ class Template
      */
     public static function setTemplateCookie(string $template): void
     {
-        $template = preg_replace('/[^a-zA-Z0-9:_-]/', '', $template);
+        $template = preg_replace(self::SANITIZATION_REGEX, '', $template);
         if ($template === '') {
             setcookie('template', '', time() - 3600); // Expire the cookie
             unset($_COOKIE['template']); // Unset the cookie value in the current request

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -143,6 +143,8 @@ class Template
     {
         $template = preg_replace('/[^a-zA-Z0-9:_-]/', '', $template);
         if ($template === '') {
+            setcookie('template', '', time() - 3600); // Expire the cookie
+            unset($_COOKIE['template']); // Unset the cookie value in the current request
             return;
         }
 

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -69,14 +69,12 @@ class Template
         }
 
         global $templatename, $templatemessage, $template, $session, $y, $z, $y2, $z2, $copyright, $lc, $x, $templatetags;
-        if (!isset($_COOKIE['template'])) {
-            $_COOKIE['template'] = '';
-        }
         $templatename = '';
         $templateType = '';
         $templatemessage = '';
-        if ($_COOKIE['template'] != '') {
-            $templatename = $_COOKIE['template'];
+        $cookieTemplate = self::getTemplateCookie();
+        if ($cookieTemplate !== '') {
+            $templatename = $cookieTemplate;
         }
         if (strpos($templatename, ':') !== false) {
             [$templateType, $templatename] = explode(':', $templatename, 2);
@@ -132,6 +130,36 @@ class Template
         }
 
         return 'legacy:' . $template;
+    }
+
+    /**
+     * Set the template cookie after sanitizing the value.
+     *
+     * @param string $template User provided template name
+     *
+     * @return void
+     */
+    public static function setTemplateCookie(string $template): void
+    {
+        $template = preg_replace('/[^a-zA-Z0-9:_-]/', '', $template);
+        if ($template === '') {
+            return;
+        }
+
+        setcookie('template', $template, strtotime('+45 days'));
+        $_COOKIE['template'] = $template;
+    }
+
+    /**
+     * Get the sanitized template cookie value.
+     *
+     * @return string Sanitized template value or empty string
+     */
+    public static function getTemplateCookie(): string
+    {
+        $template = $_COOKIE['template'] ?? '';
+
+        return preg_replace('/[^a-zA-Z0-9:_-]/', '', $template);
     }
 
     /**


### PR DESCRIPTION
## Summary
- provide `Template::setTemplateCookie()` and `Template::getTemplateCookie()` helpers
- use these functions in `home.php`, `prefs.php`, and `Template::prepareTemplate`
- sanitize template cookie values to avoid injection or path traversal

## Testing
- `php -l src/Lotgd/Template.php`
- `php -l home.php`
- `php -l prefs.php`


------
https://chatgpt.com/codex/tasks/task_e_6870373907d083299cc67a4992d0bea7