### PR TITLE
Fix popup_header argument forwarding

### DIFF
--- a/lib/pageparts.php
+++ b/lib/pageparts.php
@@ -7,7 +7,7 @@ use Lotgd\PageParts;
 function page_header(...$args){ PageParts::pageHeader(...$args); }
 function popup(string $page, string $size="550x300"){ return PageParts::popup($page, $size); }
 function page_footer(bool $saveuser=true){ PageParts::pageFooter($saveuser); }
-function popup_header(string $title="Legend of the Green Dragon"){ PageParts::popupHeader($title); }
+function popup_header(...$args){ PageParts::popupHeader(...$args); }
 function popup_footer(){ PageParts::popupFooter(); }
 function wipe_charstats(): void { PageParts::wipeCharStats(); }
 function addcharstat(string $label, mixed $value = null): void { PageParts::addCharStat($label, $value); }


### PR DESCRIPTION
## Summary
- ensure `popup_header` forwards all arguments

## Testing
- `php -l lib/pageparts.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6872cd6e1754832986bdf30c3ab37d0e