### PR TITLE
Normalize test namespaces

### DIFF
--- a/tests/AMotdTest.php
+++ b/tests/AMotdTest.php
@@ -1,109 +1,64 @@
 <?php
 
 declare(strict_types=1);
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\Tests\Stubs\Database;
-    use Lotgd\Motd;
 
-    require_once __DIR__ . '/../config/constants.php';
+namespace Lotgd\Tests;
 
-    if (!function_exists('translate_inline')) {
-        function translate_inline($t, $ns = false)
-        {
-            return $t;
-        }
-    }
-    if (!function_exists('output_notl')) {
-        function output_notl(string $f, ...$args)
-        {
-            global $forms_output;
-            $forms_output .= vsprintf($f, $args);
-        }
-    }
-    if (!function_exists('rawoutput')) {
-        function rawoutput($t)
-        {
-            global $forms_output;
-            $forms_output .= $t;
-        }
-    }
-    if (!function_exists('output')) {
-        function output(string $f, ...$args)
-        {
-            global $forms_output;
-            $forms_output .= vsprintf($f, $args);
-        }
-    }
-    if (!function_exists('addnav')) {
-        function addnav(...$args)
-        {
-        }
-    }
-    if (!function_exists('httppost')) {
-        function httppost($name)
-        {
-            return $_POST[$name] ?? false;
-        }
-    }
-    if (!function_exists('invalidatedatacache')) {
-        function invalidatedatacache(string $name)
-        {
-        }
-    }
+use Lotgd\Motd;
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
 
-    final class AMotdTest extends TestCase
+final class AMotdTest extends TestCase
+{
+    protected function setUp(): void
     {
-        protected function setUp(): void
-        {
-            global $forms_output, $session;
-            $forms_output = '';
-            $session = ['user' => ['acctid' => 1, 'loggedin' => true, 'superuser' => 0]];
-            \Lotgd\MySQL\Database::$settings_table = [];
-            \Lotgd\MySQL\Database::$onlineCounter = 0;
-            \Lotgd\MySQL\Database::$affected_rows = 0;
-            \Lotgd\MySQL\Database::$lastSql = '';
-            $_POST = [];
-        }
+        global $forms_output, $session;
+        $forms_output = '';
+        $session = ['user' => ['acctid' => 1, 'loggedin' => true, 'superuser' => 0]];
+        \Lotgd\MySQL\Database::$settings_table = [];
+        \Lotgd\MySQL\Database::$onlineCounter = 0;
+        \Lotgd\MySQL\Database::$affected_rows = 0;
+        \Lotgd\MySQL\Database::$lastSql = '';
+        $_POST = [];
+    }
 
-        protected function tearDown(): void
-        {
-            unset($GLOBALS['session'], $GLOBALS['forms_output']);
-            $_POST = [];
-        }
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['session'], $GLOBALS['forms_output']);
+        $_POST = [];
+    }
 
-        public function testPollItemShowsRadioButtonsForLoggedInUser(): void
-        {
-            global $forms_output;
-            $data = ['body' => 'Question?', 'opt' => ['Yes', 'No']];
-            $body = serialize($data);
+    public function testPollItemShowsRadioButtonsForLoggedInUser(): void
+    {
+        global $forms_output;
+        $data = ['body' => 'Question?', 'opt' => ['Yes', 'No']];
+        $body = serialize($data);
 
-            Motd::pollItem(1, 'Subject', $body, 'Author', '2024-01-01 00:00:00');
+        Motd::pollItem(1, 'Subject', $body, 'Author', '2024-01-01 00:00:00');
 
-            $this->assertStringContainsString("type='radio' name='choice'", $forms_output);
-        }
+        $this->assertStringContainsString("type='radio' name='choice'", $forms_output);
+    }
 
-        public function testPollItemUnserializesSlashedData(): void
-        {
-            global $forms_output;
-            $data = ['body' => 'Question?', 'opt' => ['Yes', 'No']];
-            $body = addslashes(serialize($data));
+    public function testPollItemUnserializesSlashedData(): void
+    {
+        global $forms_output;
+        $data = ['body' => 'Question?', 'opt' => ['Yes', 'No']];
+        $body = addslashes(serialize($data));
 
-            Motd::pollItem(1, 'Subject', $body, 'Author', '2024-01-01 00:00:00');
+        Motd::pollItem(1, 'Subject', $body, 'Author', '2024-01-01 00:00:00');
 
-            $this->assertStringContainsString("type='radio' name='choice'", $forms_output);
-        }
+        $this->assertStringContainsString("type='radio' name='choice'", $forms_output);
+    }
 
-        public function testSavePollSerializesData(): void
-        {
-            $_POST['motdtitle'] = 'Title';
-            $_POST['motdbody'] = 'Question?';
-            $_POST['opt'] = ['Yes', 'No'];
+    public function testSavePollSerializesData(): void
+    {
+        $_POST['motdtitle'] = 'Title';
+        $_POST['motdbody'] = 'Question?';
+        $_POST['opt'] = ['Yes', 'No'];
 
-            Motd::savePoll();
+        Motd::savePoll();
 
-            $expected = addslashes(serialize(['body' => 'Question?', 'opt' => ['Yes', 'No']]));
-            $this->assertStringContainsString($expected, \Lotgd\MySQL\Database::$lastSql);
-        }
+        $expected = addslashes(serialize(['body' => 'Question?', 'opt' => ['Yes', 'No']]));
+        $this->assertStringContainsString($expected, \Lotgd\MySQL\Database::$lastSql);
     }
 }

--- a/tests/AddNewsTest.php
+++ b/tests/AddNewsTest.php
@@ -2,41 +2,39 @@
 
 declare(strict_types=1);
 
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\AddNews;
-    use Lotgd\Tests\Stubs\Database;
+namespace Lotgd\Tests;
 
