### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Create archives
         run: |
           VERSION=${{ steps.vars.outputs.VERSION }}
-          tar --exclude='.git*' --exclude='.github' -czf "lotgd-${VERSION}.tar.gz" .
-          zip -r "lotgd-${VERSION}.zip" . -x '*.git*' -x '.github/*'
+          tar --exclude='.git*' --exclude='.github' --exclude='tests' --exclude='phpunit.xml' --exclude='.phpunit.result.cache' -czf "lotgd-${VERSION}.tar.gz" .
+          zip -r "lotgd-${VERSION}.zip" . -x '*.git*' -x '.github/*' -x 'tests/*' -x 'phpunit.xml' -x '.phpunit.result.cache'
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ required. Download `lotgd-<version>.tar.gz` or `lotgd-<version>.zip` from the
 to your web server and open `installer.php` in your browser. The installer
 will guide you through the setup.
 
+## Release Workflow
+
+Releases are created automatically when pushing a tag that starts with `v`.
+Update the version in `common.php`, commit the change and push a tag like
+`v2.0.0` or `v2.0.0-rc1`. GitHub Actions then builds archives that contain the
+application and its `vendor/` dependencies while omitting development files such
+as the `tests/` directory.
+
 ## Cron Job Setup
 
 `cron.php` handles automated tasks such as new day resets. It runs from the command line and reads `settings.php` to determine the game directory.


### PR DESCRIPTION
## Summary
- exclude `tests/` and PHPUnit artifacts from packaged archives
- document how releases are triggered in README

## Testing
- `composer test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872883179188329a66d95228e4fb2df