### PR TITLE
Fix unbuffered query in dbCleanup

### DIFF
--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -15,9 +15,15 @@ class Newday
     {
         savesetting("lastdboptimize", date("Y-m-d H:i:s"));
         $result = Database::query("SHOW TABLES");
+        $rows = [];
+        while ($row = Database::fetchAssoc($result)) {
+            $rows[] = $row;
+        }
+        Database::freeResult($result);
+
         $tables = [];
         $start = getmicrotime();
-        while ($row = Database::fetchAssoc($result)) {
+        foreach ($rows as $row) {
             foreach ($row as $val) {
                 Database::query("OPTIMIZE TABLE $val");
                 $tables[] = $val;


### PR DESCRIPTION
## Summary
- prevent nested queries on an unbuffered result set

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6883fc17cda88329b7f60ffad4785e52