-    require_once __DIR__ . '/../config/constants.php';
+use Lotgd\AddNews;
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
 
-    final class AddNewsTest extends TestCase
+final class AddNewsTest extends TestCase
+{
+    protected function setUp(): void
     {
-        protected function setUp(): void
-        {
-            class_exists(Database::class);
-            $GLOBALS['session'] = ['user' => ['acctid' => 3]];
-            \Lotgd\Translator::tlschema('ns');
-            \Lotgd\MySQL\Database::$lastSql = '';
-        }
+        class_exists(Database::class);
+        $GLOBALS['session'] = ['user' => ['acctid' => 3]];
+        \Lotgd\Translator::tlschema('ns');
+        \Lotgd\MySQL\Database::$lastSql = '';
+    }
 
-        protected function tearDown(): void
-        {
-            \Lotgd\Translator::tlschema(false);
-            unset($GLOBALS['session']);
-        }
+    protected function tearDown(): void
+    {
+        \Lotgd\Translator::tlschema(false);
+        unset($GLOBALS['session']);
+    }
 
-        public function testAddForUserBuildsInsertSql(): void
-        {
-            AddNews::addForUser(2, 'Hi', 'x');
-            $expectedArgs = addslashes(serialize(['x']));
-            $this->assertStringContainsString('INSERT INTO news', \Lotgd\MySQL\Database::$lastSql);
-            $this->assertStringContainsString("2,'$expectedArgs','ns')", \Lotgd\MySQL\Database::$lastSql);
-        }
+    public function testAddForUserBuildsInsertSql(): void
+    {
+        AddNews::addForUser(2, 'Hi', 'x');
+        $expectedArgs = addslashes(serialize(['x']));
+        $this->assertStringContainsString('INSERT INTO news', \Lotgd\MySQL\Database::$lastSql);
+        $this->assertStringContainsString("2,'$expectedArgs','ns')", \Lotgd\MySQL\Database::$lastSql);
+    }
 
-        public function testAddUsesSessionAccountId(): void
-        {
-            AddNews::add('Hello');
-            $this->assertStringContainsString("3,'','ns')", \Lotgd\MySQL\Database::$lastSql);
-        }
+    public function testAddUsesSessionAccountId(): void
+    {
+        AddNews::add('Hello');
+        $this->assertStringContainsString("3,'','ns')", \Lotgd\MySQL\Database::$lastSql);
     }
 }

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+namespace Lotgd\Tests;
+
 use Lotgd\Backtrace;
 use PHPUnit\Framework\Attributes\DataProvider;
