### PR TITLE
Fix redirect to store allowed navigation

### DIFF
--- a/src/Lotgd/Redirect.php
+++ b/src/Lotgd/Redirect.php
@@ -24,6 +24,8 @@ class Redirect
         global $session, $REQUEST_URI, $settings;
         if (strpos($location, 'badnav.php') === false) {
             $session['allowednavs'] = [];
+            // Append the session counter so the nav entry and redirect match
+            $location = Nav::appendCount($location);
             Nav::add('', $location);
             if (isset($settings) && $settings instanceof Settings) {
                 $charset = $settings->getSetting('charset', 'UTF-8');


### PR DESCRIPTION
## Summary
- ensure Redirect::redirect appends the session counter **before** adding the nav entry so the location stored in allowednavs matches the redirected URL

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6883f49630a88329a74827dfdc696d89