### PR TITLE
Use Translator namespace accessor

### DIFF
--- a/src/Lotgd/AddNews.php
+++ b/src/Lotgd/AddNews.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace Lotgd;
 use Lotgd\MySQL\Database;
+use Lotgd\Translator;
 
 class AddNews
 {
@@ -31,7 +32,6 @@ class AddNews
      */
     public static function addForUser(int $user, string $news, mixed ...$args): mixed
     {
-        global $translation_namespace;
         $hidefrombio = false;
 
         if (count($args) > 0) {
@@ -57,7 +57,7 @@ class AddNews
             . '\'' . addslashes($news) . '\','
             . '\'' . date('Y-m-d H:i:s') . '\','
             . $user . ',\'' . addslashes($arguments) . '\','
-            . '\'' . $translation_namespace . '\')';
+            . '\'' . Translator::getNamespace() . '\')';
 
         return Database::query($sql);
     }

--- a/src/Lotgd/Buffs.php
+++ b/src/Lotgd/Buffs.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\Substitute;
+use Lotgd\Translator;
 class Buffs
 {
     private static array $buffReplacements = [];
@@ -143,10 +144,10 @@ class Buffs
 
     public static function applyBuff(string $name, array $buff): void
     {
-        global $session, $translation_namespace;
+        global $session;
 
         if (!isset($buff['schema']) || $buff['schema'] == '') {
-            $buff['schema'] = $translation_namespace;
+            $buff['schema'] = Translator::getNamespace();
         }
 
         if (isset(self::$buffReplacements[$name])) {

--- a/src/Lotgd/Commentary.php
+++ b/src/Lotgd/Commentary.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace Lotgd;
 use Lotgd\MySQL\Database;
+use Lotgd\Translator;
 
 class Commentary
 {
@@ -116,9 +117,9 @@ class Commentary
      */
     public static function injectCommentary(string $section, string $talkline, string $comment, $schema = false): void
     {
-        global $session, $doublepost, $translation_namespace;
+        global $session, $doublepost;
         if ($schema === false) {
-            $schema = $translation_namespace;
+            $schema = Translator::getNamespace();
         }
         $comment = stripslashes($comment);
         tlschema('commentary');
@@ -195,7 +196,7 @@ class Commentary
      */
     public static function viewCommentary(string $section, string $message = 'Interject your own commentary?', int $limit = 10, string $talkline = 'says', $schema = false, bool $viewonly = false, bool $returnastext = false, $scriptname_pre = false): ?string
     {
-        global $session, $REQUEST_URI, $doublepost, $translation_namespace, $emptypost;
+        global $session, $REQUEST_URI, $doublepost, $emptypost;
 
         // The guard for null is removed as $section is declared as string and cannot be null.
 
@@ -230,7 +231,7 @@ class Commentary
         }
 
         if ($schema === false) {
-            $schema = $translation_namespace;
+            $schema = Translator::getNamespace();
         }
         tlschema('commentary');
 
@@ -668,8 +669,8 @@ class Commentary
      */
     public static function talkForm(string $section, string $talkline, int $limit = 10, $schema = false)
     {
-      global $REQUEST_URI,$session,$translation_namespace;
-        if ($schema===false) $schema=$translation_namespace;
+      global $REQUEST_URI,$session;
+        if ($schema===false) $schema=Translator::getNamespace();
         tlschema("commentary");
 
         $jump = false;

--- a/src/Lotgd/Moderate.php
+++ b/src/Lotgd/Moderate.php
@@ -178,7 +178,7 @@ class Moderate
         debug('Select: ' . $sectselect);
 
         // Determine which translation schema to use for output
-        if ($schema === false) {
+        if ($schema === null) {
             $schema = Translator::getNamespace();
         }
         tlschema('commentary');

--- a/src/Lotgd/Moderate.php
+++ b/src/Lotgd/Moderate.php
@@ -5,6 +5,7 @@ use Lotgd\MySQL\Database;
 use Lotgd\Forms;
 use Lotgd\HolidayText;
 use Lotgd\Commentary;
+use Lotgd\Translator;
 
 /**
  * Tools for comment moderation.
@@ -151,7 +152,7 @@ class Moderate
      */
     public static function viewmoderatedcommentary(string $section, string $message = 'Interject your own commentary?', int $limit = 10, string $talkline = 'says', ?string $schema = null, bool $viewall = false): void
     {
-        global $session, $REQUEST_URI, $doublepost, $translation_namespace, $emptypost;
+        global $session, $REQUEST_URI, $doublepost, $emptypost;
 
         // Decide whether to limit to a specific section or view all
         if ($viewall === false) {
@@ -178,7 +179,7 @@ class Moderate
 
         // Determine which translation schema to use for output
         if ($schema === false) {
-            $schema = $translation_namespace;
+            $schema = Translator::getNamespace();
         }
         tlschema('commentary');
 

--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -107,14 +107,14 @@ class Nav
      */
     public static function addHeader($text, bool $collapse = true, bool $translate = true): void
     {
-        global $translation_namespace, $notranslate;
+        global $notranslate;
         if (self::$block_new_navs) return;
         if (is_array($text)) {
             $text = '!array!' . serialize($text);
         }
         self::$navsection = $text;
         if (!array_key_exists($text, self::$navschema)) {
-            self::$navschema[$text] = $translation_namespace;
+            self::$navschema[$text] = Translator::getNamespace();
         }
         if (!isset(self::$navbysection[self::$navsection])) {
             self::$navbysection[self::$navsection] = [];
@@ -157,7 +157,6 @@ class Nav
 
     public static function add($text, $link = false, $priv = false, $pop = false, $popsize = '500x300'): void
     {
-        global $translation_namespace;
         if (self::$block_new_navs) return;
         if ($link === false) {
             if ($text != '') {
@@ -176,7 +175,7 @@ class Nav
                     $t = $t[0];
                 }
                 if (!array_key_exists($t, self::$navschema)) {
-                    self::$navschema[$t] = $translation_namespace;
+                    self::$navschema[$t] = Translator::getNamespace();
                 }
                 array_push(self::$navbysection[self::$navsection], array_merge($args, ['translate' => false]));
             }

--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -48,8 +48,16 @@ class Translator
 			$language=$settings->getsetting("defaultlanguage","en");
 		}
 
-		define("LANGUAGE",preg_replace("/[^a-z]/i","",$language));
-	}
+                define("LANGUAGE",preg_replace("/[^a-z]/i","",$language));
+        }
+
+    /**
+     * Return the current translation namespace.
+     */
+    public static function getNamespace(): string
+    {
+        return self::$translation_namespace;
+    }
 
     /**
      * Translate a string or array within an optional namespace.


### PR DESCRIPTION
## Summary
- expose current translation namespace via `Translator::getNamespace()`
- reference Translator namespace in AddNews, Nav, Buffs, Commentary and Moderate

## Testing
- `php -l src/Lotgd/Translator.php`
- `php -l src/Lotgd/AddNews.php`
- `php -l src/Lotgd/Nav.php`
- `php -l src/Lotgd/Buffs.php`
- `php -l src/Lotgd/Commentary.php`
- `php -l src/Lotgd/Moderate.php`
- `COMPOSER_DISABLE_NETWORK=1 composer install` *(fails: network disabled)*
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6873a203da4c8329b92fdf5e5e69ffcb