### PR TITLE
Guard nav counter for guests

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changes to 1.3.0 +nb
 *lib/sendmail.php --> sending to a non-valid email address format should not be allowed -> skipped (no good error handling optional, because it is not a system error)
 *lib/serialization.php --> unserialize() is not safe, and needs a wrapper for newer php versions
 *lib/showform.php --> unset nightmare
+*src/Lotgd/Nav.php --> skip nav counter when user is not logged in
 
 [CHANGES]
 

--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -82,6 +82,10 @@ class Nav
     public static function appendCount(string $link): string
     {
         global $session;
+        if (! (isset($session['loggedin']) && $session['loggedin'])) {
+            return $link;
+        }
+
         return self::appendLink($link, 'c=' . $session['counter'] . '-' . date('His'));
     }
 
@@ -342,13 +346,17 @@ class Nav
         } else {
             if ($text != '') {
                 $extra = '';
-                if (!isset($session['counter'])) $session['counter'] = '';
-                if (strpos($link, '?')) {
-                    $extra = "&c={$session['counter']}";
-                } else {
-                    $extra = "?c={$session['counter']}";
+                if (isset($session['loggedin']) && $session['loggedin']) {
+                    if (!isset($session['counter'])) {
+                        $session['counter'] = '';
+                    }
+                    if (strpos($link, '?')) {
+                        $extra = "&c={$session['counter']}";
+                    } else {
+                        $extra = "?c={$session['counter']}";
+                    }
+                    $extra .= '-' . date('His');
                 }
-                $extra .= '-' . date('His');
                 $key = '';
                 if ($text[1] == '?') {
                     $hchar = strtolower($text[0]);
@@ -445,12 +453,14 @@ class Nav
                 $n = str_replace('<a ', Translator::tlbuttonPop() . '<a ', $n);
                 $thisnav .= $n;
             }
-            $session['allowednavs'][$link . $extra] = true;
-            $session['allowednavs'][str_replace(' ', '%20', $link) . $extra] = true;
-            $session['allowednavs'][str_replace(' ', '+', $link) . $extra] = true;
-            if (($pos = strpos($link, '#')) !== false) {
-                $sublink = substr($link, 0, $pos);
-                $session['allowednavs'][$sublink . $extra] = true;
+            if (isset($session['loggedin']) && $session['loggedin']) {
+                $session['allowednavs'][$link . $extra] = true;
+                $session['allowednavs'][str_replace(' ', '%20', $link) . $extra] = true;
+                $session['allowednavs'][str_replace(' ', '+', $link) . $extra] = true;
+                if (($pos = strpos($link, '#')) !== false) {
+                    $sublink = substr($link, 0, $pos);
+                    $session['allowednavs'][$sublink . $extra] = true;
+                }
             }
         }
         if ($unschema) tlschema();


### PR DESCRIPTION
## Summary
- guard `appendCount` so it returns the link unchanged when the session isn't logged in
- wrap nav counter handling and `allowednavs` updates in `privateAddNav` inside a logged-in check
- document change in CHANGELOG

## Testing
- `php -l src/Lotgd/Nav.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687aa1c544488329b1d1d1404c4b0d8a