### PR TITLE
Add Doctrine entity classes and tests

### DIFF
--- a/src/Lotgd/Entity/Account.php
+++ b/src/Lotgd/Entity/Account.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="Lotgd\\Repository\\AccountRepository")
+ * @ORM\Table(name="accounts")
+ */
+class Account
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer", name="acctid")
+     * @ORM\GeneratedValue
+     */
+    private ?int $acctid = null;
+
+    /**
+     * @ORM\Column(type="string", length=50)
+     */
+    private string $login = "";
+
+    /**
+     * @ORM\Column(type="string", length=128, name="emailaddress")
+     */
+    private string $emailaddress = "";
+
+    /**
+     * @ORM\Column(type="string", length=32)
+     */
+    private string $password = "";
+
+    /**
+     * @ORM\Column(type="string", length=100, name="name")
+     */
+    private string $name = "";
+
+    /**
+     * @ORM\Column(type="smallint", options={"unsigned":true})
+     */
+    private int $level = 1;
+
+    /**
+     * @ORM\Column(type="datetime", name="laston")
+     */
+    private \DateTimeInterface $laston;
+
+    public function __construct()
+    {
+        $this->laston = new \DateTime('1970-01-01 00:00:00');
+    }
+
+    public function getAcctid(): ?int
+    {
+        return $this->acctid;
+    }
+
+    public function getLogin(): string
+    {
+        return $this->login;
+    }
+    public function setLogin(string $login): self
+    {
+        $this->login = $login;
+        return $this;
+    }
+
+    public function getEmailaddress(): string
+    {
+        return $this->emailaddress;
+    }
+
+    public function setEmailaddress(string $email): self
+    {
+        $this->emailaddress = $email;
+        return $this;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+    public function setPassword(string $password): self
+    {
+        $this->password = $password;
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getLevel(): int
+    {
+        return $this->level;
+    }
+    public function setLevel(int $level): self
+    {
+        $this->level = $level;
+        return $this;
+    }
+
+    public function getLaston(): \DateTimeInterface
+    {
+        return $this->laston;
+    }
+
+    public function setLaston(\DateTimeInterface $date): self
+    {
+        $this->laston = $date;
+        return $this;
+    }
+}

--- a/src/Lotgd/Entity/Account.php
+++ b/src/Lotgd/Entity/Account.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lotgd\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use BadMethodCallException;
 
 /**
  * @ORM\Entity(repositoryClass="Lotgd\\Repository\\AccountRepository")
@@ -385,5 +386,27 @@ class Account
     {
         $this->laston = $date;
         return $this;
+    }
+
+    /**
+     * Magic method to handle get* and set* calls for all properties.
+     */
+    public function __call(string $name, array $arguments)
+    {
+        if (str_starts_with($name, 'get')) {
+            $prop = lcfirst(substr($name, 3));
+            if (property_exists($this, $prop)) {
+                return $this->$prop;
+            }
+        }
+        if (str_starts_with($name, 'set')) {
+            $prop = lcfirst(substr($name, 3));
+            if (property_exists($this, $prop)) {
+                $this->$prop = $arguments[0] ?? null;
+                return $this;
+            }
+        }
+
+        throw new BadMethodCallException(sprintf('Undefined method %s', $name));
     }
 }

--- a/src/Lotgd/Entity/Account.php
+++ b/src/Lotgd/Entity/Account.php
@@ -19,39 +19,301 @@ class Account
      */
     private ?int $acctid = null;
 
-    /**
-     * @ORM\Column(type="string", length=50)
-     */
-    private string $login = "";
+    /** @ORM\Column(type="string", length=100) */
+    private string $name = '';
 
-    /**
-     * @ORM\Column(type="string", length=128, name="emailaddress")
-     */
-    private string $emailaddress = "";
+    /** @ORM\Column(type="string", length=40) */
+    private string $playername = '';
 
-    /**
-     * @ORM\Column(type="string", length=32)
-     */
-    private string $password = "";
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
+    private int $sex = 0;
 
-    /**
-     * @ORM\Column(type="string", length=100, name="name")
-     */
-    private string $name = "";
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
+    private int $strength = 10;
 
