### PR TITLE
Fix missing datacache prefix constant

### DIFF
--- a/src/Lotgd/DataCache.php
+++ b/src/Lotgd/DataCache.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+if (!defined('DATACACHE_FILENAME_PREFIX')) {
+    define('DATACACHE_FILENAME_PREFIX', 'datacache-');
+}
+
 /**
  * Lightweight file based data cache helper.
  */


### PR DESCRIPTION
## Summary
- define `DATACACHE_FILENAME_PREFIX` when not provided

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6884c6b2a3208329a80149e20f1d036e