### PR TITLE
Fix missing cache class

### DIFF
--- a/src/Lotgd/Doctrine/Bootstrap.php
+++ b/src/Lotgd/Doctrine/Bootstrap.php
@@ -7,6 +7,7 @@ namespace Lotgd\Doctrine;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\ORMSetup;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class Bootstrap
 {
@@ -37,11 +38,19 @@ class Bootstrap
         $paths = [$rootDir . '/src/Lotgd/Entity'];
 
         $cacheDir = ($DB_DATACACHEPATH ?? sys_get_temp_dir()) . '/doctrine';
+
+        if (class_exists(FilesystemAdapter::class)) {
+            $cache = new FilesystemAdapter('', 0, $cacheDir);
+        } else {
+            // Fallback to an in-memory cache when Symfony cache is missing.
+            $cache = new ArrayAdapter();
+        }
+
         $config = ORMSetup::createAnnotationMetadataConfiguration(
             $paths,
             true,
             null,
-            new FilesystemAdapter('', 0, $cacheDir)
+            $cache
         );
 
         return EntityManager::create($connection, $config);


### PR DESCRIPTION
## Summary
- provide fallback cache adapter if Symfony Cache isn't installed

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6882a918c76483299a3e04ca01793dba