### PR TITLE
Add composer test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ the installer fails or reports problems.
 
 Found a bug or have a feature request? Open an issue on GitHub.
 Pull requests are welcome for improvements or fixes.
+Run the unit tests locally with `composer test` before submitting PRs.
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
         }
     },
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit --configuration phpunit.xml"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,8 @@
             "Lotgd\\": "src/Lotgd/",
             "Lotgd\\Installer\\": "install/lib/"
         }
+    },
+    "scripts": {
+        "test": "phpunit"
     }
 }


### PR DESCRIPTION
## Summary
- add composer `test` script so tests run with `composer test`
- mention how to run tests in Contributing section

## Testing
- `composer test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68718470dad48329b6a93da353da4690