### PR TITLE
Fix BacktraceTest dataprovider

### DIFF
--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -15,10 +15,10 @@ final class BacktraceTest extends TestCase
         $this->assertSame('', Backtrace::showNoBacktrace());
     }
 
-    #[DataProvider('getTypeDataProvider')]
     /**
      * @dataProvider getTypeDataProvider
      */
+    #[DataProvider('getTypeDataProvider')]
     public function testGetType($input, string $expected): void
     {
         $this->assertSame($expected, Backtrace::getType($input));


### PR DESCRIPTION
## Summary
- ensure `BacktraceTest` works with both PHPUnit 9 and newer

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6872969956908329b0059807bffa29e3