### PR TITLE
Add semantic elements to Modern theme

### DIFF
--- a/templates/modern.htm
+++ b/templates/modern.htm
@@ -10,26 +10,30 @@
 {headscript}{script}
 </head>
 <body bgcolor='#000000' text='#CCCCCC'>
+<header>
 <table border='0' cellpadding=4 cellspacing=0 width='100%'>
   <tr>
-	<td class='pageheader' valign='top'><span class='pagetitle'><br>{title}</span></td>
-  </tr>
-  <tr>
-	<td width='100%' valign='top' bgcolor='#352D20'>
-<!--!popupfoot-->
-	</td>
-  </tr>
-  <tr>
-	<td class='footer'>
-	  <table border='0' cellpadding='0' cellspacing='0' width='100%' class='noborder'>
-		<tr valign='top'>
-		  <td class='noborder'>{copyright}</td>
-		  <td align='right' class='noborder'>Design: Chris Yarbrough </td>
-		</tr>
-	  </table>
-	</td>
+        <td class='pageheader' valign='top'><span class='pagetitle'><br>{title}</span></td>
   </tr>
 </table>
+</header>
+<main>
+<table border='0' cellpadding=4 cellspacing=0 width='100%'>
+  <tr>
+        <td width='100%' valign='top' bgcolor='#352D20'>
+<!--!popupfoot-->
+        </td>
+  </tr>
+</table>
+</main>
+<footer>
+<table border='0' cellpadding='0' cellspacing='0' width='100%' class='noborder'>
+        <tr valign='top'>
+          <td class='noborder'>{copyright}</td>
+          <td align='right' class='noborder'>Design: Chris Yarbrough </td>
+        </tr>
+</table>
+</footer>
 </body>
 </html>
 <!--!header-->
@@ -44,54 +48,60 @@
 {headscript}{script}
 </head>
 <body bgcolor='#000000' text='#CCCCCC'>
+<header>
 <table border='0' cellpadding=4 cellspacing=0 width='100%'>
   <tr>
-	<td colspan=2 class='pageheader' valign='top'> <img src='templates/modern/title.gif' alt='' width='395' height='55' align='right'><span class='pagetitle'><br>
-	  {title}</span></td>
+        <td colspan=2 class='pageheader' valign='top'> <img src='templates/modern/title.gif' alt='' width='395' height='55' align='right'><span class='pagetitle'><br>
+          {title}</span></td>
 
-  </tr>
-  <tr>
-	<td width=190 bgcolor='#433828' valign='top'> 
-	<div align='center'>{navad}</div>
-	<img src='templates/modern/uscroll.GIF' width='182' height='11' alt=''>
-	  <table cellspacing='0' cellpadding='0' class='nav'>
-		<tr>
-		  <td>{nav}</td>
-		</tr>
-	  </table>
-
-	  <img src='templates/modern/lscroll.GIF' alt='' width='182' height='11'> <br>
-	  {motd} <br>
-	  {mail} <br>
-	  {petition} </td>
-	<td width='100%' rowspan=2 valign='top' bgcolor='#352D20'><table align='right' border='0'><tr><td>{paypal}{verticalad}</td></tr></table>{headerad}{bodyad}
-	  <!--!footer-->
-		{petitiondisplay}
-	</td>
-
-  </tr>
-  <tr>
-	<td width='190' valign='top' bgcolor='#433828'><img src='templates/modern/uscroll.GIF' width='182' height='11' alt=''>
-	  <table border='0' cellpadding='0' cellspacing='0' class='vitalinfo'>
-		<tr>
-		  <td> {stats} </td>
-		</tr>
-
-	  </table>
-	  <img src='templates/modern/lscroll.GIF' alt='' width='182' height='11'></td>
-  </tr>
-  <tr>
-	<td colspan=2 class='footer'>
-	  <table border='0' cellpadding='0' cellspacing='0' width='100%' class='noborder'>
-		<tr>
-		  <td class='noborder'>{copyright}Design: Chris Yarbrough ({pagegen}) </td>
-
-		  <td align='right' class='noborder' valign='top'>{source}<br /><br />{version}</td>
-		</tr>
-	  </table>
-	</td>
   </tr>
 </table>
