### PR TITLE
Fix rawurlencode on integer

### DIFF
--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -504,7 +504,7 @@ class PageParts
             }
 
             $v = $logd_version;
-            $c = rawurlencode($c);
+            $c = rawurlencode((string) $c);
             $a = rawurlencode($a);
             $l = rawurlencode($l);
             $d = rawurlencode($d);


### PR DESCRIPTION
## Summary
- fix call to `rawurlencode()` when argument is integer

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6884db144cf483298cdd25863e4a4576