### PR TITLE
Refine module pref user handling

### DIFF
--- a/lib/modules.php
+++ b/lib/modules.php
@@ -112,32 +112,32 @@ function module_delete_userprefs(int $user): void
 }
 
 $module_prefs = array();
-function get_all_module_prefs(?string $module = null, $user = null): array
+function get_all_module_prefs(?string $module = null, ?int $user = null): array
 {
     return Modules::getAllModulePrefs($module, $user);
 }
 
-function get_module_pref(string $name, ?string $module = null, $user = null)
+function get_module_pref(string $name, ?string $module = null, ?int $user = null)
 {
     return Modules::getModulePref($name, $module, $user);
 }
 
-function set_module_pref(string $name, mixed $value, ?string $module = null, $user = null): void
+function set_module_pref(string $name, mixed $value, ?string $module = null, ?int $user = null): void
 {
     Modules::setModulePref($name, $value, $module, $user);
 }
 
-function increment_module_pref(string $name, int|float $value = 1, ?string $module = null, $user = null): void
+function increment_module_pref(string $name, int|float $value = 1, ?string $module = null, ?int $user = null): void
 {
     Modules::incrementModulePref($name, $value, $module, $user);
 }
 
-function clear_module_pref(string $name, ?string $module = null, $user = null): void
+function clear_module_pref(string $name, ?string $module = null, ?int $user = null): void
 {
     Modules::clearModulePref($name, $module, $user);
 }
 
-function load_module_prefs(string $module, $user = null): void
+function load_module_prefs(string $module, ?int $user = null): void
 {
     Modules::loadModulePrefs($module, $user);
 }

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -733,9 +733,9 @@ class Modules
             $user = $session['user']['acctid'] ?? 0;
         }
 
-        if ($user !== null) {
-            $user = (int) $user;
-        }
+        // No need to cast $user to (int) as it is already typed as ?int
+        // and PHP's type system ensures it is either null or an integer.
+        
 
         self::loadModulePrefs($module, $user);
 

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -722,7 +722,7 @@ class Modules
     /**
      * Retrieve all module preferences for a user.
      */
-    public static function getAllModulePrefs(?string $module = null, $user = null): array
+    public static function getAllModulePrefs(?string $module = null, ?int $user = null): array
     {
         global $module_prefs, $mostrecentmodule, $session;
 
@@ -733,6 +733,10 @@ class Modules
             $user = $session['user']['acctid'] ?? 0;
         }
 
+        if ($user !== null) {
+            $user = (int) $user;
+        }
+
         self::loadModulePrefs($module, $user);
 
         return $module_prefs[$user][$module] ?? [];
@@ -741,7 +745,7 @@ class Modules
     /**
      * Get a specific module preference value for a user.
      */
-    public static function getModulePref(string $name, ?string $module = null, $user = null)
+    public static function getModulePref(string $name, ?string $module = null, ?int $user = null)
     {
         global $module_prefs, $mostrecentmodule, $session;
 
@@ -750,6 +754,10 @@ class Modules
         }
         if ($user === null && isset($session['user']['acctid'])) {
             $user = $session['user']['acctid'];
+        }
+
+        if ($user !== null) {
+            $user = (int) $user;
         }
 
         if ($user !== null && isset($module_prefs[$user][$module][$name])) {
@@ -787,7 +795,7 @@ class Modules
     /**
      * Persist a module preference value for a user.
      */
-    public static function setModulePref(string $name, $value, ?string $module = null, $user = null): void
+    public static function setModulePref(string $name, $value, ?string $module = null, ?int $user = null): void
     {
         global $module_prefs, $mostrecentmodule, $session;
 
@@ -798,6 +806,10 @@ class Modules
             $uid = $session['user']['acctid'] ?? 0;
         } else {
             $uid = $user;
+        }
+
+        if ($uid !== null) {
+            $uid = (int) $uid;
         }
 
         self::loadModulePrefs($module, $uid);
@@ -824,7 +836,7 @@ class Modules
     /**
      * Increment a numeric module preference value.
      */
-    public static function incrementModulePref(string $name, $value = 1, ?string $module = null, $user = null): void
+    public static function incrementModulePref(string $name, $value = 1, ?string $module = null, ?int $user = null): void
     {
         global $module_prefs, $mostrecentmodule, $session;
 
@@ -837,6 +849,10 @@ class Modules
             $uid = $session['user']['acctid'];
         } else {
             $uid = $user;
+        }
+
+        if ($uid !== null) {
+            $uid = (int) $uid;
         }
 
         self::loadModulePrefs($module, $uid);
@@ -863,7 +879,7 @@ class Modules
     /**
      * Clear a module preference for a user.
      */
-    public static function clearModulePref(string $name, ?string $module = null, $user = null): void
+    public static function clearModulePref(string $name, ?string $module = null, ?int $user = null): void
     {
         global $module_prefs, $mostrecentmodule, $session;
 
@@ -874,6 +890,9 @@ class Modules
             $uid = $session['user']['acctid'];
         } else {
             $uid = $user;
+        }
+        if ($uid !== null) {
+            $uid = (int) $uid;
         }
 
         self::loadModulePrefs($module, $uid);
@@ -895,12 +914,16 @@ class Modules
     /**
      * Load user preferences for a module.
      */
-    public static function loadModulePrefs(string $module, $user = null): void
+    public static function loadModulePrefs(string $module, ?int $user = null): void
     {
         global $module_prefs, $session;
 
         if ($user === null) {
             $user = $session['user']['acctid'];
+        }
+
+        if ($user !== null) {
+            $user = (int) $user;
         }
 
         if (!isset($module_prefs[$user])) {


### PR DESCRIPTION
## Summary
- typehint `$user` as `?int` for module pref APIs
- cast legacy user values to int
- expose updated signatures in wrapper helpers

## Testing
- `php -l src/Lotgd/Modules.php`
- `php -l lib/modules.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687a88ac06a0832980c33b3c1fd45e8c