+</header>
+<main>
+<table border='0' cellpadding=4 cellspacing=0 width='100%'>
+  <tr>
+        <td width=190 bgcolor='#433828' valign='top'>
+        <nav role='navigation'>
+        <div align='center'>{navad}</div>
+        <img src='templates/modern/uscroll.GIF' width='182' height='11' alt=''>
+          <table cellspacing='0' cellpadding='0' class='nav'>
+                <tr>
+                  <td>{nav}</td>
+                </tr>
+          </table>
+
+          <img src='templates/modern/lscroll.GIF' alt='' width='182' height='11'> <br>
+          {motd} <br>
+          {mail} <br>
+          {petition}</nav> </td>
+        <td width='100%' rowspan=2 valign='top' bgcolor='#352D20'>
+            <table align='right' border='0'><tr><td>{paypal}{verticalad}</td></tr></table>{headerad}{bodyad}
+            <!--!footer-->
+                {petitiondisplay}
+        </td>
+
+  </tr>
+  <tr>
+        <td width='190' valign='top' bgcolor='#433828'><img src='templates/modern/uscroll.GIF' width='182' height='11' alt=''>
+          <table border='0' cellpadding='0' cellspacing='0' class='vitalinfo'>
+                <tr>
+                  <td> {stats} </td>
+                </tr>
+
+          </table>
+          <img src='templates/modern/lscroll.GIF' alt='' width='182' height='11'></td>
+  </tr>
+</table>
+</main>
+<footer>
+<table border='0' cellpadding='0' cellspacing='0' width='100%' class='noborder'>
+        <tr>
+          <td class='noborder'>{copyright}Design: Chris Yarbrough ({pagegen}) </td>
+
+          <td align='right' class='noborder' valign='top'>{source}<br /><br />{version}</td>
+        </tr>
+</table>
+</footer>
 </body>
 </html>
 

--- a/templates/modern.htm
+++ b/templates/modern.htm
@@ -73,7 +73,8 @@
           <img src='templates/modern/lscroll.GIF' alt='' width='182' height='11'> <br>
           {motd} <br>
           {mail} <br>
-          {petition}</nav> </td>
+          {petition}
+        </nav> </td>
         <td width='100%' rowspan=2 valign='top' bgcolor='#352D20'>
             <table align='right' border='0'><tr><td>{paypal}{verticalad}</td></tr></table>{headerad}{bodyad}
             <!--!footer-->

--- a/templates_twig/modern/page.twig
+++ b/templates_twig/modern/page.twig
@@ -10,14 +10,20 @@
     {{ headscript|raw }}{{ script|raw }}
 </head>
 <body bgcolor="#000000" text="#CCCCCC">
+<header>
 <table border="0" cellpadding="4" cellspacing="0" width="100%">
     <tr>
         <td colspan="2" class="pageheader" valign="top">
             <img src="{{ template_path }}/assets/title.gif" width="395" height="55" align="right" alt="Page title graphic"><span class="pagetitle"><br>{{ title }}</span>
         </td>
     </tr>
+</table>
+</header>
+<main>
+<table border="0" cellpadding="4" cellspacing="0" width="100%">
     <tr>
         <td width="190" bgcolor="#433828" valign="top">
+            <nav role="navigation">
             <div align="center">{{ navad|raw }}</div>
             <img src="{{ template_path }}/assets/uscroll.GIF" width="182" height="11" alt="">
             <table cellspacing="0" cellpadding="0" class="nav">
@@ -27,6 +33,7 @@
             {{ motd|raw }} <br>
             {{ mail|raw }} <br>
             {{ petition|raw }}
+            </nav>
         </td>
         <td width="100%" rowspan="2" valign="top" bgcolor="#352D20">
             <table align="right" border="0"><tr><td>{{ paypal|raw }}{{ verticalad|raw }}</td></tr></table>
@@ -53,5 +60,7 @@
         </td>
     </tr>
 </table>
+</main>
+<footer></footer>
 </body>
 </html>

--- a/templates_twig/modern/popup.twig
+++ b/templates_twig/modern/popup.twig
@@ -10,25 +10,29 @@
     {{ headscript|raw }}{{ script|raw }}
 </head>
 <body bgcolor="#000000" text="#CCCCCC">
+<header>
 <table border="0" cellpadding="4" cellspacing="0" width="100%">
     <tr>
         <td class="pageheader" valign="top"><span class="pagetitle"><br>{{ title }}</span></td>
     </tr>
+</table>
+</header>
+<main>
+<table border="0" cellpadding="4" cellspacing="0" width="100%">
     <tr>
         <td width="100%" valign="top" bgcolor="#352D20">
             {{ content|raw }}
         </td>
     </tr>
-    <tr>
-        <td class="footer">
-            <table border="0" cellpadding="0" cellspacing="0" width="100%" class="noborder">
-                <tr valign="top">
-                    <td class="noborder">{{ copyright|raw }}</td>
-                    <td align="right" class="noborder">Design: Chris Yarbrough</td>
-                </tr>
-            </table>
-        </td>
+</table>
+</main>
+<footer>
+<table border="0" cellpadding="0" cellspacing="0" width="100%" class="noborder">
+    <tr valign="top">
+        <td class="noborder">{{ copyright|raw }}</td>
+        <td align="right" class="noborder">Design: Chris Yarbrough</td>
     </tr>
 </table>
+</footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap modern template tables with `<header>`, `<main>` and `<footer>`
- mark navigation sections with `<nav role="navigation">`
- add the same structure to modern Twig templates

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687e604cc4448329848540abc16a98ff