### PR TITLE
Fix preferences unserialize

### DIFF
--- a/pages/user/user_save.php
+++ b/pages/user/user_save.php
@@ -7,6 +7,11 @@ $sql = "";
 $updates = 0;
 $post = httpallpost();
 $oldvalues = stripslashes(httppost('oldvalues'));
+$oldvalues = html_entity_decode(
+    $oldvalues,
+    ENT_COMPAT,
+    getsetting('charset', 'ISO-8859-1')
+);
 $oldvalues = unserialize($oldvalues);
 // Handle recombining the old name
 $otitle = $oldvalues['title'];

--- a/prefs.php
+++ b/prefs.php
@@ -81,6 +81,11 @@ if ($op == "suicide" && getsetting("selfdelete", 0) != 0) {
 
 
     $oldvalues = stripslashes(httppost('oldvalues'));
+    $oldvalues = html_entity_decode(
+        $oldvalues,
+        ENT_COMPAT,
+        getsetting('charset', 'ISO-8859-1')
+    );
     $oldvalues = unserialize($oldvalues);
 
     $post = httpallpost();


### PR DESCRIPTION
## Summary
- decode HTML entities before unserializing preferences
- ensure user save route uses the same logic

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6884e07f557c83298d98ddb17a0974ec