### PR TITLE
Refactor to use global settings

### DIFF
--- a/src/Lotgd/DateTime.php
+++ b/src/Lotgd/DateTime.php
@@ -1,6 +1,8 @@
 <?php
 namespace Lotgd;
 
+use Lotgd\Settings;
+
 class DateTime
 {
     /**
@@ -113,7 +115,8 @@ class DateTime
 
     public static function getGameTime(): string
     {
-        return gmdate(getsetting('gametime', 'g:i a'), self::gametime());
+        global $settings;
+        return gmdate($settings->getSetting('gametime', 'g:i a'), self::gametime());
     }
 
     public static function gameTime(): int
@@ -124,10 +127,11 @@ class DateTime
 
     public static function convertGameTime(int $intime, bool $debug = false): int
     {
-        $intime -= getsetting('gameoffsetseconds', 0);
-        $epoch = strtotime(getsetting('game_epoch', gmdate('Y-m-d 00:00:00 O', strtotime('-30 days'))));
+        global $settings;
+        $intime -= $settings->getSetting('gameoffsetseconds', 0);
+        $epoch = strtotime($settings->getSetting('game_epoch', gmdate('Y-m-d 00:00:00 O', strtotime('-30 days'))));
         $now = strtotime(gmdate('Y-m-d H:i:s O', $intime));
-        $logd_timestamp = ($now - $epoch) * getsetting('daysperday', 4);
+        $logd_timestamp = ($now - $epoch) * $settings->getSetting('daysperday', 4);
         if ($debug) {
             echo 'Game Timestamp: ' . $logd_timestamp . ', which makes it ' . gmdate('Y-m-d H:i:s', $logd_timestamp) . '<br>';
         }
@@ -136,10 +140,11 @@ class DateTime
 
     public static function gameTimeDetails(): array
     {
+        global $settings;
         $ret = [];
         $ret['now'] = date('Y-m-d 00:00:00');
         $ret['gametime'] = self::gametime();
-        $ret['daysperday'] = getsetting('daysperday', 4);
+        $ret['daysperday'] = $settings->getSetting('daysperday', 4);
         $ret['secsperday'] = 86400 / $ret['daysperday'];
         $ret['today'] = strtotime(gmdate('Y-m-d 00:00:00 O', $ret['gametime']));
         $ret['tomorrow'] = strtotime(gmdate('Y-m-d H:i:s O', $ret['gametime']) . ' + 1 day');

--- a/src/Lotgd/Forest/Outcomes.php
+++ b/src/Lotgd/Forest/Outcomes.php
@@ -31,9 +31,7 @@ class Outcomes
         $expbonus = 0;
         $count = 0;
         foreach ($enemies as $badguy) {
-            $dropMinGold = isset($settings) && $settings instanceof Settings
-                ? $settings->getSetting('dropmingold', 0)
-                : getsetting('dropmingold', 0);
+            $dropMinGold = $settings->getSetting('dropmingold', 0);
             if ($dropMinGold) {
                 $badguy['creaturegold'] = r_rand(round((int)$badguy['creaturegold'] / 4), round(3 * (int)$badguy['creaturegold'] / 4));
             } else {
@@ -66,22 +64,16 @@ class Outcomes
             output("`#You receive `^%s`# gold!`n", $gold);
             debuglog('received gold for slaying a monster.', false, false, 'forestwin', $gold);
         }
-        $gemChance = isset($settings) && $settings instanceof Settings
-            ? $settings->getSetting('forestgemchance', 25)
-            : getsetting('forestgemchance', 25);
+        $gemChance = $settings->getSetting('forestgemchance', 25);
         $args = modulehook('alter-gemchance', ['chance' => $gemChance]);
         $gemchances = (int)$args['chance'];
-        $maxLevel = isset($settings) && $settings instanceof Settings
-            ? $settings->getSetting('maxlevel', 15)
-            : getsetting('maxlevel', 15);
+        $maxLevel = $settings->getSetting('maxlevel', 15);
         if ($session['user']['level'] < $maxLevel && e_rand(1, $gemchances) == 1) {
             output("`&You find A GEM!`n`#");
             $session['user']['gems']++;
             debuglog('found gem when slaying a monster.', false, false, 'forestwingem', 1);
         }
-        $instantExp = isset($settings) && $settings instanceof Settings
-            ? $settings->getSetting('instantexp', false)
-            : getsetting('instantexp', false);
+        $instantExp = $settings->getSetting('instantexp', false);
         if ($instantExp == true) {
             $expgained = array_sum($options['experiencegained']);
             $diff = $expgained - $exp;
@@ -90,9 +82,7 @@ class Outcomes
                 $expbonus = -$exp + 1;
             }
             if ($expbonus > 0) {
-                $addExp = isset($settings) && $settings instanceof Settings
-                    ? $settings->getSetting('addexp', 5)
-                    : getsetting('addexp', 5);
+                $addExp = $settings->getSetting('addexp', 5);
                 $expbonus = round($expbonus * pow(1 + ($addExp / 100), $count - 1), 0);
                 output("`#***Because of the difficult nature of this fight, you are awarded an additional `^%s`# experience! `n", $expbonus);
             } elseif ($expbonus < 0) {
@@ -107,9 +97,7 @@ class Outcomes
                 $expbonus = -$exp + 1;
             }
             if ($expbonus > 0) {
-                $addExp = isset($settings) && $settings instanceof Settings
-                    ? $settings->getSetting('addexp', 5)
-                    : getsetting('addexp', 5);
+                $addExp = $settings->getSetting('addexp', 5);
                 $expbonus = round($expbonus * pow(1 + ($addExp / 100), $count - 1), 0);
                 output("`#***Because of the difficult nature of this fight, you are awarded an additional `^%s`# experience! `n(%s + %s = %s) ", $expbonus, $exp, abs($expbonus), $exp + $expbonus);
             } elseif ($expbonus < 0) {
@@ -152,9 +140,7 @@ class Outcomes
     public static function defeat(array $enemies, string $where = 'in the forest'): void
     {
         global $session, $settings;
-        $percent = isset($settings) && $settings instanceof Settings
-            ? $settings->getSetting('forestexploss', 10)
-            : getsetting('forestexploss', 10);
+        $percent = $settings->getSetting('forestexploss', 10);
         Nav::add('Daily news', 'news.php');
         $names = [];
         $killer = false;
@@ -218,9 +204,7 @@ class Outcomes
         $badguy['creatureattack'] += $atkflux;
         $badguy['creaturedefense'] += $defflux;
         $badguy['creaturehealth'] += $hpflux;
-        $disableBonuses = isset($settings) && $settings instanceof Settings
-            ? $settings->getSetting('disablebonuses', 1)
-            : getsetting('disablebonuses', 1);
+        $disableBonuses = $settings->getSetting('disablebonuses', 1);
         if ($disableBonuses) {
             $base = 30 - min(20, round(sqrt((int)$session['user']['dragonkills']) / 2));
             $base /= 1000;

--- a/src/Lotgd/ServerFunctions.php
+++ b/src/Lotgd/ServerFunctions.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use Lotgd\Settings;
+
 /**
  * Miscellaneous server wide helper utilities.
  */
@@ -15,17 +17,18 @@ class ServerFunctions
      */
     public static function isTheServerFull(): bool
     {
-        if (abs(getsetting('OnlineCountLast', 0) - strtotime('now')) > 60) {
-            $sql = "SELECT count(acctid) as counter FROM " . db_prefix('accounts') . " WHERE locked=0 AND loggedin=1 AND laston>'" . date('Y-m-d H:i:s', strtotime('-' . getsetting('LOGINTIMEOUT', 900) . ' seconds')) . "'";
+        global $settings;
+        if (abs($settings->getSetting('OnlineCountLast', 0) - strtotime('now')) > 60) {
+            $sql = "SELECT count(acctid) as counter FROM " . db_prefix('accounts') . " WHERE locked=0 AND loggedin=1 AND laston>'" . date('Y-m-d H:i:s', strtotime('-' . $settings->getSetting('LOGINTIMEOUT', 900) . ' seconds')) . "'";
             $result = db_query($sql);
             $onlinecount = db_fetch_assoc($result);
             $onlinecount = $onlinecount['counter'];
-            savesetting('OnlineCount', $onlinecount);
-            savesetting('OnlineCountLast', strtotime('now'));
+            $settings->saveSetting('OnlineCount', $onlinecount);
+            $settings->saveSetting('OnlineCountLast', strtotime('now'));
         } else {
-            $onlinecount = getsetting('OnlineCount', 0);
+            $onlinecount = $settings->getSetting('OnlineCount', 0);
         }
-        return $onlinecount >= getsetting('maxonline', 0) && getsetting('maxonline', 0) != 0;
+        return $onlinecount >= $settings->getSetting('maxonline', 0) && $settings->getSetting('maxonline', 0) != 0;
     }
 
     /**


### PR DESCRIPTION
## Summary
- avoid instantiating new `Settings` handler in namespaced classes
- rely on global `$settings` when retrieving configuration

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687147cd59548329acb8df603df3bb15