### PR TITLE
Fix account entity ID check

### DIFF
--- a/src/Lotgd/Accounts.php
+++ b/src/Lotgd/Accounts.php
@@ -72,7 +72,7 @@ class Accounts
 
             if ($bootstrapExists) {
                 $em = Bootstrap::getEntityManager();
-                if (self::$accountEntity && self::$accountEntity->getId() === $session['user']['acctid']) {
+                if (self::$accountEntity && self::$accountEntity->getAcctid() === $session['user']['acctid']) {
                     $account = self::$accountEntity;
                 } else {
                     $account = $em->find(Account::class, $session['user']['acctid']);


### PR DESCRIPTION
## Summary
- use Account::getAcctid() instead of getId() in Accounts

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6882819176748329b1d8ec0ff31aa126