### PR TITLE
Include OPTIMIZE queries as read ops

### DIFF
--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -101,7 +101,7 @@ class Database
             $conn = self::$doctrine ?? self::getDoctrineConnection();
             $trim = ltrim($sql);
             $keyword = strtolower(strtok($trim, " \t\n\r"));
-            $readOps = ['select', 'show', 'describe', 'desc', 'explain', 'pragma'];
+            $readOps = ['select', 'show', 'describe', 'desc', 'explain', 'pragma', 'optimize', 'analyze'];
             if (in_array($keyword, $readOps, true)) {
                 $r = $conn->executeQuery($sql);
                 $affected = $r->rowCount();


### PR DESCRIPTION
## Summary
- mark `OPTIMIZE` and `ANALYZE` statements as read operations

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6887539b61f88329a322bfd711d54030