### PR TITLE
Wrap legacy classes in namespace

### DIFF
--- a/lib/battle-functions.php
+++ b/lib/battle-functions.php
@@ -2,7 +2,7 @@
 
 namespace Lotgd;
 
-class Fightbar extends FightBar
+class Fightbar extends \FightBar
 {
 }
 

--- a/lib/battle-functions.php
+++ b/lib/battle-functions.php
@@ -1,5 +1,9 @@
 <?php
 
-class fightbar extends \Lotgd\FightBar
+namespace Lotgd;
+
+class Fightbar extends FightBar
 {
 }
+
+\class_alias(Fightbar::class, 'fightbar');

--- a/lib/output.php
+++ b/lib/output.php
@@ -1,13 +1,18 @@
 <?php
 
-// Legacy wrapper for \Lotgd\Output class
+namespace Lotgd {
 
 use Lotgd\Output;
 
-// Provide legacy class name for modules still instantiating output_collector
-class output_collector extends Output
+class OutputCollector extends Output
 {
 }
+
+\class_alias(OutputCollector::class, 'output_collector');
+
+}
+
+namespace {
 
 function set_block_new_output($block)
 {
@@ -45,4 +50,6 @@ function appoencode($data, $priv = false)
 {
     global $output;
     return $output->appoencode($data, $priv);
+}
+
 }

--- a/lib/serverfunctions.class.php
+++ b/lib/serverfunctions.class.php
@@ -1,5 +1,9 @@
 <?php
 
-class ServerFunctions extends Lotgd\ServerFunctions
+namespace Lotgd;
+
+class ServerFunctions extends \Lotgd\ServerFunctions
 {
 }
+
+\class_alias(ServerFunctions::class, 'ServerFunctions');

--- a/lib/serverfunctions.class.php
+++ b/lib/serverfunctions.class.php
@@ -6,4 +6,3 @@ class ServerFunctions extends \Lotgd\ServerFunctions
 {
 }
 
-\class_alias(ServerFunctions::class, 'ServerFunctions');

--- a/lib/settings.class.php
+++ b/lib/settings.class.php
@@ -1,5 +1,9 @@
 <?php
 
-class settings extends Lotgd\Settings
+namespace Lotgd;
+
+class Settings extends \Lotgd\Settings
 {
 }
+
+\class_alias(Settings::class, 'settings');


### PR DESCRIPTION
## Summary
- namespace legacy wrappers
- provide `class_alias` for backward compatibility

## Testing
- `php -l lib/output.php`
- `php -l lib/settings.class.php`
- `php -l lib/battle-functions.php`
- `php -l lib/serverfunctions.class.php`
- `composer test`
- `composer lint:fix` *(fails: phpcbf not found)*
- `composer install` *(fails: requires network)*

------
https://chatgpt.com/codex/tasks/task_e_687fd509db5c832999915cedefa3c93c