### PR TITLE
Fix duplicate event hooks

### DIFF
--- a/lib/modules.php
+++ b/lib/modules.php
@@ -157,6 +157,11 @@ function module_addeventhook(string $type, string $chance): void
     Modules::addEventHook($type, $chance);
 }
 
+function module_dropeventhook(string $type): void
+{
+    Modules::dropEventHook($type);
+}
+
 function module_drophook(string $hookname, $functioncall = false): void
 {
     Modules::dropHook($hookname, $functioncall);


### PR DESCRIPTION
## Summary
- ensure event hook registration removes duplicates
- expose dropEventHook wrapper
- document event hook cleanup

## Testing
- `php -l src/Lotgd/Modules.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687e593f129883298b2d4365d251dc7b