### PR TITLE
Ensure file-level docblocks appear immediately after PHP tag

### DIFF
--- a/armoreditor.php
+++ b/armoreditor.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * \file armoreditor.php
+ * This file represents the grotto armor editor where you can create or edit new weapons for the shop.
+ * @see armor.php
+ */
 
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
@@ -7,12 +12,6 @@ use Lotgd\Forms;
 
 // addnews ready
 // mail ready
-/**
-* \file armoreditor.php
-* This file represents the grotto armor editor where you can create or edit new weapons for the shop.
-* @see armor.php
-*
-*/
 require_once("common.php");
 require_once("lib/http.php");
 

--- a/badnav.php
+++ b/badnav.php
@@ -1,17 +1,15 @@
 <?php
+/**
+ * \file badnav.php
+ * This file handles the badnavs that occurr and displays either the last pagehit or an empty page where the user can petition.
+ * @see lib/redirect.php
+ */
 
 // translator ready
 use Lotgd\Accounts;
 
 // addnews ready
 // mail ready
-/**
-* \file badnav.php
-* This file handles the badnavs that occurr and displays either the last pagehit or an empty page where the user can petition.
-* @see lib/redirect.php
-*
-*
-*/
 define("OVERRIDE_FORCED_NAV", true);
 require_once("common.php");
 require_once("lib/villagenav.php");

--- a/badword.php
+++ b/badword.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * \file badword.php
+ * This file holds the Bad Word Editor for the Grotto. With this editor you can define bad words that get filtered or good words that count as exception to a rule. You have a grotto setting to turn this on or off.
+ * @see grotto.php
+ */
 
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
@@ -6,11 +11,6 @@ use Lotgd\Nav\SuperuserNav;
 // translator ready
 // addnews ready
 // mail ready
-/**
-* \file badword.php
-* This file holds the Bad Word Editor for the Grotto. With this editor you can define bad words that get filtered or good words that count as exception to a rule. You have a grotto setting to turn this on or off.
-* @see grotto.php
-*/
 require_once("common.php");
 require_once("lib/http.php");
 

--- a/bank.php
+++ b/bank.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * \file bank.php
+ * This file holds the entire bank code for the village bank. You can withdraw or depost gold here as user.
+ * @see village.php
+ */
 
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
@@ -6,12 +11,6 @@ use Lotgd\Nav\SuperuserNav;
 // addnews ready
 // mail ready
 use Lotgd\Mail;
-
-/**
-* \file bank.php
-* This file holds the entire bank code for the village bank. You can withdraw or depost gold here as user.
-* @see village.php
-*/
 
 require_once("common.php");
 require_once("lib/sanitize.php");

--- a/battle.php
+++ b/battle.php
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+/**
+ * \file battle.php
+ * This file holds the generic battle code that gets normally require()'d and executes basic fight functions.
+ * @see lib/buffs.php
+ * @see lib/battle-buffs.php
+ * @see lib/battle-skills.php
+ */
+
 use Lotgd\Buffs;
 use Lotgd\Battle;
 use Lotgd\Substitute;
@@ -9,13 +17,6 @@ use Lotgd\Substitute;
 // translator ready
 // addnews ready
 // mail ready
-/**
-* \file battle.php
-* This file holds the generic battle code that gets normally require()'d and executes basic fight functions.
-* @see lib/buffs.php
-* @see lib/battle-buffs.php
-* @see lib/battle-skills.php
-*/
 require_once("lib/bell_rand.php");
 require_once("common.php");
 require_once("lib/http.php");

--- a/bios.php
+++ b/bios.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * \file bios.php
+ * This file provides the basic block of a users bio, hence it will display a warning. Blocking and unblocking can be done from the bio of the user.
+ * @see bio.php
+ */
 
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
@@ -7,11 +12,6 @@ use Lotgd\Mail;
 // translator ready
 // addnews ready
 // mail ready
-/**
-* \file bios.php
-* This file provides the basic block of a users bio, hence it will display a warning. Blocking and unblocking can be done from the bio of the user.
-* @see bio.php
-*/
 require_once("common.php");
 require_once("lib/http.php");
 

--- a/clan.php
+++ b/clan.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * \file clan.php
+ * This file contains the base for the clans. This feature can be deactivated in the grotto.
+ * @see village.php
+ * @see pages/clan
+ */
 
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
@@ -7,12 +13,6 @@ use Lotgd\Commentary;
 // translator ready
 // addnews ready
 // mail ready
