### PR TITLE
Fix navigation header for uninstalled modules

### DIFF
--- a/modules.php
+++ b/modules.php
@@ -15,7 +15,6 @@ page_header("Module Manager");
 
 SuperuserNav::render();
 
-addnav("Module Categories");
 
 addnav("",$REQUEST_URI);
 $op = httpget('op');
@@ -72,7 +71,9 @@ $uninstmodules = ModuleManager::listUninstalled();
 $seencats = ModuleManager::getInstalledCategories();
 $ucount = count($uninstmodules);
 
+addnav("Uninstalled");
 addnav(array(" ?Uninstalled - (%s modules)", $ucount), "modules.php");
+
 foreach ($seencats as $cat=>$count) {
 	$category = $cat;
 	if (strpos($cat,"|") !== false) {

--- a/modules.php
+++ b/modules.php
@@ -74,6 +74,7 @@ $ucount = count($uninstmodules);
 addnav("Uninstalled");
 addnav(array(" ?Uninstalled - (%s modules)", $ucount), "modules.php");
 
+addnav("Module Categories");
 foreach ($seencats as $cat=>$count) {
 	$category = $cat;
 	if (strpos($cat,"|") !== false) {


### PR DESCRIPTION
## Summary
- show uninstalled modules under their own navigation header
- remove early `Module Categories` header

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68726dac5e10832981c3c15184152f78