### PR TITLE
Fix template cookie sanitization

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -165,7 +165,7 @@ class Template
     {
         $template = $_COOKIE['template'] ?? '';
 
-        return preg_replace(SANITIZATION_REGEX, '', $template);
+        return preg_replace(self::SANITIZATION_REGEX, '', $template);
     }
 
     /**

--- a/tests/TemplateHelperTest.php
+++ b/tests/TemplateHelperTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Lotgd\Template;
+
+final class TemplateHelperTest extends TestCase
+{
+    public function testSanitizesTemplateCookie(): void
+    {
+        $_COOKIE['template'] = '../foo';
+        $result = Template::getTemplateCookie();
+        $this->assertSame('foo', $result);
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize template cookie by referencing the class constant
- add PHPUnit configuration
- add regression test for Template helper

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6870b36705e88329becd8d3aac4eae81