### PR TITLE
Validate template selection

### DIFF
--- a/home.php
+++ b/home.php
@@ -8,9 +8,9 @@ use Lotgd\TwigTemplate;
 // addnews ready
 // mail ready
 
-if (isset($_POST['template'])){
+if (isset($_POST['template'])) {
         $skin = $_POST['template'];
-        if ($skin > "") {
+        if ($skin !== '' && Template::isValidTemplate($skin)) {
                 Template::setTemplateCookie($skin);
         }
 }

--- a/prefs.php
+++ b/prefs.php
@@ -9,7 +9,7 @@ require_once("common.php");
 require_once("lib/http.php");
 
 $skin = httppost('template');
-if ($skin > "") {
+if ($skin !== '' && Template::isValidTemplate($skin)) {
         Template::setTemplateCookie($skin);
 }
 

--- a/tests/TemplateHelperTest.php
+++ b/tests/TemplateHelperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use Lotgd\Template;
+require_once __DIR__ . '/../config/constants.php';
 
 final class TemplateHelperTest extends TestCase
 {
@@ -12,5 +13,16 @@ final class TemplateHelperTest extends TestCase
         $_COOKIE['template'] = '../foo';
         $result = Template::getTemplateCookie();
         $this->assertSame('foo', $result);
+    }
+
+    public function testDefaultTemplateIsAvailable(): void
+    {
+        $templates = Template::getAvailableTemplates();
+        $this->assertArrayHasKey(DEFAULT_TEMPLATE, $templates);
+    }
+
+    public function testInvalidTemplateIsRejected(): void
+    {
+        $this->assertFalse(Template::isValidTemplate('nonexistent-template'));
     }
 }


### PR DESCRIPTION
## Summary
- validate template selections before saving
- expose list of allowed templates and helper to verify
- cover template helpers with tests
- use strict non-empty check for skin

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6870b85b9bf8832987ae3429328c84b5