### PR TITLE
Add namespace docs and legacy wrapper guide

### DIFF
--- a/docs/LegacyWrappers.md
+++ b/docs/LegacyWrappers.md
@@ -1,0 +1,104 @@
+# Legacy Wrapper Functions
+
+Many older modules rely on global functions defined in `lib/*.php`. These files now act as thin wrappers around the namespaced classes in `src/Lotgd`. New code should call the classes directly.
+
+## Available Wrappers
+
+The following wrappers exist for backwards compatibility:
+
+- `lib/addnews.php` → `\Lotgd\AddNews` (`addnews()`, `addnews_for_user()`)
+- `lib/battle-buffs.php` → `\Lotgd\Buffs`
+- `lib/battle-functions.php` → `\Lotgd\FightBar`
+- `lib/battle-skills.php` → `\Lotgd\Battle`
+- `lib/bell_rand.php` → `\Lotgd\BellRand`
+- `lib/buffs.php` → `\Lotgd\Buffs` (buff and companion helpers)
+- `lib/censor.php` → `\Lotgd\Censor`
+- `lib/charcleanup.php` → `\Lotgd\PlayerFunctions`
+- `lib/checkban.php` → `\Lotgd\CheckBan`
+- `lib/commentary.php` → `\Lotgd\Commentary`
+- `lib/datacache.php` → `\Lotgd\DataCache`
+- `lib/datetime.php` → `\Lotgd\DateTime`
+- `lib/dbmysqli.php` and `lib/dbwrapper.php` → `\Lotgd\MySQL`
+- `lib/deathmessage.php` → `\Lotgd\DeathMessage`
+- `lib/debuglog.php` → `\Lotgd\DebugLog`
+- `lib/dhms.php` → `\Lotgd\Dhms`
+- `lib/dump_item.php` → `\Lotgd\DumpItem`
+- `lib/e_dom.php` → `\Lotgd\EDom`
+- `lib/errorhandler.php` → `\Lotgd\ErrorHandler`
+- `lib/events.php` → `\Lotgd\Events`
+- `lib/experience.php` → `\Lotgd\PlayerFunctions`
+- `lib/expire_chars.php` → `\Lotgd\ExpireChars`
+- `lib/fightnav.php` → `\Lotgd\Battle`
+- `lib/forcednavigation.php` → `\Lotgd\ForcedNavigation`
+- `lib/forest.php` and `lib/forestoutcomes.php` → `\Lotgd\Forest`
+- `lib/forms.php` → `\Lotgd\Forms`
+- `lib/gamelog.php` → `\Lotgd\GameLog`
+- `lib/holiday_texts.php` → `\Lotgd\HolidayText`
+- `lib/http.php` → `\Lotgd\Http`
+- `lib/increment_specialty.php` → `\Lotgd\Specialty`
+- `lib/is_email.php` → `\Lotgd\EmailValidator`
+- `lib/local_config.php` → `\Lotgd\LocalConfig`
+- `lib/lookup_user.php` → `\Lotgd\UserLookup`
+- `lib/mail.php` → `\Lotgd\Mail`
+- `lib/moderate.php` → `\Lotgd\Moderate`
+- `lib/modules.php` → `\Lotgd\Modules`
+- `lib/motd.php` → `\Lotgd\Motd`
+- `lib/mountname.php` → `\Lotgd\MountName`
+- `lib/mounts.php` → `\Lotgd\Mounts`
+- `lib/names.php` → `\Lotgd\Names`
+- `lib/nav.php` → `\Lotgd\Nav`
+- `lib/nltoappon.php` → `\Lotgd\Nltoappon`
+- `lib/output.php` → `\Lotgd\Output`
+- `lib/output_array.php` → `\Lotgd\OutputArray`
+- `lib/pageparts.php` → `\Lotgd\PageParts`
+- `lib/partner.php` → `\Lotgd\Partner`
+- `lib/php_generic_environment.php` → `\Lotgd\PhpGenericEnvironment`
+- `lib/playerfunctions.php` → `\Lotgd\PlayerFunctions`
+- `lib/pullurl.php` → `\Lotgd\PullUrl`
+- `lib/pvplist.php`, `lib/pvpsupport.php`, `lib/pvpwarning.php` → `\Lotgd\Pvp`
+- `lib/redirect.php` → `\Lotgd\Redirect`
+- `lib/register_global.php` → `\Lotgd\RegisterGlobal`
+- `lib/safeescape.php` → `\Lotgd\SafeEscape`
+- `lib/sanitize.php` → `\Lotgd\Sanitize`
+- `lib/saveuser.php` → `\Lotgd\Accounts::saveUser()`
+- `lib/sendmail.php` → `\Lotgd\Mail`
+- `lib/serialization.php` → `\Lotgd\Serialization`
+- `lib/serverfunctions.class.php` → `\Lotgd\ServerFunctions`
+- `lib/settings.class.php` and `lib/settings.php` → `\Lotgd\Settings`
+- `lib/show_backtrace.php` → `\Lotgd\Backtrace`
+- `lib/showform.php` → `\Lotgd\Forms`
+- `lib/spell.php` → `\Lotgd\Spell`
+- `lib/sql.php` → `\Lotgd\Sql`
+- `lib/stripslashes_deep.php` → `\Lotgd\Stripslashes`
+- `lib/su_access.php` → `\Lotgd\SuAccess`
+- `lib/substitute.php` → `\Lotgd\Substitute`
+- `lib/superusernav.php` → `\Lotgd\Nav\SuperuserNav`
+- `lib/systemmail.php` → `\Lotgd\Mail`
+- `lib/tabledescriptor.php` → `\Lotgd\MySQL\TableDescriptor`
+- `lib/taunt.php` → `\Lotgd\Battle`
+- `lib/template.php` → `\Lotgd\Template`
+- `lib/tempstat.php` → `\Lotgd\PlayerFunctions`
+- `lib/titles.php` → `\Lotgd\PlayerFunctions`
+- `lib/translator.php` → `\Lotgd\Translator`
+- `lib/villagenav.php` → `\Lotgd\Nav\VillageNav`
+
+These files mostly contain simple proxy functions or class aliases. They exist so that old modules written for the pre‑namespaced API continue to run.
+
+## Migration Guide
+
+1. Identify calls to global functions from `lib/`. For example `addnav()` or `mail_delete_message()`.
+2. Replace the function call with the equivalent method on the namespaced class. Example:
+
+```php
+// Old
+addnav('Return', 'village.php');
+
+// New
+\Lotgd\Nav::add('Return', 'village.php');
+```
+
+3. Remove any `require_once 'lib/xyz.php'` lines when the class is autoloaded via Composer.
+4. Test the module. The behaviour should remain the same as the wrapper simply forwards the call.
+
+Dropping the wrappers entirely will reduce global function usage and makes dependencies explicit. New modules should avoid including `lib/*.php` and instead rely solely on the namespaced API.
+

