### PR TITLE
Add sub-navigation support

### DIFF
--- a/docs/Nav.md
+++ b/docs/Nav.md
@@ -18,6 +18,14 @@ new \Lotgd\Nav\NavigationSection(string|array $headline, bool $collapse = true, 
 
 Holds a headline and a set of `NavigationItem` objects. The `$collapse` flag controls whether the section can be collapsed and `$colored` indicates a coloured headline.
 
+## NavigationSubSection
+
+```php
+new \Lotgd\Nav\NavigationSubSection(string|array $headline, bool $translate = true)
+```
+
+Represents a sub headline within a section. It contains its own list of `NavigationItem` objects.
+
 ## addColoredHeadline
 
 ```php
@@ -43,6 +51,14 @@ addHeader(string|array $text, bool $collapse = true, bool $translate = true): vo
 Starts a new navigation section. When `$collapse` is `true` the links added after the call
 can be collapsed in the UI. Set it to `false` to keep the section always expanded.
 
+## addSubHeader
+
+```php
+addSubHeader(string|array $text, bool $translate = true): void
+```
+
+Begins a sub section under the current headline. Links added afterwards are grouped under this subheader until another subheader or header is set. Pass an empty string to stop adding items to a subheader.
+
 ## add
 
 ```php
@@ -53,6 +69,7 @@ Adds a navigation link. When `$link` is `false` the call behaves like `addHeader
 If `$link` is an empty string an inactive/help line is inserted.
 The optional `$priv` flag is forwarded to `appoencode()` to control HTML escaping.
 When `$pop` is `true` the target URL opens in a popup sized by `$popsize`.
+When a subheader is active the link is stored inside that subsection.
 
 Example:
 
@@ -66,7 +83,7 @@ Example:
 ## addNotl
 
 Behaves like `add()` but never translates the text. Useful when links already
-contain colour codes or are generated dynamically.
+contain colour codes or are generated dynamically. Links are also placed in the current subheader when one is active.
 
 ## blockNav / unblockNav
 

--- a/lib/nav.php
+++ b/lib/nav.php
@@ -52,6 +52,14 @@ function addnavheader($text, bool $collapse = true, bool $translate = true): voi
 }
 
 /**
+ * Start a new sub navigation section.
+ */
+function addnavsubheader($text, bool $translate = true): void
+{
+    Nav::addSubHeader($text, $translate);
+}
+
+/**
  * Add a navigation link without translation.
  */
 function addnav_notl($text, $link = false, $priv = false, $pop = false, $popsize = '500x300'): void

--- a/src/Lotgd/Nav/NavigationSection.php
+++ b/src/Lotgd/Nav/NavigationSection.php
@@ -10,6 +10,8 @@ class NavigationSection
 {
     public string|array $headline;
     private array $items = [];
+    /** @var NavigationSubSection[] */
+    private array $subSections = [];
     public bool $collapse;
     public bool $colored = false;
 
@@ -36,6 +38,14 @@ class NavigationSection
     }
 
     /**
+     * Add a subsection below this headline.
+     */
+    public function addSubSection(NavigationSubSection $sub): void
+    {
+        $this->subSections[] = $sub;
+    }
+
+    /**
      * Get the items within the section.
      *
      * @return NavigationItem[]
@@ -46,6 +56,16 @@ class NavigationSection
     }
 
     /**
+     * Get the subsections within this section.
+     *
+     * @return NavigationSubSection[]
+     */
+    public function getSubSections(): array
+    {
+        return $this->subSections;
+    }
+
+    /**
      * Replace the list of items in the section.
      *
      * @param NavigationItem[] $items
@@ -53,5 +73,15 @@ class NavigationSection
     public function setItems(array $items): void
     {
         $this->items = $items;
+    }
+
+    /**
+     * Replace the list of subsections in the section.
+     *
+     * @param NavigationSubSection[] $subs
+     */
+    public function setSubSections(array $subs): void
+    {
+        $this->subSections = $subs;
     }
 }

--- a/src/Lotgd/Nav/NavigationSubSection.php
+++ b/src/Lotgd/Nav/NavigationSubSection.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace Lotgd\Nav;
+
+/**
+ * Represents a sub headline grouping navigation items.
+ */
+class NavigationSubSection
+{
+    public string|array $headline;
+    private array $items = [];
+    public bool $translate;
+
+    /**
+     * @param string|array $headline Subsection headline text
+     * @param bool         $translate When false the text is not translated
+     */
+    public function __construct($headline, bool $translate = true)
+    {
+        $this->headline = $headline;
+        $this->translate = $translate;
+    }
+
+    /**
+     * Add an item to the subsection.
+     */
+    public function addItem(NavigationItem $item): void
+    {
+        $this->items[] = $item;
+    }
+
+    /**
+     * @return NavigationItem[]
+     */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    /**
+     * @param NavigationItem[] $items
+     */
+    public function setItems(array $items): void
+    {
+        $this->items = $items;
+    }
+}

--- a/templates/jade.css
+++ b/templates/jade.css
@@ -34,6 +34,22 @@ table.nav {
 	text-align: center;
 	font-variant: small-caps;
 }
+.navheadsub {
+        text-decoration: none;
+        width: 170px;
+        height: auto;
+        padding: 1px;
+        float: left;
+        line-height: 18px;
+        clear: none;
+        background-color: #003800;
+        font-weight: bold;
+        color: #FFFFFF;
+        cursor: default;
+        text-align: center;
+        font-variant: small-caps;
+        margin-left: 10px;
+}
 
 a {
 	color: #D1FFD1;

--- a/templates/jade.htm
+++ b/templates/jade.htm
@@ -244,6 +244,8 @@
 </table>
 <!--!navhead-->
 <span class="navhead">&#151;{title}&#151;</span><br clear='all'>
+<!--!navheadsub-->
+<span class="navheadsub">{title}</span><br clear='all'>
 <!--!navhelp-->
 <span class="navhelp">{text}</span><br clear='all'>
 <!--!navitem-->

--- a/templates/modern.css
+++ b/templates/modern.css
@@ -78,7 +78,22 @@ a:hover.navhilite {
 	font-weight: bold;
 	color: #00CCFF;
 	cursor: default;
-	text-align: center;
+        text-align: center;
+}
+.navheadsub {
+        text-decoration: none;
+        width: 170px;
+        border: thin #003366;
+        height: auto;
+        padding: 1px;
+        line-height: 18px;
+        float: left;
+        clear: none;
+        font-weight: bold;
+        color: #00CCFF;
+        cursor: default;
+        text-align: center;
+        margin-left: 10px;
 }
 table {
 }

--- a/templates/modern.htm
+++ b/templates/modern.htm
@@ -97,6 +97,7 @@
 <!--!statbuff--><tr><td class='charhead' colspan='2'><b>{title}</b></td></tr><tr><td class='charinfo' colspan='2'>{value}</td></tr>
 <!--!statend--></table>
 <!--!navhead--><span class="navhead">&#151;{title}&#151;</span><br clear='all'>
+<!--!navheadsub--><span class="navheadsub">{title}</span><br clear='all'>
 <!--!navhelp--><span class="navhelp">{text}</span><br clear='all'>
 <!--!navitem--><a href="{link}"{accesskey}class='nav' {popup}>{text}</a><br clear='all'>
 <!--!petitioncount--><table border='0' cellpadding='5' cellspacing='0' align='right'><tr><td>{petitioncount}</td></tr></table>

--- a/templates/puritanic_ai.htm
+++ b/templates/puritanic_ai.htm
@@ -134,6 +134,8 @@
 
 <!--!navhead-->
 <span class="navhead">&#151;{title}&#151;</span><br clear='all'>
+<!--!navheadsub-->
+<span class="navheadsub">{title}</span><br clear='all'>
 <!--!navhelp-->
 <span class="navhelp">{text}</span><br clear='all'>
 <!--!navitem-->

--- a/templates/puritanic_ai/puritanic_ai.css
+++ b/templates/puritanic_ai/puritanic_ai.css
@@ -39,8 +39,22 @@ table.nav {
 	color: #FFFFFF;
 	cursor: default;
 	text-align: center;
-	font-family: Tahoma Small Cap;
-	font-weight: bolder;
+        font-family: Tahoma Small Cap;
+        font-weight: bolder;
+}
+.navheadsub {
+        text-decoration: none;
+        height: auto;
+        padding: 1px;
+        float: left;
+        line-height: 33px;
+        clear: none;
+        color: #FFFFFF;
+        cursor: default;
+        text-align: center;
+        font-family: Tahoma Small Cap;
+        font-weight: bolder;
+        margin-left: 10px;
 }
 
 a {

--- a/templates/yarbrough.css
+++ b/templates/yarbrough.css
@@ -78,7 +78,22 @@ a:hover.navhilite {
 	font-weight: bold;
 	color: #00CCFF;
 	cursor: default;
-	text-align: center;
+        text-align: center;
+}
+.navheadsub {
+        text-decoration: none;
+        width: 170px;
+        border: thin #003366;
+        height: auto;
+        padding: 1px;
+        line-height: 18px;
+        float: left;
+        clear: none;
+        font-weight: bold;
+        color: #00CCFF;
+        cursor: default;
+        text-align: center;
+        margin-left: 10px;
 }
 table {
 }

--- a/templates/yarbrough.htm
+++ b/templates/yarbrough.htm
@@ -97,6 +97,7 @@
 <!--!statbuff--><tr><td class='charhead' colspan='2'><b>{title}</b></td></tr><tr><td class='charinfo' colspan='2'>{value}</td></tr>
 <!--!statend--></table>
 <!--!navhead--><span class="navhead">&#151;{title}&#151;</span><br clear='all'>
+<!--!navheadsub--><span class="navheadsub">{title}</span><br clear='all'>
 <!--!navhelp--><span class="navhelp">{text}</span><br clear='all'>
 <!--!navitem--><a href="{link}"{accesskey}class='nav' {popup}>{text}</a><br clear='all'>
 <!--!petitioncount--><table border='0' cellpadding='5' cellspacing='0' align='right'><tr><td>{petitioncount}</td></tr></table>

--- a/templates_twig/aurora/assets/style.css
+++ b/templates_twig/aurora/assets/style.css
@@ -56,6 +56,21 @@ table.nav {
     font-family: Tahoma Small Cap;
     font-weight: bolder;
 }
+.navheadsub {
+    text-decoration: none;
+    width: 170px;
+    height: auto;
+    padding: 1px;
+    float: left;
+    line-height: 33px;
+    clear: none;
+    color: #FFFFFF;
+    cursor: default;
+    text-align: center;
+    font-family: Tahoma Small Cap;
+    font-weight: bolder;
+    margin-left: 10px;
+}
 
 a {
     color: #669933;

--- a/templates_twig/aurora/navheadsub.twig
+++ b/templates_twig/aurora/navheadsub.twig
@@ -1,0 +1,1 @@
+<span class="navheadsub">{{ title|raw }}</span><br class="clear">

--- a/templates_twig/modern/assets/style.css
+++ b/templates_twig/modern/assets/style.css
@@ -89,7 +89,21 @@ td.charinfo {
 	border-right-style: none;
 	border-bottom-style: none;
 	border-left-style: none;
-	cursor: default;
+        cursor: default;
+}
+.navheadsub {
+        text-decoration: none;
+        width: 170px;
+        border: thin #003366;
+        height: auto;
+        padding: 1px;
+        line-height: 18px;
+        float: left;
+        clear: none;
+        font-weight: bold;
+        color: #00CCFF;
+        cursor: default;
+        margin-left: 10px;
 }
 td.charhead {
 	background-color: #009900;

--- a/templates_twig/modern/navheadsub.twig
+++ b/templates_twig/modern/navheadsub.twig
@@ -1,0 +1,1 @@
+<span class="navheadsub">{{ title|raw }}</span><br clear='all'>

--- a/templates_twig/puritanic/assets/style.css
+++ b/templates_twig/puritanic/assets/style.css
@@ -42,6 +42,21 @@ table.nav {
     font-family: Tahoma Small Cap;
     font-weight: bolder;
 }
+.navheadsub {
+    text-decoration: none;
+    width: 170px;
+    height: auto;
+    padding: 1px;
+    float: left;
+    line-height: 33px;
+    clear: none;
+    color: #FFFFFF;
+    cursor: default;
+    text-align: center;
+    font-family: Tahoma Small Cap;
+    font-weight: bolder;
+    margin-left: 10px;
+}
 
 a {
     color: #669933;

--- a/templates_twig/puritanic/navheadsub.twig
+++ b/templates_twig/puritanic/navheadsub.twig
@@ -1,0 +1,1 @@
+<span class="navheadsub">{{ title|raw }}</span><br class="clear">

--- a/templates_twig/puritanic_ai/assets/style.css
+++ b/templates_twig/puritanic_ai/assets/style.css
@@ -40,6 +40,20 @@ table.nav {
     font-family: Tahoma Small Cap;
     font-weight: bolder;
 }
+.navheadsub {
+    text-decoration: none;
+    height: auto;
+    padding: 1px;
+    float: left;
+    line-height: 33px;
+    clear: none;
+    color: #FFFFFF;
+    cursor: default;
+    text-align: center;
+    font-family: Tahoma Small Cap;
+    font-weight: bolder;
+    margin-left: 10px;
+}
 
 a {
     color: #669933;

--- a/templates_twig/puritanic_ai/navheadsub.twig
+++ b/templates_twig/puritanic_ai/navheadsub.twig
@@ -1,0 +1,1 @@
+<span class="navheadsub">{{ title|raw }}</span><br class="clear">

--- a/tests/NavigationSubSectionTest.php
+++ b/tests/NavigationSubSectionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    use PHPUnit\Framework\TestCase;
+    use Lotgd\Nav;
+    use Lotgd\Output;
+    use Lotgd\Template;
+
+    require_once __DIR__ . '/../config/constants.php';
+    if (!function_exists('modulehook')) {
+        function modulehook($name, $data = [], $allowinactive = false, $only = false) { return $data; }
+    }
+    if (!function_exists('translate')) { function translate($t, $ns = false) { return $t; } }
+    if (!function_exists('translate_inline')) { function translate_inline($t, $ns = false) { return $t; } }
+    if (!function_exists('tlbutton_pop')) { function tlbutton_pop() { return ''; } }
+    if (!function_exists('tlschema')) { function tlschema($schema = false) { } }
+    if (!function_exists('popup')) { function popup(string $page, string $size = '550x300') { return ''; } }
+    if (!function_exists('appoencode')) { function appoencode($data, $priv = false) { global $output; return $output->appoencode($data, $priv); } }
+
+    final class NavigationSubSectionTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            global $session, $nav, $template, $output;
+            $session = ['user' => ['prefs' => []], 'allowednavs' => [], 'loggedin' => false];
+            $nav = '';
+            $output = new Output();
+            $template = [
+                'navhead' => '<span class="navhead">{title}</span>',
+                'navheadsub' => '<span class="navheadsub">{title}</span>',
+                'navitem' => '<a href="{link}">{text}</a>'
+            ];
+        }
+
+        protected function tearDown(): void
+        {
+            global $session, $nav, $template, $output;
+            unset($session, $nav, $template, $output);
+        }
+
+        public function testSubHeadlineOutput(): void
+        {
+            Nav::addHeader('Main', false);
+            Nav::addSubHeader('Sub');
+            Nav::add('Link', 'foo.php');
+
+            $navs = Nav::buildNavs();
+            $this->assertStringContainsString('<span class="navheadsub">Sub</span>', $navs);
+            $this->assertStringContainsString('foo.php', $navs);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce NavigationSubSection to group nav items under subheaders
- extend NavigationSection and Nav to manage subheaders
- output subheaders via new `navheadsub` template part
- add wrappers and document APIs
- style `navheadsub` in all templates
- add PHPUnit test for subheader output

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_687cad122a108329b4cf634509b10998