### PR TITLE
Centralize lgi cookie management

### DIFF
--- a/common.php
+++ b/common.php
@@ -18,6 +18,7 @@ use Lotgd\Redirect;
 use Lotgd\Template;
 use Lotgd\MySQL\Database;
 use Lotgd\DateTime;
+use Lotgd\Cookies;
 // translator ready
 // addnews ready
 // mail ready
@@ -375,32 +376,19 @@ else
 $session['bufflist'] = array();
 if (!is_array($session['bufflist'])) $session['bufflist']=array();
 if (isset($REMOTE_ADDR)) $session['user']['lastip']=$REMOTE_ADDR;   //cron i.e. doesn't have an $REMOTE_ADDR
-$secure = \Lotgd\ServerFunctions::isSecureConnection();
-if (!isset($_COOKIE['lgi']) || strlen($_COOKIE['lgi'])<32){
-        if (!isset($session['user']['uniqueid']) || strlen($session['user']['uniqueid'])<32){
-                $u=md5(microtime());
-                setcookie("lgi", $u, [
-                    'expires'  => strtotime("+365 days"),
-                    'path'     => '/',
-                    'secure'   => $secure,
-                    'httponly' => true,
-                    'samesite' => 'Lax',
-                ]);
-                $_COOKIE['lgi']=$u;
-                $session['user']['uniqueid']=$u;
-        }else{
-                if (isset($session['user']['uniqueid'])) setcookie("lgi", $session['user']['uniqueid'], [
-                    'expires'  => strtotime("+365 days"),
-                    'path'     => '/',
-                    'secure'   => $secure,
-                    'httponly' => true,
-                    'samesite' => 'Lax',
-                ]);
+$cookieId = Cookies::getLgi();
+if ($cookieId === null) {
+        if (!isset($session['user']['uniqueid']) || strlen($session['user']['uniqueid']) < 32) {
+                $u = md5(microtime());
+                Cookies::setLgi($u);
+                $session['user']['uniqueid'] = $u;
+        } else {
+                if (isset($session['user']['uniqueid'])) {
+                        Cookies::setLgi($session['user']['uniqueid']);
+                }
         }
-}else{
-        if (isset($_COOKIE['lgi']) && $_COOKIE['lgi']!='') {
-                $session['user']['uniqueid']=$_COOKIE['lgi'];
-        }
+} else {
+        $session['user']['uniqueid'] = $cookieId;
 }
 if (isset($_SERVER['SERVER_NAME'])) {
 	$url = "http://".$_SERVER['SERVER_NAME'].dirname($_SERVER['REQUEST_URI']);

--- a/create.php
+++ b/create.php
@@ -10,6 +10,7 @@ use Lotgd\CheckBan;
 use Lotgd\Settings;
 use Lotgd\Sanitize;
 use Lotgd\DebugLog;
+use Lotgd\Cookies;
 require_once("common.php");
 require_once("lib/is_email.php");
 // legacy wrapper removed, instantiate settings directly
@@ -296,7 +297,7 @@ if (getsetting("allowcreation",1)==0){
 					$sql = "INSERT INTO " . db_prefix("accounts") . "
 						(playername,name, superuser, title, password, sex, login, laston, uniqueid, lastip, gold, location, emailaddress, emailvalidation, referer, regdate,badguy,allowednavs,specialinc,specialmisc,bufflist,dragonpoints,replaceemail,forgottenpassword,prefs,hauntedby,donationconfig,bio,ctitle,companions)
 						VALUES
-						('$shortname','$title $shortname', '".getsetting("defaultsuperuser",0)."', '$title', '$dbpass', '$sex', '$shortname', '".date("Y-m-d H:i:s",strtotime("-1 day"))."', '".(isset($_COOKIE['lgi'])?$_COOKIE['lgi']:'')."', '".$_SERVER['REMOTE_ADDR']."', ".getsetting("newplayerstartgold",50).", '".addslashes(getsetting('villagename', LOCATION_FIELDS))."', '$email', '$emailverification', '$referer', NOW(),'','','','','',0,'','','','','','','','')";
+						('$shortname','$title $shortname', '".getsetting("defaultsuperuser",0)."', '$title', '$dbpass', '$sex', '$shortname', '".date("Y-m-d H:i:s",strtotime("-1 day"))."', '".(Cookies::getLgi() ?? '')."', '".$_SERVER['REMOTE_ADDR']."', ".getsetting("newplayerstartgold",50).", '".addslashes(getsetting('villagename', LOCATION_FIELDS))."', '$email', '$emailverification', '$referer', NOW(),'','','','','',0,'','','','','','','','')";
 					db_query($sql);
 					if (db_affected_rows(LINK)<=0){
 						output("`\$Error`^: Your account was not created for an unknown reason, please try again. ");

--- a/home.php
+++ b/home.php
@@ -5,6 +5,7 @@ use Lotgd\Nav;
 use Lotgd\Http;
 use Lotgd\Template;
 use Lotgd\TwigTemplate;
+use Lotgd\Cookies;
 // addnews ready
 // mail ready
 
@@ -94,10 +95,10 @@ if ($onlinecount<getsetting("maxonline",0) || getsetting("maxonline",0)==0){
 		if (!isset($session['message'])) $session['message']='';
 		$session['message'].= translate_inline(" Your session has timed out, you must log in again.`n");
 	}
-	if (!isset($_COOKIE['lgi'])){
-		$session['message'].=translate_inline("It appears that you may be blocking cookies from this site.  At least session cookies must be enabled in order to use this site.`n");
-		$session['message'].=translate_inline("`b`#If you are not sure what cookies are, please <a href='http://en.wikipedia.org/wiki/WWW_browser_cookie'>read this article</a> about them, and how to enable them.`b`n");
-	}
+        if (Cookies::getLgi() === null){
+                $session['message'].=translate_inline("It appears that you may be blocking cookies from this site.  At least session cookies must be enabled in order to use this site.`n");
+                $session['message'].=translate_inline("`b`#If you are not sure what cookies are, please <a href='http://en.wikipedia.org/wiki/WWW_browser_cookie'>read this article</a> about them, and how to enable them.`b`n");
+        }
 	if (isset($session['message']) && $session['message']>"")
 		output_notl("`b`\$%s`b`n", $session['message'],true);
 	rawoutput("<script language='JavaScript' src='lib/md5.js'></script>");
@@ -129,10 +130,10 @@ if ($onlinecount<getsetting("maxonline",0) || getsetting("maxonline",0)==0){
 	if ($op=="timeout"){
 		$session['message'].= translate_inline(" Your session has timed out, you must log in again.`n");
 	}
-	if (!isset($_COOKIE['lgi'])){
-		$session['message'].=translate_inline("It appears that you may be blocking cookies from this site. At least session cookies must be enabled in order to use this site.`n");
-		$session['message'].=translate_inline("`b`#If you are not sure what cookies are, please <a href='http://en.wikipedia.org/wiki/WWW_browser_cookie'>read this article</a> about them, and how to enable them.`b`n");
-	}
+        if (Cookies::getLgi() === null){
+                $session['message'].=translate_inline("It appears that you may be blocking cookies from this site. At least session cookies must be enabled in order to use this site.`n");
+                $session['message'].=translate_inline("`b`#If you are not sure what cookies are, please <a href='http://en.wikipedia.org/wiki/WWW_browser_cookie'>read this article</a> about them, and how to enable them.`b`n");
+        }
 	if ($session['message']>"") output("`b`\$%s`b`n", $session['message'],true);
         $templateVars = [];
         if (TwigTemplate::isActive()) {

--- a/login.php
+++ b/login.php
@@ -7,6 +7,7 @@ use Lotgd\Accounts;
 use Lotgd\CheckBan;
 use Lotgd\Mail;
 use Lotgd\Serialization;
+use Lotgd\Cookies;
 // translator ready
 define("ALLOW_ANONYMOUS",true);
 require_once("common.php");
@@ -126,7 +127,7 @@ if ($name!=""){
 				// this name.
 				while ($row=db_fetch_assoc($result)){
 					$post = httpallpost();
-					$cookielgi = (isset($_COOKIE['lgi'])?$_COOKIE['lgi']:'no cookie set');
+                                        $cookielgi = Cookies::getLgi() ?? 'no cookie set';
 					$sql = "INSERT INTO " . db_prefix("faillog") . " VALUES (0,'".date("Y-m-d H:i:s")."','".addslashes(serialize($post))."','{$_SERVER['REMOTE_ADDR']}','{$row['acctid']}','$cookielgi')";
 					db_query($sql);
 					$sql = "SELECT " . db_prefix("faillog") . ".*," . db_prefix("accounts") . ".superuser,name,login FROM " . db_prefix("faillog") . " INNER JOIN " . db_prefix("accounts") . " ON " . db_prefix("accounts") . ".acctid=" . db_prefix("faillog") . ".acctid WHERE ip='{$_SERVER['REMOTE_ADDR']}' AND date>'".date("Y-m-d H:i:s",strtotime("-1 day"))."'";

--- a/pages/bans/case_saveban.php
+++ b/pages/bans/case_saveban.php
@@ -1,4 +1,5 @@
 <?php
+use Lotgd\Cookies;
 $sql = "INSERT INTO " . db_prefix("bans") . " (banner,";
 $type = httppost("type");
 if ($type=="ip"){
@@ -29,11 +30,11 @@ if ($type=="ip"){
 		output("That's your own IP address!");
 	}
 }else{
-	if ($_COOKIE['lgi']==httppost("id")){
-		$sql = "";
-		output("You don't really want to ban yourself now do you??");
-		output("That's your own ID!");
-	}
+        if (Cookies::getLgi() == httppost("id")){
+                $sql = "";
+                output("You don't really want to ban yourself now do you??");
+                output("That's your own ID!");
+        }
 }
 if ($sql!=""){
 	$result=db_query($sql);

--- a/pages/petition/petition_default.php
+++ b/pages/petition/petition_default.php
@@ -1,14 +1,15 @@
 <?php
 use Lotgd\Stripslashes;
+use Lotgd\Cookies;
 tlschema("petition");
 popup_header("Petition for Help");
 $post = httpallpost();
 $problem = (string)(httppost('problem') ?? "");
 if (count($post)>0 && httppost('abuse')!="yes"){
-	$ip = explode(".",$_SERVER['REMOTE_ADDR']);
-	array_pop($ip);
-	$ip = implode(".",$ip).".";
-	$cookie_lgi = isset($_COOKIE['lgi'])?$_COOKIE['lgi']:'';
+        $ip = explode(".",$_SERVER['REMOTE_ADDR']);
+        array_pop($ip);
+        $ip = implode(".",$ip).".";
+        $cookie_lgi = Cookies::getLgi() ?? '';
 	$sql = "SELECT count(petitionid) AS c FROM ".db_prefix("petitions")." WHERE (ip LIKE '$ip%' OR id = '".addslashes($cookie_lgi)."') AND date > '".date("Y-m-d H:i:s",strtotime("-1 day"))."'";
 	$result = db_query($sql);
 	$row = db_fetch_assoc($result);

--- a/pages/user/user_saveban.php
+++ b/pages/user/user_saveban.php
@@ -1,4 +1,5 @@
 <?php
+use Lotgd\Cookies;
 $sql = "INSERT INTO " . db_prefix("bans") . " (banner,";
 $type = httppost("type");
 if ($type=="ip"){
@@ -29,11 +30,11 @@ if ($type=="ip"){
 		output("That's your own IP address!");
 	}
 }else{
-	if ($_COOKIE['lgi']==httppost("id")){
-		$sql = "";
-		output("You don't really want to ban yourself now do you??");
-		output("That's your own ID!");
-	}
+        if (Cookies::getLgi() == httppost("id")){
+                $sql = "";
+                output("You don't really want to ban yourself now do you??");
+                output("That's your own ID!");
+        }
 }
 if ($sql!=""){
 	$result=db_query($sql);

--- a/src/Lotgd/CheckBan.php
+++ b/src/Lotgd/CheckBan.php
@@ -1,6 +1,8 @@
 <?php
 namespace Lotgd;
 
+use Lotgd\Cookies;
+
 /**
  * Functions related to ban checking.
  */
@@ -23,7 +25,7 @@ class CheckBan
 
         if ($login === null) {
             $ip = $_SERVER['REMOTE_ADDR'];
-            $id = $_COOKIE['lgi'] ?? '';
+            $id = Cookies::getLgi() ?? '';
         } else {
             $sql = "SELECT lastip,uniqueid,banoverride,superuser FROM " . db_prefix('accounts') . " WHERE login='$login'";
             $result = db_query($sql);

--- a/src/Lotgd/Cookies.php
+++ b/src/Lotgd/Cookies.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Lotgd;
+
+class Cookies
+{
+    /**
+     * Set a cookie value with common defaults.
+     */
+    public static function set(string $name, string $value, int $expires, bool $secure = false): void
+    {
+        setcookie($name, $value, [
+            'expires'  => $expires,
+            'path'     => '/',
+            'secure'   => $secure,
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ]);
+        $_COOKIE[$name] = $value;
+    }
+
+    /**
+     * Delete a cookie by expiring it.
+     */
+    public static function delete(string $name): void
+    {
+        setcookie($name, '', [
+            'expires'  => time() - 3600,
+            'path'     => '/',
+            'secure'   => ServerFunctions::isSecureConnection(),
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ]);
+        unset($_COOKIE[$name]);
+    }
+
+    /**
+     * Get a cookie value if set.
+     */
+    public static function get(string $name): ?string
+    {
+        return isset($_COOKIE[$name]) ? (string) $_COOKIE[$name] : null;
+    }
+
+    /**
+     * Set the unique id cookie with security flags.
+     */
+    public static function setLgi(string $id): void
+    {
+        if (strlen($id) < 32) {
+            return;
+        }
+        $expires = strtotime('+365 days');
+        self::set('lgi', $id, $expires, ServerFunctions::isSecureConnection());
+    }
+
+    /**
+     * Retrieve the unique id cookie if valid.
+     */
+    public static function getLgi(): ?string
+    {
+        $id = self::get('lgi');
+        if ($id === null || strlen($id) < 32) {
+            return null;
+        }
+        return $id;
+    }
+}

--- a/tests/CookiesTest.php
+++ b/tests/CookiesTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Lotgd\Cookies;
+require_once __DIR__ . '/../config/constants.php';
+
+final class CookiesTest extends TestCase
+{
+    public function testSetLgiPopulatesCookie(): void
+    {
+        $id = str_repeat('a', 32);
+        Cookies::setLgi($id);
+        $this->assertSame($id, $_COOKIE['lgi']);
+    }
+
+    public function testGetLgiReturnsNullWhenShort(): void
+    {
+        $_COOKIE['lgi'] = 'short';
+        $this->assertNull(Cookies::getLgi());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `Cookies` helper for consistent cookie operations
- replace direct `$_COOKIE['lgi']` and `setcookie` calls with `Cookies` methods
- validate lgi cookie access across core pages
- add unit test for the new cookie helper

## Testing
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870caab488c8329976836974d2f5706