### PR TITLE
Fix AJAX timeout check for expired sessions

### DIFF
--- a/src/Lotgd/ForcedNavigation.php
+++ b/src/Lotgd/ForcedNavigation.php
@@ -41,6 +41,10 @@ class ForcedNavigation
                 }
                 if (!$session['user']['loggedin'] || ((date('U') - strtotime($session['user']['laston'])) > getsetting('LOGINTIMEOUT', 900))) {
                     $session = [];
+                    if (defined('AJAX_MODE') && AJAX_MODE) {
+                        $session['loggedin'] = false;
+                        return;
+                    }
                     redirect('index.php?op=timeout', 'Account not logged in but session thinks they are.');
                 }
             } else {
@@ -58,6 +62,11 @@ class ForcedNavigation
             }
         } else {
             if (!$anonymous) {
+                if (defined('AJAX_MODE') && AJAX_MODE) {
+                    $session = [];
+                    $session['loggedin'] = false;
+                    return;
+                }
                 redirect('index.php?op=timeout', 'Not logged in: ' . $REQUEST_URI);
             }
         }

--- a/src/Lotgd/ForcedNavigation.php
+++ b/src/Lotgd/ForcedNavigation.php
@@ -63,8 +63,8 @@ class ForcedNavigation
         } else {
             if (!$anonymous) {
                 if (defined('AJAX_MODE') && AJAX_MODE) {
-                    $session = [];
                     $session['loggedin'] = false;
+                    $session = [];
                     return;
                 }
                 redirect('index.php?op=timeout', 'Not logged in: ' . $REQUEST_URI);


### PR DESCRIPTION
## Summary
- avoid redirecting to timeout page when session expired in AJAX mode
- allow `timeout_status` to display final message for timed-out sessions

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `composer test` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687fe3aadb48832994171c9acaf53120