### PR TITLE
Fix initialization of allowed navigation list

### DIFF
--- a/login.php
+++ b/login.php
@@ -113,7 +113,8 @@ if ($name != "") {
                 modulehook("player-login");
 
                 if ($session['user']['loggedin']) {
-                                    $session['allowednavs'] = \Lotgd\Serialization::safeUnserialize($session['user']['allowednavs']);
+                    $allowednavs = \Lotgd\Serialization::safeUnserialize($session['user']['allowednavs']);
+                    $session['allowednavs'] = is_array($allowednavs) ? $allowednavs : [];
                     $link = "<a href='" . $session['user']['restorepage'] . "'>" . $session['user']['restorepage'] . "</a>";
 
                     $str = sprintf_translate("Sending you to %s, have a safe journey", $link);

--- a/src/Lotgd/ForcedNavigation.php
+++ b/src/Lotgd/ForcedNavigation.php
@@ -35,10 +35,11 @@ class ForcedNavigation
                 if (!is_array($session['user']['dragonpoints'])) {
                     $session['user']['dragonpoints'] = [];
                 }
-                if (is_array(unserialize($session['user']['allowednavs']))) {
-                    $session['allowednavs'] = unserialize($session['user']['allowednavs']);
+                $allowednavs = Serialization::safeUnserialize($session['user']['allowednavs']);
+                if (is_array($allowednavs)) {
+                    $session['allowednavs'] = $allowednavs;
                 } else {
-                    $session['allowednavs'] = [$session['user']['allowednavs']];
+                    $session['allowednavs'] = [];
                 }
                 if (!$session['user']['loggedin'] || ((date('U') - strtotime($session['user']['laston'])) > getsetting('LOGINTIMEOUT', 900))) {
                     $session = [];


### PR DESCRIPTION
## Summary
- ensure ForcedNavigation initializes `allowednavs` with `safeUnserialize`
- normalise `allowednavs` when resuming a logged-in session

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6883f2e930808329aecadc35e4178f5d