### PR TITLE
Expand namespace docs

### DIFF
--- a/docs/Forest.md
+++ b/docs/Forest.md
@@ -1,0 +1,41 @@
+# Forest Namespace
+
+The `\Lotgd\Forest` namespace currently houses logic related to battles fought in the forest area.  While small, it demonstrates how specialised gameplay helpers are separated from the legacy global functions.
+
+## Outcomes
+
+`Outcomes` defines two static methods: `victory()` and `defeat()`.  They are invoked by combat code after a player wins or loses against forest creatures.  Both methods interact with multiple classes from the root namespace:
+
+- `AddNews` to announce results on the news page.
+- `Battle` for combat messages.
+- `PageParts` and `Nav` to show navigation links after combat.
+- `Settings` and `Translator` to honour configuration and localisation.
+
+A simplified example of rewarding a player after battle:
+
+```php
+$enemy = ['creaturename' => 'Goblin', 'creaturegold' => 50, 'creatureexp' => 30];
+Lotgd\Forest\Outcomes::victory([$enemy]);
+```
+
+The function grants gold and experience based on the passed creature data and may award a flawless bonus when appropriate.
+
+## Forest Wrapper
+
+In addition to the `Outcomes` class the root namespace provides `Lotgd\Forest` – a thin wrapper that renders the classic forest navigation.  Modules can call `Lotgd\Forest::forest()` to display the default forest page with links created by `Lotgd\Nav`.
+
+```php
+Lotgd\Forest::forest();
+```
+
+Future combat or exploration related helpers may be added to this namespace.
+
+### Interaction With Modules
+
+`Outcomes::victory()` and `Outcomes::defeat()` trigger several module hooks such as `forest_victory` and `forest_defeat`. Modules can adjust gold or experience rewards through these hooks.
+
+### Entry Points
+
+The classic `forest.php` page primarily calls `Lotgd\Forest::forest()` to set up the navigation and to pick random encounters. Modules may supply additional creatures or special events during this step.
+
+

