### PR TITLE
Fix unit tests and extend ORM coverage

### DIFF
--- a/tests/AccountsDoctrineTest.php
+++ b/tests/AccountsDoctrineTest.php
@@ -6,6 +6,7 @@ namespace Lotgd\Tests;
 
 use Lotgd\Accounts;
 use Lotgd\Tests\Stubs\DbMysqli;
+use Lotgd\Tests\Stubs\Database;
 use PHPUnit\Framework\TestCase;
 
 final class AccountsDoctrineTest extends TestCase
@@ -13,9 +14,13 @@ final class AccountsDoctrineTest extends TestCase
     protected function setUp(): void
     {
         class_exists(DbMysqli::class);
+        class_exists(Database::class);
         if (!class_exists('Lotgd\\Doctrine\\Bootstrap', false)) {
             require_once __DIR__ . '/Stubs/DoctrineBootstrap.php';
         }
+        \Lotgd\MySQL\Database::$doctrineConnection = null;
+        \Lotgd\MySQL\Database::$instance = null;
+        \Lotgd\Tests\Stubs\DoctrineBootstrap::$conn = null;
 
         $GLOBALS['session'] = [
             'loggedin'    => true,

--- a/tests/DatabaseDoctrineTest.php
+++ b/tests/DatabaseDoctrineTest.php
@@ -14,6 +14,10 @@ final class DatabaseDoctrineTest extends TestCase
     {
         class_exists(DbMysqli::class);
         require_once __DIR__ . '/Stubs/DoctrineBootstrap.php';
+        \Lotgd\MySQL\Database::$doctrineConnection = null;
+        \Lotgd\MySQL\Database::$instance = null;
+        \Lotgd\Tests\Stubs\DoctrineBootstrap::$conn = null;
+        \Lotgd\MySQL\Database::getDoctrineConnection();
     }
 
     public function testQueryUsesDoctrineConnection(): void

--- a/tests/DatabaseLegacyTest.php
+++ b/tests/DatabaseLegacyTest.php
@@ -13,6 +13,11 @@ final class DatabaseLegacyTest extends TestCase
     protected function setUp(): void
     {
         class_exists(DbMysqli::class);
+        \Lotgd\MySQL\Database::$doctrineConnection = null;
+        \Lotgd\MySQL\Database::$instance = null;
+        if (class_exists('Lotgd\\Tests\\Stubs\\DoctrineBootstrap', false)) {
+            \Lotgd\Tests\Stubs\DoctrineBootstrap::$conn = null;
+        }
     }
 
     public function testQueryUsesMysqli(): void

--- a/tests/EntityPersistenceTest.php
+++ b/tests/EntityPersistenceTest.php
@@ -53,6 +53,28 @@ final class EntityPersistenceTest extends TestCase
         $this->assertSame(5, $found->getGems());
     }
 
+    public function testAccountUpdatePersistsChanges(): void
+    {
+        $account = new Account();
+        $account->setLogin('update')
+            ->setEmailaddress('user@example.com')
+            ->setPassword('secret')
+            ->setName('User')
+            ->setLevel(1)
+            ->setGems(1);
+        $account->setLaston(new \DateTime());
+        $this->em->persist($account);
+        $this->em->flush();
+
+        $account->setGems(10);
+        $this->em->flush();
+        $this->em->clear();
+
+        $repo = $this->em->getRepository(Account::class);
+        $found = $repo->findByLogin('update');
+        $this->assertSame(10, $found->getGems());
+    }
+
     public function testSettingPersistAndRetrieve(): void
     {
         $setting = new Setting();

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -17,6 +17,12 @@ final class MailTest extends TestCase
         $GLOBALS['accounts_table'] = [];
         $GLOBALS['mail_table'] = [];
         $GLOBALS['mail_sent_count'] = 0;
+        \Lotgd\MySQL\Database::$doctrineConnection = null;
+        \Lotgd\MySQL\Database::$instance = null;
+        \Lotgd\MySQL\Database::$lastSql = '';
+        if (class_exists('Lotgd\\Tests\\Stubs\\DoctrineBootstrap', false)) {
+            \Lotgd\Tests\Stubs\DoctrineBootstrap::$conn = null;
+        }
         $GLOBALS['settings_array'] = [
             'mailsizelimit' => 1024,
             'charset' => 'UTF-8',

--- a/tests/ServerFunctionsTest.php
+++ b/tests/ServerFunctionsTest.php
@@ -6,6 +6,7 @@ namespace Lotgd\Tests;
 
 use Lotgd\ServerFunctions;
 use Lotgd\Tests\Stubs\ServerDummySettings;
+use Lotgd\Tests\Stubs\Database;
 use PHPUnit\Framework\TestCase;
 
 final class ServerFunctionsTest extends TestCase
@@ -13,8 +14,11 @@ final class ServerFunctionsTest extends TestCase
     protected function setUp(): void
     {
         $_SERVER = [];
+        class_exists(Database::class);
         \Lotgd\MySQL\Database::$onlineCounter = 0;
         \Lotgd\MySQL\Database::$settings_table = [];
+        \Lotgd\MySQL\Database::$doctrineConnection = null;
+        \Lotgd\MySQL\Database::$instance = null;
     }
 
     public function testIsSecureConnection(): void

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lotgd\Tests;
 
 use Lotgd\Settings;
+use Lotgd\Tests\Stubs\Database;
 use PHPUnit\Framework\TestCase;
 
 final class SettingsTest extends TestCase
@@ -14,6 +15,11 @@ final class SettingsTest extends TestCase
         class_exists(Database::class);
         \Lotgd\MySQL\Database::$settings_table = [];
         \Lotgd\MySQL\Database::$affected_rows = 0;
+        \Lotgd\MySQL\Database::$doctrineConnection = null;
+        \Lotgd\MySQL\Database::$instance = null;
+        if (class_exists('Lotgd\\Tests\\Stubs\\DoctrineBootstrap', false)) {
+            \Lotgd\Tests\Stubs\DoctrineBootstrap::$conn = null;
+        }
     }
 
     public function testGetSettingReturnsDefault(): void


### PR DESCRIPTION
## Summary
- reset DBAL stubs between tests and avoid autoloading Doctrine
- make `Database` stub support polling and modules queries
- ensure Doctrine and mysqli tests isolate their connections
- extend `EntityPersistenceTest` with an update check

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688269d6aaec832989e7489610d38cdc