### PR TITLE
Improve temp stat formatting

### DIFF
--- a/src/Lotgd/PlayerFunctions.php
+++ b/src/Lotgd/PlayerFunctions.php
@@ -356,11 +356,18 @@ class PlayerFunctions
         if ($color === false) {
             return ($v == 0 ? '' : $v);
         }
-        // TODO ... no number formatting, it rounds to 0.1 always
+        $point = getsetting('moneydecimalpoint', '.');
+        $sep   = getsetting('moneythousandssep', ',');
+
         if ($v > 0) {
-            return " `&(" . ($session['user'][$name] - round($v,1)) . "`@+" . round($v,1) . "`&)";
+            return " `&(" . number_format($session['user'][$name] - $v, 1, $point, $sep)
+                . "`@+" . number_format($v, 1, $point, $sep) . "`&)";
         }
-        return ($v == 0 ? '' : " `&(" . ($session['user'][$name] + round($v,1)) . "`$-" . round($v,1) . "`&)");
+
+        return $v == 0
+            ? ''
+            : " `&(" . number_format($session['user'][$name] + $v, 1, $point, $sep)
+                . "`$-" . number_format($v, 1, $point, $sep) . "`&)";
     }
 
     public static function suspendTempStats(): bool

--- a/tests/PlayerFunctionsTest.php
+++ b/tests/PlayerFunctionsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Lotgd\PlayerFunctions;
+use Lotgd\Settings;
+
+require_once __DIR__ . '/../config/constants.php';
+require_once __DIR__ . '/../lib/settings.php';
+require_once __DIR__ . '/../lib/tempstat.php';
+
+class DummySettings extends Settings
+{
+    private array $values;
+
+    public function __construct(array $values = [])
+    {
+        $this->values = $values;
+    }
+
+    public function getSetting(string|int $settingname, mixed $default = false): mixed
+    {
+        return $this->values[$settingname] ?? $default;
+    }
+
+    public function loadSettings(): void {}
+    public function clearSettings(): void {}
+    public function saveSetting(string|int $settingname, mixed $value): bool { $this->values[$settingname] = $value; return true; }
+    public function getArray(): array { return $this->values; }
+}
+
+final class PlayerFunctionsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $settings, $session, $temp_user_stats;
+        $settings = new DummySettings([
+            'moneydecimalpoint' => '.',
+            'moneythousandssep' => ',',
+        ]);
+        $session = ['user' => []];
+        $temp_user_stats = ['add' => [], 'is_suspended' => false];
+    }
+
+    public function testCheckTempStatUsesDefaultFormatting(): void
+    {
+        global $session;
+        $session['user']['strength'] = 1000.0;
+        apply_temp_stat('strength', 10.4);
+        $result = PlayerFunctions::checkTempStat('strength', 1);
+        $this->assertSame(' `&(1,000.0`@+10.4`&)', $result);
+    }
+
+    public function testCheckTempStatHonorsCustomLocale(): void
+    {
+        global $settings, $session, $temp_user_stats;
+        $settings = new DummySettings([
+            'moneydecimalpoint' => ',',
+            'moneythousandssep' => '.',
+        ]);
+        $session['user']['strength'] = 1000.0;
+        $temp_user_stats = ['add' => [], 'is_suspended' => false];
+        apply_temp_stat('strength', 10.4);
+        $result = PlayerFunctions::checkTempStat('strength', 1);
+        $this->assertSame(' `&(1.000,0`@+10,4`&)', $result);
+    }
+}

--- a/tests/PlayerFunctionsTest.php
+++ b/tests/PlayerFunctionsTest.php
@@ -31,7 +31,10 @@ class DummySettings extends Settings
         $this->values[$settingname] = $value;
         return true;
     }
-    public function getArray(): array { return $this->values; }
+    public function getArray(): array
+    {
+        return $this->values;
+    }
 }
 
 final class PlayerFunctionsTest extends TestCase

--- a/tests/PlayerFunctionsTest.php
+++ b/tests/PlayerFunctionsTest.php
@@ -61,13 +61,9 @@ final class PlayerFunctionsTest extends TestCase
 
     public function testCheckTempStatHonorsCustomLocale(): void
     {
-        global $settings, $session, $temp_user_stats;
-        $settings = new DummySettings([
-            'moneydecimalpoint' => ',',
-            'moneythousandssep' => '.',
-        ]);
+        $this->setCustomLocale(',', '.');
+        global $session;
         $session['user']['strength'] = 1000.0;
-        $temp_user_stats = ['add' => [], 'is_suspended' => false];
         apply_temp_stat('strength', 10.4);
         $result = PlayerFunctions::checkTempStat('strength', 1);
         $this->assertSame(' `&(1.000,0`@+10,4`&)', $result);

--- a/tests/PlayerFunctionsTest.php
+++ b/tests/PlayerFunctionsTest.php
@@ -26,7 +26,11 @@ class DummySettings extends Settings
 
     public function loadSettings(): void {}
     public function clearSettings(): void {}
-    public function saveSetting(string|int $settingname, mixed $value): bool { $this->values[$settingname] = $value; return true; }
+    public function saveSetting(string|int $settingname, mixed $value): bool
+    {
+        $this->values[$settingname] = $value;
+        return true;
+    }
     public function getArray(): array { return $this->values; }
 }
 


### PR DESCRIPTION
## Summary
- format temporary stats with `number_format`
- add tests for locale formatting

## Testing
- `php ./vendor/bin/phpunit --configuration phpunit.xml --no-coverage` *(fails: Could not open input file)*
- `phpunit --configuration phpunit.xml --no-coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717f141f648329bcfe80531739a318