### PR TITLE
Handle missing PDO SQLite in tests

### DIFF
--- a/tests/EntityPersistenceTest.php
+++ b/tests/EntityPersistenceTest.php
@@ -19,6 +19,10 @@ final class EntityPersistenceTest extends TestCase
 
     protected function setUp(): void
     {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('PDO SQLite extension not installed');
+        }
+
         if (!class_exists('Doctrine\\Common\\Annotations\\AnnotationReader')) {
             $this->markTestSkipped('Doctrine annotations not installed');
         }

--- a/tests/RepositoryDoctrineTest.php
+++ b/tests/RepositoryDoctrineTest.php
@@ -19,6 +19,10 @@ final class RepositoryDoctrineTest extends TestCase
 
     protected function setUp(): void
     {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('PDO SQLite extension not installed');
+        }
+
         if (!class_exists('Doctrine\\Common\\Annotations\\AnnotationReader')) {
             $this->markTestSkipped('Doctrine annotations not installed');
         }


### PR DESCRIPTION
## Summary
- skip Doctrine persistence tests when `pdo_sqlite` extension is missing

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6887589495b4832983086b54e4e4c6ba