### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up PHP
+        uses: actions/setup-php@v3
+        with:
+          php-version: '8.1'
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+      - name: Lint PHP files
+        run: |
+          find . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l
+      - name: Run tests
+        run: composer test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Set up PHP
-        uses: actions/setup-php@v3
+        uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![PHP Version](https://img.shields.io/badge/PHP-8.0%2B-blue)
 ![License](https://img.shields.io/badge/license-CC%20BY--SA-lightgrey)
+[![CI](https://github.com/NB-Core/lotgd/actions/workflows/ci.yml/badge.svg)](https://github.com/NB-Core/lotgd/actions/workflows/ci.yml)
 This is a fork of the original Legend of the Green Dragon game by Eric "MightyE" Stevens (http://www.mightye.org) and JT "Kendaer" Traub (http://www.dragoncat.net)
 
 The original readme and license texts follow below, also the installation + upgrade routines which haven't changed much.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs dependencies, runs lint, and tests
- show CI status badge in README

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6872b56624688329a01a9f708cdee551