### PR TITLE
Fix release archive to ignore dist directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,9 @@ jobs:
           mkdir dist
           tar --exclude='.git*' --exclude='.github' --exclude='tests' \
               --exclude='phpunit.xml' --exclude='.phpunit.result.cache' \
-              -czf "dist/lotgd-${VERSION}.tar.gz" .
+              --exclude='dist' -czf "dist/lotgd-${VERSION}.tar.gz" .
           zip -r "dist/lotgd-${VERSION}.zip" . \
-              -x '*.git*' -x '.github/*' -x 'tests/*' -x 'phpunit.xml' -x '.phpunit.result.cache'
+              -x '*.git*' -x '.github/*' -x 'tests/*' -x 'phpunit.xml' -x '.phpunit.result.cache' -x 'dist/*'
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- exclude `dist` directory when creating release archives to avoid "file changed as we read it" error

## Testing
- `composer test`
- `composer install` *(failed: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_6872e383f4dc8329b53a44752d820faf