### PR TITLE
Fix nav text color code stripping

### DIFF
--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -705,6 +705,9 @@ class Nav
                         self::$quickkeys[$key] = "window.location='$link$extra'";
                     }
                 }
+                if (is_string($text)) {
+                    $text = preg_replace('/^`0+/', '', $text);
+                }
                 $n = Template::templateReplace('navitem', [
                     'text' => appoencode($text, $priv),
                     'link' => $link . ($pop != true ? $extra : ''),


### PR DESCRIPTION
## Summary
- prevent stray `\`0` sequences from being encoded in navigation text

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68869c5732ac8329abc7a8b434bd7621