### PR TITLE
Fix MoTD poll choices parsing

### DIFF
--- a/src/Lotgd/Motd.php
+++ b/src/Lotgd/Motd.php
@@ -77,7 +77,7 @@ class Motd
         $row = Database::numRows($result) > 0 ? Database::fetchAssoc($result) : [];
         $choice = $row['choice'] ?? null;
 
-        $bodyData = @unserialize($body);
+        $bodyData = @unserialize(stripslashes($body));
         if (!is_array($bodyData)) {
             $bodyData = ['body' => $body, 'opt' => []];
         }

--- a/tests/AMotdTest.php
+++ b/tests/AMotdTest.php
@@ -208,6 +208,17 @@ namespace {
             $this->assertStringContainsString("type='radio' name='choice'", $forms_output);
         }
 
+        public function testPollItemUnserializesSlashedData(): void
+        {
+            global $forms_output;
+            $data = ['body' => 'Question?', 'opt' => ['Yes', 'No']];
+            $body = addslashes(serialize($data));
+
+            Motd::pollItem(1, 'Subject', $body, 'Author', '2024-01-01 00:00:00');
+
+            $this->assertStringContainsString("type='radio' name='choice'", $forms_output);
+        }
+
         public function testSavePollSerializesData(): void
         {
             $_POST['motdtitle'] = 'Title';


### PR DESCRIPTION
## Summary
- fix unserialize for polls stored with slashes
- test slashed poll data

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `composer test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b989789d4832991a77112b564f9d6