### PR TITLE
Fix canonical URL generation

### DIFF
--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -738,20 +738,22 @@ class PageParts
      */
     public static function canonicalLink(): string
     {
-        global $SCRIPT_NAME, $settings;
+        global $REQUEST_URI, $SCRIPT_NAME, $settings;
 
         $serverUrl = isset($settings)
             ? rtrim($settings->getSetting('serverurl', 'http://' . $_SERVER['HTTP_HOST']), '/')
             : 'http://' . $_SERVER['HTTP_HOST'];
 
-        $page = ltrim($SCRIPT_NAME ?? '', '/');
-
-        if ($page === 'runmodule.php') {
-            $module = httpget('module');
-            if ($module !== false && $module !== '') {
-                $page .= '?module=' . urlencode((string) $module);
-            }
+        $uri = $REQUEST_URI ?? '';
+        if ($uri === '') {
+            $uri = $SCRIPT_NAME ?? '';
         }
+
+        // Remove the session "c" parameter while keeping the rest intact
+        $uri = preg_replace('/([?&])c=[^&]*(&|$)/', '$1', $uri);
+        $uri = rtrim($uri, '&?');
+
+        $page = ltrim($uri, '/');
 
         return sprintf('<link rel="canonical" href="%s/%s" />', $serverUrl, $page);
     }

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -750,11 +750,11 @@ class PageParts
         }
 
         // Remove the session "c" parameter while keeping the rest intact
-        $parsedUrl = parse_url($uri);
+        $parsedUrl = parse_url($uri) ?: [];
         parse_str($parsedUrl['query'] ?? '', $queryParams);
         unset($queryParams['c']); // Remove the 'c' parameter
         $parsedUrl['query'] = http_build_query($queryParams);
-        $uri = $parsedUrl['path'] . (!empty($parsedUrl['query']) ? '?' . $parsedUrl['query'] : '');
+        $uri = ($parsedUrl['path'] ?? '') . (!empty($parsedUrl['query']) ? '?' . $parsedUrl['query'] : '');
 
         $page = ltrim($uri, '/');
 

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -750,7 +750,11 @@ class PageParts
         }
 
         // Remove the session "c" parameter while keeping the rest intact
-        $parsedUrl = parse_url($uri) ?: [];
+        $parsedUrl = parse_url($uri);
+        if ($parsedUrl === false) {
+            // Handle the malformed URL case
+            $parsedUrl = [];
+        }
         parse_str($parsedUrl['query'] ?? '', $queryParams);
         unset($queryParams['c']); // Remove the 'c' parameter
         if (empty($queryParams)) {

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -755,7 +755,12 @@ class PageParts
             // Handle the malformed URL case
             $parsedUrl = [];
         }
-        parse_str($parsedUrl['query'] ?? '', $queryParams);
+        $queryString = $parsedUrl['query'] ?? '';
+        if (is_string($queryString)) {
+            parse_str($queryString, $queryParams);
+        } else {
+            $queryParams = [];
+        }
         unset($queryParams['c']); // Remove the 'c' parameter
         if (empty($queryParams)) {
             unset($parsedUrl['query']);

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -750,8 +750,9 @@ class PageParts
         }
 
         // Remove the session "c" parameter while keeping the rest intact
-        $uri = preg_replace('/([?&])c=[^&]*(&|$)/', '$1', $uri);
-        $uri = rtrim($uri, '&?');
+        $uri = preg_replace('/\?c=[^&]*(?:&|$)/', '?', $uri); // Handle case where 'c' is the only parameter
+        $uri = preg_replace('/&c=[^&]*/', '', $uri);         // Handle case where 'c' is not the only parameter
+        $uri = rtrim($uri, '&?');                           // Clean up any trailing '&' or '?'
 
         $page = ltrim($uri, '/');
 

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -750,9 +750,11 @@ class PageParts
         }
 
         // Remove the session "c" parameter while keeping the rest intact
-        $uri = preg_replace('/\?c=[^&]*(?:&|$)/', '?', $uri); // Handle case where 'c' is the only parameter
-        $uri = preg_replace('/&c=[^&]*/', '', $uri);         // Handle case where 'c' is not the only parameter
-        $uri = rtrim($uri, '&?');                           // Clean up any trailing '&' or '?'
+        $parsedUrl = parse_url($uri);
+        parse_str($parsedUrl['query'] ?? '', $queryParams);
+        unset($queryParams['c']); // Remove the 'c' parameter
+        $parsedUrl['query'] = http_build_query($queryParams);
+        $uri = $parsedUrl['path'] . (!empty($parsedUrl['query']) ? '?' . $parsedUrl['query'] : '');
 
         $page = ltrim($uri, '/');
 

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -753,7 +753,11 @@ class PageParts
         $parsedUrl = parse_url($uri) ?: [];
         parse_str($parsedUrl['query'] ?? '', $queryParams);
         unset($queryParams['c']); // Remove the 'c' parameter
-        $parsedUrl['query'] = http_build_query($queryParams);
+        if (empty($queryParams)) {
+            unset($parsedUrl['query']);
+        } else {
+            $parsedUrl['query'] = http_build_query($queryParams);
+        }
         $uri = ($parsedUrl['path'] ?? '') . (!empty($parsedUrl['query']) ? '?' . $parsedUrl['query'] : '');
 
         $page = ltrim($uri, '/');


### PR DESCRIPTION
## Summary
- refine canonical link generation
- remove only `c` query parameter for better canonical URLs

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6885eba3fe6c832987236662ffaa027e