### PR TITLE
fix Doctrine query return type

### DIFF
--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -105,7 +105,7 @@ class Database
                 $affected = $r->rowCount();
             } else {
                 $affected = $conn->executeStatement($sql);
-                $r = $affected;
+                $r = $affected >= 0;
             }
         } else {
             $r = self::getInstance()->query($sql);


### PR DESCRIPTION
## Summary
- ensure `Database::query` returns `bool` for Doctrine non-SELECT queries

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6883e0308cd88329b7b6c9486d1c4adc