-/**
-* \file clan.php
-* This file contains the base for the clans. This feature can be deactivated in the grotto.
-* @see village.php
-* @see pages/clan
-*/
 require_once("common.php");
 require_once("lib/nltoappon.php");
 require_once("lib/sanitize.php");

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -2,6 +2,12 @@
 
 declare(strict_types=1);
 
+/**
+ * Handles the multi step installation of Legend of the Green Dragon.
+ *
+ * Each public stage method represents a step in the installer wizard.
+ */
+
 namespace Lotgd\Installer;
 
 use Lotgd\MySQL\Database;
@@ -11,12 +17,6 @@ use Lotgd\Nav;
 use Lotgd\Translator;
 use Lotgd\Redirect;
 use Lotgd\Settings;
-
-/**
- * Handles the multi step installation of Legend of the Green Dragon.
- *
- * Each public stage method represents a step in the installer wizard.
- */
 class Installer
 {
     /**

--- a/src/Lotgd/Accounts.php
+++ b/src/Lotgd/Accounts.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
+/**
+ * Helper functions related to account management.
+ */
+
 namespace Lotgd;
 
 use Lotgd\MySQL\Database;
 use Lotgd\Buffs;
-
-/**
- * Helper functions related to account management.
- */
 class Accounts
 {
     /**

--- a/src/Lotgd/CheckBan.php
+++ b/src/Lotgd/CheckBan.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
+/**
+ * Functions related to ban checking.
+ */
+
 namespace Lotgd;
 
 use Lotgd\MySQL\Database;
 use Lotgd\Cookies;
-
-/**
- * Functions related to ban checking.
- */
 class CheckBan
 {
     /**

--- a/src/Lotgd/DeathMessage.php
+++ b/src/Lotgd/DeathMessage.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
+/**
+ * Helpers for selecting random death messages.
+ */
+
 namespace Lotgd;
 
 use Lotgd\MySQL\Database;
 use Lotgd\Substitute;
-
-/**
- * Helpers for selecting random death messages.
- */
 class DeathMessage
 {
     /**

--- a/src/Lotgd/DebugLog.php
+++ b/src/Lotgd/DebugLog.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Lotgd;
-
-use Lotgd\MySQL\Database;
-
 /**
  * Write entries to the user debug log.
  */
+
+namespace Lotgd;
+
+use Lotgd\MySQL\Database;
 class DebugLog
 {
     /**

--- a/src/Lotgd/ErrorHandler.php
+++ b/src/Lotgd/ErrorHandler.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+/**
+ * Centralized error handling utilities.
+ */
+
 namespace Lotgd;
 
 use Lotgd\Backtrace;
@@ -9,10 +13,6 @@ use Lotgd\Sanitize;
 use Lotgd\Translator;
 use Lotgd\Settings;
 use Lotgd\DataCache;
-
-/**
- * Centralized error handling utilities.
- */
 class ErrorHandler
 {
     /**

--- a/src/Lotgd/Events.php
+++ b/src/Lotgd/Events.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * Handle random special events that may occur in various locations.
+ */
+
 namespace Lotgd;
 
 use Lotgd\Http;
 
 require_once("config/constants.php");
-
-/**
- * Handle random special events that may occur in various locations.
- */
 class Events
 {
 // This file encapsulates all the special event handling for most locations

--- a/src/Lotgd/ExpireChars.php
+++ b/src/Lotgd/ExpireChars.php
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+/**
+ * Maintenance tasks for deleting inactive characters and notifying players
+ * about impending account expiration.
+ */
+
 namespace Lotgd;
 
 use Lotgd\MySQL\Database;
@@ -9,11 +14,6 @@ use Lotgd\Settings;
 use Lotgd\PlayerFunctions;
 use Lotgd\Mail;
 use Lotgd\GameLog;
-
-/**
- * Maintenance tasks for deleting inactive characters and notifying players
- * about impending account expiration.
- */
 class ExpireChars
 {
     /** @var Settings */

--- a/src/Lotgd/Forest.php
+++ b/src/Lotgd/Forest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Lotgd;
-
-use Lotgd\Nav\VillageNav;
-
 /**
  * Wrapper around the old forest() function.
  */
+
+namespace Lotgd;
+
+use Lotgd\Nav\VillageNav;
 class Forest
 {
     /**

--- a/src/Lotgd/Forest/Outcomes.php
+++ b/src/Lotgd/Forest/Outcomes.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+/**
+ * Helper methods for handling forest fight results and creature buffs.
+ */
+
 namespace Lotgd\Forest;
 
 use Lotgd\AddNews;
@@ -11,10 +15,6 @@ use Lotgd\PageParts;
 use Lotgd\Translator;
 use Lotgd\Settings;
 use Lotgd\Nav;
-
-/**
- * Helper methods for handling forest fight results and creature buffs.
- */
 class Outcomes
 {
     /**

--- a/src/Lotgd/GameLog.php
+++ b/src/Lotgd/GameLog.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Lotgd;
-
-use Lotgd\MySQL\Database;
-
 /**
  * Simple wrapper around the gamelog table.
  */
+
+namespace Lotgd;
+
+use Lotgd\MySQL\Database;
 class GameLog
 {
     /**

--- a/src/Lotgd/Mail.php
+++ b/src/Lotgd/Mail.php
@@ -2,14 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Lotgd;
-
-use Lotgd\MySQL\Database;
-
 /**
  * Placeholder class for future mail handling refactoring.
  */
 
+namespace Lotgd;
+
+use Lotgd\MySQL\Database;
 use Lotgd\Settings;
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;

--- a/src/Lotgd/Moderate.php
+++ b/src/Lotgd/Moderate.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+/**
+ * Tools for comment moderation.
+ */
+
 namespace Lotgd;
 
 use Lotgd\MySQL\Database;
@@ -9,10 +13,6 @@ use Lotgd\Forms;
 use Lotgd\HolidayText;
 use Lotgd\Commentary;
 use Lotgd\Translator;
-
-/**
- * Tools for comment moderation.
- */
 class Moderate
 {
     /**

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+/**
+ * Collection of module helper functions migrated from legacy modules.php
+ */
+
 namespace Lotgd;
 
 use Lotgd\MySQL\Database;
@@ -10,10 +14,6 @@ use Lotgd\Translator;
 use Lotgd\Forms;
 use Lotgd\Sanitize;
 use Lotgd\Modules\Installer;
-
-/**
- * Collection of module helper functions migrated from legacy modules.php
- */
 class Modules
 {
     private static array $injectedModules = [1 => [], 0 => []];

--- a/src/Lotgd/Motd.php
+++ b/src/Lotgd/Motd.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
+/**
+ * Helpers for MOTD administration.
+ */
+
 namespace Lotgd;
 
 use Lotgd\MySQL\Database;
 use Lotgd\Forms;
-
-/**
- * Helpers for MOTD administration.
- */
 class Motd
 {
     /**

--- a/src/Lotgd/Mounts.php
+++ b/src/Lotgd/Mounts.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Lotgd;
-
-use Lotgd\MySQL\Database;
-
 /**
  * Access to mount data.
  */
+
+namespace Lotgd;
+
+use Lotgd\MySQL\Database;
 class Mounts
 {
     /**

--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+/**
+ * Collection of database helper methods.
+ */
+
 namespace Lotgd\MySQL;
 
 use Lotgd\Backtrace;
@@ -11,10 +15,6 @@ use Lotgd\DateTime;
 global $dbinfo;
 
 $dbinfo = [];
-
-/**
- * Collection of database helper methods.
- */
 class Database
 {
     /** @var DbMysqli|null */

--- a/src/Lotgd/MySQL/DbMysqli.php
+++ b/src/Lotgd/MySQL/DbMysqli.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Lotgd\MySQL;
-
-use Lotgd\DataCache;
-
 /**
  * MySQLi helper used by the database wrapper.
  */
+
+namespace Lotgd\MySQL;
+
+use Lotgd\DataCache;
 class DbMysqli
 {
     /** @var \mysqli|null */

--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+/**
+ * Navigation helper functions.
+ */
+
 namespace Lotgd;
 
 use Lotgd\HolidayText;
@@ -13,10 +17,6 @@ use Lotgd\Nav\NavigationSubSection;
 
 // Maintain state within the class instead of the global namespace
 
-
-/**
- * Navigation helper functions.
- */
 class Nav
 {
     private static array $blockednavs = [

--- a/src/Lotgd/Nav/NavigationItem.php
+++ b/src/Lotgd/Nav/NavigationItem.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Lotgd\Nav;
-
-use Lotgd\Nav;
-
 /**
  * Represents a single navigation link.
  */
+
+namespace Lotgd\Nav;
+
+use Lotgd\Nav;
 class NavigationItem
 {
     public string|array $text;

--- a/src/Lotgd/Output.php
+++ b/src/Lotgd/Output.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
+/**
+ * Collects formatted page output which can later be rendered by the template.
+ * Refactored from the legacy output_collector class in lib/output.php.
+ */
+
 namespace Lotgd;
 
 use Lotgd\DumpItem;
 use Lotgd\HolidayText;
 use Lotgd\Translator;
-
-/**
- * Collects formatted page output which can later be rendered by the template.
- * Refactored from the legacy output_collector class in lib/output.php.
- */
 class Output
 {
     private $output;             // text collected for display

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -2,6 +2,16 @@
 
 declare(strict_types=1);
 
+/**
+ * Library (supporting) functions for page output
+ *      addnews ready
+ *      translator ready
+ *      mail ready
+ *
+ * @author core_module
+ * @package defaultPackage
+ */
+
 namespace Lotgd;
 
 use Lotgd\MySQL\Database;
@@ -16,17 +26,6 @@ use Lotgd\Sanitize;
 use Lotgd\Nav;
 use Lotgd\DateTime;
 use Lotgd\Settings;
-
-/**
- * Library (supporting) functions for page output
- *      addnews ready
- *      translator ready
- *      mail ready
- *
- * @author core_module
- * @package defaultPackage
- *
- */
 class PageParts
 {
     /**

--- a/src/Lotgd/Partner.php
+++ b/src/Lotgd/Partner.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Lotgd;
-
-use Lotgd\MySQL\Database;
-
 /**
  * Helper to resolve the partner name for a player.
  */
+
+namespace Lotgd;
+
+use Lotgd\MySQL\Database;
 class Partner
 {
     /**

--- a/src/Lotgd/PlayerFunctions.php
+++ b/src/Lotgd/PlayerFunctions.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Lotgd;
-
-use Lotgd\MySQL\Database;
-
 /**
  * Utility methods for player maintenance tasks.
  */
+
+namespace Lotgd;
+
+use Lotgd\MySQL\Database;
 class PlayerFunctions
 {
     /**

--- a/src/Lotgd/PullUrl.php
+++ b/src/Lotgd/PullUrl.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Lotgd;
-
-use Lotgd\Settings;
-
 /**
  * Helper methods to fetch remote URLs using different mechanisms.
  */
+
+namespace Lotgd;
+
+use Lotgd\Settings;
 class PullUrl
 {
     private static function curl(string $url)

--- a/src/Lotgd/Pvp.php
+++ b/src/Lotgd/Pvp.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * Collection of Player versus Player helper routines.
+ */
+
 namespace Lotgd;
 
 use Lotgd\MySQL\Database;
 use Lotgd\DateTime;
 use Lotgd\Mail;
-
-/**
- * Collection of Player versus Player helper routines.
- */
 class Pvp
 {
     /**

--- a/src/Lotgd/ServerFunctions.php
+++ b/src/Lotgd/ServerFunctions.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
+/**
+ * Miscellaneous server wide helper utilities.
+ */
+
 namespace Lotgd;
 
 use Lotgd\MySQL\Database;
 use Lotgd\Settings;
-
-/**
- * Miscellaneous server wide helper utilities.
- */
 class ServerFunctions
 {
     /**

--- a/src/Lotgd/Settings.php
+++ b/src/Lotgd/Settings.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
+/**
+ * Lightweight wrapper around the settings table.
+ */
+
 namespace Lotgd;
 
 use Lotgd\MySQL\Database;
 use Lotgd\DataCache;
-
-/**
- * Lightweight wrapper around the settings table.
- */
 class Settings
 {
     private string $tablename;

--- a/src/Lotgd/Sql.php
+++ b/src/Lotgd/Sql.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Lotgd;
-
-use Lotgd\MySQL\Database;
-
 /**
  * Utility methods related to SQL operations.
  */
+
+namespace Lotgd;
+
+use Lotgd\MySQL\Database;
 class Sql
 {
     /**

--- a/src/Lotgd/SuAccess.php
+++ b/src/Lotgd/SuAccess.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Lotgd;
-
-use Lotgd\MySQL\Database;
-
 /**
  * Helper for validating superuser permissions.
  */
+
+namespace Lotgd;
+
+use Lotgd\MySQL\Database;
 class SuAccess
 {
     /** @var int Bitmask of superuser levels required on this page */

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
+/**
+ * Helper methods for working with output templates.
+ */
+
 namespace Lotgd;
 
 use Lotgd\ServerFunctions;
 use Lotgd\Cookies;
-
-/**
- * Helper methods for working with output templates.
- */
 class Template
 {
     /**


### PR DESCRIPTION
## Summary
- relocate file headers right after `<?php` opening tag
- keep optional `declare(strict_types=1)` before the header

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_687f767cdef08329a153f4b182ff1d2a