### PR TITLE
Fix query() returning true for DESCRIBE statements

### DIFF
--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -100,7 +100,9 @@ class Database
         if (self::$doctrine || $bootstrapExists) {
             $conn = self::$doctrine ?? self::getDoctrineConnection();
             $trim = ltrim($sql);
-            if (strncasecmp($trim, 'select', 6) === 0) {
+            $keyword = strtolower(strtok($trim, " \t\n\r"));
+            $readOps = ['select', 'show', 'describe', 'desc', 'explain', 'pragma'];
+            if (in_array($keyword, $readOps, true)) {
                 $r = $conn->executeQuery($sql);
                 $affected = $r->rowCount();
             } else {


### PR DESCRIPTION
## Summary
- treat `DESCRIBE` and similar read-only SQL statements as queries

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6883f98fda848329918fc8daff062a5e