### PR TITLE
Add canonical link support

### DIFF
--- a/src/Lotgd/Page/Footer.php
+++ b/src/Lotgd/Page/Footer.php
@@ -71,8 +71,8 @@ class Footer
 				"<link rel=\"icon\" type=\"image/png\" sizes=\"16x16\" href=\"/images/favicon/favicon-16x16.png\">" .
 				"<link rel=\"manifest\" href=\"/images/favicon/site.webmanifest\">",
 			];
-			$favicon        = modulehook('pageparts-favicon', $favicon);
-			$pre_headscript = $favicon['favicon-link'];
+                        $favicon        = modulehook('pageparts-favicon', $favicon);
+                        $pre_headscript = PageParts::canonicalLink() . $favicon['favicon-link'];
 			if (isset($settings) && $settings->getSetting('ajax', 1) == 1 && isset($session['user']['prefs']['ajax']) && $session['user']['prefs']['ajax']) {
 				if (file_exists('ext/ajax_base_setup.php')) {
 					require 'ext/ajax_base_setup.php';
@@ -201,8 +201,8 @@ class Footer
 		} else {
 			$footer = $template['popupfoot'];
 		}
-		$pre_headscript   = '';
-		$maillink_add_after = '';
+                $pre_headscript   = PageParts::canonicalLink();
+                $maillink_add_after = '';
 		if (getsetting('ajax', 1) == 1 && isset($session['user']['prefs']['ajax']) && $session['user']['prefs']['ajax']) {
 			if (file_exists('ext/ajax_base_setup.php')) {
 				require 'ext/ajax_base_setup.php';

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -734,6 +734,29 @@ class PageParts
     }
 
     /**
+     * Generate the canonical link element for the current page.
+     */
+    public static function canonicalLink(): string
+    {
+        global $SCRIPT_NAME, $settings;
+
+        $serverUrl = isset($settings)
+            ? rtrim($settings->getSetting('serverurl', 'http://' . $_SERVER['HTTP_HOST']), '/')
+            : 'http://' . $_SERVER['HTTP_HOST'];
+
+        $page = ltrim($SCRIPT_NAME ?? '', '/');
+
+        if ($page === 'runmodule.php') {
+            $module = httpget('module');
+            if ($module !== false && $module !== '') {
+                $page .= '?module=' . urlencode((string) $module);
+            }
+        }
+
+        return sprintf('<link rel="canonical" href="%s/%s" />', $serverUrl, $page);
+    }
+
+    /**
      * Strip advertisement placeholders from the header.
      *
      * @internal This method is intended for internal use only and is not part of the public API.


### PR DESCRIPTION
## Summary
- include canonical `<link>` tag for SEO
- generate canonical URL in `PageParts`
- inject canonical link in page footers

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6884dd2761c88329be79d67fb78385b8