### PR TITLE
Fix open font tags between nav items

### DIFF
--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -580,6 +580,8 @@ class Nav
         }
         $extra = '';
         $ignoreuntil = '';
+        global $output;
+        $output->closeOpenFont();
         if ($link === false) {
             $text = HolidayText::holidayize($text, 'nav');
             $thisnav .= Translator::tlbuttonPop() . Template::templateReplace('navhead', ['title' => appoencode($text, $priv)]);

--- a/src/Lotgd/Output.php
+++ b/src/Lotgd/Output.php
@@ -388,6 +388,18 @@ class Output
         return $this->nestedtags_eval;
     }
 
+    public function hasOpenFont(): bool
+    {
+        return !empty($this->nestedtags['font']);
+    }
+
+    public function closeOpenFont(): void
+    {
+        if ($this->hasOpenFont()) {
+            $this->appoencode('`0');
+        }
+    }
+
     public function getColormap()
     {
         return implode('', $this->colormap);

--- a/tests/NavFontResetTest.php
+++ b/tests/NavFontResetTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Nav;
+use Lotgd\Output;
+use Lotgd\Template;
+use PHPUnit\Framework\TestCase;
+
+final class NavFontResetTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $session, $nav, $template, $output;
+        $session = ['user' => ['prefs' => []], 'allowednavs' => [], 'loggedin' => false];
+        $nav = '';
+        $output = new Output();
+        $template = [
+            'navitem' => '<a href="{link}">{text}</a>'
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        global $session, $nav, $template, $output;
+        unset($session, $nav, $template, $output);
+    }
+
+    public function testUnmatchedColorDoesNotInsertClosingSpanBeforeNextNav(): void
+    {
+        Nav::add('`!Red', 'red.php');
+        Nav::add('Plain', 'plain.php');
+
+        $navs = Nav::buildNavs();
+        $this->assertStringNotContainsString('</span><a href="plain.php">', $navs);
+    }
+
+    public function testUnmatchedColorBeforeAnotherColorHasNoClosingSpan(): void
+    {
+        Nav::add('`!Red', 'red.php');
+        Nav::add('`@Green', 'green.php');
+
+        $navs = Nav::buildNavs();
+        $this->assertStringNotContainsString('</span><span', $navs);
+    }
+}


### PR DESCRIPTION
## Summary
- add helper methods to detect and close open font spans
- close any open font before encoding nav text
- add regression tests for color code handling in navigation

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688729f08ce48329bc5d383a94e1ab4c