### PR TITLE
Fix DateTime conversion before entity update

### DIFF
--- a/src/Lotgd/Accounts.php
+++ b/src/Lotgd/Accounts.php
@@ -87,6 +87,22 @@ class Accounts
                         if ($baseaccount[$key] != $val) {
                             $method = 'set' . ucfirst($key);
                             if (method_exists($account, $method)) {
+                                if ($val && in_array($key, [
+                                    'laston',
+                                    'lastmotd',
+                                    'lasthit',
+                                    'pvpflag',
+                                    'recentcomments',
+                                    'biotime',
+                                    'regdate',
+                                    'clanjoindate',
+                                ], true) && ! $val instanceof \DateTimeInterface) {
+                                    try {
+                                        $val = new \DateTime($val);
+                                    } catch (\Exception $e) {
+                                        $val = new \DateTime(DATETIME_DATEMIN);
+                                    }
+                                }
                                 $account->$method($val);
                             }
                         }

--- a/src/Lotgd/Accounts.php
+++ b/src/Lotgd/Accounts.php
@@ -15,6 +15,22 @@ use Lotgd\Entity\Account;
 
 class Accounts
 {
+    /**
+     * Fields in the account entity that store date and time values.
+     *
+     * @var string[]
+     */
+    private const DATE_FIELDS = [
+        'laston',
+        'lastmotd',
+        'lasthit',
+        'pvpflag',
+        'recentcomments',
+        'biotime',
+        'regdate',
+        'clanjoindate',
+    ];
+
     private static ?Account $accountEntity = null;
 
     public static function setAccountEntity(?Account $account): void
@@ -87,16 +103,11 @@ class Accounts
                         if ($baseaccount[$key] != $val) {
                             $method = 'set' . ucfirst($key);
                             if (method_exists($account, $method)) {
-                                if ($val && in_array($key, [
-                                    'laston',
-                                    'lastmotd',
-                                    'lasthit',
-                                    'pvpflag',
-                                    'recentcomments',
-                                    'biotime',
-                                    'regdate',
-                                    'clanjoindate',
-                                ], true) && ! $val instanceof \DateTimeInterface) {
+                                if (
+                                    $val
+                                    && in_array($key, self::DATE_FIELDS, true)
+                                    && ! $val instanceof \DateTimeInterface
+                                ) {
                                     try {
                                         $val = new \DateTime($val);
                                     } catch (\Exception $e) {


### PR DESCRIPTION
## Summary
- convert date string fields into DateTime objects in `Accounts::saveUser` before calling entity setters

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6883e4e689648329a87b5d7f2b5eae75