### PR TITLE
Improve navheadsub display

### DIFF
--- a/templates/jade.htm
+++ b/templates/jade.htm
@@ -245,7 +245,7 @@
 <!--!navhead-->
 <span class="navhead">&#151;{title}&#151;</span><br clear='all'>
 <!--!navheadsub-->
-<span class="navheadsub">{title}</span><br clear='all'>
+<span class="navheadsub">&#172;{title}&#8976;</span><br clear='all'>
 <!--!navhelp-->
 <span class="navhelp">{text}</span><br clear='all'>
 <!--!navitem-->

--- a/templates/modern.htm
+++ b/templates/modern.htm
@@ -97,7 +97,7 @@
 <!--!statbuff--><tr><td class='charhead' colspan='2'><b>{title}</b></td></tr><tr><td class='charinfo' colspan='2'>{value}</td></tr>
 <!--!statend--></table>
 <!--!navhead--><span class="navhead">&#151;{title}&#151;</span><br clear='all'>
-<!--!navheadsub--><span class="navheadsub">{title}</span><br clear='all'>
+<!--!navheadsub--><span class="navheadsub">&#172;{title}&#8976;</span><br clear='all'>
 <!--!navhelp--><span class="navhelp">{text}</span><br clear='all'>
 <!--!navitem--><a href="{link}"{accesskey}class='nav' {popup}>{text}</a><br clear='all'>
 <!--!petitioncount--><table border='0' cellpadding='5' cellspacing='0' align='right'><tr><td>{petitioncount}</td></tr></table>

--- a/templates/puritanic_ai.htm
+++ b/templates/puritanic_ai.htm
@@ -135,7 +135,7 @@
 <!--!navhead-->
 <span class="navhead">&#151;{title}&#151;</span><br clear='all'>
 <!--!navheadsub-->
-<span class="navheadsub">{title}</span><br clear='all'>
+<span class="navheadsub">&#172;{title}&#8976;</span><br clear='all'>
 <!--!navhelp-->
 <span class="navhelp">{text}</span><br clear='all'>
 <!--!navitem-->

--- a/templates/yarbrough.htm
+++ b/templates/yarbrough.htm
@@ -97,7 +97,7 @@
 <!--!statbuff--><tr><td class='charhead' colspan='2'><b>{title}</b></td></tr><tr><td class='charinfo' colspan='2'>{value}</td></tr>
 <!--!statend--></table>
 <!--!navhead--><span class="navhead">&#151;{title}&#151;</span><br clear='all'>
-<!--!navheadsub--><span class="navheadsub">{title}</span><br clear='all'>
+<!--!navheadsub--><span class="navheadsub">&#172;{title}&#8976;</span><br clear='all'>
 <!--!navhelp--><span class="navhelp">{text}</span><br clear='all'>
 <!--!navitem--><a href="{link}"{accesskey}class='nav' {popup}>{text}</a><br clear='all'>
 <!--!petitioncount--><table border='0' cellpadding='5' cellspacing='0' align='right'><tr><td>{petitioncount}</td></tr></table>


### PR DESCRIPTION
## Summary
- highlight navigation subhead titles with ¬ and the reversed sign around the title
- keep padding consistent with `navhead` across themes

## Testing
- `composer test`
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687d0bf54bdc8329b71ec4500bb6fcde