### PR TITLE
Add colored nav headline support

### DIFF
--- a/docs/Nav.md
+++ b/docs/Nav.md
@@ -1,0 +1,19 @@
+# Navigation Helpers
+
+This page documents helper methods in `\Lotgd\Nav`.
+
+## addColoredHeadline
+
+```php
+addColoredHeadline(string $text, bool $collapse = true): void
+```
+
+Adds a navigation headline that supports LOTGD colour codes. Any open colour span is automatically closed by appending `` `0`` before the headline is rendered.
+
+Use it when you want section titles with coloured text:
+
+```php
+\Lotgd\Nav::addColoredHeadline('`!Important Section');
+```
+
+The example renders the header using the `!` colour and ends with the default colour.

--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -28,7 +28,7 @@ class Nav
     private static array $accesskeys = [];
     private static array $quickkeys = [];
     /**
-     * Store which nav sections use coloured headlines so we can
+     * Store which nav sections use colored headlines so we can
      * append the colour reset when rendering.
      *
      * @var array<string,bool>

--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -28,6 +28,13 @@ class Nav
     private static array $accesskeys = [];
     private static array $quickkeys = [];
     /**
+     * Store which nav sections use coloured headlines so we can
+     * append the colour reset when rendering.
+     *
+     * @var array<string,bool>
+     */
+    private static array $coloredsections = [];
+    /**
      * Block a navigation link.
      */
     public static function blockNav(string $link, bool $partial = false): void
@@ -132,6 +139,18 @@ class Nav
             }
             array_push($notranslate, [$text, '']);
         }
+    }
+
+    /**
+     * Add a navigation headline that can include LOTGD colour codes.
+     * The headline is automatically terminated with `0 so any
+     * open colour span closes before rendering.
+     */
+    public static function addColoredHeadline(string $text, bool $collapse = true): void
+    {
+        if (self::$block_new_navs) return;
+        self::addHeader($text, $collapse);
+        self::$coloredsections[self::$navsection] = true;
     }
 
     public static function addNotl($text, $link = false, $priv = false, $pop = false, $popsize = '500x300'): void
@@ -248,7 +267,15 @@ class Nav
                     if (substr($key, 0, 7) == '!array!') {
                         $key = unserialize(substr($key, 7));
                     }
-                    $navbanner = self::privateAddNav($key);
+                    $header = $key;
+                    if (isset(self::$coloredsections[$tkey]) && self::$coloredsections[$tkey]) {
+                        if (is_array($header)) {
+                            $header[0] .= '`0';
+                        } else {
+                            $header .= '`0';
+                        }
+                    }
+                    $navbanner = self::privateAddNav($header);
                     if (isset($session['loggedin']) && $session['loggedin']) tlschema();
                 }
                 $style = 'default';
@@ -293,6 +320,7 @@ class Nav
             }
         }
         self::$navbysection = [];
+        self::$coloredsections = [];
         return $builtnavs;
     }
 

--- a/tests/NavColoredHeadlineTest.php
+++ b/tests/NavColoredHeadlineTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    use PHPUnit\Framework\TestCase;
+    use Lotgd\Nav;
+    use Lotgd\Output;
+    use Lotgd\Template;
+
+    require_once __DIR__ . '/../config/constants.php';
+    if (!function_exists('modulehook')) { function modulehook($name, $data = [], $allowinactive = false, $only = false){ return $data; } }
+    if (!function_exists('translate')) { function translate($t, $ns = false){ return $t; } }
+    if (!function_exists('translate_inline')) { function translate_inline($t, $ns = false){ return $t; } }
+    if (!function_exists('tlbutton_pop')) { function tlbutton_pop(){ return ''; } }
+    if (!function_exists('tlschema')) { function tlschema($schema = false){} }
+    if (!function_exists('popup')) { function popup(string $page, string $size = '550x300'){ return ''; } }
+    if (!function_exists('rawoutput')) { function rawoutput($t){} }
+    if (!function_exists('output_notl')) { function output_notl($f,$t=true){} }
+    if (!function_exists('output')) { function output($f,$t=true){} }
+    if (!function_exists('debug')) { function debug($t,$force=false){} }
+    if (!function_exists('appoencode')) { function appoencode($data,$priv=false){ global $output; return $output->appoencode($data,$priv); } }
+
+    final class NavColoredHeadlineTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            global $session, $nav, $template, $output;
+            $session = ['user' => ['prefs' => []], 'allowednavs' => [], 'loggedin' => false];
+            $nav = '';
+            $output = new Output();
+            $template = [
+                'navhead' => '<span class="navhead">{title}</span>',
+                'navitem' => '<a href="{link}">{text}</a>'
+            ];
+        }
+
+        protected function tearDown(): void
+        {
+            global $session, $nav, $template, $output;
+            unset($session, $nav, $template, $output);
+        }
+
+        public function testRegularHeadlineUncolored(): void
+        {
+            Nav::addHeader('Section', false);
+            Nav::add('Link', 'foo.php');
+
+            $navs = Nav::buildNavs();
+            $this->assertStringContainsString('<span class="navhead">Section</span>', $navs);
+            $this->assertStringNotContainsString('colLtBlue', $navs);
+        }
+
+        public function testColoredHeadlineRendersColors(): void
+        {
+            Nav::addColoredHeadline('`!Section', false);
+            Nav::add('Link', 'foo.php');
+
+            $navs = Nav::buildNavs();
+            $this->assertMatchesRegularExpression('/<span class="navhead">.*<span class=\'colLtBlue\'>Section<\/span>.*<\/span>/', $navs);
+        }
+
+        public function testColoredHeadlineSkippedWhenNoLinks(): void
+        {
+            $navs = Nav::buildNavs();
+            $this->assertSame('', $navs);
+
+            Nav::addColoredHeadline('`!Empty');
+            $navs = Nav::buildNavs();
+            $this->assertSame('', $navs);
+        }
+
+        public function testColoredHeadlineWithBlockedLink(): void
+        {
+            Nav::addColoredHeadline('`!Section', false);
+            Nav::add('Link', 'foo.php');
+            Nav::blockNav('foo.php');
+
+            $navs = Nav::buildNavs();
+            $this->assertSame('', $navs);
+            Nav::unblockNav('foo.php');
+        }
+
+        public function testColoredHeadlineWithColoredNavItem(): void
+        {
+            Nav::addColoredHeadline('`!Section', false);
+            Nav::add('`$Link', 'foo.php');
+
+            $navs = Nav::buildNavs();
+            $this->assertStringContainsString('colLtBlue', $navs);
+            $this->assertStringContainsString('colLtRed', $navs);
+            $this->assertStringContainsString('foo.php', $navs);
+        }
+    }
+}

