### PR TITLE
Fix bool assignments in account entity

### DIFF
--- a/src/Lotgd/Entity/Account.php
+++ b/src/Lotgd/Entity/Account.php
@@ -402,7 +402,15 @@ class Account
         if (str_starts_with($name, 'set')) {
             $prop = lcfirst(substr($name, 3));
             if (property_exists($this, $prop)) {
-                $this->$prop = $arguments[0] ?? null;
+                $value = $arguments[0] ?? null;
+
+                $ref = new \ReflectionProperty($this, $prop);
+                $type = $ref->hasType() ? $ref->getType()->getName() : null;
+                if ($type === 'bool') {
+                    $value = (bool) $value;
+                }
+
+                $this->$prop = $value;
                 return $this;
             }
         }

--- a/tests/AccountsDoctrineTest.php
+++ b/tests/AccountsDoctrineTest.php
@@ -50,4 +50,12 @@ final class AccountsDoctrineTest extends TestCase
         $mysqli = \Lotgd\MySQL\Database::getInstance();
         $this->assertSame([], $mysqli->queries);
     }
+
+    public function testSaveUserCastsBooleanFields(): void
+    {
+        $GLOBALS['session']['user']['alive'] = 1;
+        Accounts::saveUser();
+        $entity = Accounts::getAccountEntity();
+        $this->assertTrue($entity->getAlive());
+    }
 }


### PR DESCRIPTION
## Summary
- prevent type errors by casting bool properties to boolean
- test Accounts::saveUser converts integer alive flag to bool

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6884d7cebe008329910568192e06ea69