### PR TITLE
Implement template cookie helpers

### DIFF
--- a/src/Lotgd/Cookies.php
+++ b/src/Lotgd/Cookies.php
@@ -66,4 +66,35 @@ class Cookies
         }
         return $id;
     }
+
+    /**
+     * Set the template cookie value after sanitizing.
+     *
+     * @param string $template Template identifier
+     *
+     * @return void
+     */
+    public static function setTemplate(string $template): void
+    {
+        $template = preg_replace('/[^a-zA-Z0-9:_-]/', '', $template);
+
+        if ($template === '') {
+            self::delete('template');
+
+            return;
+        }
+
+        $expires = strtotime('+45 days');
+        self::set('template', $template, $expires, ServerFunctions::isSecureConnection());
+    }
+
+    /**
+     * Get the sanitized template cookie value.
+     */
+    public static function getTemplate(): string
+    {
+        $template = self::get('template') ?? '';
+
+        return preg_replace('/[^a-zA-Z0-9:_-]/', '', $template);
+    }
 }

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\ServerFunctions;
+use Lotgd\Cookies;
 
 /**
  * Helper methods for working with output templates.
@@ -147,29 +148,7 @@ class Template
      */
     public static function setTemplateCookie(string $template): void
     {
-        $template = preg_replace(self::SANITIZATION_REGEX, '', $template);
-        $secure   = ServerFunctions::isSecureConnection();
-
-        if ($template === '') {
-            setcookie('template', '', [
-                'expires'  => time() - 3600,
-                'path'     => '/',
-                'secure'   => $secure,
-                'httponly' => true,
-                'samesite' => 'Lax',
-            ]); // Expire the cookie
-            unset($_COOKIE['template']); // Unset the cookie value in the current request
-            return;
-        }
-
-        setcookie('template', $template, [
-            'expires'  => strtotime('+45 days'),
-            'path'     => '/',
-            'secure'   => $secure,
-            'httponly' => true,
-            'samesite' => 'Lax',
-        ]);
-        $_COOKIE['template'] = $template;
+        Cookies::setTemplate($template);
     }
 
     /**
@@ -179,9 +158,7 @@ class Template
      */
     public static function getTemplateCookie(): string
     {
-        $template = $_COOKIE['template'] ?? '';
-
-        return preg_replace(self::SANITIZATION_REGEX, '', $template);
+        return Cookies::getTemplate();
     }
 
     /**

--- a/tests/CookiesTest.php
+++ b/tests/CookiesTest.php
@@ -20,4 +20,23 @@ final class CookiesTest extends TestCase
         $_COOKIE['lgi'] = 'short';
         $this->assertNull(Cookies::getLgi());
     }
+
+    public function testSetTemplateStoresSanitizedValue(): void
+    {
+        Cookies::setTemplate('../foo');
+        $this->assertSame('foo', $_COOKIE['template']);
+    }
+
+    public function testSetTemplateDeletesWhenEmpty(): void
+    {
+        $_COOKIE['template'] = 'bar';
+        Cookies::setTemplate('..');
+        $this->assertArrayNotHasKey('template', $_COOKIE);
+    }
+
+    public function testGetTemplateSanitizesValue(): void
+    {
+        $_COOKIE['template'] = '../baz';
+        $this->assertSame('baz', Cookies::getTemplate());
+    }
 }

--- a/tests/TemplateHelperTest.php
+++ b/tests/TemplateHelperTest.php
@@ -15,6 +15,12 @@ final class TemplateHelperTest extends TestCase
         $this->assertSame('foo', $result);
     }
 
+    public function testSetTemplateCookieStoresSanitizedValue(): void
+    {
+        Template::setTemplateCookie('../bar');
+        $this->assertSame('bar', $_COOKIE['template']);
+    }
+
     public function testDefaultTemplateIsAvailable(): void
     {
         $templates = Template::getAvailableTemplates();


### PR DESCRIPTION
## Summary
- add `Cookies::setTemplate()` and `Cookies::getTemplate()` helper methods
- delegate template cookie logic in `Template` to these helpers
- extend unit tests for cookie helper and template helper

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6870d1a4efb48329a8f441f5a34ca40b