-    /**
-     * @ORM\Column(type="smallint", options={"unsigned":true})
-     */
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
+    private int $dexterity = 10;
+
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
+    private int $intelligence = 10;
+
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
+    private int $constitution = 10;
+
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
+    private int $wisdom = 10;
+
+    /** @ORM\Column(type="string", length=20) */
+    private string $specialty = '';
+
+    /** @ORM\Column(type="bigint", options={"unsigned":true}) */
+    private int $experience = 0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $gold = 0;
+
+    /** @ORM\Column(type="string", length=50) */
+    private string $weapon = 'Fists';
+
+    /** @ORM\Column(type="string", length=50) */
+    private string $armor = 'T-Shirt';
+
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
+    private int $seenmaster = 0;
+
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
     private int $level = 1;
 
-    /**
-     * @ORM\Column(type="datetime", name="laston")
-     */
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $defense = 0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $attack = 0;
+
+    /** @ORM\Column(type="boolean") */
+    private bool $alive = true;
+
+    /** @ORM\Column(type="bigint") */
+    private int $goldinbank = 0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $marriedto = 0;
+
+    /** @ORM\Column(type="integer") */
+    private int $spirits = 0;
+
+    /** @ORM\Column(type="datetime") */
     private \DateTimeInterface $laston;
+
+    /** @ORM\Column(type="integer") */
+    private int $hitpoints = 10;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $maxhitpoints = 10;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $gems = 0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $weaponvalue = 0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $armorvalue = 0;
+
+    /** @ORM\Column(type="string", length=50) */
+    private string $location = 'Degolburg';
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $turns = 10;
+
+    /** @ORM\Column(type="string", length=50) */
+    private string $title = '';
+
+    /** @ORM\Column(type="string", length=32) */
+    private string $password = '';
+
+    /** @ORM\Column(type="text") */
+    private string $badguy = '';
+
+    /** @ORM\Column(type="text") */
+    private string $companions = '';
+
+    /** @ORM\Column(type="text") */
+    private string $allowednavs = '';
+
+    /** @ORM\Column(type="boolean") */
+    private bool $loggedin = false;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $resurrections = 0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $superuser = 1;
+
+    /** @ORM\Column(type="integer") */
+    private int $weapondmg = 0;
+
+    /** @ORM\Column(type="integer") */
+    private int $armordef = 0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $age = 0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $charm = 0;
+
+    /** @ORM\Column(type="string", length=50) */
+    private string $specialinc = '';
+
+    /** @ORM\Column(type="string", length=1000) */
+    private string $specialmisc = '';
+
+    /** @ORM\Column(type="string", length=50) */
+    private string $login = '';
+
+    /** @ORM\Column(type="datetime") */
+    private \DateTimeInterface $lastmotd;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $playerfights = 3;
+
+    /** @ORM\Column(type="datetime") */
+    private \DateTimeInterface $lasthit;
+
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
+    private int $seendragon = 0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $dragonkills = 0;
+
+    /** @ORM\Column(type="boolean") */
+    private bool $locked = false;
+
+    /** @ORM\Column(type="string", length=255, nullable=true) */
+    private ?string $restorepage = null;
+
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
+    private int $hashorse = 0;
+
+    /** @ORM\Column(type="text") */
+    private string $bufflist = '';
+
+    /** @ORM\Column(type="float") */
+    private float $gentime = 0.0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $gentimecount = 0;
+
+    /** @ORM\Column(type="string", length=40) */
+    private string $lastip = '';
+
+    /** @ORM\Column(type="string", length=32, nullable=true) */
+    private ?string $uniqueid = null;
+
+    /** @ORM\Column(type="text") */
+    private string $dragonpoints = '';
+
+    /** @ORM\Column(type="smallint") */
+    private int $boughtroomtoday = 0;
+
+    /** @ORM\Column(type="string", length=128) */
+    private string $emailaddress = '';
+
+    /** @ORM\Column(type="string", length=128) */
+    private string $replaceemail = '';
+
+    /** @ORM\Column(type="string", length=32) */
+    private string $emailvalidation = '';
+
+    /** @ORM\Column(type="string", length=32) */
+    private string $forgottenpassword = '';
+
+    /** @ORM\Column(type="smallint") */
+    private int $sentnotice = 0;
+
+    /** @ORM\Column(type="text") */
+    private string $prefs = '';
+
+    /** @ORM\Column(type="datetime") */
+    private \DateTimeInterface $pvpflag;
+
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
+    private int $transferredtoday = 0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $soulpoints = 0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $gravefights = 0;
+
+    /** @ORM\Column(type="string", length=50) */
+    private string $hauntedby = '';
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $deathpower = 0;
+
+    /** @ORM\Column(type="bigint", options={"unsigned":true}) */
+    private int $gensize = 0;
+
+    /** @ORM\Column(type="datetime") */
+    private \DateTimeInterface $recentcomments;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $donation = 0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $donationspent = 0;
+
+    /** @ORM\Column(type="text") */
+    private string $donationconfig = '';
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $referer = 0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $refererawarded = 0;
+
+    /** @ORM\Column(type="string", length=255) */
+    private string $bio = '';
+
+    /** @ORM\Column(type="string", length=50) */
+    private string $race = '0';
+
+    /** @ORM\Column(type="datetime") */
+    private \DateTimeInterface $biotime;
+
+    /** @ORM\Column(type="smallint", nullable=true) */
+    private ?int $banoverride = 0;
+
+    /** @ORM\Column(type="string", length=128) */
+    private string $translatorlanguages = 'en';
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $amountouttoday = 0;
+
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
+    private int $pk = 0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $dragonage = 0;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $bestdragonage = 0;
+
+    /** @ORM\Column(type="string", length=25) */
+    private string $ctitle = '';
+
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
+    private int $beta = 0;
+
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
+    private int $slaydragon = 0;
+
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
+    private int $fedmount = 0;
+
+    /** @ORM\Column(type="datetime") */
+    private \DateTimeInterface $regdate;
+
+    /** @ORM\Column(type="integer", options={"unsigned":true}) */
+    private int $clanid = 0;
+
+    /** @ORM\Column(type="smallint", options={"unsigned":true}) */
+    private int $clanrank = 0;
+
+    /** @ORM\Column(type="datetime") */
+    private \DateTimeInterface $clanjoindate;
 
     public function __construct()
     {
         $this->laston = new \DateTime('1970-01-01 00:00:00');
+        $this->lastmotd = new \DateTime('1970-01-01 00:00:00');
+        $this->lasthit = new \DateTime('1970-01-01 00:00:00');
+        $this->pvpflag = new \DateTime('1970-01-01 00:00:00');
+        $this->recentcomments = new \DateTime('1970-01-01 00:00:00');
+        $this->biotime = new \DateTime('1970-01-01 00:00:00');
+        $this->regdate = new \DateTime('1970-01-01 00:00:00');
+        $this->clanjoindate = new \DateTime('1970-01-01 00:00:00');
     }
 
     public function getAcctid(): ?int
