### PR TITLE
Fix restorepage clearing on logout

### DIFF
--- a/login.php
+++ b/login.php
@@ -213,15 +213,7 @@ if ($name != "") {
     }
 } elseif ($op == "logout") {
     if ($session['user']['loggedin']) {
-        $location = $session['user']['location'];
-        if ($location == $iname) {
-            $session['user']['restorepage'] = "inn.php?op=strolldown";
-        } elseif ($session['user']['superuser'] & (0xFFFFFFFF & ~ SU_DOESNT_GIVE_GROTTO)) {
-            $session['user']['restorepage'] = "superuser.php";
-        } else {
-            $session['user']['restorepage'] = "news.php";
-        }
-        $sql = "UPDATE " . db_prefix("accounts") . " SET loggedin=0,restorepage='{$session['user']['restorepage']}', allowednavs='' WHERE acctid = " . $session['user']['acctid'];
+        $sql = "UPDATE " . db_prefix("accounts") . " SET loggedin=0 WHERE acctid = " . $session['user']['acctid'];
         db_query($sql);
         invalidatedatacache("charlisthomepage");
         invalidatedatacache("list.php-warsonline");


### PR DESCRIPTION
## Summary
- prevent clearing allowed navs and restorepage when logging out
- rely on existing restorepage to avoid badnav after login

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6885258bae74832984083a1a5be343a8