--- a/tests/NavColoredHeadlineTest.php
+++ b/tests/NavColoredHeadlineTest.php
@@ -9,17 +9,57 @@ namespace {
     use Lotgd\Template;
 
     require_once __DIR__ . '/../config/constants.php';
-    if (!function_exists('modulehook')) { function modulehook($name, $data = [], $allowinactive = false, $only = false){ return $data; } }
-    if (!function_exists('translate')) { function translate($t, $ns = false){ return $t; } }
-    if (!function_exists('translate_inline')) { function translate_inline($t, $ns = false){ return $t; } }
-    if (!function_exists('tlbutton_pop')) { function tlbutton_pop(){ return ''; } }
-    if (!function_exists('tlschema')) { function tlschema($schema = false){} }
-    if (!function_exists('popup')) { function popup(string $page, string $size = '550x300'){ return ''; } }
-    if (!function_exists('rawoutput')) { function rawoutput($t){} }
-    if (!function_exists('output_notl')) { function output_notl($f,$t=true){} }
-    if (!function_exists('output')) { function output($f,$t=true){} }
-    if (!function_exists('debug')) { function debug($t,$force=false){} }
-    if (!function_exists('appoencode')) { function appoencode($data,$priv=false){ global $output; return $output->appoencode($data,$priv); } }
+    if (!function_exists('modulehook')) {
+        function modulehook($name, $data = [], $allowinactive = false, $only = false) {
+            return $data;
+        }
+    }
+    if (!function_exists('translate')) {
+        function translate($t, $ns = false) {
+            return $t;
+        }
+    }
+    if (!function_exists('translate_inline')) {
+        function translate_inline($t, $ns = false) {
+            return $t;
+        }
+    }
+    if (!function_exists('tlbutton_pop')) {
+        function tlbutton_pop() {
+            return '';
+        }
+    }
+    if (!function_exists('tlschema')) {
+        function tlschema($schema = false) {
+        }
+    }
+    if (!function_exists('popup')) {
+        function popup(string $page, string $size = '550x300') {
+            return '';
+        }
+    }
+    if (!function_exists('rawoutput')) {
+        function rawoutput($t) {
+        }
+    }
+    if (!function_exists('output_notl')) {
+        function output_notl($f, $t = true) {
+        }
+    }
+    if (!function_exists('output')) {
+        function output($f, $t = true) {
+        }
+    }
+    if (!function_exists('debug')) {
+        function debug($t, $force = false) {
+        }
+    }
+    if (!function_exists('appoencode')) {
+        function appoencode($data, $priv = false) {
+            global $output;
+            return $output->appoencode($data, $priv);
+        }
+    }
 
     final class NavColoredHeadlineTest extends TestCase
     {


### PR DESCRIPTION
## Summary
- enhance Nav navigation helper with addColoredHeadline
- append color reset when building navs for colored headlines
- document new feature in docs/Nav.md
- add unit tests for colored headlines

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_687c14fea3608329985b83b0097eeb4b