### PR TITLE
Add Template tests

### DIFF
--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Lotgd\Template;
+
+require_once __DIR__ . '/../config/constants.php';
+
+final class TemplateTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // Simple template fixture
+        $GLOBALS['template'] = ['greet' => 'Hello {name}!'];
+    }
+
+    public function testTemplateReplace(): void
+    {
+        $result = Template::templateReplace('greet', ['name' => 'Bob']);
+        $this->assertSame('Hello Bob!', $result);
+    }
+
+    public function testAddTypePrefixReturnsLegacyWhenTwigDirMissing(): void
+    {
+        $dir = dirname(__DIR__) . '/templates_twig/aurora';
+        $temp = $dir . '.tmp';
+        $renamed = false;
+        if (is_dir($dir)) {
+            $renamed = rename($dir, $temp);
+        }
+        try {
+            $result = Template::addTypePrefix('aurora');
+        } finally {
+            if ($renamed) {
+                rename($temp, $dir);
+            }
+        }
+
+        $this->assertSame('legacy:aurora', $result);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for Template helper functions

## Testing
- `phpunit tests/TemplateTest.php`
- `composer test` *(fails: ArgumentCountError in BacktraceTest)*

------
https://chatgpt.com/codex/tasks/task_e_68728ada33708329bb3b0482e3d832d4