### PR TITLE
Update docs for session persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ Want to have this running in no time?
 4. Instantiate the entity manager with `Lotgd\Doctrine\Bootstrap::getEntityManager()`
    or include `config/doctrine.php` when using Doctrine CLI tools.
 
+Account changes are flushed through Doctrine's EntityManager when calling
+`Lotgd\Accounts::saveUser()`. The `$session['user']` array remains available for
+legacy code. Run `composer test` to verify the setup works as expected.
+
 ## Twig Templates
 
 Twig templates reside in the `templates_twig/` directory. Each template should
@@ -579,9 +583,9 @@ Additional information about the navigation helper API can be found in
 
 Found a bug or have a feature request? Open an issue on GitHub.
 Pull requests are welcome for improvements or fixes.
-Run the unit tests locally with `composer test` before submitting PRs.
-Check coding style with `composer lint` and apply automatic fixes using
-`composer lint:fix`.
+Run the unit tests with `composer test` and check modified PHP files using
+`php -l` before submitting PRs. Check coding style with `composer lint` and
+apply automatic fixes using `composer lint:fix`.
 
 ## License
 

--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -87,4 +87,11 @@ vendor/bin/doctrine-migrations migrations:migrate
 
 This will apply all new migrations to the configured database. During development you can generate additional migrations using `migrations:diff` or `migrations:generate`.
 
+## Session Persistence
+
+`Lotgd\Accounts::saveUser()` now persists account updates through Doctrine when the
+EntityManager is available.  The `$session['user']` array is still populated for
+legacy code, but changes are flushed to the database via Doctrine whenever
+possible.
+
 


### PR DESCRIPTION
## Summary
- document account session persistence in docs/MySQL.md
- clarify quick start uses Doctrine's EntityManager
- instruct contributors to run `composer test` and `php -l` in README

## Testing
- `composer test` *(fails: RuntimeException: dbconnect.php not found, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688258ba83e88329ae43f3fd72cd62d0