### PR TITLE
Add Substitute tests

### DIFF
--- a/tests/DumpOutputTest.php
+++ b/tests/DumpOutputTest.php
@@ -6,6 +6,10 @@ namespace Lotgd {
     if (!function_exists('Lotgd\\getsetting')) {
         function getsetting(string|int $name, mixed $default = ''): mixed
         {
+            if (function_exists('\\getsetting')) {
+                return \getsetting($name, $default);
+            }
+
             return $default;
         }
     }

--- a/tests/SubstituteTest.php
+++ b/tests/SubstituteTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Lotgd\Substitute;
+
+require_once __DIR__ . '/../config/constants.php';
+
+if (!function_exists('translate_inline')) {
+    function translate_inline($text, $ns = false) { return $text; }
+}
+
+final class SubstituteTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $session, $badguy;
+        $session = ['user' => [
+            'name'   => 'Hero',
+            'sex'    => SEX_MALE,
+            'weapon' => 'Sword',
+            'armor'  => 'Leather',
+        ]];
+        $badguy = [
+            'creaturename'  => 'Goblin',
+            'creatureweapon'=> 'Club',
+        ];
+    }
+
+    public function testApplyReturnsGoodguyWeapon(): void
+    {
+        $this->assertSame('Sword', Substitute::apply('{goodguyweapon}'));
+    }
+
+    public function testApplyWithExtraPlaceholders(): void
+    {
+        $extra = ['{foo}', '{bar}'];
+        $extrarep = ['magic', 'force'];
+        $result = Substitute::apply('{goodguyweapon} uses {foo} with {bar}', $extra, $extrarep);
+        $this->assertSame('Sword uses magic with force', $result);
+    }
+
+    public function testApplyArrayReturnsFormatAndValues(): void
+    {
+        $extra = ['{foo}'];
+        $extrarep = ['energy'];
+        $array = Substitute::applyArray('Attack with {goodguyweapon} and {foo}.', $extra, $extrarep);
+        $this->assertSame('Attack with %s and %s.', $array[0]);
+        $this->assertSame('Sword', $array[1]);
+        $this->assertSame('energy', $array[2]);
+        $formatted = vsprintf($array[0], array_slice($array, 1));
+        $this->assertSame(Substitute::apply('Attack with {goodguyweapon} and {foo}.', $extra, $extrarep), $formatted);
+    }
+}

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -23,12 +23,18 @@ final class TemplateTest extends TestCase
 
     public function testAddTypePrefixReturnsLegacyWhenTwigDirMissing(): void
     {
-        $tempDir = sys_get_temp_dir() . '/templates_twig_aurora';
-        mkdir($tempDir);
+        $dir = dirname(__DIR__) . '/templates_twig/aurora';
+        $temp = $dir . '.tmp';
+        $renamed = false;
+        if (is_dir($dir)) {
+            $renamed = rename($dir, $temp);
+        }
         try {
             $result = Template::addTypePrefix('aurora');
         } finally {
-            rmdir($tempDir);
+            if ($renamed) {
+                rename($temp, $dir);
+            }
         }
 
         $this->assertSame('legacy:aurora', $result);


### PR DESCRIPTION
## Summary
- add dedicated test coverage for Substitute helper
- prevent DumpOutputTest from overriding `Lotgd\getsetting` for later tests
- ensure TemplateTest simulates missing Twig template directory

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68728de960508329ae0a6e3ce58f6e1e