### PR TITLE
Fix subnav display for modules without subcategory

### DIFF
--- a/modules.php
+++ b/modules.php
@@ -79,14 +79,18 @@ $currentHeader = "Module Categories";
 foreach ($seencats as $cat => $count) {
         $category = $cat;
         $header   = "Module Categories";
+        $subnav   = '';
         if (strpos($cat, "|") !== false) {
-                list($header, $category) = explode("|", $cat, 2);
+                list($header, $subnav) = explode("|", $cat, 2);
+                $category = $subnav;
         }
         if ($header !== $currentHeader) {
                 addnavheader($header);
                 $currentHeader = $header;
         }
-        addnavsubheader($category);
+        if ($subnav !== '') {
+                addnavsubheader($subnav);
+        }
         addnav(array(" ?%s - (%s modules)", $category, $count), "modules.php?cat=$cat");
 }
 


### PR DESCRIPTION
## Summary
- only render a subheader when the module category contains a subnav

## Testing
- `php -l modules.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687e66718b648329a263c627daad2728