### PR TITLE
Fix MOTD cache invalidation

### DIFF
--- a/motd.php
+++ b/motd.php
@@ -81,8 +81,8 @@ if ($op=="") {
 		$p_month = $date_array[1];
 		$month_post_end = date("Y-m-t", strtotime($p_year."-".$p_month."-"."01")); // get last day of month this way, it's a valid DATETIME now
 		$sql = "SELECT " . db_prefix("motd") . ".*,name AS motdauthorname FROM " . db_prefix("motd") . " LEFT JOIN " . db_prefix("accounts") . " ON " . db_prefix("accounts") . ".acctid = " . db_prefix("motd") . ".motdauthor WHERE motddate >= '{$month_post}-01' AND motddate <= '{$month_post_end}' ORDER BY motddate DESC";
-		$result = db_query_cached($sql,"motd-$month_post");output($month_post_end);
-		$result = db_query($sql);
+                $result = db_query_cached($sql, "motd-$month_post");
+                $result = db_query($sql);
 	}else{
 		$sql = "SELECT " . db_prefix("motd") . ".*,name AS motdauthorname FROM " . db_prefix("motd") . " LEFT JOIN " . db_prefix("accounts") . " ON " . db_prefix("accounts") . ".acctid = " . db_prefix("motd") . ".motdauthor ORDER BY motddate DESC limit $newcount,".($newcount+$count);
 		if ($newcount=0) //cache only the last x items

--- a/src/Lotgd/Motd.php
+++ b/src/Lotgd/Motd.php
@@ -231,6 +231,8 @@ class Motd
         }
         Database::query($sql);
         invalidatedatacache('motd');
+        invalidatedatacache('lastmotd');
+        invalidatedatacache('motddate');
     }
 
     /**
@@ -262,6 +264,8 @@ class Motd
         $sql = 'DELETE FROM ' . Database::prefix('motd') . " WHERE motditem='$id'";
         Database::query($sql);
         invalidatedatacache('motd');
+        invalidatedatacache('lastmotd');
+        invalidatedatacache('motddate');
     }
 
     /**


### PR DESCRIPTION
## Summary
- refresh `lastmotd` and `motddate` caches when saving/deleting MOTD entries
- clean up stray output statement in `motd.php`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68797f77ebfc8329baa723f69459e552