### PR TITLE
Add pavilion sample and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Oliver
 - [Install from Release Archive](#install-from-release-archive)
 - [Cron Job Setup](#cron-job-setup)
 - [SMTP Mail Setup](#smtp-mail-setup)
+- [Beta Setup](#beta-setup)
 - [After Upgrading](#after-upgrading)
 - [Upgrading](#upgrading)
 - [Installation](#installation)
@@ -162,6 +163,14 @@ Enable `notify_on_warn` or `notify_on_error` and set `notify_address` in the
 These notifications rely on the data cache, so ensure `$DB_USEDATACACHE` is set
 to `1` and `$DB_DATACACHEPATH` points to a writable directory in
 `dbconnect.php`.
+
+## Beta Setup
+
+`pavilion.php` is an optional script used when beta features are enabled per
+player. Players flagged for beta access see a link to the pavilion in the
+village and can use it to try experimental features. The repository provides a
+minimal template for this file which simply displays a message and a commentary
+section. Customize it to implement your own beta content.
 
 ## After Upgrading
 

--- a/pavilion.php
+++ b/pavilion.php
@@ -20,4 +20,3 @@ villagenav();
 Commentary::commentdisplay('', 'beta', 'Talk with other testers:', 25);
 
 page_footer();
-?>

--- a/pavilion.php
+++ b/pavilion.php
@@ -1,0 +1,23 @@
+<?php
+use Lotgd\Commentary;
+require_once 'common.php';
+require_once 'lib/villagenav.php';
+
+// translator ready
+// addnews ready
+// mail ready
+
+tlschema('pavilion');
+Commentary::addcommentary();
+checkday();
+
+page_header('Eye-catching Pavilion');
+
+output("`b`cThe Pavilion`c`b`n");
+output("This page is a placeholder for beta features. Customize it to showcase experimental content.`n");
+
+villagenav();
+Commentary::commentdisplay('', 'beta', 'Talk with other testers:', 25);
+
+page_footer();
+?>


### PR DESCRIPTION
## Summary
- add a `pavilion.php` template for beta players
- document the pavilion under a new **Beta Setup** section in `README.md`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6872ab3da7e88329bf01e169e790a361