### PR TITLE
Add colored subheader support

### DIFF
--- a/docs/Nav.md
+++ b/docs/Nav.md
@@ -59,6 +59,16 @@ addSubHeader(string|array $text, bool $translate = true): void
 
 Begins a sub section under the current headline. Links added afterwards are grouped under this subheader until another subheader or header is set. Pass an empty string to stop adding items to a subheader.
 
+## addColoredSubHeader
+
+```php
+addColoredSubHeader(string $text, bool $translate = true): void
+```
+
+Works like `addSubHeader()` but the text may contain LOTGD colour codes. The
+subheader automatically appends `` `0`` so colours do not bleed into
+following items.
+
 ## add
 
 ```php

--- a/lib/nav.php
+++ b/lib/nav.php
@@ -60,6 +60,14 @@ function addnavsubheader($text, bool $translate = true): void
 }
 
 /**
+ * Start a coloured sub navigation section.
+ */
+function addnavcoloredsubheader(string $text, bool $translate = true): void
+{
+    Nav::addColoredSubHeader($text, $translate);
+}
+
+/**
  * Add a navigation link without translation.
  */
 function addnav_notl($text, $link = false, $priv = false, $pop = false, $popsize = '500x300'): void

--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -218,6 +218,19 @@ class Nav
     }
 
     /**
+     * Start a new coloured sub navigation section.
+     * Items added afterwards belong to this subsection until a new header is set.
+     */
+    public static function addColoredSubHeader(string $text, bool $translate = true): void
+    {
+        if (self::$block_new_navs) return;
+        self::addSubHeader($text, $translate);
+        if (self::$currentSubSection instanceof NavigationSubSection) {
+            self::$currentSubSection->colored = true;
+        }
+    }
+
+    /**
      * Add a link without translating the label.
      *
      * @param string|array $text    Link label or header text
@@ -440,7 +453,15 @@ class Nav
                     if (! $has) {
                         continue;
                     }
-                    $sublinks .= self::privateAddSubHeader($sub->headline, $sub->translate ?? true);
+                    $header = $sub->headline;
+                    if ($sub->colored) {
+                        if (is_array($header)) {
+                            $header[0] .= '`0';
+                        } else {
+                            $header .= '`0';
+                        }
+                    }
+                    $sublinks .= self::privateAddSubHeader($header, $sub->translate ?? true);
                     foreach ($sub->getItems() as $v) {
                         $sublinks .= $v->render();
                     }

--- a/src/Lotgd/Nav/NavigationSubSection.php
+++ b/src/Lotgd/Nav/NavigationSubSection.php
@@ -11,6 +11,7 @@ class NavigationSubSection
     public string|array $headline;
     private array $items = [];
     public bool $translate;
+    public bool $colored = false;
 
     /**
      * @param string|array $headline Subsection headline text

--- a/tests/NavColoredSubHeaderTest.php
+++ b/tests/NavColoredSubHeaderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    use PHPUnit\Framework\TestCase;
+    use Lotgd\Nav;
+    use Lotgd\Output;
+    use Lotgd\Template;
+
+    require_once __DIR__ . '/../config/constants.php';
+    if (!function_exists('modulehook')) {
+        function modulehook($name, $data = [], $allowinactive = false, $only = false) {
+            return $data;
+        }
+    }
+    if (!function_exists('translate')) { function translate($t, $ns = false) { return $t; } }
+    if (!function_exists('translate_inline')) { function translate_inline($t, $ns = false) { return $t; } }
+    if (!function_exists('tlbutton_pop')) { function tlbutton_pop() { return ''; } }
+    if (!function_exists('tlschema')) { function tlschema($schema = false) { } }
+    if (!function_exists('popup')) { function popup(string $page, string $size = '550x300') { return ''; } }
+    if (!function_exists('appoencode')) { function appoencode($data, $priv = false) { global $output; return $output->appoencode($data, $priv); } }
+
+    final class NavColoredSubHeaderTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            global $session, $nav, $template, $output;
+            $session = ['user' => ['prefs' => []], 'allowednavs' => [], 'loggedin' => false];
+            $nav = '';
+            $output = new Output();
+            $template = [
+                'navhead' => '<span class="navhead">{title}</span>',
+                'navheadsub' => '<span class="navheadsub">{title}</span>',
+                'navitem' => '<a href="{link}">{text}</a>'
+            ];
+        }
+
+        protected function tearDown(): void
+        {
+            global $session, $nav, $template, $output;
+            unset($session, $nav, $template, $output);
+        }
+
+        public function testColoredSubHeaderRendersColors(): void
+        {
+            Nav::addHeader('Main', false);
+            Nav::addColoredSubHeader('`!Sub');
+            Nav::add('Link', 'foo.php');
+
+            $navs = Nav::buildNavs();
+            $this->assertStringContainsString("colLtBlue", $navs);
+            $this->assertStringContainsString('</span>', $navs);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `colored` flag to `NavigationSubSection`
- implement `addColoredSubHeader` in `Nav`
- respect colored flag when building navs
- expose helper function `addnavcoloredsubheader`
- document coloured subheaders
- test coloured subheaders

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687cb8a7b5b88329b2729268f0e4ccd5