### PR TITLE
Fix dragon kill reset defaults

### DIFF
--- a/dragon.php
+++ b/dragon.php
@@ -173,9 +173,22 @@ if ($op == "") {
             array_key_exists($row['Field'], $nochange) &&
                 $nochange[$row['Field']]
         ) {
-        } else {
-            $session['user'][$row['Field']] = $row["Default"];
+            continue;
         }
+
+        $value = $row['Default'];
+        $type = strtolower($row['Type']);
+        $baseType = strtok($type, '(');
+
+        if (strpos($baseType, 'int') !== false) {
+            $value = (int) $value;
+        } elseif (in_array($baseType, ['float', 'double', 'decimal'])) {
+            $value = (float) $value;
+        } elseif ($baseType === 'tinyint' && $type === 'tinyint(1)') {
+            $value = (bool) $value;
+        }
+
+        $session['user'][$row['Field']] = $value;
     }
     $session['user']['gold'] = getsetting("newplayerstartgold", 50);
     $session['user']['location'] = getsetting('villagename', LOCATION_FIELDS);


### PR DESCRIPTION
## Summary
- ensure account defaults get cast to the correct PHP types when resetting a user after a dragon kill

## Testing
- `composer install`
- `composer test`
- `php -l dragon.php`


------
https://chatgpt.com/codex/tasks/task_e_68872f8bbd0083298bfd0d5b94399fbe