### PR TITLE
Fix superuser lookup when replying to messages

### DIFF
--- a/pages/mail/case_write.php
+++ b/pages/mail/case_write.php
@@ -23,6 +23,13 @@ if ($msgid > 0) {
         if ($forwardto > 0) {
             $row['login'] = '';
         }
+        if (isset($row['login']) && $row['login'] !== '') {
+            $sql = "SELECT superuser FROM " . db_prefix('accounts')
+                . " WHERE login = '" . addslashes($row['login']) . "'";
+            $result = db_query($sql);
+            $acct = db_fetch_assoc($result);
+            $row['superuser'] = $acct['superuser'] ?? 0;
+        }
     } else {
         output("Eek, no such message was found!`n");
     }


### PR DESCRIPTION
## Summary
- prevent undefined superuser warning in mail compose

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6886517a49b8832980684a2d95549d03