### PR TITLE
Fix installer null value handling

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -363,19 +363,19 @@ class Installer
             $this->output->output("`iIf you are unsure of the answer to any of these questions, please check with your server's ISP, or read the documentation on MySQL`i`n");
 
             $this->output->output("`nWhat is the address of your database server?`n");
-            $this->output->rawOutput("<input name='DB_HOST' value=\"" . htmlentities($session['dbinfo']['DB_HOST'], ENT_COMPAT, $this->getSetting("charset", "ISO-8859-1")) . "\">");
+            $this->output->rawOutput("<input name='DB_HOST' value=\"" . htmlentities((string)($session['dbinfo']['DB_HOST'] ?? ''), ENT_COMPAT, $this->getSetting("charset", "ISO-8859-1")) . "\">");
             $this->tip("If you are running LoGD from the same server as your database, use 'localhost' here.  Otherwise, you will have to find out what the address is of your database server.  Your server's ISP might be able to provide this information.");
 
             $this->output->output("`nWhat is the username you use to connect to the database server?`n");
-            $this->output->rawOutput("<input name='DB_USER' value=\"" . htmlentities($session['dbinfo']['DB_USER'], ENT_COMPAT, $this->getSetting("charset", "ISO-8859-1")) . "\">");
+            $this->output->rawOutput("<input name='DB_USER' value=\"" . htmlentities((string)($session['dbinfo']['DB_USER'] ?? ''), ENT_COMPAT, $this->getSetting("charset", "ISO-8859-1")) . "\">");
             $this->tip("This username does not have to be the same one you use to connect to the database server for administrative reasons.  However, in order to use this installer, and to install some of the modules, the account you provide here must have the ability to create, modify, and drop tables.  If you want the installer to create a new database for LoGD, the account will also have to have the ability to create databases.  Finally, to run the game, this account must at a minimum be able to select, insert, update, and delete records, and be able to lock tables.  If you're uncertain, grant the account the following privileges: SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, INDEX, and ALTER.");
 
             $this->output->output("`nWhat is the password for this username?`n");
-            $this->output->rawOutput("<input name='DB_PASS' value=\"" . htmlentities($session['dbinfo']['DB_PASS'], ENT_COMPAT, $this->getSetting("charset", "ISO-8859-1")) . "\">");
+            $this->output->rawOutput("<input name='DB_PASS' value=\"" . htmlentities((string)($session['dbinfo']['DB_PASS'] ?? ''), ENT_COMPAT, $this->getSetting("charset", "ISO-8859-1")) . "\">");
             $this->tip("The password is necessary here in order for the game to successfully connect to the database server.  This information is not shared with anyone, it is simply used to configure the game.");
 
             $this->output->output("`nWhat is the name of the database you wish to install LoGD in?`n");
-            $this->output->rawOutput("<input name='DB_NAME' value=\"" . htmlentities($session['dbinfo']['DB_NAME'], ENT_COMPAT, $this->getSetting("charset", "ISO-8859-1")) . "\">");
+            $this->output->rawOutput("<input name='DB_NAME' value=\"" . htmlentities((string)($session['dbinfo']['DB_NAME'] ?? ''), ENT_COMPAT, $this->getSetting("charset", "ISO-8859-1")) . "\">");
             $this->tip("Database servers such as MySQL can control many different databases.  This is very useful if you have many different programs each needing their own database.  Each database has a unique name.  Provide the name you wish to use for LoGD in this field.");
 
             $this->output->output("`nDo you want to use datacaching (high load optimization)?`n");
@@ -386,7 +386,7 @@ class Installer
             $this->tip("Do you want to use a datacache for the sql queries? Many internal queries produce the same results and can be cached. This feature is *highly* recommended to use as the MySQL server is usually high frequented. When using in an environment where Safe Mode is enabled; this needs to be a path that has the same UID as the web server runs.");
 
             $this->output->output("`nIf yes, what is the path to the datacache directory?`n");
-            $this->output->rawOutput("<input name='DB_DATACACHEPATH' value=\"" . htmlentities($session['dbinfo']['DB_DATACACHEPATH'], ENT_COMPAT, $this->getSetting("charset", "ISO-8859-1")) . "\">");
+            $this->output->rawOutput("<input name='DB_DATACACHEPATH' value=\"" . htmlentities((string)($session['dbinfo']['DB_DATACACHEPATH'] ?? ''), ENT_COMPAT, $this->getSetting("charset", "ISO-8859-1")) . "\">");
             $this->tip("If you have chosen to use the datacache function, you have to enter a path here to where temporary files may be stored. Verify that you have the proper permission (777) set to this folder, else you will have lots of errors. Do NOT end with a slash / ... just enter the dir");
 
             /*


### PR DESCRIPTION
## Summary
- avoid null values when displaying database info in installer

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68829691e5508329887ce98cf0b29e7c