### PR TITLE
Add phpunit as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,9 @@
         "twig/twig": "^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
+    },
     "autoload": {
         "psr-4": {
             "Lotgd\\": "src/Lotgd/",


### PR DESCRIPTION
## Summary
- add `require-dev` section with phpunit in composer.json

## Testing
- `composer test`

Failed attempts to update lock file due to network restrictions during `composer update phpunit/phpunit` and `composer install`.

------
https://chatgpt.com/codex/tasks/task_e_6872c52d4234832995786085e468f965