### PR TITLE
Fix NavigationItem render return type

### DIFF
--- a/src/Lotgd/Nav/NavigationItem.php
+++ b/src/Lotgd/Nav/NavigationItem.php
@@ -42,6 +42,14 @@ class NavigationItem
      */
     public function render(): string
     {
-        return Nav::privateAddNav($this->text, $this->link, $this->priv, $this->popup, $this->popupSize);
+        $output = Nav::privateAddNav(
+            $this->text,
+            $this->link,
+            $this->priv,
+            $this->popup,
+            $this->popupSize
+        );
+
+        return is_string($output) ? $output : '';
     }
 }


### PR DESCRIPTION
## Summary
- ensure `NavigationItem::render()` always returns a string

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_687cbbbab6a08329b60da73083695182