### PR TITLE
Update release workflow version logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Extract version
         id: vars
         run: |
-          VERSION=$(grep -oP '[0-9]+\.[0-9]+\.[0-9]+' common.php | head -1)
+          VERSION="${GITHUB_REF_NAME#v}"
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Create archives
         run: |


### PR DESCRIPTION
## Summary
- derive VERSION from tag name instead of parsing `common.php`
- keep the versioned archive names unchanged

## Testing
- `composer test`
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6872d2a6d0d483298d4cee71d02cabc3