### PR TITLE
Fix float experience in forest fights

### DIFF
--- a/src/Lotgd/Forest/Outcomes.php
+++ b/src/Lotgd/Forest/Outcomes.php
@@ -54,14 +54,14 @@ class Outcomes
             if (!$denyflawless && isset($badguy['denyflawless']) && !empty($badguy['denyflawless'])) {
                 $denyflawless = $badguy['denyflawless'];
             }
-            $expbonus += round(((int)$badguy['creatureexp'] * (1 + .25 * ((int)$badguy['creaturelevel'] - (int)$session['user']['level']))) - (int)$badguy['creatureexp'], 0);
+        $expbonus += (int) round(((int) $badguy['creatureexp'] * (1 + .25 * ((int) $badguy['creaturelevel'] - (int) $session['user']['level']))) - (int) $badguy['creatureexp'], 0);
         }
         $multibonus = $count > 1 ? 1 : 0;
         $expbonus += (int)$session['user']['dragonkills'] * (int)$session['user']['level'] * $multibonus;
         $totalexp = array_sum($options['experience']);
-        $exp = round($totalexp / $count);
-        $gold = round(r_rand(round($gold / $count), round($gold), 0));
-        $expbonus = round($expbonus / $count, 0);
+        $exp = (int) round($totalexp / $count, 0);
+        $gold = (int) round(r_rand(round($gold / $count), round($gold)), 0);
+        $expbonus = (int) round($expbonus / $count, 0);
 
         if ($gold) {
             output("`#You receive `^%s`# gold!`n", $gold);
@@ -94,7 +94,7 @@ class Outcomes
             if (count($enemies) > 1) {
                 output("During this fight you received `^%s`# total experience!`n`0", $exp + $expbonus);
             }
-            $session['user']['experience'] += $expbonus;
+            $session['user']['experience'] += (int) $expbonus;
         } else {
             if (floor($exp + $expbonus) < 0) {
                 $expbonus = -$exp + 1;
@@ -107,9 +107,9 @@ class Outcomes
                 output("`#***Because of the simplistic nature of this fight, you are penalized `^%s`# experience! `n(%s - %s = %s) ", abs($expbonus), $exp, abs($expbonus), $exp + $expbonus);
             }
             output("You receive `^%s`# total experience!`n`0", $exp + $expbonus);
-            $session['user']['experience'] += ($exp + $expbonus);
+            $session['user']['experience'] += (int) ($exp + $expbonus);
         }
-        $session['user']['gold'] += $gold;
+        $session['user']['gold'] += (int) $gold;
         if (!$creaturelevel) {
             $creaturelevel = $badguy['creaturelevel'];
         } else {
@@ -198,11 +198,11 @@ class Outcomes
             $add = ($session['user']['dragonkills'] / 100) * .10;
             $dk = round($dk * (.25 + $add));
         }
-        $expflux = round($badguy['creatureexp'] / 10, 0);
-        $expflux = round(r_rand(-$expflux, $expflux), 0);
+        $expflux = (int) round($badguy['creatureexp'] / 10, 0);
+        $expflux = (int) round(r_rand(-$expflux, $expflux), 0);
         $badguy['creatureexp'] += $expflux;
-        $atkflux = round(r_rand(0, $dk), 0);
-        $defflux = round(r_rand(0, ($dk - $atkflux)), 0);
+        $atkflux = (int) round(r_rand(0, $dk), 0);
+        $defflux = (int) round(r_rand(0, ($dk - $atkflux)), 0);
         $hpflux = ($dk - ($atkflux + $defflux)) * 5;
         $badguy['creatureattack'] += $atkflux;
         $badguy['creaturedefense'] += $defflux;
@@ -212,8 +212,8 @@ class Outcomes
             $base = 30 - min(20, round(sqrt((int)$session['user']['dragonkills']) / 2));
             $base /= 1000;
             $bonus = 1 + $base * ($atkflux + $defflux) + .001 * $hpflux;
-            $badguy['creaturegold'] = round((int)$badguy['creaturegold'] * $bonus, 0);
-            $badguy['creatureexp'] = round((int)$badguy['creatureexp'] * $bonus, 0);
+            $badguy['creaturegold'] = (int) round((int) $badguy['creaturegold'] * $bonus, 0);
+            $badguy['creatureexp'] = (int) round((int) $badguy['creatureexp'] * $bonus, 0);
         }
         $badguy = modulehook('creatureencounter', $badguy);
         debug("DEBUG: $dk modification points total.");


### PR DESCRIPTION
## Summary
- prevent floats from being assigned to `experience` by casting to int after rounding
- ensure gold and various forest fight calculations return ints

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6885d2d4843c83299898ec6f6e267842