### PR TITLE
Add strict types declaration

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd\Installer;
 
 use Lotgd\MySQL\Database;

--- a/install/lib/InstallerLogger.php
+++ b/install/lib/InstallerLogger.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd\Installer;
 
 use RuntimeException;

--- a/src/Lotgd/Accounts.php
+++ b/src/Lotgd/Accounts.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 use Lotgd\MySQL\Database;
 

--- a/src/Lotgd/AddNews.php
+++ b/src/Lotgd/AddNews.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 use Lotgd\MySQL\Database;
 

--- a/src/Lotgd/Backtrace.php
+++ b/src/Lotgd/Backtrace.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 /**

--- a/src/Lotgd/Battle.php
+++ b/src/Lotgd/Battle.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 use Lotgd\MySQL\Database;
 

--- a/src/Lotgd/BellRand.php
+++ b/src/Lotgd/BellRand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 /**

--- a/src/Lotgd/Buffs.php
+++ b/src/Lotgd/Buffs.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\Substitute;

--- a/src/Lotgd/Censor.php
+++ b/src/Lotgd/Censor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 use Lotgd\MySQL\Database;
 

--- a/src/Lotgd/CharStats.php
+++ b/src/Lotgd/CharStats.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 class CharStats

--- a/src/Lotgd/CheckBan.php
+++ b/src/Lotgd/CheckBan.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 use Lotgd\MySQL\Database;
 

--- a/src/Lotgd/Commentary.php
+++ b/src/Lotgd/Commentary.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 use Lotgd\MySQL\Database;
 

--- a/src/Lotgd/DataCache.php
+++ b/src/Lotgd/DataCache.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 

--- a/src/Lotgd/DateTime.php
+++ b/src/Lotgd/DateTime.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\Settings;
@@ -181,10 +182,11 @@ class DateTime
 
     public static function dateDifferenceEvents(string $date_1, bool $abs = false): int
     {
-        $year = date('Y');
-        $diff1 = self::dateDifference($year . '-' . $date_1);
-        $diff2 = self::dateDifference(($year + 1) . '-' . $date_1);
-        $diff3 = self::dateDifference(($year - 1) . '-' . $date_1);
+        $year  = (int) date('Y');
+        $diff1 = (int) self::dateDifference($year . '-' . $date_1);
+        $diff2 = (int) self::dateDifference(($year + 1) . '-' . $date_1);
+        $diff3 = (int) self::dateDifference(($year - 1) . '-' . $date_1);
+
         if (abs($diff1) < abs($diff2) && abs($diff1) < abs($diff3)) {
             $d_return = $diff1;
         } elseif (abs($diff2) < abs($diff1) && abs($diff2) < abs($diff3)) {
@@ -192,9 +194,7 @@ class DateTime
         } else {
             $d_return = $diff3;
         }
-        if ($abs === true) {
-            return abs($d_return);
-        }
-        return $d_return;
+
+        return $abs ? abs($d_return) : $d_return;
     }
 }

--- a/src/Lotgd/DeathMessage.php
+++ b/src/Lotgd/DeathMessage.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 use Lotgd\MySQL\Database;
 

--- a/src/Lotgd/DebugLog.php
+++ b/src/Lotgd/DebugLog.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 use Lotgd\MySQL\Database;
 

--- a/src/Lotgd/Dhms.php
+++ b/src/Lotgd/Dhms.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Lotgd;
 
 /**
@@ -26,7 +27,7 @@ class Dhms
             . (int)($secs / 60 % 60)
             . translate_inline('m', 'datetime')
             . ($secs % 60)
-            . ($dec ? substr($secs - (int)$secs, 1) : '')
+            . ($dec ? substr((string)($secs - (int)$secs), 1) : '')
             . translate_inline('s', 'datetime');
     }
 }


### PR DESCRIPTION
## Summary
- declare strict types for all PHP files in `src/` and `install/lib/`
- fix runtime issues in `DateTime` and `Dhms` for strict mode

## Testing
- `php -l install/lib/Installer.php`
- `php -l install/lib/InstallerLogger.php`
- `php -l src/Lotgd/Accounts.php`
- `php -l src/Lotgd/AddNews.php`
- `php -l src/Lotgd/Backtrace.php`
- `php -l src/Lotgd/Battle.php`
- `php -l src/Lotgd/BellRand.php`
- `php -l src/Lotgd/Buffs.php`
- `php -l src/Lotgd/Censor.php`
- `php -l src/Lotgd/CharStats.php`
- `php -l src/Lotgd/CheckBan.php`
- `php -l src/Lotgd/Commentary.php`
- `php -l src/Lotgd/DataCache.php`
- `php -l src/Lotgd/DateTime.php`
- `php -l src/Lotgd/DeathMessage.php`
- `php -l src/Lotgd/DebugLog.php`
- `php -l src/Lotgd/Dhms.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6872b4f0497c8329b55e4e015f0560e3