### PR TITLE
Use Cookies helper for language cookie

### DIFF
--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -37,8 +37,11 @@ class Translator
 		$language = "";
 		if (isset($session['user']['prefs']['language'])) {
 			$language = $session['user']['prefs']['language'];
-                } elseif (null !== Cookies::get('language')) {
-                        $language = Cookies::get('language');
+                } else {
+                        $cookieLanguage = Cookies::get('language');
+                        if (null !== $cookieLanguage) {
+                            $language = $cookieLanguage;
+                        }
                 }
 		if ($language=="") {
 			$language=$settings->getsetting("defaultlanguage","en");


### PR DESCRIPTION
## Summary
- reference the cookie helper when getting the user's language
- import the Cookies class

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870d4deaf9c832996bd06cbbd392630