### PR TITLE
Fix unbuffered query error in dbCleanup

### DIFF
--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -14,12 +14,11 @@ class Newday
     public static function dbCleanup(): void
     {
         savesetting("lastdboptimize", date("Y-m-d H:i:s"));
-        $result = Database::query("SHOW TABLES");
-        $rows = [];
-        while ($row = Database::fetchAssoc($result)) {
-            $rows[] = $row;
-        }
-        Database::freeResult($result);
+        // Fetch all table names at once to avoid leaving an unbuffered
+        // result active which can cause "Cannot execute queries while other
+        // unbuffered queries are active" errors with PDO MySQL.
+        $rows = Database::getDoctrineConnection()
+            ->fetchAllAssociative('SHOW TABLES');
 
         $tables = [];
         $start = getmicrotime();


### PR DESCRIPTION
## Summary
- avoid unbuffered result during table optimization
- load table names using Doctrine buffered `fetchAllAssociative`

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68864defa1cc8329a21faeeaf95bbdff