--- a/docs/Namespaces.md
+++ b/docs/Namespaces.md
@@ -1,0 +1,96 @@
+# Namespace Overview
+
+This document describes the main namespaces and helper classes within the `src/` directory. The project organizes most PHP code under the `\Lotgd` root namespace. Each file in `src/Lotgd` provides a class of the same name. The following tables summarise what each class is used for and highlight notable methods.
+
+## \Lotgd (root namespace)
+
+The root namespace contains many helper classes. Each file usually offers a collection of static methods or utility features. Below is a short summary of the purpose of every class:
+
+- **Accounts** – utility methods related to account handling. Provides `saveUser()` to persist session data.
+- **AddNews** – helper for inserting news entries. Functions `add()` and `addForUser()` log stories for all players or a particular account.
+- **Backtrace** – formats call stack information. Methods `show()` and `showNoBacktrace()` return HTML traces used by the error handler.
+- **Battle** – common battle logic shared by combat modules.
+- **BellRand** – random number helper using a bell‑curve algorithm.
+- **Buffs** – manipulation of buffs and companions. Includes `applyBuff()`, `stripBuff()`, `restoreBuffFields()` and related routines.
+- **Censor** – replaces banned words in user supplied text.
+- **CharStats** – manages sidebar statistics in the template.
+- **CheckBan** – functions for checking IP bans.
+- **Commentary** – handles the comment system. Important methods are `addComment()` and `renderCommentary()`.
+- **Cookies** – cookie helper for storing template preference and similar data.
+- **DataCache** – lightweight file cache with `datacache()` and `updateDataCache()` wrappers.
+- **DateTime** – date helpers such as `relativeDate()` and `secondsToNextGameDay()`.
+- **DeathMessage** – selects random death messages used during combat.
+- **DebugLog** – writes entries to `debuglog` table.
+- **Dhms** – converts seconds into `D H M S` strings.
+- **DumpItem** – exports PHP variables for debugging.
+- **EDom** – wrapper around DOMDocument with helper methods.
+- **EmailValidator** – validates e‑mail addresses.
+- **ErrorHandler** – central error/exception handling. Registers handlers and renders debug output.
+- **Events** – helper for the random event system.
+- **ExpireChars** – maintenance job for expiring inactive characters.
+- **FightBar** – builds the in-combat navigation.
+- **ForcedNavigation** – used when the code sets `forcepage` to redirect the player.
+- **Forest\Outcomes** – methods for victory/defeat handling in the forest.
+- **Forms** – utilities for building HTML forms from descriptor arrays.
+- **GameLog** – game activity logging functions.
+- **HolidayText** – manages seasonal text replacements.
+- **Http** – small HTTP client used to fetch remote content.
+- **LocalConfig** – reads the local configuration file.
+- **Mail** – handles the internal mail system (sending, deleting and counting messages).
+- **Moderate** – moderation tools for the comment board.
+- **ModuleManager** – basic loader used during installation.
+- **Modules** – large collection of module helper functions. Deals with hooks, preferences and activation.
+- **Motd** – message-of-the-day handling.
+- **MountName** – generates mount names shown to players.
+- **Mounts** – manages purchased mounts.
+- **MySQL** – see dedicated section below.
+- **Names** – random name generator.
+- **Nav** – central navigation builder. See `docs/Nav.md` for details.
+- **Newday** – logic run at the start of each game day.
+- **Nltoappon** – converts newlines and colour codes.
+- **Output** – collects and formats page output before rendering. Replaces the old `output_collector`.
+- **OutputArray** – simplified output collector used by the installer.
+- **PageParts** – page header/footer generation and stats display.
+- **Partner** – generates partner names for the player character.
+- **PhpGenericEnvironment** – wrapper to access PHP global variables in a controlled way.
+- **PlayerFunctions** – legacy player operations such as incrementing speciality usage.
+- **PullUrl** – constructs query strings for module hooks.
+- **Pvp** – provides PvP fight checks and warnings.
+- **Redirect** – safe HTTP redirects.
+- **RegisterGlobal** – recreates deprecated `register_globals` behaviour for compatibility.
+- **SafeEscape** – quoting helper for database strings.
+- **Sanitize** – sanitizes input values and arrays recursively.
+- **Serialization** – wrappers around PHP serialisation with error handling.
+- **ServerFunctions** – assorted helper utilities used across the project.
+- **Settings** – loads and stores configuration options.
+- **Specialty** – manages player specialties.
+- **Spell** – helper for mage spells.
+- **Sql** – small wrapper around database errors.
+- **Stripslashes** – removes slashes from arrays/strings.
+- **SuAccess** – determines superuser access rights.
+- **Substitute** – simple text substitution engine used by buffs.
+- **Template** – loads and selects templates; manages user template cookie.
+- **Translator** – translation layer for all user facing text.
+- **TwigTemplate** – Template adapter that renders Twig files.
+- **UserLookup** – helper to fetch account details by name or id.
+
+## \Lotgd\MySQL
+
+Database related classes reside in the `MySQL` sub‑namespace:
+
+- **Database** – static connection manager with `query()`, caching methods and helper functions like `affectedRows()` and `prefix()`.
+- **DbMysqli** – thin wrapper over `mysqli` used by `Database` to perform actual queries.
+- **TableDescriptor** – synchronises schema definitions and can generate `CREATE TABLE` statements.
+
+## \Lotgd\Nav
+
+Contains the navigation builder used throughout the game. See `docs/Nav.md` for detailed usage of `NavigationItem`, `NavigationSection` and related helpers. Additional classes include `VillageNav` for the village page and `SuperuserNav` for the admin menu.
+
+## \Lotgd\Forest
+
+Currently hosts only `Outcomes` with functions for forest battle results. Future combat helpers may live here as well.
+
+# Why Namespaces?
+
+The original codebase used many global functions defined in `lib/*.php`. Namespaces allow grouping related functionality into classes, improving autoloading and reducing name collisions. Modules should prefer these namespaced classes over the legacy wrappers documented in `docs/LegacyWrappers.md`.
+


### PR DESCRIPTION
## Summary
- document every namespace and helper class
- add a list of legacy wrapper files and show how to migrate

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed)*
- `composer test -- --filter nothing` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e9470bda48329bd0543d3570f64c2