### PR TITLE
Add alt attributes in templates

### DIFF
--- a/templates/jade.htm
+++ b/templates/jade.htm
@@ -121,7 +121,7 @@
 	   </tr>
 	  </table>
 	 </td>
-	 <td align='right' valign="top"><img src='templates/jade/logo.jpg'></td>
+	 <td align='right' valign="top"><img src='templates/jade/logo.jpg' alt='Logo'></td>
 	</tr>
 	<tr>
 		<td valign='top' colspan='2'>
@@ -277,7 +277,7 @@
 <!--!login-->
 <table border='0' cellpadding='0' cellspacing='0'>
  <tr>
-  <td><img src='images/logindragon.gif' class='noborder'></td>
+  <td><img src='images/logindragon.gif' alt='Login dragon' class='noborder'></td>
  </tr>
  <tr>
   <td valign='center' align='center' class='noborder'>
@@ -300,7 +300,7 @@
 <!--!loginfull-->
 <table border='0' cellpadding='0' cellspacing='0'>
  <tr>
-  <td><img src='images/serverfull.jpg' class='noborder'></td>
+  <td><img src='images/serverfull.jpg' alt='Server full' class='noborder'></td>
  </tr>
  <tr>
   <td valign='center' align='center' class='noborder'>

--- a/templates/modern.htm
+++ b/templates/modern.htm
@@ -46,7 +46,7 @@
 <body bgcolor='#000000' text='#CCCCCC'>
 <table border='0' cellpadding=4 cellspacing=0 width='100%'>
   <tr>
-	<td colspan=2 class='pageheader' valign='top'> <img src='templates/modern/title.gif' width='395' height='55' align='right'><span class='pagetitle'><br>
+	<td colspan=2 class='pageheader' valign='top'> <img src='templates/modern/title.gif' alt='' width='395' height='55' align='right'><span class='pagetitle'><br>
 	  {title}</span></td>
 
   </tr>
@@ -60,7 +60,7 @@
 		</tr>
 	  </table>
 
-	  <img src='templates/modern/lscroll.GIF' width='182' height='11'> <br>
+	  <img src='templates/modern/lscroll.GIF' alt='' width='182' height='11'> <br>
 	  {motd} <br>
 	  {mail} <br>
 	  {petition} </td>
@@ -78,7 +78,7 @@
 		</tr>
 
 	  </table>
-	  <img src='templates/modern/lscroll.GIF' width='182' height='11'></td>
+	  <img src='templates/modern/lscroll.GIF' alt='' width='182' height='11'></td>
   </tr>
   <tr>
 	<td colspan=2 class='footer'>
@@ -112,7 +112,7 @@
 <!--!login-->
 <table border='0' cellpadding='0' cellspacing='0'>
   <tr>
-	<td><img src='templates/modern/logindragon.gif' class='noborder'></td>
+	<td><img src='templates/modern/logindragon.gif' alt='Login dragon' class='noborder'></td>
   </tr>
   <tr>
 	<td valign='center' align='center' class='noborder'>
@@ -135,7 +135,7 @@
 <!--!loginfull-->
 <table border='0' cellpadding='0' cellspacing='0'>
   <tr>
-	<td><img src='templates/modern/logindragon.gif' class='noborder'></td>
+	<td><img src='templates/modern/logindragon.gif' alt='Login dragon' class='noborder'></td>
   </tr>
   <tr>
 	<td valign='center' align='center' class='noborder'>

--- a/templates/puritanic_ai.htm
+++ b/templates/puritanic_ai.htm
@@ -59,7 +59,7 @@
                         </td>
                         <td align='center' class='noborder pageheader-center'>{title}</td>
                         <td class='noborder pageheader-right'>
-                            <img src='templates/puritanic_ai/images/mail.gif' width='24' height='19'><b>{mail}</b>&nbsp;&nbsp;
+                            <img src='templates/puritanic_ai/images/mail.gif' alt='' width='24' height='19'><b>{mail}</b>&nbsp;&nbsp;
 	    		   {petitiondisplay}
                         </td>
                     </tr>

--- a/templates/yarbrough.htm
+++ b/templates/yarbrough.htm
@@ -46,7 +46,7 @@
 <body bgcolor='#000000' text='#CCCCCC'>
 <table border='0' cellpadding=4 cellspacing=0 width='100%'>
   <tr>
