### PR TITLE
Fix translator and template calls in popup header

### DIFF
--- a/src/Lotgd/Page/Header.php
+++ b/src/Lotgd/Page/Header.php
@@ -76,8 +76,8 @@ class Header
     {
         global $header, $template;
 
-        \Lotgd\Translator::setup();
-        Template::prepare();
+        Translator::translatorSetup();
+        Template::prepareTemplate();
 
         modulehook('header-popup');
 
@@ -85,7 +85,7 @@ class Header
         if (!$arguments || count($arguments) === 0) {
             $arguments = ['Legend of the Green Dragon'];
         }
-        $title = \Lotgd\Translator::translateWithSprintf(...$arguments);
+        $title = Translator::sprintfTranslate(...$arguments);
         $title = HolidayText::holidayize($title, 'title');
 
         $lang     = defined('LANGUAGE') ? LANGUAGE : getsetting('defaultlanguage', 'en');


### PR DESCRIPTION
## Summary
- fix incorrect method names used in popup header

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6883f308fdac832984964508ec723ec8