### PR TITLE
Fix inline closing brace comments

### DIFF
--- a/src/Lotgd/Battle.php
+++ b/src/Lotgd/Battle.php
@@ -832,12 +832,13 @@ class Battle
                                     tlschema();
                                     $healed = true;
                                     $companions[$myname] = $mycompanion;
-                                } // else   // These
-                            } // foreach    // are
-                        } // else           // some
-                    } // foreach            // totally
-                } // if                     // senseless
-            } // else                       // comments.
+                                // These are some totally senseless comments.
+                                }
+                            }
+                        }
+                    }
+                }
+            }
                 unset($mynewcompanions);
                 unset($mycompanions);
                 $roll = self::rollCompanionDamage($badguy, $companion);

--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -121,7 +121,8 @@ class TableDescriptor
                         $sql = "DROP {$val['name']}";
                     }
                     array_push($changes, $sql);
-                }//end foreach
+                // end foreach
+                }
             }
             if (count($changes) > 0) {
                 //we have changes to do!  Woohoo!
@@ -130,9 +131,11 @@ class TableDescriptor
                 Database::query($sql);
                 return count($changes);
             }
-        }//end if
+        // end if
+        }
         return null; //no changes made
-    }//end function
+    // end function
+    }
 
     /**
      * Generate SQL to create a table from the given descriptor.


### PR DESCRIPTION
## Summary
- move inline comments after closing braces to preceding lines in TableDescriptor
- remove stray inline comments in Battle and add single note

## Testing
- `composer lint:fix` *(fails: phpcbf not found)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_687fd542fa9083298681577526673866