### PR TITLE
Adjust release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,18 +22,16 @@ jobs:
       - name: Create archives
         run: |
           VERSION=${{ steps.vars.outputs.VERSION }}
-          tar --exclude='./lotgd-${VERSION}.tar.gz' \
-              --exclude='./lotgd-${VERSION}.zip' \
-              --exclude='.git*' --exclude='.github' --exclude='tests' \
+          mkdir dist
+          tar --exclude='.git*' --exclude='.github' --exclude='tests' \
               --exclude='phpunit.xml' --exclude='.phpunit.result.cache' \
-              -czf "lotgd-${VERSION}.tar.gz" .
-          zip -r "lotgd-${VERSION}.zip" . \
-              -x "./lotgd-${VERSION}.tar.gz" -x "./lotgd-${VERSION}.zip" \
+              -czf "dist/lotgd-${VERSION}.tar.gz" .
+          zip -r "dist/lotgd-${VERSION}.zip" . \
               -x '*.git*' -x '.github/*' -x 'tests/*' -x 'phpunit.xml' -x '.phpunit.result.cache'
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: lotgd-${{ steps.vars.outputs.VERSION }}
           path: |
-            lotgd-${{ steps.vars.outputs.VERSION }}.tar.gz
-            lotgd-${{ steps.vars.outputs.VERSION }}.zip
+            dist/lotgd-${{ steps.vars.outputs.VERSION }}.tar.gz
+            dist/lotgd-${{ steps.vars.outputs.VERSION }}.zip


### PR DESCRIPTION
## Summary
- update release archives path to use `dist/`

## Testing
- `composer test`
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6872e097e7ec8329904f8058f88a7157