### PR TITLE
Add labels for select elements

### DIFF
--- a/bank.php
+++ b/bank.php
@@ -93,8 +93,10 @@ if ($op==""){
 		addnav("","bank.php?op=transfer2");
 	}elseif(db_num_rows($result)>1){
 		rawoutput("<form action='bank.php?op=transfer3' method='POST'>");
-		output("`6Transfer `^%s`6 to ",$amt);
-		rawoutput("<select name='to' class='input'>");
+                rawoutput("<label for='bank_to'>");
+                output("`6Transfer `^%s`6 to ",$amt);
+                rawoutput("</label>");
+                rawoutput("<select name='to' id='bank_to' class='input'>");
 		while ($row = db_fetch_assoc($result)) {
 			rawoutput("<option value=\"".HTMLEntities($row['login'], ENT_COMPAT, getsetting("charset", "ISO-8859-1"))."\">".full_sanitize($row['name'])."</option>");
 		}

--- a/masters.php
+++ b/masters.php
@@ -65,8 +65,10 @@ if ($op == "del") {
 	}
 	addnav("","masters.php?op=save&id=$id");
 	rawoutput("<form action='masters.php?op=save&id=$id' method='POST'>");
-	output("`^Master's level:`n");
-	rawoutput("<select name='level'>");
+        rawoutput("<label for='level'>");
+        output("`^Master's level:`n");
+        rawoutput("</label>");
+        rawoutput("<select name='level' id='level'>");
 	$maxlevel=getsetting('maxlevel');
 	for ($i=0;$i<$maxlevel;$i++) {
 		$selected=($i==$row['creaturelevel']?' selected':'');

--- a/modules/mpdf_downloader.php
+++ b/modules/mpdf_downloader.php
@@ -51,7 +51,7 @@ function mpdf_downloader_dohook(string $hookname, array $args): array
 			rawoutput("<form action='runmodule.php?module=mpdf_downloader&op=grab' method='POST' style='display:inline'>");
 			rawoutput("<input type='hidden' name='section' value='$section'>");
 			rawoutput("Lines: <input name='lines' value='100' size='4'> ");
-			rawoutput("<select name='format'><option value='pdf'>PDF</option><option value='text'>Text</option></select> ");
+                        rawoutput("<label for='format'>Format:</label> <select name='format' id='format'><option value='pdf'>PDF</option><option value='text'>Text</option></select> ");
 			rawoutput("<input type='submit' class='button' value='Download'>");
 			rawoutput("</form>");
 			addnav('', "runmodule.php?module=mpdf_downloader&op=grab");

--- a/motd.php
+++ b/motd.php
@@ -119,8 +119,10 @@ if ($op=="") {
 	$result = db_query("SELECT mid(motddate,1,7) AS d, count(*) AS c FROM ".db_prefix("motd")." GROUP BY d ORDER BY d DESC");
 	$row = db_fetch_assoc($result);
 	rawoutput("<form action='motd.php' method='POST'>");
-	output("MoTD Archives:");
-	rawoutput("<select name='month' onChange='this.form.submit();' >");
+        rawoutput("<label for='month'>");
+        output("MoTD Archives:");
+        rawoutput("</label>");
+        rawoutput("<select name='month' id='month' onChange='this.form.submit();' >");
 	rawoutput("<option value=''>--Current--</option>");
 	while ($row = db_fetch_assoc($result)){
 		$time = strtotime("{$row['d']}-01");

--- a/mounts.php
+++ b/mounts.php
@@ -340,8 +340,9 @@ function mountform($mount){
 	output("Mount Category:");
 	rawoutput("</td><td><input name='mount[mountcategory]' value=\"".htmlentities($mount['mountcategory'], ENT_COMPAT, getsetting("charset", "ISO-8859-1"))."\"></td></tr>");
 	rawoutput("<tr><td nowrap>");
-	output("Mount Availability:");
-	rawoutput("</td><td nowrap>");
+        rawoutput("<label for='mount_location'>");
+        output("Mount Availability:");
+        rawoutput("</label></td><td nowrap>");
 	// Run a modulehook to find out where stables are located.  By default
 	// they are located in 'Degolburg' (ie, getgamesetting('villagename'));
 	// Some later module can remove them however.
@@ -351,7 +352,7 @@ function mountform($mount){
 	$locs['all'] = translate_inline("Everywhere");
 	ksort($locs);
 	reset($locs);
-	rawoutput("<select name='mount[mountlocation]'>");
+        rawoutput("<select name='mount[mountlocation]' id='mount_location'>");
 	foreach($locs as $loc=>$name) {
 		rawoutput("<option value='$loc'".($mount['mountlocation']==$loc?" selected":"").">$name</option>");
 	}

--- a/pages/bans/case_searchban.php
+++ b/pages/bans/case_searchban.php
@@ -46,8 +46,10 @@ if ($target=='') {
 	if ($names[0]!==false) {
 		rawoutput("<form action='bans.php?op=searchban' method='POST'>");
 		addnav("","bans.php?op=searchban");
-		output("Search banned user by name: ");
-		rawoutput("<select name='target'>");
+                rawoutput("<label for='target'>");
+                output("Search banned user by name: ");
+                rawoutput("</label>");
+                rawoutput("<select name='target' id='target'>");
 		while ($row=db_fetch_assoc($names[0])) {
 			rawoutput("<option value='".$row['acctid']."'>".$row['login']."</option>");
 		}

--- a/pages/mail/case_default.php
+++ b/pages/mail/case_default.php
@@ -138,7 +138,7 @@ if ($db_num_rows>0){
 	$checkall = htmlentities(translate_inline("Check All"), ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
 	$delchecked = htmlentities(translate_inline("Delete Checked"), ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
 	$checknames = htmlentities(translate_inline("`vCheck by Name"), ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
-	output_notl($checknames." <select onchange='check_name()' id='check_name_select'>".$option."</select><br>",true);
+        output_notl("<label for='check_name_select'>".$checknames."</label> <select onchange='check_name()' id='check_name_select'>".$option."</select><br>", true);
 	rawoutput("<input type='button' id='button_check' value=\"$checkall\" class='button' onClick='check_all()'>");
 	rawoutput("<input type='submit' class='button' value=\"$delchecked\">");
 	//enter here more input buttons as you like, you can then evaluate them via the mailfunctions hook

--- a/pages/mail/case_write.php
+++ b/pages/mail/case_write.php
@@ -63,7 +63,9 @@ if (isset($row['login']) && $row['login']!="" && $forwardto==0){
 		array_push($superusers,$row['login']);
 	}
 }else{ 
-	output("`2To: ");
+        rawoutput("<label for='to'>");
+        output("`2To: ");
+        rawoutput("</label>");
 	$to = httppost('to');
 	$sql = "SELECT acctid,login,name,superuser FROM ".db_prefix('accounts')." WHERE login = '".addslashes($to)."' AND locked = 0";
 	$result = db_query($sql);

--- a/pages/petition/petition_default.php
+++ b/pages/petition/petition_default.php
@@ -85,8 +85,10 @@ if (count($post)>0 && httppost('abuse')!="yes"){
 		$nolog = translate_inline("Character is not logged in!!");
 		rawoutput("<input name='unverified' type='hidden' value='$nolog'>");
 	}
-	output("`nType of your Problem / Enquiry: ");
-	rawoutput("<select name='problem_type'>");
+        rawoutput("<label for='problem_type'>");
+        output("`nType of your Problem / Enquiry: ");
+        rawoutput("</label>");
+        rawoutput("<select name='problem_type' id='problem_type'>");
 	$types=getsetting('petition_types','General');
 	$types=explode(",",$types);
 	foreach ($types as $type) {

--- a/pages/user/user_searchban.php
+++ b/pages/user/user_searchban.php
@@ -46,8 +46,10 @@ if ($target=='') {
 	if ($names[0]!==false) {
 		rawoutput("<form action='user.php?op=searchban' method='POST'>");
 		addnav("","user.php?op=searchban");
-		output("Search banned user by name: ");
-		rawoutput("<select name='target'>");
+                rawoutput("<label for='target'>");
+                output("Search banned user by name: ");
+                rawoutput("</label>");
+                rawoutput("<select name='target' id='target'>");
 		while ($row=db_fetch_assoc($names[0])) {
 			rawoutput("<option value='".$row['acctid']."'>".$row['login']."</option>");
 		}

--- a/translatortool.php
+++ b/translatortool.php
@@ -98,8 +98,10 @@ if ($op==""){
 	$result = db_query($sql);
 	output_notl("<form action='translatortool.php' method='GET'>",true);
 	output_notl("<input type='hidden' name='op' value='list'>",true);
-	output("Known Namespaces:");
-	output_notl("<select name='u'>",true);
+        output_notl("<label for='u'>", true);
+        output("Known Namespaces:");
+        output_notl("</label>", true);
+        output_notl("<select name='u' id='u'>", true);
 	while ($row = db_fetch_assoc($result)){
 		output_notl("<option value=\"".htmlentities($row['uri'])."\">".htmlentities($row['uri'], ENT_COMPAT, getsetting("charset", "ISO-8859-1"))." ({$row['c']})</option>",true);
 	}

--- a/untranslated.php
+++ b/untranslated.php
@@ -56,8 +56,10 @@ if ($op == "list") {
 	$sql = "SELECT namespace,count(*) AS c FROM " . db_prefix("untranslated") . " WHERE language='".$session['user']['prefs']['language']."' GROUP BY namespace ORDER BY namespace ASC";
 	$result = db_query($sql);
 	rawoutput("<input type='hidden' name='op' value='list'>");
-	output("Known Namespaces:");
-	rawoutput("<select name='ns'>");
+        rawoutput("<label for='ns'>");
+        output("Known Namespaces:");
+        rawoutput("</label>");
+        rawoutput("<select name='ns' id='ns'>");
 	while ($row = db_fetch_assoc($result)){
 		rawoutput("<option value=\"".htmlentities($row['namespace'], ENT_COMPAT, getsetting("charset", "ISO-8859-1"))."\"".((htmlentities($row['namespace'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) == $namespace) ? "selected" : "").">".htmlentities($row['namespace'], ENT_COMPAT, getsetting("charset", "ISO-8859-1"))." ({$row['c']})</option>");
 	}


### PR DESCRIPTION
## Summary
- improve accessibility by adding `<label>` elements for `<select>` fields
- update petition form, ban searches, mail screens, and other pages

## Testing
- `php -l pages/petition/petition_default.php`
- `php -l pages/mail/case_write.php`
- `php -l pages/mail/case_default.php`
- `php -l pages/bans/case_searchban.php`
- `php -l pages/user/user_searchban.php`
- `php -l bank.php`
- `php -l masters.php`
- `php -l modules/mpdf_downloader.php`
- `php -l motd.php`
- `php -l mounts.php`
- `php -l translatortool.php`
- `php -l untranslated.php`
- `composer install` *(fails: CONNECT tunnel failed)*
- `composer test` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687e54dfb4d48329a9a0e2256cfaeebd