### PR TITLE
Fix migration plan for installer

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1489,7 +1489,9 @@ class Installer
             }
         }
 
-        $plan = $dependencyFactory->getMigrationPlanCalculator()->getPlanUntilLatest();
+        $aliasResolver = $dependencyFactory->getVersionAliasResolver();
+        $latestVersion = $aliasResolver->resolveVersionAlias('latest');
+        $plan = $dependencyFactory->getMigrationPlanCalculator()->getPlanUntilVersion($latestVersion);
         $factory = $dependencyFactory->getConsoleInputMigratorConfigurationFactory();
         $migratorConfig = $factory->getMigratorConfiguration(new ArrayInput([]));
         $dependencyFactory->getMigrator()->migrate($plan, $migratorConfig);


### PR DESCRIPTION
## Summary
- stop calling non-existent getPlanUntilLatest
- resolve 'latest' alias and build plan to that version

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6884c842339083298c38dfe80929d3ec