### PR TITLE
Fix template prefix logic and phpunit compatibility

### DIFF
--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -141,7 +141,7 @@ class Template
         // unavailable (for example, during tests that rename the
         // directory to simulate absence).
         if (defined('DEFAULT_TEMPLATE') && str_starts_with((string) DEFAULT_TEMPLATE, 'twig:')) {
-            $defaultName = substr((string) DEFAULT_TEMPLATE, 5);
+            $defaultName = substr((string) DEFAULT_TEMPLATE, strlen('twig:'));
             if ($defaultName === $template) {
                 return 'twig:' . $template;
             }

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -135,6 +135,18 @@ class Template
             return 'twig:' . $template;
         }
 
+        // Fall back to twig prefix when DEFAULT_TEMPLATE specifies
+        // this template as a Twig one. This allows Twig templates to
+        // be referenced even when their directory is temporarily
+        // unavailable (for example, during tests that rename the
+        // directory to simulate absence).
+        if (defined('DEFAULT_TEMPLATE') && str_starts_with((string) DEFAULT_TEMPLATE, 'twig:')) {
+            $defaultName = substr((string) DEFAULT_TEMPLATE, 5);
+            if ($defaultName === $template) {
+                return 'twig:' . $template;
+            }
+        }
+
         return 'legacy:' . $template;
     }
 

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -15,9 +15,7 @@ final class BacktraceTest extends TestCase
         $this->assertSame('', Backtrace::showNoBacktrace());
     }
 
-    /**
-     * @dataProvider getTypeDataProvider
-     */
+    
     #[DataProvider('getTypeDataProvider')]
     public function testGetType($input, string $expected): void
     {

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Lotgd\Backtrace;
 
 require_once __DIR__ . '/../config/constants.php';
@@ -17,6 +18,7 @@ final class BacktraceTest extends TestCase
     /**
      * @dataProvider getTypeDataProvider
      */
+    #[DataProvider('getTypeDataProvider')]
     public function testGetType($input, string $expected): void
     {
         $this->assertSame($expected, Backtrace::getType($input));


### PR DESCRIPTION
## Summary
- ensure templates without directories fall back to `twig:` if default template specifies so
- update BacktraceTest for PHPUnit attribute compatibility

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68729223de2c8329af0d2200a7430278