### PR TITLE
Fix login session timeout with Doctrine

### DIFF
--- a/login.php
+++ b/login.php
@@ -125,6 +125,9 @@ if ($name != "") {
 
                 db_query("UPDATE " . db_prefix("accounts") . " SET loggedin=" . true . ", laston='" . date("Y-m-d H:i:s") . "' WHERE acctid = " . $session['user']['acctid']);
 
+                // Persist updated login time when using Doctrine ORM
+                Accounts::saveUser();
+
                 $session['user']['loggedin'] = true;
                 $location = $session['user']['location'];
                 if ($session['user']['location'] == $iname) {


### PR DESCRIPTION
## Summary
- persist updated `laston` time during login when Doctrine is enabled

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6883e9ed94708329a956dabd2438456c