### PR TITLE
Fix hauntedby preference retrieval

### DIFF
--- a/modules/graveyard_haunt.php
+++ b/modules/graveyard_haunt.php
@@ -126,7 +126,7 @@ $sql = "SELECT name,level,acctid FROM " . Database::prefix("accounts") . " WHERE
 $result = Database::query($sql);
 if (Database::numRows($result)>0){
 	$row = Database::fetchAssoc($result);
-       $already_haunted=(int)get_module_pref('hauntedby', 'graveyard_haunt', $row['acctid']);
+	$already_haunted=(int)get_module_pref('hauntedby', 'graveyard_haunt', $row['acctid']);
 	if ($row['hauntedby']!=0){
 		output("That person has already been haunted, please select another target");
 	}else{

--- a/modules/graveyard_haunt.php
+++ b/modules/graveyard_haunt.php
@@ -126,7 +126,7 @@ $sql = "SELECT name,level,acctid FROM " . Database::prefix("accounts") . " WHERE
 $result = Database::query($sql);
 if (Database::numRows($result)>0){
 	$row = Database::fetchAssoc($result);
-	$already_haunted=(int)get_module_pref('hauntedby',$row['acctid']);
+       $already_haunted=(int)get_module_pref('hauntedby', 'graveyard_haunt', $row['acctid']);
 	if ($row['hauntedby']!=0){
 		output("That person has already been haunted, please select another target");
 	}else{


### PR DESCRIPTION
## Summary
- fix retrieval of `hauntedby` pref in `graveyard_haunt`

## Testing
- `php -l modules/graveyard_haunt.php`
- `composer test`
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_687a88bb71cc83298f4651e8d40f8b90