--- a/docs/Lotgd.md
+++ b/docs/Lotgd.md
@@ -1,0 +1,332 @@
+# Lotgd Root Namespace
+
+This page provides an overview of the many helper classes located directly under the `\Lotgd` namespace.  Most gameplay functions that were historically global have been refactored into these classes.  They can be autoloaded via Composer and used directly from modules or internal pages.
+
+Each file in `src/Lotgd/` defines a single class.  The classes are largely static collections of methods and act as entry points to the engine.  The following sections highlight the most important groups of functionality.
+
+## Gameplay and Player Helpers
+
+Classes such as `Accounts`, `Newday`, `PlayerFunctions`, `Pvp`, `Specialty` and `Battle` operate on the player session and game state.  They manipulate the `$session` global and frequently call into the database layer.
+
+Example – awarding a player turns at the start of the day:
+
+```php
+Lotgd\Newday::dawn();
+```
+
+## Output and Templates
+
+`Output`, `PageParts`, `Template`, `TwigTemplate` and `CharStats` compose the HTML pages shown to the user.  They replace the historical `output_collector` and template system.
+
+```php
+$output = new Lotgd\Output();
+$output->output("Welcome, %s!", $session['user']['name']);
+$body = $output->getOutput();
+```
+
+`Translator` manages localisation.  The engine pushes and pops translation namespaces internally so module text can be isolated.  Custom pages can call `Lotgd\Translator::translate()` manually.
+
+## Modules and Hooks
+
+The module system allows third party code to extend the game.  `Modules` and `ModuleManager` contain helper functions to install modules, execute hooks and manage preferences.  Module hooks fire throughout the engine via `modulehook()` which proxies to `Lotgd\Modules::modulehook()`.
+
+## Data and Configuration
+
+`Settings`, `LocalConfig` and `DataCache` deal with persistence of configuration and cached data.  `Accounts::saveUser()` writes the `$session['user']` array back to the `accounts` table.
+
+The `MySQL` sub-namespace (see `MySQL.md`) implements the actual database wrapper used by nearly every class.
+
+## Miscellaneous Utilities
+
+Many other files provide focused helpers: `AddNews` writes stories to the news feed, `Http` performs simple HTTP requests, `Mail` implements the in-game mail system and `Substitute` offers a very small template engine used by buffs.  The complete list is available in `docs/Namespaces.md`.
+
+### Usage Example
+
+A typical page will combine several of these helpers:
+
+```php
+Lotgd\ErrorHandler::register();
+Lotgd\Translator::translatorSetup();
+Lotgd\Output::appoencode("`@Hello %s!`0", true);
+Lotgd\Nav::add("Return", "village.php");
+```
+
+Understanding these classes makes it easier to port old `lib/*.php` calls to the modern API.
+
+## Class Reference
+
+Below is a more detailed list of the classes found directly in the `\Lotgd` namespace. Each entry highlights common methods and how they relate to other parts of the engine.
+
+### Accounts
+
+Handles saving and loading of player accounts. `saveUser()` writes the current `$session['user']` data back to the database and is typically called after any change to player stats.
+
+```php
+Lotgd\Accounts::saveUser();
+```
+
+### AddNews
+
+Adds entries to the `news` table. `add()` is a convenience wrapper for the currently logged-in user while `addForUser()` allows specifying an account id.
+
+```php
+Lotgd\AddNews::add('`@%s defeated the dragon!`0', $session['user']['name']);
+```
+
+### Backtrace
+
+Utility for displaying error traces. `show()` returns a formatted HTML table of the current stack which is consumed by `ErrorHandler`.
+
+### Battle
+
+Shared combat logic used by different fight modules. Functions such as `fightNav()` and `doAttack()` interact with `Buffs`, `Settings` and the `Translator` to perform damage calculations and messaging.
+
+### BellRand
+
+Generates random numbers with a bell curve distribution. Called by modules that need less predictable results than `mt_rand()`.
+
+### Buffs
+
+Applies and manages temporary effects on the player character. Methods like `applyBuff()` and `stripBuff()` cooperate with `Battle` during fights.
+
+### Censor
+
+Filters banned words from player supplied text. Often used before saving commentary or mail.
+
+### CharStats
+
+Builds the right-hand sidebar showing hitpoints, gold and similar statistics. Depends on `Settings` for display options.
+
+### CheckBan
+
+Checks IP or account bans when a page is loaded. Works together with `Http` and `DbMysqli` to record attempts.
+
+### Commentary
+
+Contains the entire commentary system. Important functions are `addComment()` for inserting a new line and `renderCommentary()` for displaying it in a template section.
+
+### Cookies
+
+Stores simple values such as the selected template name. Used heavily by `Template` and `Translator`.
+
+### DataCache
+
+Implements a lightweight file-based cache. `datacache()` reads a key while `updateDataCache()` writes data. Used internally by `Database::queryCached()`.
+
+### DateTime
+
+Helper for date calculations, e.g. `secondsToNextGameDay()` is referenced by the newday countdown in the village.
+
+### DeathMessage
+
+Selects random phrases shown on the "You are Dead" screen.
+
+### DebugLog
+
+Writes debug entries to the `debuglog` table. Called throughout the engine to record significant actions.
+
+### Dhms
+
+Converts seconds to a `D H M S` formatted string.
+
+### DumpItem
+
+Pretty prints PHP variables for debugging. Commonly wrapped by `Output::debug()`.
+
+### EDom
+
+Simplifies DOMDocument usage when building admin pages or the installer.
+
+### EmailValidator
+
+Validates e-mail addresses when players change their settings.
+
+### ErrorHandler
+
+Centralised exception and error handling. Registers custom handlers that make use of `Backtrace` and `Output` to produce readable pages.
+
+### Events
+
+Hosts the random event system. Functions pick events from modules and integrate with `AddNews` and `PageParts`.
+
+### ExpireChars
+
+Maintenance job that removes inactive characters based on configuration thresholds.
+
+### FightBar
+
+Builds the in-combat navigation shown during fights. Heavily relies on `Nav`.
+
+### ForcedNavigation
+
+Redirects the user when game logic requires it, e.g. after newday.
+
+### Forest
+
+Wrapper that outputs the classic forest navigation menu via `Nav`. See `Forest.md` for combat outcomes.
+
+### Forms
+
+Simplified form builder used by setup pages and some modules. Generates HTML from descriptor arrays similar to Drupal's FAPI.
+
+### GameLog
+
+Writes entries describing player actions to the `gamelog` table for later analysis.
+
+### HolidayText
+
+Replaces certain words with seasonal alternatives around special dates.
+
+### Http
+
+Lightweight HTTP client with timeout handling. Modules may fetch remote data using `Http::fetch()`.
+
+### LocalConfig
+
+Reads site configuration values from `config/local.php`.
+
+### Mail
+
+Implements the in-game private mail system. Functions exist for sending, deleting and counting messages.
+
+### Moderate
+
+Administrative tools for moderating the comment boards.
+
+### ModuleManager
+
+Loader used by the installer. Scans module directories and verifies meta information.
+
+### Modules
+
+The heart of the module system. Provides `modulehook()` to call hook points and `set_module_pref()` for storing preferences.
+
+### Motd
+
+Handles the message of the day. Players see it upon login or newday.
+
+### MountName
+
+Generates the names of mounts as shown to the player, using templates defined in the database.
+
+### Mounts
+
+Business logic for buying and managing mounts.
+
+### Names
+
+Random name generator used by certain modules and monsters.
+
+### Nav
+
+Entry point for menu building. Documented separately in `Nav.md`.
+
+### Newday
+
+Contains everything that happens when a new game day starts: refill turns, award interest, reset buffs and more.
+
+### Nltoappon
+
+Converts newlines into LOTGD colour aware `<br>` tags.
+
+### Output
+
+Collects HTML output and provides colour code parsing. All game pages eventually call `Output::getOutput()` to render their body.
+
+### OutputArray
+
+Smaller variant used during installation.
+
+### PageParts
+
+Renders the header, footer and various stat columns. It combines `Output`, `CharStats` and `Template`.
+
+### Partner
+
+Generates default partner names for the marriage feature.
+
+### PhpGenericEnvironment
+
+Wrapper for accessing PHP globals in a controlled way – mainly used in tests.
+
+### PlayerFunctions
+
+Legacy helper with odds and ends related to the player character.
+
+### PullUrl
+
+Builds URLs for module hooks with encoded parameters.
+
+### Pvp
+
+Checks whether a player can engage in PvP combat and shows warnings when necessary.
+
+### Redirect
+
+Safe `Location:` redirects with optional delay and messaging.
+
+### RegisterGlobal
+
+Recreates the old `register_globals` behaviour in a safer fashion.
+
+### SafeEscape
+
+Quoting helper for strings destined for the database layer.
+
+### Sanitize
+
+Recursively cleans arrays or values from potentially dangerous input.
+
+### Serialization
+
+Wraps PHP `serialize()` and `unserialize()` with extra error checks.
+
+### ServerFunctions
+
+Miscellaneous utilities used across the project: sending headers, managing superuser logins and more.
+
+### Settings
+
+Reads and writes configuration values cached in `$settings`.
+
+### Specialty
+
+Manages player specialties including use of speciality points in combat.
+
+### Spell
+
+Mage spell helper invoked during fights.
+
+### Sql
+
+Wrapper around database error information.
+
+### Stripslashes
+
+Removes slashes from arrays or strings that were escaped earlier.
+
+### SuAccess
+
+Determines whether the current user has certain superuser rights.
+
+### Substitute
+
+Very small template engine used internally by buff definitions.
+
+### Template
+
+Selects the HTML template engine and stores template preference cookies.
+
+### Translator
+
+Loads translation resources and exposes `translate()` for modules.
+
+### TwigTemplate
+
+Adapter used when the Twig engine is active.
+
+### UserLookup
+
+Convenience method to fetch account ids or names with `getUserByEmail()` and friends.
+
+

