### PR TITLE
Restore MOTD administration features

### DIFF
--- a/motd.php
+++ b/motd.php
@@ -36,6 +36,15 @@ if ($op=="vote"){
 	header("Location: motd.php");
 	exit();
 }
+if (($op == "save" || $op == "savenew") && ($session['user']['superuser'] & SU_POST_MOTD)) {
+        if ($op == "save") {
+                Motd::saveMotd((int)$id);
+        } else {
+                Motd::savePoll();
+        }
+        header("Location: motd.php");
+        exit();
+}
 if ($op == "add" || $op == "addpoll" || $op == "del")  {
 	if ($session['user']['superuser'] & SU_POST_MOTD) {
             if ($op == "add") Motd::motdForm($id);

--- a/src/Lotgd/Motd.php
+++ b/src/Lotgd/Motd.php
@@ -48,6 +48,7 @@ class Motd
         modulehook('motd-item-intercept', ['id' => $id]);
         rawoutput('<div>' . $body . '</div>');
         rawoutput('<small>' . translate_inline('Posted by') . ' ' . $author . ' - ' . $date . '</small>');
+        self::motdAdminLinks($id, false);
         rawoutput('</div>');
     }
 
@@ -63,6 +64,7 @@ class Motd
         if ($showpoll) {
             rawoutput('<div>' . translate_inline('Poll ID') . ': ' . $id . '</div>');
         }
+        self::motdAdminLinks($id, true);
         rawoutput('</div>');
     }
 
@@ -90,8 +92,13 @@ class Motd
             'motdbody'  => 'Body,textarea',
             'motdtype'  => 'Type,viewhiddenonly',
         );
+        if ($id > 0) {
+            $form['changeauthor'] = 'Change Author,checkbox';
+            $form['changedate'] = 'Change Date (force popup),checkbox';
+        }
         output('<form action="motd.php?op=save&id=' . (int)$id . '" method="post">', true);
-        Forms::showForm($form, array('motdtitle' => $title, 'motdbody' => $body, 'motdtype' => $poll));
+        $data = ['motdtitle' => $title, 'motdbody' => $body, 'motdtype' => $poll, 'changeauthor' => 0, 'changedate' => 0];
+        Forms::showForm($form, $data);
         rawoutput('</form>');
     }
 
@@ -103,13 +110,73 @@ class Motd
         require_once 'lib/showform.php';
         $form = array(
             'Poll,title',
-            'motdtitle' => 'Title,text',
-            'motdbody'  => 'Body,textarea',
+            'motdtitle' => 'Question,text',
+            'choice1'   => 'Option 1,text',
+            'choice2'   => 'Option 2,text',
+            'choice3'   => 'Option 3,text',
+            'choice4'   => 'Option 4,text',
             'motdtype'  => 'Type,viewhiddenonly',
         );
+        output('`b`4Note:`0 Polls cannot be edited after creation.`n`n');
         output('<form action="motd.php?op=savenew" method="post">', true);
-        Forms::showForm($form, array('motdtitle' => '', 'motdbody' => '', 'motdtype' => '1'));
+        Forms::showForm($form, array('motdtitle' => '', 'motdtype' => '1', 'choice1' => '', 'choice2' => '', 'choice3' => '', 'choice4' => ''));
         rawoutput('</form>');
+    }
+
+    /**
+     * Insert or update a MOTD entry.
+     */
+    public static function saveMotd(int $id): void
+    {
+        global $session;
+        $title = httppost('motdtitle');
+        $body = httppost('motdbody');
+        $type = (int) httppost('motdtype');
+        $changeauthor = (bool) httppost('changeauthor');
+        $changedate = (bool) httppost('changedate');
+
+        $author = $session['user']['acctid'];
+        $date = date('Y-m-d H:i:s');
+        if ($id > 0) {
+            $sql = 'SELECT motdauthor,motddate FROM ' . Database::prefix('motd') . " WHERE motditem=$id";
+            $res = Database::query($sql);
+            $row = Database::numRows($res) > 0 ? Database::fetchAssoc($res) : [];
+            if (!$changeauthor && isset($row['motdauthor'])) {
+                $author = $row['motdauthor'];
+            }
+            if (!$changedate && isset($row['motddate'])) {
+                $date = $row['motddate'];
+            }
+            $sql = 'UPDATE ' . Database::prefix('motd') .
+                " SET motdtitle=\"$title\",motdbody=\"$body\",motdtype=$type,motddate=\"$date\",motdauthor=$author WHERE motditem=$id";
+        } else {
+            $sql = 'INSERT INTO ' . Database::prefix('motd') .
+                " (motdtitle,motdbody,motddate,motdtype,motdauthor) VALUES (\"$title\",\"$body\",\"$date\",$type,$author)";
+        }
+        Database::query($sql);
+        invalidatedatacache('motd');
+    }
+
+    /**
+     * Create a new poll entry from form data.
+     */
+    public static function savePoll(): void
+    {
+        global $session;
+        $title = httppost('motdtitle');
+        $choices = [];
+        for ($i = 1; $i <= 4; $i++) {
+            $c = trim((string) httppost("choice$i"));
+            if ($c !== '') {
+                $choices[] = $c;
+            }
+        }
+        $body = serialize($choices);
+        $date = date('Y-m-d H:i:s');
+        $sql = 'INSERT INTO ' . Database::prefix('motd') .
+            " (motdtitle,motdbody,motddate,motdtype,motdauthor) VALUES (\"$title\",\"$body\",\"$date\",1,{$session['user']['acctid']})";
+        Database::query($sql);
+        invalidatedatacache('motd');
     }
 
     /**
@@ -120,5 +187,22 @@ class Motd
         $sql = 'DELETE FROM ' . Database::prefix('motd') . " WHERE motditem='$id'";
         Database::query($sql);
         invalidatedatacache('motd');
+    }
+
+    /**
+     * Output edit and delete links for an entry if user can post.
+     */
+    private static function motdAdminLinks(int $id, bool $poll): void
+    {
+        global $session;
+        if ($session['user']['superuser'] & SU_POST_MOTD) {
+            $edit = translate_inline('Edit');
+            $del = translate_inline('Del');
+            $conf = translate_inline('Are you sure you wish to delete this entry?');
+            $editop = $poll ? 'addpoll' : 'add';
+            rawoutput(" [ <a href='motd.php?op=$editop&id=$id'>$edit</a> | <a href='motd.php?op=del&id=$id' onClick='return confirm(\"$conf\");'>$del</a> ]");
+            addnav('', "motd.php?op=$editop&id=$id");
+            addnav('', "motd.php?op=del&id=$id");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add saveMotd and savePoll helpers
- add admin links helper and extend forms
- restore op=save and op=savenew handling
- reintroduce admin links in MOTD display

## Testing
- `composer test`
- `php -l src/Lotgd/Motd.php motd.php`


------
https://chatgpt.com/codex/tasks/task_e_68795a82bf508329a3d5771a258f5d68