-	<td colspan=2 class='pageheader' valign='top'> <img src='templates/yarbrough/title.gif' width='395' height='55' align='right'><span class='pagetitle'><br>
+	<td colspan=2 class='pageheader' valign='top'> <img src='templates/yarbrough/title.gif' alt='' width='395' height='55' align='right'><span class='pagetitle'><br>
 	  {title}</span></td>
 
   </tr>
@@ -60,7 +60,7 @@
 		</tr>
 	  </table>
 
-	  <img src='templates/yarbrough/lscroll.GIF' width='182' height='11'> <br>
+	  <img src='templates/yarbrough/lscroll.GIF' alt='' width='182' height='11'> <br>
 	  {motd} <br>
 	  {mail} <br>
 	  {petition} </td>
@@ -78,7 +78,7 @@
 		</tr>
 
 	  </table>
-	  <img src='templates/yarbrough/lscroll.GIF' width='182' height='11'></td>
+	  <img src='templates/yarbrough/lscroll.GIF' alt='' width='182' height='11'></td>
   </tr>
   <tr>
 	<td colspan=2 class='footer'>
@@ -112,7 +112,7 @@
 <!--!login-->
 <table border='0' cellpadding='0' cellspacing='0'>
   <tr>
-	<td><img src='templates/yarbrough/logindragon.gif' class='noborder'></td>
+	<td><img src='templates/yarbrough/logindragon.gif' alt='Login dragon' class='noborder'></td>
   </tr>
   <tr>
 	<td valign='center' align='center' class='noborder'>
@@ -135,7 +135,7 @@
 <!--!loginfull-->
 <table border='0' cellpadding='0' cellspacing='0'>
   <tr>
-	<td><img src='templates/yarbrough/logindragon.gif' class='noborder'></td>
+	<td><img src='templates/yarbrough/logindragon.gif' alt='Login dragon' class='noborder'></td>
   </tr>
   <tr>
 	<td valign='center' align='center' class='noborder'>

--- a/templates_twig/modern/login.twig
+++ b/templates_twig/modern/login.twig
@@ -1,6 +1,6 @@
 <table border='0' cellpadding='0' cellspacing='0'>
     <tr>
-        <td><img src='{{ template_path }}/assets/logindragon.gif' class='noborder'></td>
+        <td><img src='{{ template_path }}/assets/logindragon.gif' alt='Login dragon' class='noborder'></td>
     </tr>
     <tr>
         <td valign='center' align='center' class='noborder'>

--- a/templates_twig/modern/loginfull.twig
+++ b/templates_twig/modern/loginfull.twig
@@ -1,6 +1,6 @@
 <table border='0' cellpadding='0' cellspacing='0'>
     <tr>
-        <td><img src='{{ template_path }}/assets/logindragon.gif' class='noborder'></td>
+        <td><img src='{{ template_path }}/assets/logindragon.gif' alt='Login dragon' class='noborder'></td>
     </tr>
     <tr>
         <td valign='center' align='center' class='noborder'>

--- a/templates_twig/modern/page.twig
+++ b/templates_twig/modern/page.twig
@@ -23,7 +23,7 @@
             <table cellspacing="0" cellpadding="0" class="nav">
                 <tr><td>{{ nav|raw }}</td></tr>
             </table>
-            <img src="{{ template_path }}/assets/lscroll.GIF" width="182" height="11"> <br>
+            <img src="{{ template_path }}/assets/lscroll.GIF" alt="" width="182" height="11"> <br>
             {{ motd|raw }} <br>
             {{ mail|raw }} <br>
             {{ petition|raw }}
@@ -40,7 +40,7 @@
             <table border="0" cellpadding="0" cellspacing="0" class="vitalinfo">
                 <tr><td> {{ stats|raw }} </td></tr>
             </table>
-            <img src="{{ template_path }}/assets/lscroll.GIF" width="182" height="11"></td>
+            <img src="{{ template_path }}/assets/lscroll.GIF" alt="" width="182" height="11"></td>
     </tr>
     <tr>
         <td colspan="2" class="footer">


### PR DESCRIPTION
## Summary
- add alt text to template images in HTML and Twig
- update login pages and layout templates

## Testing
- `composer test`
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687e4eed6a608329b01b6ae810fdb1c3