@@ -63,6 +325,7 @@ class Account
     {
         return $this->login;
     }
+
     public function setLogin(string $login): self
     {
         $this->login = $login;
@@ -84,6 +347,7 @@ class Account
     {
         return $this->password;
     }
+
     public function setPassword(string $password): self
     {
         $this->password = $password;
@@ -105,6 +369,7 @@ class Account
     {
         return $this->level;
     }
+
     public function setLevel(int $level): self
     {
         $this->level = $level;

--- a/src/Lotgd/Entity/ExtendedSetting.php
+++ b/src/Lotgd/Entity/ExtendedSetting.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="Lotgd\\Repository\\ExtendedSettingRepository")
+ * @ORM\Table(name="settings_extended")
+ */
+class ExtendedSetting
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string", length=50)
+     */
+    private string $setting = '';
+
+    /**
+     * @ORM\Column(type="text")
+     */
+    private string $value = '';
+
+    public function getSetting(): string
+    {
+        return $this->setting;
+    }
+
+    public function setSetting(string $setting): self
+    {
+        $this->setting = $setting;
+        return $this;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function setValue(string $value): self
+    {
+        $this->value = $value;
+        return $this;
+    }
+}

--- a/src/Lotgd/Entity/ExtendedSetting.php
+++ b/src/Lotgd/Entity/ExtendedSetting.php
@@ -14,7 +14,7 @@ class ExtendedSetting
 {
     /**
      * @ORM\Id
-     * @ORM\Column(type="string", length=50)
+     * @ORM\Column(name="setting", type="string", length=50)
      */
     private string $setting = '';
 

--- a/src/Lotgd/Entity/Setting.php
+++ b/src/Lotgd/Entity/Setting.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="Lotgd\\Repository\\SettingRepository")
+ * @ORM\Table(name="settings")
+ */
+class Setting
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string", length=25, name="setting")
+     */
+    private string $setting = '';
+
+    /**
+     * @ORM\Column(type="string", length=255, name="value")
+     */
+    private string $value = '';
+
+    public function getSetting(): string
+    {
+        return $this->setting;
+    }
+
+    public function setSetting(string $setting): self
+    {
+        $this->setting = $setting;
+        return $this;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function setValue(string $value): self
+    {
+        $this->value = $value;
+        return $this;
+    }
+}

--- a/src/Lotgd/Repository/AccountRepository.php
+++ b/src/Lotgd/Repository/AccountRepository.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Lotgd\Entity\Account;
+
+class AccountRepository extends EntityRepository
+{
+    public function findByLogin(string $login): ?Account
+    {
+        return $this->findOneBy(['login' => $login]);
+    }
+}

--- a/src/Lotgd/Repository/ExtendedSettingRepository.php
+++ b/src/Lotgd/Repository/ExtendedSettingRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Lotgd\Entity\ExtendedSetting;
+
+class ExtendedSettingRepository extends EntityRepository
+{
+    public function findValue(string $setting): ?string
+    {
+        $entity = $this->find($setting);
+        return $entity?->getValue();
+    }
+}

--- a/src/Lotgd/Repository/SettingRepository.php
+++ b/src/Lotgd/Repository/SettingRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Lotgd\Entity\Setting;
+
+class SettingRepository extends EntityRepository
+{
+    public function findValue(string $setting): ?string
+    {
+        $entity = $this->find($setting);
+        return $entity?->getValue();
+    }
+}

--- a/tests/EntityPersistenceTest.php
+++ b/tests/EntityPersistenceTest.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Tools\Setup;
 use Lotgd\Entity\Account;
 use Lotgd\Entity\Setting;
+use Lotgd\Entity\ExtendedSetting;
 use PHPUnit\Framework\TestCase;
 
 final class EntityPersistenceTest extends TestCase
@@ -56,5 +57,18 @@ final class EntityPersistenceTest extends TestCase
         $repo = $this->em->getRepository(Setting::class);
         $found = $repo->find('foo');
         $this->assertSame('bar', $found->getValue());
+    }
+
+    public function testExtendedSettingPersistAndRetrieve(): void
+    {
+        $setting = new ExtendedSetting();
+        $setting->setSetting('long')->setValue('value');
+        $this->em->persist($setting);
+        $this->em->flush();
+        $this->em->clear();
+
+        $repo = $this->em->getRepository(ExtendedSetting::class);
+        $found = $repo->find('long');
+        $this->assertSame('value', $found->getValue());
     }
 }

