### PR TITLE
Fix nav header sorting

### DIFF
--- a/docs/Nav.md
+++ b/docs/Nav.md
@@ -120,9 +120,9 @@ navsort(string $headerOrder = 'asc', string $subOrder = 'asc'): void
 ```
 
 Sorts navigation links alphabetically. `$headerOrder` controls the ordering of
-subsections while `$subOrder` determines the order of items within each section
-and subsection. Each argument may be `'asc'`, `'desc'` or `'off'`. Use `'off'`
-to keep the original order.
+sections and their subsections while `$subOrder` determines the order of items
+within each section and subsection. Each argument may be `'asc'`, `'desc'` or
+`'off'`. Use `'off'` to keep the original order.
 
 User preferences `navsort_headers` and `navsort_subheaders` store the chosen
 values for headlines and subheadlines. `buildNavs()` reads these preferences and

--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -749,7 +749,16 @@ class Nav
     public static function navSort(string $headerOrder = 'asc', string $subOrder = 'asc'): void
     {
         global $session;
-        foreach (self::$sections as $key => $section) {
+
+        $sections = array_values(self::$sections);
+        if ($headerOrder !== 'off') {
+            usort($sections, [self::class, 'navASortSection']);
+            if ($headerOrder === 'desc') {
+                $sections = array_reverse($sections);
+            }
+        }
+
+        foreach ($sections as $index => $section) {
             $val = $section->getItems();
             if ($subOrder !== 'off') {
                 usort($val, [self::class, 'navASortItem']);
@@ -757,7 +766,7 @@ class Nav
                     $val = array_reverse($val);
                 }
             }
-            self::$sections[$key]->setItems($val);
+            $sections[$index]->setItems($val);
 
             $subs = $section->getSubSections();
             if ($headerOrder !== 'off') {
@@ -776,8 +785,9 @@ class Nav
                 }
                 $s->setItems($items);
             }
-            self::$sections[$key]->setSubSections($subs);
+            $sections[$index]->setSubSections($subs);
         }
+        self::$sections = $sections;
     }
 
     protected static function navASort($a, $b)
@@ -801,6 +811,27 @@ class Nav
     {
         $ta = $a->text;
         $tb = $b->text;
+        if (is_array($ta)) {
+            $ta = call_user_func_array('sprintf', $ta);
+        }
+        if (is_array($tb)) {
+            $tb = call_user_func_array('sprintf', $tb);
+        }
+        $ta = sanitize($ta);
+        $tb = sanitize($tb);
+        $posA = strpos(substr($ta, 0, 2), '?');
+        $posB = strpos(substr($tb, 0, 2), '?');
+        if ($posA === false) $posA = -1;
+        if ($posB === false) $posB = -1;
+        $ta = substr($ta, $posA + 1);
+        $tb = substr($tb, $posB + 1);
+        return strcmp($ta, $tb);
+    }
+
+    protected static function navASortSection(NavigationSection $a, NavigationSection $b): int
+    {
+        $ta = $a->headline;
+        $tb = $b->headline;
         if (is_array($ta)) {
             $ta = call_user_func_array('sprintf', $ta);
         }

--- a/tests/NavSortTest.php
+++ b/tests/NavSortTest.php
@@ -99,7 +99,7 @@ namespace {
 
             $navs = strip_tags(Nav::buildNavs());
 
-            $this->assertLessThan(strpos($navs, 'Alpha'), strpos($navs, 'Beta'));
+            $this->assertGreaterThan(strpos($navs, 'Alpha'), strpos($navs, 'Beta'));
         }
 
         public function testHeaderDescendingSorting(): void
@@ -115,7 +115,7 @@ namespace {
 
             $navs = strip_tags(Nav::buildNavs());
 
-            $this->assertLessThan(strpos($navs, 'Beta'), strpos($navs, 'Alpha'));
+            $this->assertGreaterThan(strpos($navs, 'Beta'), strpos($navs, 'Alpha'));
         }
     }
 }

--- a/tests/NavSortTest.php
+++ b/tests/NavSortTest.php
@@ -85,5 +85,37 @@ namespace {
             $this->assertLessThan(strpos($navs, 'A1'), strpos($navs, 'B1'));
             $this->assertLessThan(strpos($navs, 'Alpha'), strpos($navs, 'Beta'));
         }
+
+        public function testHeaderAscendingSorting(): void
+        {
+            global $session;
+            Nav::addHeader('Beta', false);
+            Nav::add('B Item', 'b.php');
+            Nav::addHeader('Alpha', false);
+            Nav::add('A Item', 'a.php');
+
+            $session['user']['prefs']['navsort_headers'] = 'asc';
+            $session['user']['prefs']['navsort_subheaders'] = 'asc';
+
+            $navs = strip_tags(Nav::buildNavs());
+
+            $this->assertLessThan(strpos($navs, 'Alpha'), strpos($navs, 'Beta'));
+        }
+
+        public function testHeaderDescendingSorting(): void
+        {
+            global $session;
+            Nav::addHeader('Alpha', false);
+            Nav::add('A Item', 'a.php');
+            Nav::addHeader('Beta', false);
+            Nav::add('B Item', 'b.php');
+
+            $session['user']['prefs']['navsort_headers'] = 'desc';
+            $session['user']['prefs']['navsort_subheaders'] = 'asc';
+
+            $navs = strip_tags(Nav::buildNavs());
+
+            $this->assertLessThan(strpos($navs, 'Beta'), strpos($navs, 'Alpha'));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow navSort to order navigation sections
- document behaviour of header order
- test header sorting

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `composer test` *(fails: phpunit not found)*


------
https://chatgpt.com/codex/tasks/task_e_687e6ebf317c8329bebbc4a258ec2def