### PR TITLE
Update release workflow to use tag version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Extract version
         id: vars
         run: |
-          VERSION=$(grep -oP '[0-9]+\.[0-9]+\.[0-9]+' common.php | head -1)
+          VERSION="${GITHUB_REF_NAME}"
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Create archives
         run: |


### PR DESCRIPTION
## Summary
- use `GITHUB_REF_NAME` as release version
- keep archive names as `lotgd-${VERSION}.tar.gz` and `lotgd-${VERSION}.zip`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6872d2a71ea48329a97c562233558555