--- a/tests/EntityPersistenceTest.php
+++ b/tests/EntityPersistenceTest.php
@@ -34,7 +34,8 @@ final class EntityPersistenceTest extends TestCase
             ->setEmailaddress('tester@example.com')
             ->setPassword('secret')
             ->setName('Tester')
-            ->setLevel(2);
+            ->setLevel(2)
+            ->setGems(5);
         $account->setLaston(new \DateTime());
         $this->em->persist($account);
         $this->em->flush();
@@ -44,6 +45,7 @@ final class EntityPersistenceTest extends TestCase
         $found = $repo->findByLogin('tester');
         $this->assertNotNull($found);
         $this->assertSame('tester@example.com', $found->getEmailaddress());
+        $this->assertSame(5, $found->getGems());
     }
 
     public function testSettingPersistAndRetrieve(): void


### PR DESCRIPTION
## Summary
- create Account and Setting Doctrine entities
- add AccountRepository and SettingRepository
- wire unit tests for persisting these entities with SQLite

## Testing
- `php -l src/Lotgd/Entity/Account.php`
- `php -l src/Lotgd/Entity/Setting.php`
- `php -l src/Lotgd/Repository/AccountRepository.php`
- `php -l src/Lotgd/Repository/SettingRepository.php`
- `php -l tests/EntityPersistenceTest.php`
- `composer test` *(fails: symfony/polyfill-intl-grapheme missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881eea9e6788329bab96ef8379dad09