### PR TITLE
Fix query return type for Doctrine integration

### DIFF
--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -79,9 +79,9 @@ class Database
     /**
      * Execute a SQL query.
      *
-     * @return array|bool|\mysqli_result
+     * @return array|bool|\mysqli_result|DoctrineResult
      */
-    public static function query(string $sql, bool $die = true): array|bool|\mysqli_result
+    public static function query(string $sql, bool $die = true): array|bool|\mysqli_result|DoctrineResult
     {
         if ((defined('DB_NODB') && DB_NODB) && !defined('LINK')) {
             return [];


### PR DESCRIPTION
## Summary
- allow Database::query to return Doctrine\DBAL\Result

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6883deee3dd483299996603bb74cc31b