### PR TITLE
Add PHP_CodeSniffer and lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
           php-version: '8.1'
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-interaction
+      - name: Run PHPCS
+        run: composer lint
       - name: Lint PHP files
         run: |
           find . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "autoload": {
         "psr-4": {
@@ -15,7 +16,8 @@
         }
     },
     "scripts": {
-        "test": "phpunit --configuration phpunit.xml"
+        "test": "phpunit --configuration phpunit.xml",
+        "lint": "phpcs"
     },
     "extra": {
         "merge-plugin": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<ruleset name="lotgd">
+    <rule ref="PSR12" />
+    <exclude-pattern>vendor/*</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
## Summary
- require `squizlabs/php_codesniffer` for development
- add a PSR12 config with vendor exclusion
- expose a `composer lint` script
- run PHPCS in CI

## Testing
- `composer test`
- `composer require --dev squizlabs/php_codesniffer` *(fails: CONNECT tunnel failed)*
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687eb400bac4832985ca9705d4625a9d