### PR TITLE
Fix navigation color codes in module editor

### DIFF
--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -1329,7 +1329,11 @@ class Modules
                 $curcat = $row['category'];
                 addnav(["%s Modules", $curcat]);
             }
-            addnav_notl(($row['active'] ? '' : '`') . $row['formalname'] . '`0', $linkprefix . $row['modulename']);
+            // Prefix inactive modules with a valid colour code so the name
+            // does not start with an unescaped backtick. Without a colour
+            // letter the first character of the name would be parsed as one,
+            // causing unbalanced HTML tags like `<em>`.
+            addnav_notl(($row['active'] ? '' : '`&') . $row['formalname'] . '`0', $linkprefix . $row['modulename']);
         }
     }
 


### PR DESCRIPTION
## Summary
- prefix inactive module names with a valid color code to avoid unbalanced HTML tags

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6885041dcd64832992dc496da794d1f2