--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -1,0 +1,76 @@
+# MySQL Namespace
+
+The `\Lotgd\MySQL` namespace contains the database abstraction layer.  All SQL queries issued by the engine ultimately pass through these classes.  They provide a thin wrapper over PHP's `mysqli` extension while recording statistics and offering convenience helpers.
+
+## Database
+
+`Database` exposes static methods that operate on a singleton `DbMysqli` instance.  Typical usage:
+
+```php
+$result = Lotgd\MySQL\Database::query('SELECT * FROM ' . Lotgd\MySQL\Database::prefix('accounts'));
+while ($row = Lotgd\MySQL\Database::fetchAssoc($result)) {
+    // work with $row
+}
+```
+
+Important methods include:
+
+- `query()` – execute a SQL statement and track execution time.
+- `queryCached()` – wrapper that caches results through `DataCache`.
+- `fetchAssoc()` – fetch a single row as an associative array.
+- `insertId()` – retrieve the last auto increment value.
+- `affectedRows()` – number of rows changed by the last query.
+- `prefix()` – prepend the configured table prefix.
+
+The wrapper also stores various counters in the `$dbinfo` global, such as `queriesthishit` and total query time.
+
+## DbMysqli
+
+This class is a lightweight container around `mysqli` providing instance methods like `connect`, `escape` and `tableExists`.  It is normally only used via the higher level `Database` class but can be instantiated directly for custom connections during the installer.
+
+## TableDescriptor
+
+`TableDescriptor` is used by the installer and maintenance scripts to synchronise database schemas.  Given a descriptor array it can generate the SQL needed to create or modify tables.  Modules rarely call this directly unless they need to create additional tables.
+
+### Example – Creating a Table
+
+```php
+$desc = [
+    'id'   => ['name' => 'id', 'type' => 'int unsigned auto_increment'],
+    'name' => ['name' => 'name', 'type' => 'varchar(255)'],
+    'key-id' => ['type' => 'primary key', 'columns' => 'id'],
+];
+Lotgd\MySQL\Database::query(TableDescriptor::tableCreateFromDescriptor('mytable', $desc));
+```
+
+The engine uses these tools throughout installation and whenever modules call `synctable()` to ensure their schema is up to date.
+
+### Connection Flow
+
+1. `LocalConfig` loads the database credentials from `config/local.php`.
+2. `Database::prefix()` is used by nearly every query to apply the table prefix.
+3. When `Database::query()` is called for the first time, it lazily constructs a `DbMysqli` object and connects to the database server.
+4. The connection resource is reused for subsequent queries, reducing overhead.
+
+```php
+$db = Lotgd\MySQL\DbMysqli::fromDefault();
+$db->connect();
+```
+
+### Caching Results
+
+`queryCached()` stores the result of SELECT statements in `DataCache` to reduce load. The cache key is based on the SQL string and the specified timeout.
+
+```php
+$rows = Lotgd\MySQL\Database::queryCached('SELECT * FROM '.Lotgd\MySQL\Database::prefix('armor'), 3600);
+```
+
+### Error Handling
+
+SQL errors throw exceptions with detailed messages from `DbMysqli`. In debug mode `ErrorHandler` will display the failing query along with a stack trace from `Backtrace`.
+
+### Using TableDescriptor
+
+Modules may ship schema descriptions for their tables. `TableDescriptor::schematize()` converts descriptor arrays into CREATE or ALTER statements during `install.php`.
+
+

