### PR TITLE
Add server and settings tests

### DIFF
--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -28,20 +28,25 @@ $GLOBALS['settings_array'] = [
 
 // --- Database stub ---
 namespace Lotgd\MySQL {
+    if (!class_exists('Lotgd\\MySQL\\Database', false)) {
     class Database {
+        public static array $settings_table = [];
+        public static int $onlineCounter = 0;
+        public static int $affected_rows = 0;
+
         public static function prefix(string $name, bool $force = false): string {
             return $name;
         }
 
         public static function query(string $sql, bool $die = true) {
             global $accounts_table, $mail_table, $last_query_result;
-    if (preg_match("/SELECT prefs,emailaddress FROM accounts WHERE acctid='?(\d+)'?;/", $sql, $m)) {
-        $acctid = (int)$m[1];
-        $row = $accounts_table[$acctid] ?? ['prefs'=>'', 'emailaddress'=>''];
-        $last_query_result = [$row];
-        return $last_query_result;
-    }
-    if (strpos($sql, 'INSERT INTO mail') === 0) {
+            if (preg_match("/SELECT prefs,emailaddress FROM accounts WHERE acctid='?(\d+)'?;/", $sql, $m)) {
+                $acctid = (int)$m[1];
+                $row = $accounts_table[$acctid] ?? ['prefs'=>'', 'emailaddress'=>''];
+                $last_query_result = [$row];
+                return $last_query_result;
+            }
+            if (strpos($sql, 'INSERT INTO mail') === 0) {
         if (preg_match("/\((?:'|\")?(\d+)(?:'|\")?,(?:'|\")?(\d+)(?:'|\")?,(?:'|\")?(.*?)(?:'|\")?,(?:'|\")?(.*?)(?:'|\")?,(?:'|\")?(.*?)(?:'|\")?\)/", $sql, $m)) {
             $from=(int)$m[1];
             $to=(int)$m[2];
@@ -53,28 +58,67 @@ namespace Lotgd\MySQL {
         }
         $id = count($mail_table)+1;
         $mail_table[] = ['messageid'=>$id,'msgfrom'=>$from,'msgto'=>$to,'subject'=>$subject,'body'=>$body,'sent'=>$sent,'seen'=>0];
-        $last_query_result = true;
-        return true;
-    }
-    if (preg_match("/SELECT name FROM accounts WHERE acctid='?(\d+)'?;/", $sql, $m)) {
-        $acctid=(int)$m[1];
-        $row=['name'=>$accounts_table[$acctid]['name'] ?? ''];
-        $last_query_result = [$row];
-        return $last_query_result;
-    }
-    if (preg_match("/SELECT count\(messageid\) AS count FROM mail WHERE msgto=(\d+)(.*)/", $sql, $m)) {
-        $userId=(int)$m[1];
-        $onlyUnread=strpos($sql,'seen=0')!==false;
-        $count=0;
-        foreach($mail_table as $row){
-            if($row['msgto']==$userId && (!$onlyUnread || $row['seen']==0)) $count++;
+                $last_query_result = true;
+                return true;
+            }
+            if (preg_match("/SELECT name FROM accounts WHERE acctid='?(\d+)'?;/", $sql, $m)) {
+                $acctid=(int)$m[1];
+                $row=['name'=>$accounts_table[$acctid]['name'] ?? ''];
+                $last_query_result = [$row];
+                return $last_query_result;
+            }
+            if (preg_match("/SELECT count\(messageid\) AS count FROM mail WHERE msgto=(\d+)(.*)/", $sql, $m)) {
+                $userId=(int)$m[1];
+                $onlyUnread=strpos($sql,'seen=0')!==false;
+                $count=0;
+                foreach($mail_table as $row){
+                    if($row['msgto']==$userId && (!$onlyUnread || $row['seen']==0)) $count++;
+                }
+                $last_query_result=[[ 'count'=>$count ]];
+                return $last_query_result;
+            }
+            if (strpos($sql, 'SELECT count(acctid) as counter FROM accounts') === 0) {
+                $last_query_result=[[ 'counter'=>self::$onlineCounter ]];
+                return $last_query_result;
+            }
+            if (preg_match('/SELECT \* FROM (.+)/', $sql, $m)) {
+                if ($m[1] === 'settings') {
+                    $last_query_result = [];
+                    foreach (self::$settings_table as $k=>$v) {
+                        $last_query_result[] = ['setting'=>$k,'value'=>$v];
+                    }
+                    return $last_query_result;
+                }
+            }
+            if (strpos($sql, 'INSERT INTO settings') === 0) {
+                if (preg_match('/VALUES\((.+),(.+)\)/', $sql, $m)) {
+                    $name = trim($m[1], "'\"");
+                    $value = trim($m[2], "'\"");
+                } else {
+                    $name = $value = '';
+                }
+                self::$settings_table[$name] = $value;
+                self::$affected_rows = 1;
+                $last_query_result = true;
+                return true;
+            }
+            if (preg_match('/UPDATE (.+) SET value=(.+) WHERE setting=(.+)/', $sql, $m)) {
+                if ($m[1] === 'settings') {
+                    $value = trim($m[2], "'\"");
+                    $name = trim($m[3], "'\"");
+                    if (isset(self::$settings_table[$name])) {
+                        self::$settings_table[$name] = $value;
+                        self::$affected_rows = 1;
+                    } else {
+                        self::$affected_rows = 0;
+                    }
+                    $last_query_result = true;
+                    return true;
+                }
+            }
+            $last_query_result = [];
+            return [];
         }
-        $last_query_result=[[ 'count'=>$count ]];
-        return $last_query_result;
-    }
-    $last_query_result = [];
-    return [];
-    }
         public static function fetchAssoc(array|\mysqli_result &$result) {
             return array_shift($result);
         }
@@ -87,6 +131,10 @@ namespace Lotgd\MySQL {
         public static function numRows(array|\mysqli_result $result): int {
             return is_array($result) ? count($result) : 0;
         }
+        public static function affectedRows(): int {
+            return self::$affected_rows;
+        }
+    }
     }
 }
 
@@ -112,14 +160,7 @@ if (!function_exists('output')) {
 }
 
 // --- Class stubs ---
-namespace Lotgd {
-class Settings {
-    public function __construct(string|false $table=false){}
-    public function getSetting(string|int $name, mixed $default=false): mixed {
-        return $GLOBALS['settings_array'][$name] ?? $default;
-    }
-}
-}
+
 
 namespace PHPMailer\PHPMailer {
 class PHPMailer {

--- a/tests/ServerFunctionsTest.php
+++ b/tests/ServerFunctionsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Lotgd\ServerFunctions;
+use Lotgd\Settings;
+
+require_once __DIR__ . '/../config/constants.php';
+
+class ServerDummySettings extends Settings
+{
+    private array $values;
+    public function __construct(array $values = []) { $this->values = $values; }
+    public function getSetting(string|int $settingname, mixed $default = false): mixed { return $this->values[$settingname] ?? $default; }
+    public function loadSettings(): void {}
+    public function clearSettings(): void {}
+    public function saveSetting(string|int $settingname, mixed $value): bool { $this->values[$settingname] = $value; return true; }
+    public function getArray(): array { return $this->values; }
+}
+
+final class ServerFunctionsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SERVER = [];
+        \Lotgd\MySQL\Database::$onlineCounter = 0;
+        \Lotgd\MySQL\Database::$settings_table = [];
+    }
+
+    public function testIsSecureConnection(): void
+    {
+        $_SERVER['HTTPS'] = 'on';
+        $this->assertTrue(ServerFunctions::isSecureConnection());
+
+        unset($_SERVER['HTTPS']);
+        $_SERVER['SERVER_PORT'] = 443;
+        $this->assertTrue(ServerFunctions::isSecureConnection());
+
+        $_SERVER['HTTPS'] = 'off';
+        $_SERVER['SERVER_PORT'] = 80;
+        $this->assertFalse(ServerFunctions::isSecureConnection());
+    }
+
+    public function testIsTheServerFull(): void
+    {
+        $settings = new ServerDummySettings([
+            'OnlineCountLast' => 0,
+            'maxonline' => 5,
+            'LOGINTIMEOUT' => 900,
+        ]);
+        $GLOBALS['settings'] = $settings;
+
+        \Lotgd\MySQL\Database::$onlineCounter = 3;
+        $this->assertFalse(ServerFunctions::isTheServerFull());
+        $this->assertSame(3, $settings->getSetting('OnlineCount'));
+
+        $settings->saveSetting('OnlineCount', 6);
+        $settings->saveSetting('maxonline', 6);
+        $this->assertTrue(ServerFunctions::isTheServerFull());
+    }
+}

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Lotgd\Settings;
+
+require_once __DIR__ . '/../config/constants.php';
+
+final class SettingsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        \Lotgd\MySQL\Database::$settings_table = [];
+        \Lotgd\MySQL\Database::$affected_rows = 0;
+    }
+
+    public function testGetSettingReturnsDefault(): void
+    {
+        $settings = new Settings('settings');
+        $this->assertSame('def', $settings->getSetting('missing', 'def'));
+    }
+
+    public function testSaveSettingStoresValue(): void
+    {
+        $settings = new Settings('settings');
+        $settings->saveSetting('alpha', 'beta');
+        $this->assertSame('beta', $settings->getSetting('alpha'));
+    }
+
+    public function testClearSettingsReloadsFromDatabase(): void
+    {
+        \Lotgd\MySQL\Database::$settings_table = ['foo' => 'bar'];
+        $settings = new Settings('settings');
+        $this->assertSame('bar', $settings->getSetting('foo'));
+        \Lotgd\MySQL\Database::$settings_table['foo'] = 'baz';
+        $settings->clearSettings();
+        $this->assertSame('baz', $settings->getSetting('foo'));
+    }
+
+    public function testLoadSettingsFetchesAfterClear(): void
+    {
+        \Lotgd\MySQL\Database::$settings_table = ['x' => '1'];
+        $settings = new Settings('settings');
+        $settings->clearSettings();
+        \Lotgd\MySQL\Database::$settings_table['x'] = '2';
+        $settings->loadSettings();
+        $this->assertSame('2', $settings->getSetting('x'));
+    }
+}


### PR DESCRIPTION
## Summary
- extend MailTest database stub so other tests can re-use it
- add PHPUnit tests for Settings operations
- add PHPUnit tests for ServerFunctions logic

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6872827ced8c8329af8045fe2fd511eb