### PR TITLE
Add explicit fallthrough comments

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1509,8 +1509,10 @@ class Installer
             // The 'G' modifier is available since PHP 5.1.0
             case 'g':
                 $numericPart *= 1024;
+                // no break
             case 'm':
                 $numericPart *= 1024;
+                // no break
             case 'k':
                 $numericPart *= 1024;
         }

--- a/src/Lotgd/Battle.php
+++ b/src/Lotgd/Battle.php
@@ -480,7 +480,7 @@ class Battle
                     rawoutput("</td><td>");
                     output_notl("%s`0`n", $badguy['creaturehealth'] > 0 ? "" : translate_inline("`7DEFEATED`0"), true);
                     rawoutput("</td></tr></table>");
-
+                    // no break
 
                 default:
                     output(
@@ -548,6 +548,7 @@ class Battle
                 rawoutput("</td><td>");
 
                 rawoutput("</td></tr></table>");
+                // no break
 
             default:
                 output("`l%s: `6%s`0`n", $hitpointstext, $u['hitpoints']);


### PR DESCRIPTION
## Summary
- add `// no break` hints for intentional fallthrough in `Battle.php`
- mark fallthrough for memory-size switch in `Installer.php`

## Testing
- `composer install` *(fails: blocked from downloading packages)*
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687faedd13b883298553d7592b22419e