--- a/docs/Namespaces.md
+++ b/docs/Namespaces.md
@@ -2,6 +2,12 @@
 
 This document describes the main namespaces and helper classes within the `src/` directory. The project organizes most PHP code under the `\Lotgd` root namespace. Each file in `src/Lotgd` provides a class of the same name. The following tables summarise what each class is used for and highlight notable methods.
 
+For in-depth explanations see:
+- [Lotgd.md](Lotgd.md) – exhaustive reference for every class in the root namespace
+- [MySQL.md](MySQL.md) – details on the database layer and connection handling
+- [Nav.md](Nav.md) – how to create and render navigation links
+- [Forest.md](Forest.md) – combat helpers and forest outcomes
+
 ## \Lotgd (root namespace)
 
 The root namespace contains many helper classes. Each file usually offers a collection of static methods or utility features. Below is a short summary of the purpose of every class:
@@ -93,4 +99,5 @@ Currently hosts only `Outcomes` with functions for forest battle results. Future
 # Why Namespaces?
 
 The original codebase used many global functions defined in `lib/*.php`. Namespaces allow grouping related functionality into classes, improving autoloading and reducing name collisions. Modules should prefer these namespaced classes over the legacy wrappers documented in `docs/LegacyWrappers.md`.
+
 

--- a/docs/Nav.md
+++ b/docs/Nav.md
@@ -129,3 +129,17 @@ the chosen values. `buildNavs()` reads these preferences and automatically sorts
 the navigation.
 
 
+
+## Building the Final Menu
+
+After links have been added with the helper methods above, call `Lotgd\Nav::buildNavs()` to produce the HTML navigation list.  The method automatically applies user preferences such as sorting order and collapsible sections.
+
+```php
+Lotgd\Nav::addHeader('Main');
+Lotgd\Nav::add('Return', 'village.php');
+$html = Lotgd\Nav::buildNavs();
+```
+
+`buildNavs()` clears the internal cache so links for the next page must be added again.
+
+Developers can reset access keys or start fresh output with `Lotgd\Nav::resetAccessKeys()` and `Lotgd\Nav::clearOutput()` respectively.


### PR DESCRIPTION
## Summary
- elaborate root namespace with per-class reference
- expand MySQL guide with connection flow and caching
- extend Forest docs with module hooks info
- clarify namespace links in overview

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_687e979ad5948329b4ea07264d71c110