-
-require_once __DIR__ . '/../config/constants.php';
+use PHPUnit\Framework\TestCase;
 
 final class BacktraceTest extends TestCase
 {
@@ -33,7 +33,7 @@ final class BacktraceTest extends TestCase
             'boolean true' => [true, "<span class='bool'>true</span>"],
             'boolean false' => [false, "<span class='bool'>false</span>"],
             'null' => [null, "<span class='null'>NULL</span>"],
-            'object' => [new stdClass(), "<span class='object'>stdClass</span>"],
+            'object' => [new \stdClass(), "<span class='object'>stdClass</span>"],
             'array' => [
                 [1, 'foo'],
                 "<span class='array'>Array(<blockquote><span class='number'>0</span>=><span class='number'>1</span>, <span class='number'>1</span>=><span class='string'>\"foo\"</span></blockquote>)</span>"

--- a/tests/BellRandTest.php
+++ b/tests/BellRandTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
-use Lotgd\BellRand;
+namespace Lotgd\Tests;
 
-require_once __DIR__ . '/../config/constants.php';
+use Lotgd\BellRand;
+use PHPUnit\Framework\TestCase;
 
 final class BellRandTest extends TestCase
 {

--- a/tests/CookiesTest.php
+++ b/tests/CookiesTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
-use Lotgd\Cookies;
+namespace Lotgd\Tests;
 
-require_once __DIR__ . '/../config/constants.php';
+use Lotgd\Cookies;
+use PHPUnit\Framework\TestCase;
 
 final class CookiesTest extends TestCase
 {

--- a/tests/DataCacheTest.php
+++ b/tests/DataCacheTest.php
@@ -2,20 +2,14 @@
 
 declare(strict_types=1);
 
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\DataCache;
-    use Lotgd\Tests\Stubs\CacheDummySettings;
+namespace Lotgd\Tests;
 
-    require_once __DIR__ . '/../config/constants.php';
+use Lotgd\DataCache;
+use Lotgd\Tests\Stubs\CacheDummySettings;
+use PHPUnit\Framework\TestCase;
 
-    if (!defined('DATACACHE_FILENAME_PREFIX')) {
-        define('DATACACHE_FILENAME_PREFIX', 'datacache-');
-    }
-
-
-    final class DataCacheTest extends TestCase
-    {
+final class DataCacheTest extends TestCase
+{
         private string $cacheDir;
 
         protected function setUp(): void
@@ -74,4 +68,3 @@ namespace {
             $this->assertFileExists(DataCache::makecachetempname('other'));
         }
     }
-}

--- a/tests/DateTimeTest.php
+++ b/tests/DateTimeTest.php
@@ -2,28 +2,14 @@
 
 declare(strict_types=1);
 
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\DateTime;
-    use Lotgd\Dhms;
-    use Lotgd\Settings;
+namespace Lotgd\Tests;
 
-    require_once __DIR__ . '/../config/constants.php';
+use Lotgd\DateTime;
+use Lotgd\Dhms;
+use Lotgd\Settings;
+use PHPUnit\Framework\TestCase;
 
-    if (!function_exists('translate_inline')) {
-        function translate_inline($text, $ns = false)
-        {
-            return $text;
-        }
-    }
-}
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\DateTime;
-    use Lotgd\Dhms;
-    use Lotgd\Settings;
-
-    final class DateTimeTest extends TestCase
+final class DateTimeTest extends TestCase
     {
         public function testReadableTimeShortFormat(): void
         {
@@ -80,4 +66,3 @@ namespace {
             $this->assertSame('0d1h1m1.5s', Dhms::format(3661.5, true));
         }
     }
-}

--- a/tests/DumpOutputTest.php
+++ b/tests/DumpOutputTest.php
@@ -2,30 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Lotgd {
-    if (!function_exists('Lotgd\\getsetting')) {
-        function getsetting(string|int $name, mixed $default = ''): mixed
-        {
-            if (function_exists('\\getsetting')) {
-                return \getsetting($name, $default);
-            }
+namespace Lotgd\Tests;
 
-            return $default;
-        }
-    }
-}
+use Lotgd\DumpItem;
+use Lotgd\OutputArray;
+use Lotgd\Tests\Stubs\DumpDummySettings;
+use PHPUnit\Framework\TestCase;
 
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\OutputArray;
-    use Lotgd\Tests\Stubs\DumpDummySettings;
-    use Lotgd\DumpItem;
-
-    require_once __DIR__ . '/../config/constants.php';
-    require_once __DIR__ . '/../lib/settings.php';
-
-
-    final class DumpOutputTest extends TestCase
+final class DumpOutputTest extends TestCase
     {
         protected function setUp(): void
         {
@@ -65,4 +49,3 @@ namespace {
             $this->assertSame($codeExpected, DumpItem::dumpAsCode($array));
         }
     }
-}

--- a/tests/FormsTest.php
+++ b/tests/FormsTest.php
@@ -2,81 +2,12 @@
 
 declare(strict_types=1);
 
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\Forms;
+namespace Lotgd\Tests;
 
-    require_once __DIR__ . '/../config/constants.php';
+use Lotgd\Forms;
+use PHPUnit\Framework\TestCase;
 
-    if (!function_exists('translate_inline')) {
-        function translate_inline($t, $ns = false)
-        {
-            return $t;
-        }
-    }
-    if (!function_exists('translate')) {
-        function translate($t, $ns = false)
-        {
-            return $t;
-        }
-    }
-    if (!function_exists('modulehook')) {
-        function modulehook($name, $data)
-        {
-            return $data;
-        }
-    }
-    if (!function_exists('tlbutton_pop')) {
-        function tlbutton_pop()
-        {
-            return '';
-        }
-    }
-    if (!function_exists('tlschema')) {
-        function tlschema($schema = false)
-        {
-        }
-    }
-    if (!function_exists('getsetting')) {
-        function getsetting($name, $default)
-        {
-            return $default;
-        }
-    }
-    if (!function_exists('httppost')) {
-        function httppost($name)
-        {
-            return false;
-        }
-    }
-    if (!function_exists('rawoutput')) {
-        function rawoutput($t)
-        {
-            global $forms_output;
-            $forms_output .= $t;
-        }
-    }
-    if (!function_exists('output_notl')) {
-        function output_notl($f, $t = true)
-        {
-            global $forms_output;
-            $forms_output .= sprintf($f, $t);
-        }
-    }
-    if (!function_exists('output')) {
-        function output($f, $t = true)
-        {
-            global $forms_output;
-            $forms_output .= sprintf($f, $t);
-        }
-    }
-    if (!function_exists('debug')) {
-        function debug($t, $force = false)
-        {
-        }
-    }
-
-    final class FormsTest extends TestCase
+final class FormsTest extends TestCase
     {
         protected function setUp(): void
         {
@@ -99,4 +30,3 @@ namespace {
             $this->assertStringNotContainsString('checked', $forms_output);
         }
     }
-}

--- a/tests/HttpHelperTest.php
+++ b/tests/HttpHelperTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
-use Lotgd\Http;
+namespace Lotgd\Tests;
 
-require_once __DIR__ . '/../config/constants.php';
+use Lotgd\Http;
+use PHPUnit\Framework\TestCase;
 
 final class HttpHelperTest extends TestCase
 {

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -2,112 +2,57 @@
 
 declare(strict_types=1);
 
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\Tests\Stubs\Database;
-    use Lotgd\Tests\Stubs\PHPMailer;
-    use Lotgd\Tests\Stubs\MailDummySettings;
-    use Lotgd\Mail;
+namespace Lotgd\Tests;
 
-    require_once __DIR__ . '/../config/constants.php';
-    require_once __DIR__ . '/../lib/settings.php';
+use Lotgd\Mail;
+use Lotgd\Tests\Stubs\Database;
+use Lotgd\Tests\Stubs\MailDummySettings;
+use Lotgd\Tests\Stubs\PHPMailer;
+use PHPUnit\Framework\TestCase;
 
-    // --- Stubs and helper globals ---
-
-// Simple in-memory tables
-    $GLOBALS['accounts_table'] = [];
-    $GLOBALS['mail_table'] = [];
-    $GLOBALS['settings_array'] = [
-    'mailsizelimit' => 1024,
-    'charset' => 'UTF-8',
-    'serverurl' => 'http://example.com',
-    'gameadminemail' => 'admin@example.com',
-    'inboxlimit' => 50,
-    'notificationmailsubject' => '{subject}',
-    'notificationmailtext' => '{body}',
-    ];
-}
-
-namespace {
-    if (!function_exists('invalidatedatacache')) {
-        function invalidatedatacache(string $name)
-        {
-        }
-    }
-    if (!function_exists('full_sanitize')) {
-        function full_sanitize($in)
-        {
-            return $in;
-        }
-    }
-    if (!function_exists('translate_inline')) {
-        function translate_inline($text, $ns = false)
-        {
-            return $text;
-        }
-    }
-    if (!function_exists('translate_mail')) {
-        function translate_mail($text, $to = 0)
-        {
-            return $text;
-        }
-    }
-    if (!function_exists('soap')) {
-        function soap($input, $debug = false, $skiphook = false)
-        {
-            return $input;
-        }
-    }
-    if (!function_exists('output')) {
-        function output(string $format, ...$args)
-        {
-        }
-    }
-}
-
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\Mail;
-    use Lotgd\Tests\Stubs\Database;
-    use Lotgd\Tests\Stubs\PHPMailer;
-    use Lotgd\Tests\Stubs\MailDummySettings;
-
-
-    final class MailTest extends TestCase
+final class MailTest extends TestCase
+{
+    protected function setUp(): void
     {
-        protected function setUp(): void
-        {
-            $GLOBALS['accounts_table'] = [];
-            $GLOBALS['mail_table'] = [];
-            $GLOBALS['mail_sent_count'] = 0;
-            $GLOBALS['settings'] = new MailDummySettings($GLOBALS['settings_array']);
-        }
+        $GLOBALS['accounts_table'] = [];
+        $GLOBALS['mail_table'] = [];
+        $GLOBALS['mail_sent_count'] = 0;
+        $GLOBALS['settings_array'] = [
+            'mailsizelimit' => 1024,
+            'charset' => 'UTF-8',
+            'serverurl' => 'http://example.com',
+            'gameadminemail' => 'admin@example.com',
+            'inboxlimit' => 50,
+            'notificationmailsubject' => '{subject}',
+            'notificationmailtext' => '{body}',
+        ];
+        $GLOBALS['settings'] = new MailDummySettings($GLOBALS['settings_array']);
+    }
 
-        public function testSystemMailStoresMessageAndSkipsInvalidEmail(): void
-        {
-            $GLOBALS['accounts_table'][1] = [
-            'prefs' => serialize(['emailonmail' => true,'systemmail' => true]),
+    public function testSystemMailStoresMessageAndSkipsInvalidEmail(): void
+    {
+        $GLOBALS['accounts_table'][1] = [
+            'prefs' => serialize(['emailonmail' => true, 'systemmail' => true]),
             'emailaddress' => 'invalid-email',
             'name' => 'User1'
-            ];
-            Mail::systemMail(1, 'Subject', 'Body', 0);
-            $this->assertCount(1, $GLOBALS['mail_table']);
-            $this->assertSame('Subject', $GLOBALS['mail_table'][0]['subject']);
-            $this->assertSame(0, $GLOBALS['mail_sent_count']);
-        }
+        ];
+        Mail::systemMail(1, 'Subject', 'Body', 0);
+        $this->assertCount(1, $GLOBALS['mail_table']);
+        $this->assertSame('Subject', $GLOBALS['mail_table'][0]['subject']);
+        $this->assertSame(0, $GLOBALS['mail_sent_count']);
+    }
 
-        public function testInboxCountAndFull(): void
-        {
-            $GLOBALS['settings_array']['inboxlimit'] = 3;
-            $GLOBALS['settings'] = new MailDummySettings($GLOBALS['settings_array']);
-            $GLOBALS['mail_table'] = [
-            ['messageid' => 1,'msgfrom' => 0,'msgto' => 1,'subject' => 'a','body' => 'b','sent' => 't','seen' => 0],
-            ['messageid' => 2,'msgfrom' => 0,'msgto' => 1,'subject' => 'c','body' => 'd','sent' => 't','seen' => 1],
-            ['messageid' => 3,'msgfrom' => 0,'msgto' => 1,'subject' => 'e','body' => 'f','sent' => 't','seen' => 0],
-            ];
-            $this->assertSame(3, Mail::inboxCount(1));
-            $this->assertSame(2, Mail::inboxCount(1, true));
-            $this->assertTrue(Mail::isInboxFull(1));
-        }
+    public function testInboxCountAndFull(): void
+    {
+        $GLOBALS['settings_array']['inboxlimit'] = 3;
+        $GLOBALS['settings'] = new MailDummySettings($GLOBALS['settings_array']);
+        $GLOBALS['mail_table'] = [
+            ['messageid' => 1, 'msgfrom' => 0, 'msgto' => 1, 'subject' => 'a', 'body' => 'b', 'sent' => 't', 'seen' => 0],
+            ['messageid' => 2, 'msgfrom' => 0, 'msgto' => 1, 'subject' => 'c', 'body' => 'd', 'sent' => 't', 'seen' => 1],
+            ['messageid' => 3, 'msgfrom' => 0, 'msgto' => 1, 'subject' => 'e', 'body' => 'f', 'sent' => 't', 'seen' => 0],
+        ];
+        $this->assertSame(3, Mail::inboxCount(1));
+        $this->assertSame(2, Mail::inboxCount(1, true));
+        $this->assertTrue(Mail::isInboxFull(1));
     }
 }

--- a/tests/ModuleManagerTest.php
+++ b/tests/ModuleManagerTest.php
@@ -2,69 +2,13 @@
 
 declare(strict_types=1);
 
-namespace {
-    if (!function_exists('install_module')) {
-        function install_module(string $module): bool
-        {
-            $GLOBALS['install_called'][] = $module;
-            return true;
-        }
-    }
-    if (!function_exists('uninstall_module')) {
-        function uninstall_module(string $module): bool
-        {
-            $GLOBALS['uninstall_called'][] = $module;
-            return true;
-        }
-    }
-    if (!function_exists('activate_module')) {
-        function activate_module(string $module): bool
-        {
-            $GLOBALS['activate_called'][] = $module;
-            return true;
-        }
-    }
-    if (!function_exists('deactivate_module')) {
-        function deactivate_module(string $module): bool
-        {
-            $GLOBALS['deactivate_called'][] = $module;
-            return true;
-        }
-    }
-    if (!function_exists('injectmodule')) {
-        function injectmodule(string $module, bool $b): void
-        {
-            $GLOBALS['inject_called'][] = $module;
-        }
-    }
-    if (!function_exists('invalidatedatacache')) {
-        function invalidatedatacache(string $name): void
-        {
-            $GLOBALS['invalidates'][] = $name;
-        }
-    }
-    if (!function_exists('massinvalidate')) {
-        function massinvalidate(string $name): void
-        {
-            $GLOBALS['massinvalidates'][] = $name;
-        }
-    }
-    if (!function_exists('get_module_install_status')) {
-        function get_module_install_status(bool $with_db = true): array
-        {
-            return $GLOBALS['module_status'];
-        }
-    }
-}
+namespace Lotgd\Tests;
 
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\ModuleManager;
+use Lotgd\ModuleManager;
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
 
-    use Lotgd\Tests\Stubs\Database;
-    require_once __DIR__ . '/../config/constants.php';
-
-    final class ModuleManagerTest extends TestCase
+final class ModuleManagerTest extends TestCase
     {
         protected function setUp(): void
         {
@@ -125,4 +69,3 @@ namespace {
             $this->assertStringContainsString("SET filemoddate='" . DATETIME_DATEMIN . "'", \Lotgd\MySQL\Database::$lastSql);
         }
     }
-}

--- a/tests/MountsTest.php
+++ b/tests/MountsTest.php
@@ -2,14 +2,13 @@
 
 declare(strict_types=1);
 
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\Mounts;
+namespace Lotgd\Tests;
 
-    use Lotgd\Tests\Stubs\Database;
-    require_once __DIR__ . '/../config/constants.php';
+use Lotgd\Mounts;
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
 
-    final class MountsTest extends TestCase
+final class MountsTest extends TestCase
     {
         protected function setUp(): void
         {
@@ -33,4 +32,3 @@ namespace {
             $this->assertSame([], $row);
         }
     }
-}

--- a/tests/NamesTest.php
+++ b/tests/NamesTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
-use Lotgd\Names;
+namespace Lotgd\Tests;
 
-require_once __DIR__ . '/../config/constants.php';
+use Lotgd\Names;
+use PHPUnit\Framework\TestCase;
 
 final class NamesTest extends TestCase
 {

--- a/tests/NavColoredHeadlineTest.php
+++ b/tests/NavColoredHeadlineTest.php
@@ -2,77 +2,14 @@
 
 declare(strict_types=1);
 
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\Nav;
-    use Lotgd\Output;
-    use Lotgd\Template;
+namespace Lotgd\Tests;
 
-    require_once __DIR__ . '/../config/constants.php';
-    if (!function_exists('modulehook')) {
-        function modulehook($name, $data = [], $allowinactive = false, $only = false)
-        {
-            return $data;
-        }
-    }
-    if (!function_exists('translate')) {
-        function translate($t, $ns = false)
-        {
-            return $t;
-        }
-    }
-    if (!function_exists('translate_inline')) {
-        function translate_inline($t, $ns = false)
-        {
-            return $t;
-        }
-    }
-    if (!function_exists('tlbutton_pop')) {
-        function tlbutton_pop()
-        {
-            return '';
-        }
-    }
-    if (!function_exists('tlschema')) {
-        function tlschema($schema = false)
-        {
-        }
-    }
-    if (!function_exists('popup')) {
-        function popup(string $page, string $size = '550x300')
-        {
-            return '';
-        }
-    }
-    if (!function_exists('rawoutput')) {
-        function rawoutput($t)
-        {
-        }
-    }
-    if (!function_exists('output_notl')) {
-        function output_notl($f, $t = true)
-        {
-        }
-    }
-    if (!function_exists('output')) {
-        function output($f, $t = true)
-        {
-        }
-    }
-    if (!function_exists('debug')) {
-        function debug($t, $force = false)
-        {
-        }
-    }
-    if (!function_exists('appoencode')) {
-        function appoencode($data, $priv = false)
-        {
-            global $output;
-            return $output->appoencode($data, $priv);
-        }
-    }
+use Lotgd\Nav;
+use Lotgd\Output;
+use Lotgd\Template;
+use PHPUnit\Framework\TestCase;
 
-    final class NavColoredHeadlineTest extends TestCase
+final class NavColoredHeadlineTest extends TestCase
     {
         protected function setUp(): void
         {
@@ -143,4 +80,3 @@ namespace {
             $this->assertStringContainsString('foo.php', $navs);
         }
     }
-}

--- a/tests/NavColoredSubHeaderTest.php
+++ b/tests/NavColoredSubHeaderTest.php
@@ -2,57 +2,14 @@
 
 declare(strict_types=1);
 
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\Nav;
-    use Lotgd\Output;
-    use Lotgd\Template;
+namespace Lotgd\Tests;
 
-    require_once __DIR__ . '/../config/constants.php';
-    if (!function_exists('modulehook')) {
-        function modulehook($name, $data = [], $allowinactive = false, $only = false)
-        {
-            return $data;
-        }
-    }
-    if (!function_exists('translate')) {
-        function translate($t, $ns = false)
-        {
-            return $t;
-        }
-    }
-    if (!function_exists('translate_inline')) {
-        function translate_inline($t, $ns = false)
-        {
-            return $t;
-        }
-    }
-    if (!function_exists('tlbutton_pop')) {
-        function tlbutton_pop()
-        {
-            return '';
-        }
-    }
-    if (!function_exists('tlschema')) {
-        function tlschema($schema = false)
-        {
-        }
-    }
-    if (!function_exists('popup')) {
-        function popup(string $page, string $size = '550x300')
-        {
-            return '';
-        }
-    }
-    if (!function_exists('appoencode')) {
-        function appoencode($data, $priv = false)
-        {
-            global $output;
-            return $output->appoencode($data, $priv);
-        }
-    }
+use Lotgd\Nav;
+use Lotgd\Output;
+use Lotgd\Template;
+use PHPUnit\Framework\TestCase;
 
-    final class NavColoredSubHeaderTest extends TestCase
+final class NavColoredSubHeaderTest extends TestCase
     {
         protected function setUp(): void
         {
@@ -84,4 +41,3 @@ namespace {
             $this->assertStringContainsString('</span>', $navs);
         }
     }
-}

--- a/tests/NavSortTest.php
+++ b/tests/NavSortTest.php
@@ -2,63 +2,14 @@
 
 declare(strict_types=1);
 
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\Nav;
-    use Lotgd\Output;
-    use Lotgd\Template;
+namespace Lotgd\Tests;
 
-    require_once __DIR__ . '/../config/constants.php';
-    if (!function_exists('modulehook')) {
-        function modulehook($name, $data = [], $allowinactive = false, $only = false)
-        {
-            return $data;
-        }
-    }
-    if (!function_exists('translate')) {
-        function translate($t, $ns = false)
-        {
-            return $t;
-        }
-    }
-    if (!function_exists('translate_inline')) {
-        function translate_inline($t, $ns = false)
-        {
-            return $t;
-        }
-    }
-    if (!function_exists('tlbutton_pop')) {
-        function tlbutton_pop()
-        {
-            return '';
-        }
-    }
-    if (!function_exists('tlschema')) {
-        function tlschema($schema = false)
-        {
-        }
-    }
-    if (!function_exists('popup')) {
-        function popup(string $page, string $size = '550x300')
-        {
-            return '';
-        }
-    }
-    if (!function_exists('appoencode')) {
-        function appoencode($data, $priv = false)
-        {
-            global $output;
-            return $output->appoencode($data, $priv);
-        }
-    }
-    if (!function_exists('sanitize')) {
-        function sanitize($in)
-        {
-            return $in;
-        }
-    }
+use Lotgd\Nav;
+use Lotgd\Output;
+use Lotgd\Template;
+use PHPUnit\Framework\TestCase;
 
-    final class NavSortTest extends TestCase
+final class NavSortTest extends TestCase
     {
         protected function setUp(): void
         {
@@ -181,4 +132,3 @@ namespace {
             $this->assertLessThan(strpos($navs, 'Y Item'), strpos($navs, 'B Item'));
         }
     }
-}

--- a/tests/NavigationItemTest.php
+++ b/tests/NavigationItemTest.php
@@ -2,58 +2,15 @@
 
 declare(strict_types=1);
 
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\Nav\NavigationItem;
-    use Lotgd\Output;
-    use Lotgd\Template;
-    use Lotgd\Nav;
+namespace Lotgd\Tests;
 
-    require_once __DIR__ . '/../config/constants.php';
-    if (!function_exists('modulehook')) {
-        function modulehook($name, $data = [], $allowinactive = false, $only = false)
-        {
-            return $data;
-        }
-    }
-    if (!function_exists('translate')) {
-        function translate($t, $ns = false)
-        {
-            return $t;
-        }
-    }
-    if (!function_exists('translate_inline')) {
-        function translate_inline($t, $ns = false)
-        {
-            return $t;
-        }
-    }
-    if (!function_exists('tlbutton_pop')) {
-        function tlbutton_pop()
-        {
-            return '';
-        }
-    }
-    if (!function_exists('tlschema')) {
-        function tlschema($schema = false)
-        {
-        }
-    }
-    if (!function_exists('popup')) {
-        function popup(string $page, string $size = '550x300')
-        {
-            return '';
-        }
-    }
-    if (!function_exists('appoencode')) {
-        function appoencode($data, $priv = false)
-        {
-            global $output;
-            return $output->appoencode($data, $priv);
-        }
-    }
+use Lotgd\Nav;
+use Lotgd\Nav\NavigationItem;
+use Lotgd\Output;
+use Lotgd\Template;
+use PHPUnit\Framework\TestCase;
 
-    final class NavigationItemTest extends TestCase
+final class NavigationItemTest extends TestCase
     {
         protected function setUp(): void
         {
@@ -80,4 +37,3 @@ namespace {
             $this->assertStringContainsString('navhi', $html);
         }
     }
-}

--- a/tests/NavigationSubSectionTest.php
+++ b/tests/NavigationSubSectionTest.php
@@ -2,57 +2,14 @@
 
 declare(strict_types=1);
 
-namespace {
-    use PHPUnit\Framework\TestCase;
-    use Lotgd\Nav;
-    use Lotgd\Output;
-    use Lotgd\Template;
+namespace Lotgd\Tests;
 
-    require_once __DIR__ . '/../config/constants.php';
-    if (!function_exists('modulehook')) {
-        function modulehook($name, $data = [], $allowinactive = false, $only = false)
-        {
-            return $data;
-        }
-    }
-    if (!function_exists('translate')) {
-        function translate($t, $ns = false)
-        {
-            return $t;
-        }
-    }
-    if (!function_exists('translate_inline')) {
-        function translate_inline($t, $ns = false)
-        {
-            return $t;
-        }
-    }
-    if (!function_exists('tlbutton_pop')) {
-        function tlbutton_pop()
-        {
-            return '';
-        }
-    }
-    if (!function_exists('tlschema')) {
-        function tlschema($schema = false)
-        {
-        }
-    }
-    if (!function_exists('popup')) {
-        function popup(string $page, string $size = '550x300')
-        {
-            return '';
-        }
-    }
-    if (!function_exists('appoencode')) {
-        function appoencode($data, $priv = false)
-        {
-            global $output;
-            return $output->appoencode($data, $priv);
-        }
-    }
+use Lotgd\Nav;
+use Lotgd\Output;
+use Lotgd\Template;
+use PHPUnit\Framework\TestCase;
 
-    final class NavigationSubSectionTest extends TestCase
+final class NavigationSubSectionTest extends TestCase
     {
         protected function setUp(): void
         {
@@ -84,4 +41,3 @@ namespace {
             $this->assertStringContainsString('foo.php', $navs);
         }
     }
-}

--- a/tests/PlayerFunctionsExtraTest.php
+++ b/tests/PlayerFunctionsExtraTest.php
@@ -2,18 +2,12 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
-use Lotgd\PlayerFunctions;
+namespace Lotgd\Tests;
+
 use Lotgd\DataCache;
+use Lotgd\PlayerFunctions;
 use Lotgd\Tests\Stubs\DummySettingsExtra;
-
-require_once __DIR__ . '/../config/constants.php';
-require_once __DIR__ . '/../lib/settings.php';
-require_once __DIR__ . '/../lib/tempstat.php';
-
-if (!defined('DATACACHE_FILENAME_PREFIX')) {
-    define('DATACACHE_FILENAME_PREFIX', 'datacache-');
-}
+use PHPUnit\Framework\TestCase;
 
 final class PlayerFunctionsExtraTest extends TestCase
 {

--- a/tests/PlayerFunctionsTest.php
+++ b/tests/PlayerFunctionsTest.php
@@ -2,13 +2,11 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+namespace Lotgd\Tests;
+
 use Lotgd\PlayerFunctions;
 use Lotgd\Tests\Stubs\DummySettings;
-
-require_once __DIR__ . '/../config/constants.php';
-require_once __DIR__ . '/../lib/settings.php';
-require_once __DIR__ . '/../lib/tempstat.php';
+use PHPUnit\Framework\TestCase;
 
 final class PlayerFunctionsTest extends TestCase
 {

--- a/tests/SanitizeExtraTest.php
+++ b/tests/SanitizeExtraTest.php
@@ -2,20 +2,12 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
-use Lotgd\Sanitize;
+namespace Lotgd\Tests;
+
 use Lotgd\Output;
+use Lotgd\Sanitize;
 use Lotgd\Tests\Stubs\DummySettingsSanitize;
-
-require_once __DIR__ . '/../config/constants.php';
-
-if (!function_exists('getsetting')) {
-    function getsetting(string|int $name, mixed $default = ''): mixed
-    {
-        return $default;
-    }
-}
-
+use PHPUnit\Framework\TestCase;
 
 final class SanitizeExtraTest extends TestCase
 {

--- a/tests/ServerFunctionsTest.php
+++ b/tests/ServerFunctionsTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+namespace Lotgd\Tests;
+
 use Lotgd\ServerFunctions;
 use Lotgd\Tests\Stubs\ServerDummySettings;
-
-require_once __DIR__ . '/../config/constants.php';
+use PHPUnit\Framework\TestCase;
 
 final class ServerFunctionsTest extends TestCase
 {

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
-use Lotgd\Settings;
+namespace Lotgd\Tests;
 
-require_once __DIR__ . '/../config/constants.php';
+use Lotgd\Settings;
+use PHPUnit\Framework\TestCase;
 
 final class SettingsTest extends TestCase
 {

--- a/tests/Stubs/Functions.php
+++ b/tests/Stubs/Functions.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (!function_exists('translate_inline')) {
+        function translate_inline($text, $ns = false)
+        {
+            return $text;
+        }
+    }
+
+    if (!function_exists('translate')) {
+        function translate($text, $ns = false)
+        {
+            return $text;
+        }
+    }
+
+    if (!function_exists('output_notl')) {
+        function output_notl(string $format, ...$args)
+        {
+            global $forms_output;
+            $forms_output .= vsprintf($format, $args);
+        }
+    }
+
+    if (!function_exists('rawoutput')) {
+        function rawoutput($text)
+        {
+            global $forms_output;
+            $forms_output .= $text;
+        }
+    }
+
+    if (!function_exists('output')) {
+        function output(string $format, ...$args)
+        {
+            global $forms_output;
+            $forms_output .= vsprintf($format, $args);
+        }
+    }
+
+    if (!function_exists('addnav')) {
+        function addnav(...$args): void
+        {
+        }
+    }
+
+    if (!function_exists('httppost')) {
+        function httppost($name)
+        {
+            return $_POST[$name] ?? false;
+        }
+    }
+
+    if (!function_exists('invalidatedatacache')) {
+        function invalidatedatacache(string $name): void
+        {
+        }
+    }
+
+    if (!function_exists('modulehook')) {
+        function modulehook($name, $data = [], $allowinactive = false, $only = false)
+        {
+            return $data;
+        }
+    }
+
+    if (!function_exists('tlbutton_pop')) {
+        function tlbutton_pop()
+        {
+            return '';
+        }
+    }
+
+    if (!function_exists('tlschema')) {
+        function tlschema($schema = false): void
+        {
+            \Lotgd\Translator::tlschema($schema);
+        }
+    }
+
+    if (!function_exists('getsetting')) {
+        function getsetting($name, $default)
+        {
+            global $settings;
+            if (isset($settings) && method_exists($settings, 'getSetting')) {
+                return $settings->getSetting($name, $default);
+            }
+
+            return $default;
+        }
+    }
+
+    if (!function_exists('debug')) {
+        function debug($t, $force = false): void
+        {
+        }
+    }
+
+    if (!function_exists('popup')) {
+        function popup(string $page, string $size = '550x300')
+        {
+            return '';
+        }
+    }
+
+    if (!function_exists('appoencode')) {
+        function appoencode($data, $priv = false)
+        {
+            global $output;
+            return $output->appoencode($data, $priv);
+        }
+    }
+
+    if (!function_exists('sanitize')) {
+        function sanitize($in)
+        {
+            return $in;
+        }
+    }
+
+    if (!function_exists('full_sanitize')) {
+        function full_sanitize($in)
+        {
+            return $in;
+        }
+    }
+
+    if (!function_exists('translate_mail')) {
+        function translate_mail($text, $to = 0)
+        {
+            return $text;
+        }
+    }
+
+    if (!function_exists('soap')) {
+        function soap($input, $debug = false, $skiphook = false)
+        {
+            return $input;
+        }
+    }
+
+    if (!function_exists('install_module')) {
+        function install_module(string $module): bool
+        {
+            $GLOBALS['install_called'][] = $module;
+            return true;
+        }
+    }
+
+    if (!function_exists('uninstall_module')) {
+        function uninstall_module(string $module): bool
+        {
+            $GLOBALS['uninstall_called'][] = $module;
+            return true;
+        }
+    }
+
+    if (!function_exists('activate_module')) {
+        function activate_module(string $module): bool
+        {
+            $GLOBALS['activate_called'][] = $module;
+            return true;
+        }
+    }
+
+    if (!function_exists('deactivate_module')) {
+        function deactivate_module(string $module): bool
+        {
+            $GLOBALS['deactivate_called'][] = $module;
+            return true;
+        }
+    }
+
+    if (!function_exists('injectmodule')) {
+        function injectmodule(string $module, bool $b): void
+        {
+            $GLOBALS['inject_called'][] = $module;
+        }
+    }
+
+    if (!function_exists('massinvalidate')) {
+        function massinvalidate(string $name): void
+        {
+            $GLOBALS['massinvalidates'][] = $name;
+        }
+    }
+
+    if (!function_exists('get_module_install_status')) {
+        function get_module_install_status(bool $with_db = true): array
+        {
+            return $GLOBALS['module_status'] ?? [];
+        }
+    }
+
+    if (!function_exists('apply_temp_stat')) {
+        function apply_temp_stat($name, $value, $type = 'add')
+        {
+            return \Lotgd\PlayerFunctions::applyTempStat($name, $value, $type);
+        }
+    }
+
+    if (!function_exists('check_temp_stat')) {
+        function check_temp_stat($name, $color = false)
+        {
+            return \Lotgd\PlayerFunctions::checkTempStat($name, $color);
+        }
+    }
+
+    if (!function_exists('suspend_temp_stats')) {
+        function suspend_temp_stats()
+        {
+            return \Lotgd\PlayerFunctions::suspendTempStats();
+        }
+    }
+
+    if (!function_exists('restore_temp_stats')) {
+        function restore_temp_stats()
+        {
+            return \Lotgd\PlayerFunctions::restoreTempStats();
+        }
+    }
+
+    if (!defined('DATACACHE_FILENAME_PREFIX')) {
+        define('DATACACHE_FILENAME_PREFIX', 'datacache-');
+    }
+}
+
+namespace Lotgd {
+    if (!function_exists('Lotgd\\getsetting')) {
+        function getsetting(string|int $name, mixed $default = ''): mixed
+        {
+            if (function_exists('\\getsetting')) {
+                return \getsetting($name, $default);
+            }
+
+            return $default;
+        }
+    }
+}

--- a/tests/SubstituteTest.php
+++ b/tests/SubstituteTest.php
@@ -2,17 +2,10 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+namespace Lotgd\Tests;
+
 use Lotgd\Substitute;
-
-require_once __DIR__ . '/../config/constants.php';
-
-if (!function_exists('translate_inline')) {
-    function translate_inline($text, $ns = false)
-    {
-        return $text;
-    }
-}
+use PHPUnit\Framework\TestCase;
 
 final class SubstituteTest extends TestCase
 {

--- a/tests/TemplateHelperTest.php
+++ b/tests/TemplateHelperTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
-use Lotgd\Template;
+namespace Lotgd\Tests;
 
-require_once __DIR__ . '/../config/constants.php';
+use Lotgd\Template;
+use PHPUnit\Framework\TestCase;
 
 final class TemplateHelperTest extends TestCase
 {

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
-use Lotgd\Template;
+namespace Lotgd\Tests;
 
-require_once __DIR__ . '/../config/constants.php';
+use Lotgd\Template;
+use PHPUnit\Framework\TestCase;
 
 final class TemplateTest extends TestCase
 {

--- a/tests/TwigTemplateTest.php
+++ b/tests/TwigTemplateTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
-use Lotgd\TwigTemplate;
+namespace Lotgd\Tests;
 
-require_once __DIR__ . '/../config/constants.php';
+use Lotgd\TwigTemplate;
+use PHPUnit\Framework\TestCase;
 
 final class TwigTemplateTest extends TestCase
 {
@@ -30,9 +30,9 @@ final class TwigTemplateTest extends TestCase
             return;
         }
 
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
         );
 
         foreach ($iterator as $item) {

--- a/tests/UtilityTest.php
+++ b/tests/UtilityTest.php
@@ -2,22 +2,15 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
-use Lotgd\EmailValidator;
-use Lotgd\SafeEscape;
-use Lotgd\Stripslashes;
+namespace Lotgd\Tests;
+
 use Lotgd\Dhms;
-use Lotgd\Sanitize;
+use Lotgd\EmailValidator;
 use Lotgd\Output;
-
-require_once __DIR__ . '/../config/constants.php';
-
-if (!function_exists('translate_inline')) {
-    function translate_inline($text, $ns = false)
-    {
-        return $text;
-    }
-}
+use Lotgd\SafeEscape;
+use Lotgd\Sanitize;
+use Lotgd\Stripslashes;
+use PHPUnit\Framework\TestCase;
 
 final class UtilityTest extends TestCase
 {


### PR DESCRIPTION
## Summary
- add shared test helper functions
- namespace tests under `Lotgd\Tests`
- drop inline helpers and redundant includes

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687fc2cfff6c832981204738830fd903