### PR TITLE
Improve login forms with labels and autocomplete

### DIFF
--- a/templates/jade.htm
+++ b/templates/jade.htm
@@ -282,14 +282,14 @@
  <tr>
   <td valign='center' align='center' class='noborder'>
    <table border='0'>
-	<tr>
-	 <td align='center'><font color='#ffff00'>{username}:</font></td>
-	 <td align='center'><font color='#ffff00'>{password}:</font></td>
-	</tr>
-	<tr>
-	 <td><input name='name' id='name' accesskey='u' size='10'></td>
-	 <td><input name='password' id='password' accesskey='p' type='password' size='10'></td>
-	</tr>
+        <tr>
+         <td align='center'><label for='name'><font color='#ffff00'>{username}:</font></label></td>
+         <td align='center'><label for='password'><font color='#ffff00'>{password}:</font></label></td>
+        </tr>
+        <tr>
+         <td><input name='name' id='name' accesskey='u' size='10' autocomplete='username'></td>
+         <td><input name='password' id='password' accesskey='p' type='password' size='10' autocomplete='current-password'></td>
+        </tr>
 	<tr>
 	 <td colspan='2' align='center'><input type='submit' value='{button}' class='button'><br></td>
 	</tr>

--- a/templates/modern.htm
+++ b/templates/modern.htm
@@ -117,14 +117,14 @@
   <tr>
 	<td valign='center' align='center' class='noborder'>
 	  <table border='0'>
-		<tr>
-		  <td align='center'><font color='#ffff00'>{username}:</font></td>
-		  <td align='center'><font color='#ffff00'>{password}:</font></td>
-		</tr>
-		<tr>
-		  <td><input name='name' id="name" accesskey='u' size='10'></td>
-		  <td><input name='password' id="password" accesskey='p' type='password' size='10'></td>
-		</tr>
+                <tr>
+                  <td align='center'><label for='name'><font color='#ffff00'>{username}:</font></label></td>
+                  <td align='center'><label for='password'><font color='#ffff00'>{password}:</font></label></td>
+                </tr>
+                <tr>
+                  <td><input name='name' id="name" accesskey='u' size='10' autocomplete='username'></td>
+                  <td><input name='password' id="password" accesskey='p' type='password' size='10' autocomplete='current-password'></td>
+                </tr>
 		<tr>
 		  <td colspan='2' align='center'><input type='submit' value='{button}' class='button'><br></td>
 		</tr>

--- a/templates/puritanic_ai.htm
+++ b/templates/puritanic_ai.htm
@@ -159,12 +159,12 @@
         <td class="noborder">
             <table class="login-inner">
                 <tr>
-                    <td class="login-label">{username}:</td>
-                    <td class="login-label">{password}:</td>
+                    <td class="login-label"><label for='name'>{username}:</label></td>
+                    <td class="login-label"><label for='password'>{password}:</label></td>
                 </tr>
                 <tr>
-                    <td><input name='name' id='name' accesskey='u' size='10'></td>
-                    <td><input name='password' id='password' accesskey='p' type='password' size='10'></td>
+                    <td><input name='name' id='name' accesskey='u' size='10' autocomplete='username'></td>
+                    <td><input name='password' id='password' accesskey='p' type='password' size='10' autocomplete='current-password'></td>
                 </tr>
                 <tr>
                     <td colspan='2' class="login-submit"><input type='submit' value='{button}' class='button'></td>

--- a/templates/yarbrough.htm
+++ b/templates/yarbrough.htm
@@ -117,14 +117,14 @@
   <tr>
 	<td valign='center' align='center' class='noborder'>
 	  <table border='0'>
