### PR TITLE
Refactor tests to remove Settings stubs

### DIFF
--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -14,15 +14,13 @@ final class BacktraceTest extends TestCase
         $this->assertSame('', Backtrace::showNoBacktrace());
     }
 
-    /**
-     * @dataProvider getTypeDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getTypeDataProvider')]
     public function testGetType($input, string $expected): void
     {
         $this->assertSame($expected, Backtrace::getType($input));
     }
 
-    public function getTypeDataProvider(): array
+    public static function getTypeDataProvider(): array
     {
         return [
             'string' => ['foo', "<span class='string'>\"foo\"</span>"],

--- a/tests/DataCacheTest.php
+++ b/tests/DataCacheTest.php
@@ -2,21 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Lotgd {
-    if (!class_exists('Lotgd\\Settings', false)) {
-        class Settings {
-            public function __construct(string|false $table = false){}
-            public function getSetting(string|int $name, mixed $default = false): mixed {
-                return $GLOBALS['settings_array'][$name] ?? $default;
-            }
-        }
-    }
-}
-
 namespace {
     use PHPUnit\Framework\TestCase;
     use Lotgd\DataCache;
-    use Lotgd\Settings;
 
     require_once __DIR__ . '/../config/constants.php';
 
@@ -25,7 +13,7 @@ namespace {
     }
 
     if (!class_exists('CacheDummySettings')) {
-        class CacheDummySettings extends Settings
+        class CacheDummySettings
         {
             private array $values;
 

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace {
     use PHPUnit\Framework\TestCase;
     use Lotgd\Mail;
-    use Lotgd\Settings;
 
     require_once __DIR__ . '/../config/constants.php';
     require_once __DIR__ . '/../lib/settings.php';
@@ -158,18 +157,7 @@ if (!function_exists('output')) {
     function output(string $format,...$args){}
 }
 }
-
 // --- Class stubs ---
-namespace Lotgd {
-    if (!class_exists('Lotgd\\Settings', false)) {
-        class Settings {
-            public function __construct(string|false $table=false){}
-            public function getSetting(string|int $name, mixed $default=false): mixed {
-                return $GLOBALS['settings_array'][$name] ?? $default;
-            }
-        }
-    }
-}
 
 namespace PHPMailer\PHPMailer {
 class PHPMailer {
@@ -189,10 +177,9 @@ class PHPMailer {
 namespace {
 use PHPUnit\Framework\TestCase;
 use Lotgd\Mail;
-use Lotgd\Settings;
 
     if (!class_exists('MailDummySettings')) {
-        class MailDummySettings extends Settings
+        class MailDummySettings
         {
             private array $values;
 


### PR DESCRIPTION
## Summary
- remove settings stubs from `DataCacheTest` and `MailTest`
- introduce local dummy settings classes
- update `BacktraceTest` for PHPUnit 12

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68728acddb3c832995314547dcd616e3