### PR TITLE
Secure cookie flags

### DIFF
--- a/common.php
+++ b/common.php
@@ -375,19 +375,21 @@ else
 $session['bufflist'] = array();
 if (!is_array($session['bufflist'])) $session['bufflist']=array();
 if (isset($REMOTE_ADDR)) $session['user']['lastip']=$REMOTE_ADDR;   //cron i.e. doesn't have an $REMOTE_ADDR
+$secure = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+    || (($_SERVER['SERVER_PORT'] ?? 80) == 443);
 if (!isset($_COOKIE['lgi']) || strlen($_COOKIE['lgi'])<32){
-	if (!isset($session['user']['uniqueid']) || strlen($session['user']['uniqueid'])<32){
-		$u=md5(microtime());
-		setcookie("lgi",$u,strtotime("+365 days"));
-		$_COOKIE['lgi']=$u;
-		$session['user']['uniqueid']=$u;
-	}else{
-		if (isset($session['user']['uniqueid'])) setcookie("lgi",$session['user']['uniqueid'],strtotime("+365 days"));
-	}
+        if (!isset($session['user']['uniqueid']) || strlen($session['user']['uniqueid'])<32){
+                $u=md5(microtime());
+                setcookie("lgi",$u,strtotime("+365 days"), '/', '', $secure, true);
+                $_COOKIE['lgi']=$u;
+                $session['user']['uniqueid']=$u;
+        }else{
+                if (isset($session['user']['uniqueid'])) setcookie("lgi",$session['user']['uniqueid'],strtotime("+365 days"), '/', '', $secure, true);
+        }
 }else{
-	if (isset($_COOKIE['lgi']) && $_COOKIE['lgi']!='') {
-		$session['user']['uniqueid']=$_COOKIE['lgi'];
-	} 
+        if (isset($_COOKIE['lgi']) && $_COOKIE['lgi']!='') {
+                $session['user']['uniqueid']=$_COOKIE['lgi'];
+        }
 }
 if (isset($_SERVER['SERVER_NAME'])) {
 	$url = "http://".$_SERVER['SERVER_NAME'].dirname($_SERVER['REQUEST_URI']);

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -146,13 +146,16 @@ class Template
     public static function setTemplateCookie(string $template): void
     {
         $template = preg_replace(self::SANITIZATION_REGEX, '', $template);
+        $secure  = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+            || (($_SERVER['SERVER_PORT'] ?? 80) == 443);
+
         if ($template === '') {
-            setcookie('template', '', time() - 3600); // Expire the cookie
+            setcookie('template', '', time() - 3600, '/', '', $secure, true); // Expire the cookie
             unset($_COOKIE['template']); // Unset the cookie value in the current request
             return;
         }
 
-        setcookie('template', $template, strtotime('+45 days'));
+        setcookie('template', $template, strtotime('+45 days'), '/', '', $secure, true);
         $_COOKIE['template'] = $template;
     }
 


### PR DESCRIPTION
## Summary
- set cookies for the template with secure and httponly flags
- apply the same flags to the login cookie

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870bfc098888329a10aab22be68182c