### PR TITLE
Fix undefined login key in mail reply logic

### DIFF
--- a/pages/mail/case_write.php
+++ b/pages/mail/case_write.php
@@ -13,18 +13,18 @@ if ($replyto > 0) {
     $msgid = $forwardto;
 }
 if ($msgid > 0) {
-        $row = Mail::getMessage($session["user"]["acctid"], $msgid);
+    $row = Mail::getMessage($session['user']['acctid'], $msgid);
     if ($row) {
-        if ($row["login"] == "" && $forwardto == 0) {
-                output("You cannot reply to a system message.`n`nPress the \"Back\" button in your browser to get back.");
-                    $row = array();
-                    popup_footer();
+        if ((!isset($row['login']) || $row['login'] === '') && $forwardto == 0) {
+            output("You cannot reply to a system message.`n`nPress the \"Back\" button in your browser to get back.");
+            $row = [];
+            popup_footer();
         }
         if ($forwardto > 0) {
-            $row["login"] = 0;
+            $row['login'] = '';
         }
     } else {
-            output("Eek, no such message was found!`n");
+        output("Eek, no such message was found!`n");
     }
 }
 $to = httpget('to');

--- a/src/Lotgd/Mail.php
+++ b/src/Lotgd/Mail.php
@@ -254,7 +254,7 @@ class Mail
     {
         $mail = Database::prefix('mail');
         $acc = Database::prefix('accounts');
-        $sql = "SELECT $mail.*,$acc.name,$acc.acctid FROM $mail "
+        $sql = "SELECT $mail.*,$acc.name,$acc.acctid,$acc.login FROM $mail "
              . "LEFT JOIN $acc ON $acc.acctid=$mail.msgfrom "
              . "WHERE msgto='$userId' AND messageid='$messageId'";
 


### PR DESCRIPTION
## Summary
- include `login` when fetching a message
- guard for missing `login` key when replying/forwarding mail

## Testing
- `composer install`
- `composer test`
- `php -l src/Lotgd/Mail.php`
- `php -l pages/mail/case_write.php`


------
https://chatgpt.com/codex/tasks/task_e_6885d6267a7c832989b8f7185d8bf8f6