-		<tr>
-		  <td align='center'><font color='#ffff00'>{username}:</font></td>
-		  <td align='center'><font color='#ffff00'>{password}:</font></td>
-		</tr>
-		<tr>
-		  <td><input name='name' id="name" accesskey='u' size='10'></td>
-		  <td><input name='password' id="password" accesskey='p' type='password' size='10'></td>
-		</tr>
+                <tr>
+                  <td align='center'><label for='name'><font color='#ffff00'>{username}:</font></label></td>
+                  <td align='center'><label for='password'><font color='#ffff00'>{password}:</font></label></td>
+                </tr>
+                <tr>
+                  <td><input name='name' id="name" accesskey='u' size='10' autocomplete='username'></td>
+                  <td><input name='password' id="password" accesskey='p' type='password' size='10' autocomplete='current-password'></td>
+                </tr>
 		<tr>
 		  <td colspan='2' align='center'><input type='submit' value='{button}' class='button'><br></td>
 		</tr>

--- a/templates_twig/aurora/login.twig
+++ b/templates_twig/aurora/login.twig
@@ -5,16 +5,16 @@
             <td class="noborder">
                 <table class="login-inner">
                     <tr>
-                        <td class="login-label">{{ username|raw }}:</td>
-                        <td class="login-label">{{ password|raw }}:</td>
+                        <td class="login-label"><label for='name'>{{ username|raw }}:</label></td>
+                        <td class="login-label"><label for='password'>{{ password|raw }}:</label></td>
                     </tr>
                     <tr>
                         <td>
-							<input name='name' id='name' autocomplete ='username' accesskey='u' size='10'></input>
-						</td>
+                                                        <input name='name' id='name' autocomplete='username' accesskey='u' size='10'></input>
+                                                </td>
                         <td>
-							<input name='password' autocomplete='password' id='password' accesskey='p' type='password' size='10'></input>
-						</td>
+                                                        <input name='password' autocomplete='current-password' id='password' accesskey='p' type='password' size='10'></input>
+                                                </td>
                     </tr>
                     <tr>
                         <td colspan='2' class="login-submit">

--- a/templates_twig/modern/login.twig
+++ b/templates_twig/modern/login.twig
@@ -6,12 +6,12 @@
         <td valign='center' align='center' class='noborder'>
             <table border='0'>
                 <tr>
-                    <td align='center'><font color='#ffff00'>{{ username|raw }}:</font></td>
-                    <td align='center'><font color='#ffff00'>{{ password|raw }}:</font></td>
+                    <td align='center'><label for='name'><font color='#ffff00'>{{ username|raw }}:</font></label></td>
+                    <td align='center'><label for='password'><font color='#ffff00'>{{ password|raw }}:</font></label></td>
                 </tr>
                 <tr>
-                    <td><input name='name' id="name" accesskey='u' size='10'></td>
-                    <td><input name='password' id="password" accesskey='p' type='password' size='10'></td>
+                    <td><input name='name' id="name" accesskey='u' size='10' autocomplete='username'></td>
+                    <td><input name='password' id="password" accesskey='p' type='password' size='10' autocomplete='current-password'></td>
                 </tr>
                 <tr>
                     <td colspan='2' align='center'><input type='submit' value='{{ button|raw }}' class='button'><br></td>

--- a/templates_twig/puritanic/login.twig
+++ b/templates_twig/puritanic/login.twig
@@ -3,12 +3,12 @@
         <td class="noborder">
             <table class="login-inner">
                 <tr>
-                    <td class="login-label">{{ username|raw }}:</td>
-                    <td class="login-label">{{ password|raw }}:</td>
+                    <td class="login-label"><label for='name'>{{ username|raw }}:</label></td>
+                    <td class="login-label"><label for='password'>{{ password|raw }}:</label></td>
                 </tr>
                 <tr>
-                    <td><input name='name' id='name' accesskey='u' size='10'></td>
-                    <td><input name='password' id='password' accesskey='p' type='password' size='10'></td>
+                    <td><input name='name' id='name' accesskey='u' size='10' autocomplete='username'></td>
+                    <td><input name='password' id='password' accesskey='p' type='password' size='10' autocomplete='current-password'></td>
                 </tr>
                 <tr>
                     <td colspan='2' class="login-submit"><input type='submit' value='{{ button|raw }}' class='button'></td>


### PR DESCRIPTION
## Summary
- add label tags and autocomplete attributes to login forms
- modernize Twig login forms to match HTML templates

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687e5215f77883299478e9ff31077c46