### PR TITLE
Load db settings from array file

### DIFF
--- a/common.php
+++ b/common.php
@@ -166,7 +166,14 @@ $session =& $_SESSION['session'];
 // like LotGD.net experienced on 7/20/04.
 ob_start();
 if (file_exists("dbconnect.php")) {
-    require_once("dbconnect.php");
+    $config = require "dbconnect.php";
+    $DB_HOST = $config['DB_HOST'] ?? '';
+    $DB_USER = $config['DB_USER'] ?? '';
+    $DB_PASS = $config['DB_PASS'] ?? '';
+    $DB_NAME = $config['DB_NAME'] ?? '';
+    $DB_PREFIX = $config['DB_PREFIX'] ?? '';
+    $DB_USEDATACACHE = $config['DB_USEDATACACHE'] ?? 0;
+    $DB_DATACACHEPATH = $config['DB_DATACACHEPATH'] ?? '';
 } else {
     if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
         if (!defined("DB_NODB")) {
@@ -198,7 +205,7 @@ if (file_exists("dbconnect.php")) {
 //  $link = db_pconnect($DB_HOST, $DB_USER, $DB_PASS);
 $link = false;
 if (!defined("DB_NODB")) {
-        $link = Database::connect($DB_HOST, $DB_USER, $DB_PASS);
+        $link = Database::connect($config['DB_HOST'], $config['DB_USER'], $config['DB_PASS']);
 
         //set charset to utf8 (table default, don't change that!)
     if (!Database::setCharset("utf8mb4")) {
@@ -209,11 +216,6 @@ if (!defined("DB_NODB")) {
 
 $out = ob_get_contents();
 ob_end_clean();
-if (!defined("DB_NODB")) {
-    unset($DB_HOST);
-    unset($DB_USER);
-    unset($DB_PASS);
-}
 
 if ($link === false) {
     if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
@@ -257,7 +259,7 @@ if ($link === false) {
 }
 
 if (!defined("DB_NODB")) {
-    if (!DB_CONNECTED || !@Database::selectDb($DB_NAME)) {
+    if (!DB_CONNECTED || !@Database::selectDb($config['DB_NAME'])) {
         if ((!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) && DB_CONNECTED) {
             // Ignore this bit.  It's only really for Eric's server or people that want to trigger something when the database is jerky
             if (file_exists("lib/smsnotify.php")) {

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -1,13 +1,13 @@
 <?php
 
-require_once dirname(__DIR__) . '/dbconnect.php';
+$config = require dirname(__DIR__) . '/dbconnect.php';
 
 return [
     'driver' => 'pdo_mysql',
-    'host' => $DB_HOST ?? 'localhost',
-    'dbname' => $DB_NAME ?? '',
-    'user' => $DB_USER ?? '',
-    'password' => $DB_PASS ?? '',
+    'host' => $config['DB_HOST'] ?? 'localhost',
+    'dbname' => $config['DB_NAME'] ?? '',
+    'user' => $config['DB_USER'] ?? '',
+    'password' => $config['DB_PASS'] ?? '',
     'charset' => 'utf8mb4',
     'migrations_paths' => [
         'Lotgd\Migrations' => dirname(__DIR__) . '/migrations',

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -891,7 +891,7 @@ class Installer
                     . "    'DB_NAME' => '{$DB_NAME}',\n"
                     . "    'DB_PREFIX' => '{$DB_PREFIX}',\n"
                     . "    'DB_USEDATACACHE' => " . ((int)$DB_USEDATACACHE) . ",\n"
-                    . "    'DB_DATACACHEPATH' => '" . addslashes($DB_DATACACHEPATH) . "',\n"
+                    . "    'DB_DATACACHEPATH' => " . var_export($DB_DATACACHEPATH, true) . ",\n"
                     . "];\n";
                 // Check if the file is writeable for us. If yes, we will change the file and notice the admin
                 // if not, they have to change the file themselves...

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -809,16 +809,17 @@ class Installer
             $this->output->output("`2I'm attempting to write a file named 'dbconnect.php' to your site root.");
             $this->output->output("This file tells LoGD how to connect to the database, and is necessary to continue installation.`n");
             $dbconnect =
-            "<?php\n"
-               . "//This file automatically created by installer.php on " . date("M d, Y h:i a") . "\n"
-            . "\$DB_HOST = \"{$session['dbinfo']['DB_HOST']}\";\n"
-            . "\$DB_USER = \"{$session['dbinfo']['DB_USER']}\";\n"
-            . "\$DB_PASS = \"{$session['dbinfo']['DB_PASS']}\";\n"
-            . "\$DB_NAME = \"{$session['dbinfo']['DB_NAME']}\";\n"
-            . "\$DB_PREFIX = \"{$session['dbinfo']['DB_PREFIX']}\";\n"
-            . "\$DB_USEDATACACHE = " . ((int)$session['dbinfo']['DB_USEDATACACHE']) . ";\n"
-            . "\$DB_DATACACHEPATH = \"{$session['dbinfo']['DB_DATACACHEPATH']}\";\n"
-            . "?>\n";
+                "<?php\n"
+                . "//This file automatically created by installer.php on " . date("M d, Y h:i a") . "\n"
+                . "return [\n"
+                . "    'DB_HOST' => '{$session['dbinfo']['DB_HOST']}',\n"
+                . "    'DB_USER' => '{$session['dbinfo']['DB_USER']}',\n"
+                . "    'DB_PASS' => '{$session['dbinfo']['DB_PASS']}',\n"
+                . "    'DB_NAME' => '{$session['dbinfo']['DB_NAME']}',\n"
+                . "    'DB_PREFIX' => '{$session['dbinfo']['DB_PREFIX']}',\n"
+                . "    'DB_USEDATACACHE' => " . ((int)$session['dbinfo']['DB_USEDATACACHE']) . ",\n"
+                . "    'DB_DATACACHEPATH' => '{$session['dbinfo']['DB_DATACACHEPATH']}',\n"
+                . "];\n";
                 $failure = false;
                 $dir = dirname('dbconnect.php');
             if (is_writable($dir)) {
@@ -882,15 +883,16 @@ class Installer
                 }
                 $dbconnect =
                     "<?php\n"
-                               . "//This file automatically created by installer.php on " . date("M d, Y h:i a") . "\n"
-                    . "$DB_HOST = \"{$DB_HOST}\";\n"
-                    . "$DB_USER = \"{$DB_USER}\";\n"
-                    . "$DB_PASS = \"{$DB_PASS}\";\n"
-                    . "$DB_NAME = \"{$DB_NAME}\";\n"
-                    . "$DB_PREFIX = \"{$DB_PREFIX}\";\n"
-                    . "$DB_USEDATACACHE = " . ((int)$DB_USEDATACACHE) . ";\n"
-                    . "$DB_DATACACHEPATH = \"" . addslashes($DB_DATACACHEPATH) . "\";\n"
-                    . "?>\n";
+                    . "//This file automatically created by installer.php on " . date("M d, Y h:i a") . "\n"
+                    . "return [\n"
+                    . "    'DB_HOST' => '{$DB_HOST}',\n"
+                    . "    'DB_USER' => '{$DB_USER}',\n"
+                    . "    'DB_PASS' => '{$DB_PASS}',\n"
+                    . "    'DB_NAME' => '{$DB_NAME}',\n"
+                    . "    'DB_PREFIX' => '{$DB_PREFIX}',\n"
+                    . "    'DB_USEDATACACHE' => " . ((int)$DB_USEDATACACHE) . ",\n"
+                    . "    'DB_DATACACHEPATH' => '" . addslashes($DB_DATACACHEPATH) . "',\n"
+                    . "];\n";
                 // Check if the file is writeable for us. If yes, we will change the file and notice the admin
                 // if not, they have to change the file themselves...
                         $failure = false;

--- a/src/Lotgd/Doctrine/Bootstrap.php
+++ b/src/Lotgd/Doctrine/Bootstrap.php
@@ -21,23 +21,23 @@ class Bootstrap
         $rootDir = dirname(__DIR__, 3);
         $dbConfig = realpath($rootDir . '/dbconnect.php');
         if ($dbConfig && strpos($dbConfig, $rootDir) === 0) {
-            include_once $dbConfig;
+            $config = require $dbConfig;
         } else {
             throw new \RuntimeException('dbconnect.php not found');
         }
 
         $connection = [
             'driver' => 'pdo_mysql',
-            'host' => $DB_HOST ?? 'localhost',
-            'dbname' => $DB_NAME ?? '',
-            'user' => $DB_USER ?? '',
-            'password' => $DB_PASS ?? '',
+            'host' => $config['DB_HOST'] ?? 'localhost',
+            'dbname' => $config['DB_NAME'] ?? '',
+            'user' => $config['DB_USER'] ?? '',
+            'password' => $config['DB_PASS'] ?? '',
             'charset' => 'utf8mb4',
         ];
 
         $paths = [$rootDir . '/src/Lotgd/Entity'];
 
-        $cacheDir = ($DB_DATACACHEPATH ?? sys_get_temp_dir()) . '/doctrine';
+        $cacheDir = ($config['DB_DATACACHEPATH'] ?? sys_get_temp_dir()) . '/doctrine';
 
         if (class_exists(FilesystemAdapter::class)) {
             $cache = new FilesystemAdapter('', 0, $cacheDir);

--- a/src/Lotgd/Settings.php
+++ b/src/Lotgd/Settings.php
@@ -100,11 +100,16 @@ class Settings
      */
     public function getSetting(string|int $settingname, mixed $default = false): mixed
     {
-        global $DB_USEDATACACHE, $DB_DATACACHEPATH;
+        global $config;
+        if (!is_array($config)) {
+            $root = dirname(__DIR__, 2);
+            $path = realpath($root . '/dbconnect.php');
+            $config = $path ? require $path : [];
+        }
         if ($settingname == 'usedatacache') {
-            return $DB_USEDATACACHE;
+            return $config['DB_USEDATACACHE'] ?? 0;
         } elseif ($settingname == 'datacachepath') {
-            return $DB_DATACACHEPATH;
+            return $config['DB_DATACACHEPATH'] ?? '';
         }
         if (!isset($this->settings[$settingname])) {
             $this->loadSettings();


### PR DESCRIPTION
## Summary
- update installer to create `dbconnect.php` returning an array
- load the array in Doctrine bootstrap and config scripts
- use configuration array in common.php and Settings
- respect `DB_DATACACHEPATH` for doctrine cache

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6883d5051f188329af757a825a0cb472