### PR TITLE
Refactor user pages to use namespaced helpers

### DIFF
--- a/pages/user/user_.php
+++ b/pages/user/user_.php
@@ -1,36 +1,39 @@
 <?php
 declare(strict_types=1);
 
+use Lotgd\Nav;
+use Lotgd\Translator;
+
 if ($display == 1) {
     $q = "";
     if ($query) {
         $q = "&q=$query";
     }
-    $ops = translate_inline("Ops");
-    $acid = translate_inline("AcctID");
-    $login = translate_inline("Login");
-    $nm = translate_inline("Name");
-    $lev = translate_inline("Level");
-    $lon = translate_inline("Last On");
-    $hits = translate_inline("Hits");
-    $lip = translate_inline("Last IP");
-    $lid = translate_inline("Last ID");
-    $email = translate_inline("Email");
-    $ed = translate_inline("Edit");
-    $del = translate_inline("Del");
-    $conf = translate_inline("Are you sure you wish to delete this user?");
-    $ban = translate_inline("Ban");
-    $log = translate_inline("Log");
-        rawoutput("<table>");
-    rawoutput("<tr class='trhead'><td>$ops</td><td><a href='user.php?sort=acctid$q'>$acid</a></td><td><a href='user.php?sort=login$q'>$login</a></td><td><a href='user.php?sort=name$q'>$nm</a></td><td><a href='user.php?sort=level$q'>$lev</a></td><td><a href='user.php?sort=laston$q'>$lon</a></td><td><a href='user.php?sort=gentimecount$q'>$hits</a></td><td><a href='user.php?sort=lastip$q'>$lip</a></td><td><a href='user.php?sort=uniqueid$q'>$lid</a></td><td><a href='user.php?sort=emailaddress$q'>$email</a></td></tr>");
-    addnav("", "user.php?sort=acctid$q");
-    addnav("", "user.php?sort=login$q");
-    addnav("", "user.php?sort=name$q");
-    addnav("", "user.php?sort=level$q");
-    addnav("", "user.php?sort=laston$q");
-    addnav("", "user.php?sort=gentimecount$q");
-    addnav("", "user.php?sort=lastip$q");
-    addnav("", "user.php?sort=uniqueid$q");
+    $ops = Translator::translateInline("Ops");
+    $acid = Translator::translateInline("AcctID");
+    $login = Translator::translateInline("Login");
+    $nm = Translator::translateInline("Name");
+    $lev = Translator::translateInline("Level");
+    $lon = Translator::translateInline("Last On");
+    $hits = Translator::translateInline("Hits");
+    $lip = Translator::translateInline("Last IP");
+    $lid = Translator::translateInline("Last ID");
+    $email = Translator::translateInline("Email");
+    $ed = Translator::translateInline("Edit");
+    $del = Translator::translateInline("Del");
+    $conf = Translator::translateInline("Are you sure you wish to delete this user?");
+    $ban = Translator::translateInline("Ban");
+    $log = Translator::translateInline("Log");
+        $output->rawOutput("<table>");
+    $output->rawOutput("<tr class='trhead'><td>$ops</td><td><a href='user.php?sort=acctid$q'>$acid</a></td><td><a href='user.php?sort=login$q'>$login</a></td><td><a href='user.php?sort=name$q'>$nm</a></td><td><a href='user.php?sort=level$q'>$lev</a></td><td><a href='user.php?sort=laston$q'>$lon</a></td><td><a href='user.php?sort=gentimecount$q'>$hits</a></td><td><a href='user.php?sort=lastip$q'>$lip</a></td><td><a href='user.php?sort=uniqueid$q'>$lid</a></td><td><a href='user.php?sort=emailaddress$q'>$email</a></td></tr>");
+    Nav::add("", "user.php?sort=acctid$q");
+    Nav::add("", "user.php?sort=login$q");
+    Nav::add("", "user.php?sort=name$q");
+    Nav::add("", "user.php?sort=level$q");
+    Nav::add("", "user.php?sort=laston$q");
+    Nav::add("", "user.php?sort=gentimecount$q");
+    Nav::add("", "user.php?sort=lastip$q");
+    Nav::add("", "user.php?sort=uniqueid$q");
     $rn = 0;
     $oorder = "";
     while ($row = db_fetch_assoc($searchresult)) {
@@ -39,44 +42,44 @@ if ($display == 1) {
             (date("U") - strtotime($row['laston']) <
              getsetting("LOGINTIMEOUT", 900) && $row['loggedin']);
         if ($loggedin) {
-            $laston = translate_inline("`#Online`0");
+            $laston = Translator::translateInline("`#Online`0");
         }
         $row['laston'] = $laston;
         if ($row[$order] != $oorder) {
             $rn++;
         }
         $oorder = $row[$order];
-        rawoutput("<tr class='" . ($rn % 2 ? "trlight" : "trdark") . "'>");
-        rawoutput("<td nowrap>");
-        rawoutput("[ <a href='user.php?op=edit&userid={$row['acctid']}$m'>$ed</a> | <a href='user.php?op=del&userid={$row['acctid']}' onClick=\"return confirm('$conf');\">$del</a> | <a href='bans.php?op=setupban&userid={$row['acctid']}'>$ban</a> | <a href='user.php?op=debuglog&userid={$row['acctid']}'>$log</a> ]");
-        addnav("", "user.php?op=edit&userid={$row['acctid']}$m");
-        addnav("", "user.php?op=del&userid={$row['acctid']}");
-        addnav("", "bans.php?op=setupban&userid={$row['acctid']}");
-        addnav("", "user.php?op=debuglog&userid={$row['acctid']}");
-        rawoutput("</td><td>");
-        output_notl("%s", $row['acctid']);
-        rawoutput("</td><td>");
-        output_notl("%s", $row['login']);
-        rawoutput("</td><td>");
-        output_notl("`&%s`0", $row['name']);
-        rawoutput("</td><td>");
-        output_notl("`^%s`0", $row['level']);
-        rawoutput("</td><td>");
-        output_notl("%s", $row['laston']);
-        rawoutput("</td><td>");
-        output_notl("%s", $row['gentimecount']);
-        rawoutput("</td><td>");
-        output_notl("%s", $row['lastip']);
-        rawoutput("</td><td>");
-        output_notl("%s", $row['uniqueid']);
-        rawoutput("</td><td>");
-        output_notl("%s", $row['emailaddress']);
-        rawoutput("</td></tr>");
+        $output->rawOutput("<tr class='" . ($rn % 2 ? "trlight" : "trdark") . "'>");
+        $output->rawOutput("<td nowrap>");
+        $output->rawOutput("[ <a href='user.php?op=edit&userid={$row['acctid']}$m'>$ed</a> | <a href='user.php?op=del&userid={$row['acctid']}' onClick=\"return confirm('$conf');\">$del</a> | <a href='bans.php?op=setupban&userid={$row['acctid']}'>$ban</a> | <a href='user.php?op=debuglog&userid={$row['acctid']}'>$log</a> ]");
+        Nav::add("", "user.php?op=edit&userid={$row['acctid']}$m");
+        Nav::add("", "user.php?op=del&userid={$row['acctid']}");
+        Nav::add("", "bans.php?op=setupban&userid={$row['acctid']}");
+        Nav::add("", "user.php?op=debuglog&userid={$row['acctid']}");
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['acctid']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['login']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("`&%s`0", $row['name']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("`^%s`0", $row['level']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['laston']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['gentimecount']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['lastip']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['uniqueid']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['emailaddress']);
+        $output->rawOutput("</td></tr>");
         $gentimecount += $row['gentimecount'];
         $gentime += $row['gentime'];
     }
-    rawoutput("</table>");
-    output("Total hits: %s`n", $gentimecount);
-    output("Total CPU time: %s seconds`n", round($gentime, 3));
-    output("Average page gen time is %s seconds`n", round($gentime / max($gentimecount, 1), 4));
+    $output->rawOutput("</table>");
+    $output->output("Total hits: %s`n", $gentimecount);
+    $output->output("Total CPU time: %s seconds`n", round($gentime, 3));
+    $output->output("Average page gen time is %s seconds`n", round($gentime / max($gentimecount, 1), 4));
 }

--- a/pages/user/user_debuglog.php
+++ b/pages/user/user_debuglog.php
@@ -1,9 +1,12 @@
 <?php
 declare(strict_types=1);
 
+use Lotgd\Nav;
+use Lotgd\Translator;
+
 if ($petition != "") {
-    addnav("Navigation");
-    addnav("Return to the petition", "viewpetition.php?op=view&id=$petition");
+    Nav::add("Navigation");
+    Nav::add("Return to the petition", "viewpetition.php?op=view&id=$petition");
 }
 $debuglog = db_prefix('debuglog');
 $debuglog_archive = db_prefix('debuglog_archive');
@@ -70,15 +73,15 @@ $sql = "(
 
 $next = $start + 500;
 $prev = $start - 500;
-addnav("Operations");
-addnav("Edit user info", "user.php?op=edit&userid=$userid$returnpetition");
-addnav("Refresh", "user.php?op=debuglog&userid=$userid&start=$start$returnpetition");
-addnav("Debug Log");
+Nav::add("Operations");
+Nav::add("Edit user info", "user.php?op=edit&userid=$userid$returnpetition");
+Nav::add("Refresh", "user.php?op=debuglog&userid=$userid&start=$start$returnpetition");
+Nav::add("Debug Log");
 if ($next < $max) {
-    addnav("Next page", "user.php?op=debuglog&userid=$userid&start=$next$returnpetition");
+    Nav::add("Next page", "user.php?op=debuglog&userid=$userid&start=$next$returnpetition");
 }
 if ($start > 0) {
-    addnav(
+    Nav::add(
         "Previous page",
         "user.php?op=debuglog&userid=$userid&start=$prev$returnpetition"
     );
@@ -88,13 +91,13 @@ $odate = "";
 while ($row = db_fetch_assoc($result)) {
     $dom = date("D, M d", strtotime($row['date']));
     if ($odate != $dom) {
-        output_notl("`n`b`@%s`0`b`n", $dom);
+        $output->outputNotl("`n`b`@%s`0`b`n", $dom);
         $odate = $dom;
     }
     $time = date("H:i:s", strtotime($row['date'])) . " (" . reltime(strtotime($row['date'])) . ")";
-    output_notl("`#%s (%s) `^%s - `&%s`7 %s`0", $row['field'], $row['value'], $time, $row['actorname'], $row['message']);
+    $output->outputNotl("`#%s (%s) `^%s - `&%s`7 %s`0", $row['field'], $row['value'], $time, $row['actorname'], $row['message']);
     if ($row['target']) {
-        output(" \-- Recipient = `\$%s`0", $row['targetname']);
+        $output->output(" \-- Recipient = `\$%s`0", $row['targetname']);
     }
-    output_notl("`n");
+    $output->outputNotl("`n");
 }

--- a/pages/user/user_del.php
+++ b/pages/user/user_del.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Lotgd\PlayerFunctions;
+use Lotgd\Translator;
 
 $sql = "SELECT name,superuser from " . db_prefix("accounts") . " WHERE acctid='$userid'";
 $res = db_query($sql);
@@ -9,7 +10,7 @@ PlayerFunctions::charCleanup($userid, CHAR_DELETE_MANUAL);
 $fail = false;
 while ($row = db_fetch_assoc($res)) {
     if ($row['superuser'] > 0 && ($session['user']['superuser'] & SU_MEGAUSER) != SU_MEGAUSER) {
-        output("`\$You are trying to delete a user with superuser powers. Regardless of the type, ONLY a megauser can do so due to security reasons.");
+        $output->output("`\$You are trying to delete a user with superuser powers. Regardless of the type, ONLY a megauser can do so due to security reasons.");
         $fail = true;
         break;
     }
@@ -19,5 +20,5 @@ while ($row = db_fetch_assoc($res)) {
 if ($fail !== true) {
     $sql = "DELETE FROM " . db_prefix("accounts") . " WHERE acctid='$userid'";
     db_query($sql);
-    output(db_affected_rows() . " user deleted.");
+    $output->output(db_affected_rows() . " user deleted.");
 }

--- a/pages/user/user_delban.php
+++ b/pages/user/user_delban.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+use Lotgd\Redirect;
+
 $sql = "DELETE FROM " . db_prefix("bans") . " WHERE ipfilter = '" . httpget("ipfilter") . "' AND uniqueid = '" . httpget("uniqueid") . "'";
 db_query($sql);
-redirect("user.php?op=removeban");
+Redirect::redirect("user.php?op=removeban");

--- a/pages/user/user_edit.php
+++ b/pages/user/user_edit.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 use Lotgd\PlayerFunctions;
 use Lotgd\Forms;
+use Lotgd\Nav;
+use Lotgd\Translator;
+use Lotgd\Modules;
 
 $result = db_query("SELECT * FROM " . db_prefix("accounts") . " WHERE acctid=" . (int)$userid);
 $row = db_fetch_assoc($result);
@@ -11,40 +14,40 @@ if ($petition != "") {
     $returnpetition = "&returnpetition=$petition";
 }
 if ($petition != "") {
-    addnav("Navigation");
-    addnav("Return to the petition", "viewpetition.php?op=view&id=$petition");
+    Nav::add("Navigation");
+    Nav::add("Return to the petition", "viewpetition.php?op=view&id=$petition");
 }
-    addnav("Operations");
-addnav("View last page hit", "user.php?op=lasthit&userid=$userid", false, true);
-addnav("Display debug log", "user.php?op=debuglog&userid=$userid$returnpetition");
-addnav("View user bio", "bio.php?char=" . $row['acctid'] . "&ret=" . urlencode($_SERVER['REQUEST_URI']));
+    Nav::add("Operations");
+Nav::add("View last page hit", "user.php?op=lasthit&userid=$userid", false, true);
+Nav::add("Display debug log", "user.php?op=debuglog&userid=$userid$returnpetition");
+Nav::add("View user bio", "bio.php?char=" . $row['acctid'] . "&ret=" . urlencode($_SERVER['REQUEST_URI']));
 if ($session['user']['superuser'] & SU_EDIT_DONATIONS) {
-    addnav("Add donation points", "donators.php?op=add1&name=" . rawurlencode($row['login']) . "&ret=" . urlencode($_SERVER['REQUEST_URI']));
+    Nav::add("Add donation points", "donators.php?op=add1&name=" . rawurlencode($row['login']) . "&ret=" . urlencode($_SERVER['REQUEST_URI']));
 }
-    addnav("", "user.php?op=edit&userid=$userid$returnpetition");
-addnav("Bans");
-addnav("Set up ban", "bans.php?op=setupban&userid={$row['acctid']}");
+    Nav::add("", "user.php?op=edit&userid=$userid$returnpetition");
+Nav::add("Bans");
+Nav::add("Set up ban", "bans.php?op=setupban&userid={$row['acctid']}");
 if (httpget("subop") == "") {
-    rawoutput("<form action='user.php?op=special&userid=$userid$returnpetition' method='POST'>");
-    addnav("", "user.php?op=special&userid=$userid$returnpetition");
-    $grant = translate_inline("Grant New Day");
-    rawoutput("<input type='submit' class='button' name='newday' value='$grant'>");
-    $fix = translate_inline("Fix Broken Navs");
-    rawoutput("<input type='submit' class='button' name='fixnavs' value='$fix'>");
-    $mark = translate_inline("Mark Email As Valid");
-    rawoutput("<input type='submit' class='button' name='clearvalidation' value='$mark'>");
-    rawoutput("</form>");
+    $output->rawOutput("<form action='user.php?op=special&userid=$userid$returnpetition' method='POST'>");
+    Nav::add("", "user.php?op=special&userid=$userid$returnpetition");
+    $grant = Translator::translateInline("Grant New Day");
+    $output->rawOutput("<input type='submit' class='button' name='newday' value='$grant'>");
+    $fix = Translator::translateInline("Fix Broken Navs");
+    $output->rawOutput("<input type='submit' class='button' name='fixnavs' value='$fix'>");
+    $mark = Translator::translateInline("Mark Email As Valid");
+    $output->rawOutput("<input type='submit' class='button' name='clearvalidation' value='$mark'>");
+    $output->rawOutput("</form>");
         //Show a user's usertable
-    rawoutput("<form action='user.php?op=save&userid=$userid$returnpetition' method='POST'>");
-    addnav("", "user.php?op=save&userid=$userid$returnpetition");
-    $save = translate_inline("Save");
-    rawoutput("<input type='submit' class='button' value='$save'>");
+    $output->rawOutput("<form action='user.php?op=save&userid=$userid$returnpetition' method='POST'>");
+    Nav::add("", "user.php?op=save&userid=$userid$returnpetition");
+    $save = Translator::translateInline("Save");
+    $output->rawOutput("<input type='submit' class='button' value='$save'>");
     if ($row['loggedin'] == 1 && $row['laston'] > date("Y-m-d H:i:s", strtotime("-" . getsetting("LOGINTIMEOUT", 900) . " seconds"))) {
-        output_notl("`\$");
-        rawoutput("<span style='font-size: 20px'>");
-        output("`\$Warning:`0");
-        rawoutput("</span>");
-        output("`\$This user is probably logged in at the moment!`0");
+        $output->outputNotl("`\$");
+        $output->rawOutput("<span style='font-size: 20px'>");
+        $output->output("`\$Warning:`0");
+        $output->rawOutput("</span>");
+        $output->output("`\$This user is probably logged in at the moment!`0");
     }
     //Add new composita attack
     $row['totalattack'] = PlayerFunctions::getPlayerAttack($row['acctid']);
@@ -66,17 +69,17 @@ if (httpget("subop") == "") {
     */
     $showformargs = modulehook("modifyuserview", array("userinfo" => $userinfo, "user" => $row));
     $info = Forms::showForm($showformargs['userinfo'], $showformargs['user']);
-    rawoutput("<input type='hidden' value=\"" . htmlentities(serialize($info), ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\" name='oldvalues'>");
-    rawoutput("</form>");
-        output("`n`nLast Page Viewed:`n");
-    rawoutput("<iframe src='user.php?op=lasthit&userid=$userid' width='100%' height='400'>");
-    output("You need iframes to view the user's last hit here.");
-    output("Use the link in the nav instead.");
-    rawoutput("</iframe>");
+    $output->rawOutput("<input type='hidden' value=\"" . htmlentities(serialize($info), ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\" name='oldvalues'>");
+    $output->rawOutput("</form>");
+        $output->output("`n`nLast Page Viewed:`n");
+    $output->rawOutput("<iframe src='user.php?op=lasthit&userid=$userid' width='100%' height='400'>");
+    $output->output("You need iframes to view the user's last hit here.");
+    $output->output("Use the link in the nav instead.");
+    $output->rawOutput("</iframe>");
 } elseif (httpget("subop") == "module") {
     //Show a user's prefs for a given module.
-    addnav("Operations");
-    addnav("Edit user", "user.php?op=edit&userid=$userid$returnpetition");
+    Nav::add("Operations");
+    Nav::add("Edit user", "user.php?op=edit&userid=$userid$returnpetition");
     $module = httpget('module');
     $info = get_module_info($module);
     if (count($info['prefs']) > 0) {
@@ -103,15 +106,15 @@ if (httpget("subop") == "") {
         while ($row = db_fetch_assoc($result)) {
             $data[$row['setting']] = $row['value'];
         }
-        rawoutput("<form action='user.php?op=savemodule&module=$module&userid=$userid$returnpetition' method='POST'>");
-        addnav("", "user.php?op=savemodule&module=$module&userid=$userid$returnpetition");
+        $output->rawOutput("<form action='user.php?op=savemodule&module=$module&userid=$userid$returnpetition' method='POST'>");
+        Nav::add("", "user.php?op=savemodule&module=$module&userid=$userid$returnpetition");
         tlschema("module-$module");
         Forms::showForm($msettings, $data);
         tlschema();
-        rawoutput("</form>");
+        $output->rawOutput("</form>");
     } else {
-        output("The $module module doesn't appear to define any user preferences.");
+        $output->output("The $module module doesn't appear to define any user preferences.");
     }
 }
-module_editor_navs('prefs', "user.php?op=edit&subop=module&userid=$userid$returnpetition&module=");
-addnav("", "user.php?op=lasthit&userid=$userid");
+Modules::editorNavs('prefs', "user.php?op=edit&subop=module&userid=$userid$returnpetition&module=");
+Nav::add("", "user.php?op=lasthit&userid=$userid");

--- a/pages/user/user_removeban.php
+++ b/pages/user/user_removeban.php
@@ -1,8 +1,11 @@
 <?php
 declare(strict_types=1);
 
+use Lotgd\Nav;
+use Lotgd\Translator;
+
 $subop = httpget("subop");
-$none = translate_inline('NONE');
+$none = Translator::translateInline('NONE');
 if ($subop == "xml") {
     header("Content-Type: text/xml");
     $sql = "SELECT DISTINCT " . db_prefix("accounts") . ".name FROM " . db_prefix("bans") . ", " . db_prefix("accounts") . " WHERE (ipfilter='" . addslashes(httpget("ip")) . "' AND " .
@@ -35,52 +38,52 @@ if (httpget('notbefore')) {
 
 if ($duration == "") {
     $since = " WHERE banexpire $operator '" . date("Y-m-d H:i:s", strtotime("+2 weeks")) . "' AND banexpire > '0000-00-00 00:00:00'";
-        output("`bShowing bans that will expire within 2 weeks.`b`n`n");
+        $output->output("`bShowing bans that will expire within 2 weeks.`b`n`n");
 } else {
     if ($duration == "forever") {
         $since = " WHERE banexpire='0000-00-00 00:00:00'";
-        output("`bShowing all permanent bans`b`n`n");
+        $output->output("`bShowing all permanent bans`b`n`n");
     } elseif ($duration == "all") {
         $since = "";
-        output("`bShowing all bans`b`n`n");
+        $output->output("`bShowing all bans`b`n`n");
     } else {
         $since = " WHERE banexpire $operator '" . date("Y-m-d H:i:s", strtotime("+" . $duration)) . "' AND banexpire > '0000-00-00 00:00:00'";
-        output("`bShowing bans that will expire within %s.`b`n`n", $duration);
+        $output->output("`bShowing bans that will expire within %s.`b`n`n", $duration);
     }
 }
-addnav("Perma-Bans");
-addnav("Show", "user.php?op=removeban&duration=forever");
-addnav("Will Expire Within");
-addnav("1 week", "user.php?op=removeban&duration=1+week");
-addnav("2 weeks", "user.php?op=removeban&duration=2+weeks");
-addnav("3 weeks", "user.php?op=removeban&duration=3+weeks");
-addnav("4 weeks", "user.php?op=removeban&duration=4+weeks");
-addnav("2 months", "user.php?op=removeban&duration=2+months");
-addnav("3 months", "user.php?op=removeban&duration=3+months");
-addnav("4 months", "user.php?op=removeban&duration=4+months");
-addnav("5 months", "user.php?op=removeban&duration=5+months");
-addnav("6 months", "user.php?op=removeban&duration=6+months");
-addnav("1 year", "user.php?op=removeban&duration=1+year");
-addnav("2 years", "user.php?op=removeban&duration=2+years");
-addnav("4 years", "user.php?op=removeban&duration=4+years");
-addnav("Show all", "user.php?op=removeban&duration=all");
-addnav("Will Expire not before");
-addnav("1 week", "user.php?op=removeban&duration=1+week&notbefore=1");
-addnav("2 weeks", "user.php?op=removeban&duration=2+weeks&notbefore=1");
-addnav("3 weeks", "user.php?op=removeban&duration=3+weeks&notbefore=1");
-addnav("4 weeks", "user.php?op=removeban&duration=4+weeks&notbefore=1");
-addnav("2 months", "user.php?op=removeban&duration=2+months&notbefore=1");
-addnav("3 months", "user.php?op=removeban&duration=3+months&notbefore=1");
-addnav("4 months", "user.php?op=removeban&duration=4+months&notbefore=1");
-addnav("5 months", "user.php?op=removeban&duration=5+months&notbefore=1");
-addnav("6 months", "user.php?op=removeban&duration=6+months&notbefore=1");
-addnav("1 year", "user.php?op=removeban&duration=1+year&notbefore=1");
-addnav("2 years", "user.php?op=removeban&duration=2+years&notbefore=1");
-addnav("4 years", "user.php?op=removeban&duration=4+years&notbefore=1");
+Nav::add("Perma-Bans");
+Nav::add("Show", "user.php?op=removeban&duration=forever");
+Nav::add("Will Expire Within");
+Nav::add("1 week", "user.php?op=removeban&duration=1+week");
+Nav::add("2 weeks", "user.php?op=removeban&duration=2+weeks");
+Nav::add("3 weeks", "user.php?op=removeban&duration=3+weeks");
+Nav::add("4 weeks", "user.php?op=removeban&duration=4+weeks");
+Nav::add("2 months", "user.php?op=removeban&duration=2+months");
+Nav::add("3 months", "user.php?op=removeban&duration=3+months");
+Nav::add("4 months", "user.php?op=removeban&duration=4+months");
+Nav::add("5 months", "user.php?op=removeban&duration=5+months");
+Nav::add("6 months", "user.php?op=removeban&duration=6+months");
+Nav::add("1 year", "user.php?op=removeban&duration=1+year");
+Nav::add("2 years", "user.php?op=removeban&duration=2+years");
+Nav::add("4 years", "user.php?op=removeban&duration=4+years");
+Nav::add("Show all", "user.php?op=removeban&duration=all");
+Nav::add("Will Expire not before");
+Nav::add("1 week", "user.php?op=removeban&duration=1+week&notbefore=1");
+Nav::add("2 weeks", "user.php?op=removeban&duration=2+weeks&notbefore=1");
+Nav::add("3 weeks", "user.php?op=removeban&duration=3+weeks&notbefore=1");
+Nav::add("4 weeks", "user.php?op=removeban&duration=4+weeks&notbefore=1");
+Nav::add("2 months", "user.php?op=removeban&duration=2+months&notbefore=1");
+Nav::add("3 months", "user.php?op=removeban&duration=3+months&notbefore=1");
+Nav::add("4 months", "user.php?op=removeban&duration=4+months&notbefore=1");
+Nav::add("5 months", "user.php?op=removeban&duration=5+months&notbefore=1");
+Nav::add("6 months", "user.php?op=removeban&duration=6+months&notbefore=1");
+Nav::add("1 year", "user.php?op=removeban&duration=1+year&notbefore=1");
+Nav::add("2 years", "user.php?op=removeban&duration=2+years&notbefore=1");
+Nav::add("4 years", "user.php?op=removeban&duration=4+years&notbefore=1");
 
 $sql = "SELECT * FROM " . db_prefix("bans") . " $since ORDER BY banexpire ASC";
 $result = db_query($sql);
-rawoutput("<script language='JavaScript'>
+$output->rawOutput("<script language='JavaScript'>
 function getUserInfo(ip,id,divid){
 	var filename='user.php?op=removeban&subop=xml&ip='+ip+'&id='+id;
 	//set up the DOM object
@@ -103,30 +106,30 @@ function getUserInfo(ip,id,divid){
 }
 </script>
 ");
-rawoutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
-$ops = translate_inline("Ops");
-$bauth = translate_inline("Ban Author");
-$ipd = translate_inline("IP/ID");
-$dur = translate_inline("Duration");
-$mssg = translate_inline("Message");
-$aff = translate_inline("Affects");
-$l = translate_inline("Last");
-    rawoutput("<tr class='trhead'><td>$ops</td><td>$bauth</td><td>$ipd</td><td>$dur</td><td>$mssg</td><td>$aff</td><td>$l</td></tr>");
+$output->rawOutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
+$ops = Translator::translateInline("Ops");
+$bauth = Translator::translateInline("Ban Author");
+$ipd = Translator::translateInline("IP/ID");
+$dur = Translator::translateInline("Duration");
+$mssg = Translator::translateInline("Message");
+$aff = Translator::translateInline("Affects");
+$l = Translator::translateInline("Last");
+    $output->rawOutput("<tr class='trhead'><td>$ops</td><td>$bauth</td><td>$ipd</td><td>$dur</td><td>$mssg</td><td>$aff</td><td>$l</td></tr>");
 $i = 0;
 while ($row = db_fetch_assoc($result)) {
-    $liftban = translate_inline("Lift&nbsp;ban");
-    $showuser = translate_inline("Click&nbsp;to&nbsp;show&nbsp;users");
-    rawoutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'>");
-    rawoutput("<td><a href='user.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']) . "'>");
-    output_notl("%s", $liftban, true);
-    rawoutput("</a>");
-    addnav("", "user.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']));
-    rawoutput("</td><td>");
-    output_notl("`&%s`0", $row['banner']);
-    rawoutput("</td><td>");
-    output_notl("%s", $row['ipfilter']);
-    output_notl("%s", $row['uniqueid']);
-    rawoutput("</td><td>");
+    $liftban = Translator::translateInline("Lift&nbsp;ban");
+    $showuser = Translator::translateInline("Click&nbsp;to&nbsp;show&nbsp;users");
+    $output->rawOutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'>");
+    $output->rawOutput("<td><a href='user.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']) . "'>");
+    $output->outputNotl("%s", $liftban, true);
+    $output->rawOutput("</a>");
+    Nav::add("", "user.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']));
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("`&%s`0", $row['banner']);
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("%s", $row['ipfilter']);
+    $output->outputNotl("%s", $row['uniqueid']);
+    $output->rawOutput("</td><td>");
         // "43200" used so will basically round to nearest day rather than floor number of days
 
     $expire = sprintf_translate(
@@ -134,32 +137,32 @@ while ($row = db_fetch_assoc($result)) {
         round((strtotime($row['banexpire']) + 43200 - strtotime("now")) / 86400, 0)
     );
     if (substr($expire, 0, 2) == "1 ") {
-        $expire = translate_inline("1 day");
+        $expire = Translator::translateInline("1 day");
     }
     if (date("Y-m-d", strtotime($row['banexpire'])) == date("Y-m-d")) {
-        $expire = translate_inline("Today");
+        $expire = Translator::translateInline("Today");
     }
     if (
         date("Y-m-d", strtotime($row['banexpire'])) ==
             date("Y-m-d", strtotime("1 day"))
     ) {
-        $expire = translate_inline("Tomorrow");
+        $expire = Translator::translateInline("Tomorrow");
     }
     if ($row['banexpire'] == "0000-00-00 00:00:00") {
-        $expire = translate_inline("Never");
+        $expire = Translator::translateInline("Never");
     }
-    output_notl("%s", $expire);
-    rawoutput("</td><td>");
-    output_notl("%s", $row['banreason']);
-    rawoutput("</td><td>");
+    $output->outputNotl("%s", $expire);
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("%s", $row['banreason']);
+    $output->rawOutput("</td><td>");
     $file = "user.php?op=removeban&subop=xml&ip={$row['ipfilter']}&id={$row['uniqueid']}";
-    rawoutput("<div id='user$i'><a href='$file' target='_blank' onClick=\"getUserInfo('{$row['ipfilter']}','{$row['uniqueid']}',$i); return false;\">");
-    output_notl("%s", $showuser, true);
-    rawoutput("</a></div>");
-    addnav("", $file);
-    rawoutput("</td><td>");
-    output_notl("%s", relativedate($row['lasthit']));
-    rawoutput("</td></tr>");
+    $output->rawOutput("<div id='user$i'><a href='$file' target='_blank' onClick=\"getUserInfo('{$row['ipfilter']}','{$row['uniqueid']}',$i); return false;\">");
+    $output->outputNotl("%s", $showuser, true);
+    $output->rawOutput("</a></div>");
+    Nav::add("", $file);
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("%s", relativedate($row['lasthit']));
+    $output->rawOutput("</td></tr>");
     $i++;
 }
-rawoutput("</table>");
+$output->rawOutput("</table>");

--- a/pages/user/user_save.php
+++ b/pages/user/user_save.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Lotgd\Names;
+use Lotgd\Nav;
 
 $sql = "";
 $updates = 0;
@@ -27,14 +28,14 @@ if (!isset($oldvalues['playername']) || $oldvalues['playername'] == '') {
     }
 }
 // End Naming
-output_notl("`n");
+$output->outputNotl("`n");
 foreach ($post as $key => $val) {
     if (isset($userinfo[$key])) {
         if ($key == "newpassword") {
             if ($val > "") {
                 $sql .= "password=\"" . md5(md5($val)) . "\",";
                 $updates++;
-                output("`\$Password value has been updated.`0`n");
+                $output->output("`\$Password value has been updated.`0`n");
                 debuglog($session['user']['name'] . "`0 changed password to $val", $userid);
                 if ($session['user']['acctid'] == $userid) {
                     $session['user']['password'] = md5(md5($val));
@@ -59,7 +60,7 @@ foreach ($post as $key => $val) {
             if ((int)$value != (int)$oldvalues['superuser']) {
                 $sql .= "$key = \"$value\",";
                 $updates++;
-                output("`\$Superuser values have changed.`0`n");
+                $output->output("`\$Superuser values have changed.`0`n");
                 if ($session['user']['acctid'] == $userid) {
                     $session['user']['superuser'] = $value;
                 }
@@ -76,16 +77,16 @@ foreach ($post as $key => $val) {
             $tmp = preg_replace("/[`][cHw]/", "", $tmp);
             $tmp = sanitize_html($tmp);
             if ($tmp != stripslashes($val)) {
-                output("`\$Illegal characters removed from player name!`0`n");
+                $output->output("`\$Illegal characters removed from player name!`0`n");
             }
             if (soap($tmp) != ($tmp)) {
-                output("`^The new name doesn't pass the bad word filter!`0");
+                $output->output("`^The new name doesn't pass the bad word filter!`0");
             }
             debug($tmp);
             $newname = Names::changePlayerName($tmp, $oldvalues);
             debug($newname);
             $sql .= "$key = \"" . addslashes($newname) . "\",";
-            output("`2Changed player name to %s`0`n", $newname);
+            $output->output("`2Changed player name to %s`0`n", $newname);
             debuglog($session['user']['name'] . "`0 changed player name to $newname`0", $userid);
             $oldvalues['name'] = $newname;
             if ($session['user']['acctid'] == $userid) {
@@ -97,18 +98,18 @@ foreach ($post as $key => $val) {
             $tmp = preg_replace("/[`][cHw]/", "", $tmp);
             $tmp = sanitize_html($tmp);
             if ($tmp != stripslashes($val)) {
-                output("`\$Illegal characters removed from player title!`0`n");
+                $output->output("`\$Illegal characters removed from player title!`0`n");
             }
             if (soap($tmp) != ($tmp)) {
-                output("`^The new title doesn't pass the bad word filter!`0");
+                $output->output("`^The new title doesn't pass the bad word filter!`0");
             }
                 $newname = Names::changePlayerTitle($tmp, $oldvalues);
             $sql .= "$key = \"$val\",";
-            output("Changed player title from %s`0 to %s`0`n", $oldvalues['title'], $tmp);
+            $output->output("Changed player title from %s`0 to %s`0`n", $oldvalues['title'], $tmp);
             $oldvalues[$key] = $tmp;
             if ($newname != $oldvalues['name']) {
                 $sql .= "name = \"" . addslashes($newname) . "\",";
-                output("`2Changed player name to %s`2 due to changed dragonkill title`n", $newname);
+                $output->output("`2Changed player name to %s`2 due to changed dragonkill title`n", $newname);
                 debuglog($session['user']['name'] . "`0 changed player name to $newname`0 due to changed dragonkill title", $userid);
                 $oldvalues['name'] = $newname;
                 if ($session['user']['acctid'] == $userid) {
@@ -124,14 +125,14 @@ foreach ($post as $key => $val) {
             $tmp = preg_replace("/[`][cHw]/", "", $tmp);
             $tmp = sanitize_html($tmp);
             if ($tmp != stripslashes($val)) {
-                output("`\$Illegal characters removed from custom title!`0`n");
+                $output->output("`\$Illegal characters removed from custom title!`0`n");
             }
             if (soap($tmp) != ($tmp)) {
-                output("`^The new custom title doesn't pass the bad word filter!`0");
+                $output->output("`^The new custom title doesn't pass the bad word filter!`0");
             }
             $newname = Names::changePlayerCtitle($tmp, $oldvalues);
             $sql .= "$key = \"$val\",";
-            output("`2Changed player ctitle from `\$%s`2 to `\$%s`2`n", $oldvalues['ctitle'], $tmp);
+            $output->output("`2Changed player ctitle from `\$%s`2 to `\$%s`2`n", $oldvalues['ctitle'], $tmp);
             $oldvalues[$key] = $tmp;
             if ($newname != $oldvalues['name']) {
                 $sql .= "name = \"" . addslashes($newname) . "\",";
@@ -139,7 +140,7 @@ foreach ($post as $key => $val) {
                     //no valid title currently, add update
                     $post['playername'] = Names::getPlayerBasename($tmp);
                 }
-                output("`2Changed player name to `\$%s`2 due to changed custom title`n", $newname);
+                $output->output("`2Changed player name to `\$%s`2 due to changed custom title`n", $newname);
                 debuglog($session['user']['name'] . "`0 changed player name to $newname`0 due to changed custom title", $userid);
                 $oldvalues['name'] = $newname;
                 if ($session['user']['acctid'] == $userid) {
@@ -155,16 +156,16 @@ foreach ($post as $key => $val) {
             $tmp = preg_replace("/[`][cHw]/", "", $tmp);
             $tmp = sanitize_html($tmp);
             if ($tmp != stripslashes($val)) {
-                output("`\$Illegal characters removed from playername!`0`n");
+                $output->output("`\$Illegal characters removed from playername!`0`n");
             }
             if (soap($tmp) != ($tmp)) {
-                output("`^The new playername doesn't pass the bad word filter!`0");
+                $output->output("`^The new playername doesn't pass the bad word filter!`0");
             }
             debug($tmp);
             $newname = Names::changePlayerName($tmp, $oldvalues);
             debug($newname);
             $sql .= "$key = \"$val\",";
-            output("`2Changed player name from `\$%s`2 to `\$%s`2`n", $oldvalues['playername'], $tmp);
+            $output->output("`2Changed player name from `\$%s`2 to `\$%s`2`n", $oldvalues['playername'], $tmp);
             $oldvalues[$key] = $tmp;
             if ($newname != $oldvalues['name']) {
                 $sql .= "name = \"" . addslashes($newname) . "\",";
@@ -185,7 +186,7 @@ foreach ($post as $key => $val) {
             }
             $sql .= "$key = \"$val\",";
             $updates++;
-            output("`2 Value `\$'%s`2' has changed to '`\$%s`2'.`n", $key, stripslashes($val));
+            $output->output("`2 Value `\$'%s`2' has changed to '`\$%s`2'.`n", $key, stripslashes($val));
             debuglog($session['user']['name'] . "`0 changed $key from {$oldvalues[$key]} to $val", $userid);
             if ($session['user']['acctid'] == $userid) {
                 $session['user'][$key] = stripslashes($val);
@@ -197,15 +198,15 @@ foreach ($post as $key => $val) {
 $sql = "UPDATE " . db_prefix("accounts") . " SET " . $sql . " WHERE acctid=\"$userid\"";
     $petition = httpget("returnpetition");
 if ($petition != "") {
-    addnav("", "viewpetition.php?op=view&id=$petition");
+    Nav::add("", "viewpetition.php?op=view&id=$petition");
 }
-addnav("", "user.php");
+Nav::add("", "user.php");
 if ($updates > 0) {
     db_query($sql);
     debug("Updated $updates fields in the user record with:\n$sql");
-    output("%s fields in the user's record were updated.", $updates);
+    $output->output("%s fields in the user's record were updated.", $updates);
 } else {
-    output("No fields were changed in the user's record.");
+    $output->output("No fields were changed in the user's record.");
 }
 $op = "edit";
 httpset($op, "edit");

--- a/pages/user/user_saveban.php
+++ b/pages/user/user_saveban.php
@@ -34,20 +34,20 @@ if ($type == "ip") {
             httppost("ip")
     ) {
         $sql = "";
-        output("You don't really want to ban yourself now do you??");
-        output("That's your own IP address!");
+        $output->output("You don't really want to ban yourself now do you??");
+        $output->output("That's your own IP address!");
     }
 } else {
     if (Cookies::getLgi() == httppost("id")) {
             $sql = "";
-            output("You don't really want to ban yourself now do you??");
-            output("That's your own ID!");
+            $output->output("You don't really want to ban yourself now do you??");
+            $output->output("That's your own ID!");
     }
 }
 if ($sql != "") {
     $result = db_query($sql);
-    output("%s ban rows entered.`n`n", db_affected_rows($result));
-    output_notl("%s", db_error(LINK));
+    $output->output("%s ban rows entered.`n`n", db_affected_rows($result));
+    $output->outputNotl("%s", db_error(LINK));
     debuglog("entered a ban: " .  ($type == "ip" ?  "IP: " . httppost("ip") : "ID: " . httppost("id")) . " Ends after: $duration  Reason: \"" .  httppost("reason") . "\"");
     /* log out affected players */
     $sql = "SELECT acctid FROM " . db_prefix('accounts') . " WHERE $key='$key_value'";
@@ -60,11 +60,11 @@ if ($sql != "") {
         $sql = " UPDATE " . db_prefix('accounts') . " SET loggedin=0 WHERE acctid IN (" . implode(",", $acctids) . ")";
         $result = db_query($sql);
         if ($result) {
-            output("`\$%s people have been logged out!`n`n`0", db_affected_rows($result));
+            $output->output("`\$%s people have been logged out!`n`n`0", db_affected_rows($result));
         } else {
-            output("`\$Nobody was logged out. Acctids (%s) did not return rows!`n`n`0", implode(",", $acctids));
+            $output->output("`\$Nobody was logged out. Acctids (%s) did not return rows!`n`n`0", implode(",", $acctids));
         }
     } else {
-        output("`\$No account-ids found for that IP/ID!`n`n`0");
+        $output->output("`\$No account-ids found for that IP/ID!`n`n`0");
     }
 }

--- a/pages/user/user_savemodule.php
+++ b/pages/user/user_savemodule.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+use Lotgd\Translator;
+
 //save module settings.
 $userid = (int)httpget('userid');
 $module = httpget('module');
@@ -9,13 +11,13 @@ $post = modulehook("validateprefs", $post, true, $module);
 if (isset($post['validation_error']) && $post['validation_error']) {
     tlschema("module-$module");
     $post['validation_error'] =
-        translate_inline($post['validation_error']);
+        Translator::translateInline($post['validation_error']);
     tlschema();
-    output("Unable to change settings: `\$%s`0", $post['validation_error']);
+    $output->output("Unable to change settings: `\$%s`0", $post['validation_error']);
 } else {
-    output_notl("`n");
+    $output->outputNotl("`n");
     foreach ($post as $key => $val) {
-        output("`\$Setting '`2%s`\$' to '`2%s`\$'`n", $key, htmlspecialchars($val, ENT_QUOTES, 'UTF-8'));
+        $output->output("`\$Setting '`2%s`\$' to '`2%s`\$'`n", $key, htmlspecialchars($val, ENT_QUOTES, 'UTF-8'));
                $sql = "REPLACE INTO " . db_prefix("module_userprefs") .
                        " (modulename,userid,setting,value) VALUES ('" .
                        db_real_escape_string($module) . "',$userid,'" .
@@ -23,7 +25,7 @@ if (isset($post['validation_error']) && $post['validation_error']) {
                        db_real_escape_string($val) . "')";
         db_query($sql);
     }
-    output("`^Preferences for module %s saved.`n", $module);
+    $output->output("`^Preferences for module %s saved.`n", $module);
 }
 $op = "edit";
 httpset("op", "edit");

--- a/pages/user/user_searchban.php
+++ b/pages/user/user_searchban.php
@@ -2,9 +2,11 @@
 declare(strict_types=1);
 
 use Lotgd\UserLookup;
+use Lotgd\Nav;
+use Lotgd\Translator;
 
 $subop = httpget("subop");
-$none = translate_inline('NONE');
+$none = Translator::translateInline('NONE');
 if ($subop == "xml") {
     header("Content-Type: text/xml");
     $sql = "SELECT DISTINCT " . db_prefix("accounts") . ".name FROM " . db_prefix("bans") . ", " . db_prefix("accounts") . " WHERE (ipfilter='" . addslashes(httpget("ip")) . "' AND " .
@@ -32,13 +34,13 @@ $operator = "<=";
 
 $target = httppost('target');
 $since = 'WHERE 0';
-$submit = translate_inline("Search");
+$submit = Translator::translateInline("Search");
 if ($target == '') {
-    rawoutput("<form action='user.php?op=searchban' method='POST'>");
-    addnav("", "user.php?op=searchban");
-    output("Search banned user by name: ");
-    rawoutput("<input name='target' value='$target'>");
-    rawoutput("<input type='submit' class='button' value='$submit'></from><br><br>");
+    $output->rawOutput("<form action='user.php?op=searchban' method='POST'>");
+    Nav::add("", "user.php?op=searchban");
+    $output->output("Search banned user by name: ");
+    $output->rawOutput("<input name='target' value='$target'>");
+    $output->rawOutput("<input type='submit' class='button' value='$submit'></from><br><br>");
 } elseif (is_numeric($target)) {
     //none
     $sql = "SELECT lastip,uniqueid FROM accounts WHERE acctid=" . $target;
@@ -48,23 +50,23 @@ if ($target == '') {
 } else {
     $names = UserLookup::lookup($target);
     if ($names[0] !== false) {
-        rawoutput("<form action='user.php?op=searchban' method='POST'>");
-        addnav("", "user.php?op=searchban");
-                rawoutput("<label for='target'>");
-                output("Search banned user by name: ");
-                rawoutput("</label>");
-                rawoutput("<select name='target' id='target'>");
+        $output->rawOutput("<form action='user.php?op=searchban' method='POST'>");
+        Nav::add("", "user.php?op=searchban");
+                $output->rawOutput("<label for='target'>");
+                $output->output("Search banned user by name: ");
+                $output->rawOutput("</label>");
+                $output->rawOutput("<select name='target' id='target'>");
         while ($row = db_fetch_assoc($names[0])) {
-            rawoutput("<option value='" . $row['acctid'] . "'>" . $row['login'] . "</option>");
+            $output->rawOutput("<option value='" . $row['acctid'] . "'>" . $row['login'] . "</option>");
         }
-        rawoutput("</select>");
-        rawoutput("<input type='submit' class='button' value='$submit'></from><br><br>");
+        $output->rawOutput("</select>");
+        $output->rawOutput("<input type='submit' class='button' value='$submit'></from><br><br>");
     }
 }
 
 $sql = "SELECT * FROM " . db_prefix("bans") . " $since ORDER BY banexpire ASC";
 $result = db_query($sql);
-rawoutput("<script language='JavaScript'>
+$output->rawOutput("<script language='JavaScript'>
 function getUserInfo(ip,id,divid){
 	var filename='user.php?op=removeban&subop=xml&ip='+ip+'&id='+id;
 	//set up the DOM object
@@ -87,30 +89,30 @@ function getUserInfo(ip,id,divid){
 }
 </script>
 ");
-rawoutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
-$ops = translate_inline("Ops");
-$bauth = translate_inline("Ban Author");
-$ipd = translate_inline("IP/ID");
-$dur = translate_inline("Duration");
-$mssg = translate_inline("Message");
-$aff = translate_inline("Affects");
-$l = translate_inline("Last");
-    rawoutput("<tr class='trhead'><td>$ops</td><td>$bauth</td><td>$ipd</td><td>$dur</td><td>$mssg</td><td>$aff</td><td>$l</td></tr>");
+$output->rawOutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
+$ops = Translator::translateInline("Ops");
+$bauth = Translator::translateInline("Ban Author");
+$ipd = Translator::translateInline("IP/ID");
+$dur = Translator::translateInline("Duration");
+$mssg = Translator::translateInline("Message");
+$aff = Translator::translateInline("Affects");
+$l = Translator::translateInline("Last");
+    $output->rawOutput("<tr class='trhead'><td>$ops</td><td>$bauth</td><td>$ipd</td><td>$dur</td><td>$mssg</td><td>$aff</td><td>$l</td></tr>");
 $i = 0;
 while ($row = db_fetch_assoc($result)) {
-    $liftban = translate_inline("Lift&nbsp;ban");
-    $showuser = translate_inline("Click&nbsp;to&nbsp;show&nbsp;users");
-    rawoutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'>");
-    rawoutput("<td><a href='user.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']) . "'>");
-    output_notl("%s", $liftban, true);
-    rawoutput("</a>");
-    addnav("", "user.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']));
-    rawoutput("</td><td>");
-    output_notl("`&%s`0", $row['banner']);
-    rawoutput("</td><td>");
-    output_notl("%s", $row['ipfilter']);
-    output_notl("%s", $row['uniqueid']);
-    rawoutput("</td><td>");
+    $liftban = Translator::translateInline("Lift&nbsp;ban");
+    $showuser = Translator::translateInline("Click&nbsp;to&nbsp;show&nbsp;users");
+    $output->rawOutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'>");
+    $output->rawOutput("<td><a href='user.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']) . "'>");
+    $output->outputNotl("%s", $liftban, true);
+    $output->rawOutput("</a>");
+    Nav::add("", "user.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']));
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("`&%s`0", $row['banner']);
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("%s", $row['ipfilter']);
+    $output->outputNotl("%s", $row['uniqueid']);
+    $output->rawOutput("</td><td>");
         // "43200" used so will basically round to nearest day rather than floor number of days
 
     $expire = sprintf_translate(
@@ -118,32 +120,32 @@ while ($row = db_fetch_assoc($result)) {
         round((strtotime($row['banexpire']) + 43200 - strtotime("now")) / 86400, 0)
     );
     if (substr($expire, 0, 2) == "1 ") {
-        $expire = translate_inline("1 day");
+        $expire = Translator::translateInline("1 day");
     }
     if (date("Y-m-d", strtotime($row['banexpire'])) == date("Y-m-d")) {
-        $expire = translate_inline("Today");
+        $expire = Translator::translateInline("Today");
     }
     if (
         date("Y-m-d", strtotime($row['banexpire'])) ==
             date("Y-m-d", strtotime("1 day"))
     ) {
-        $expire = translate_inline("Tomorrow");
+        $expire = Translator::translateInline("Tomorrow");
     }
     if ($row['banexpire'] == "0000-00-00 00:00:00") {
-        $expire = translate_inline("Never");
+        $expire = Translator::translateInline("Never");
     }
-    output_notl("%s", $expire);
-    rawoutput("</td><td>");
-    output_notl("%s", $row['banreason']);
-    rawoutput("</td><td>");
+    $output->outputNotl("%s", $expire);
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("%s", $row['banreason']);
+    $output->rawOutput("</td><td>");
     $file = "user.php?op=removeban&subop=xml&ip={$row['ipfilter']}&id={$row['uniqueid']}";
-    rawoutput("<div id='user$i'><a href='$file' target='_blank' onClick=\"getUserInfo('{$row['ipfilter']}','{$row['uniqueid']}',$i); return false;\">");
-    output_notl("%s", $showuser, true);
-    rawoutput("</a></div>");
-    addnav("", $file);
-    rawoutput("</td><td>");
-    output_notl("%s", relativedate($row['lasthit']));
-    rawoutput("</td></tr>");
+    $output->rawOutput("<div id='user$i'><a href='$file' target='_blank' onClick=\"getUserInfo('{$row['ipfilter']}','{$row['uniqueid']}',$i); return false;\">");
+    $output->outputNotl("%s", $showuser, true);
+    $output->rawOutput("</a></div>");
+    Nav::add("", $file);
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("%s", relativedate($row['lasthit']));
+    $output->rawOutput("</td></tr>");
     $i++;
 }
-rawoutput("</table>");
+$output->rawOutput("</table>");

--- a/pages/user/user_setupban.php
+++ b/pages/user/user_setupban.php
@@ -1,47 +1,50 @@
 <?php
 declare(strict_types=1);
 
+use Lotgd\Nav;
+use Lotgd\Translator;
+
 $sql = "SELECT name,lastip,uniqueid FROM " . db_prefix("accounts") . " WHERE acctid=\"$userid\"";
 $result = db_query($sql);
 $row = db_fetch_assoc($result);
 if ($row['name'] != "") {
-    output("Setting up ban information based on `\$%s`0", $row['name']);
+    $output->output("Setting up ban information based on `\$%s`0", $row['name']);
 }
-rawoutput("<form action='user.php?op=saveban' method='POST'>");
-output("Set up a new ban by IP or by ID (recommended IP, though if you have several different users behind a NAT, you can try ID which is easily defeated)`n");
-rawoutput("<input type='radio' value='ip' id='ipradio' name='type' checked>");
-output("IP: ");
-rawoutput("<input name='ip' id='ip' value=\"" . HTMLEntities($row['lastip'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\">");
-output_notl("`n");
-rawoutput("<input type='radio' value='id' name='type'>");
-output("ID: ");
-rawoutput("<input name='id' value=\"" . HTMLEntities($row['uniqueid'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\">");
-output("`nDuration: ");
-rawoutput("<input name='duration' id='duration' size='3' value='14'>");
-output("Days (0 for permanent)`n");
+$output->rawOutput("<form action='user.php?op=saveban' method='POST'>");
+$output->output("Set up a new ban by IP or by ID (recommended IP, though if you have several different users behind a NAT, you can try ID which is easily defeated)`n");
+$output->rawOutput("<input type='radio' value='ip' id='ipradio' name='type' checked>");
+$output->output("IP: ");
+$output->rawOutput("<input name='ip' id='ip' value=\"" . HTMLEntities($row['lastip'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\">");
+$output->outputNotl("`n");
+$output->rawOutput("<input type='radio' value='id' name='type'>");
+$output->output("ID: ");
+$output->rawOutput("<input name='id' value=\"" . HTMLEntities($row['uniqueid'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\">");
+$output->output("`nDuration: ");
+$output->rawOutput("<input name='duration' id='duration' size='3' value='14'>");
+$output->output("Days (0 for permanent)`n");
 $reason = httpget("reason");
 if ($reason == "") {
-    $reason = translate_inline("Don't mess with me.");
+    $reason = Translator::translateInline("Don't mess with me.");
 }
-output("Reason for the ban: ");
-rawoutput("<input name='reason' size=50 value=\"$reason\">");
-output_notl("`n");
-$pban = translate_inline("Post ban");
-$conf = translate_inline("Are you sure you wish to issue a permanent ban?");
-rawoutput("<input type='submit' class='button' value='$pban' onClick='if (document.getElementById(\"duration\").value==0) {return confirm(\"$conf\");} else {return true;}'>");
-rawoutput("</form>");
-output("For an IP ban, enter the beginning part of the IP you wish to ban if you wish to ban a range, or simply a full IP to ban a single IP`n`n");
-addnav("", "user.php?op=saveban");
+$output->output("Reason for the ban: ");
+$output->rawOutput("<input name='reason' size=50 value=\"$reason\">");
+$output->outputNotl("`n");
+$pban = Translator::translateInline("Post ban");
+$conf = Translator::translateInline("Are you sure you wish to issue a permanent ban?");
+$output->rawOutput("<input type='submit' class='button' value='$pban' onClick='if (document.getElementById(\"duration\").value==0) {return confirm(\"$conf\");} else {return true;}'>");
+$output->rawOutput("</form>");
+$output->output("For an IP ban, enter the beginning part of the IP you wish to ban if you wish to ban a range, or simply a full IP to ban a single IP`n`n");
+Nav::add("", "user.php?op=saveban");
 if ($row['name'] != "") {
     $id = $row['uniqueid'];
     $ip = $row['lastip'];
     $name = $row['name'];
-    output("`0To help locate similar users to `@%s`0, here are some other users who are close:`n", $name);
-    output("`bSame ID (%s):`b`n", $id);
+    $output->output("`0To help locate similar users to `@%s`0, here are some other users who are close:`n", $name);
+    $output->output("`bSame ID (%s):`b`n", $id);
     $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . db_prefix("accounts") . " WHERE uniqueid='" . addslashes($id) . "' ORDER BY lastip";
     $result = db_query($sql);
     while ($row = db_fetch_assoc($result)) {
-        output(
+        $output->output(
             "`0• (%s) `%%s`0 - %s hits, last: %s`n",
             $row['lastip'],
             $row['name'],
@@ -49,27 +52,27 @@ if ($row['name'] != "") {
             reltime(strtotime($row['laston']))
         );
     }
-    output_notl("`n");
+    $output->outputNotl("`n");
         $oip = "";
     $dots = 0;
-    output("`bSimilar IP's`b`n");
+    $output->output("`bSimilar IP's`b`n");
     for ($x = strlen($ip); $x > 0; $x--) {
         if ($dots > 1) {
             break;
         }
         $thisip = substr($ip, 0, $x);
         $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . db_prefix("accounts") . " WHERE lastip LIKE '$thisip%' AND NOT (lastip LIKE '$oip') ORDER BY uniqueid";
-        //output("$sql`n");
+        //$output->output("$sql`n");
         $result = db_query($sql);
         if (db_num_rows($result) > 0) {
-            output("• IP Filter: %s ", $thisip);
-            rawoutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
-            output("Use this filter");
-            rawoutput("</a>");
-            output_notl("`n");
+            $output->output("• IP Filter: %s ", $thisip);
+            $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
+            $output->output("Use this filter");
+            $output->rawOutput("</a>");
+            $output->outputNotl("`n");
             while ($row = db_fetch_assoc($result)) {
-                output("&nbsp;&nbsp;", true);
-                output(
+                $output->output("&nbsp;&nbsp;", true);
+                $output->output(
                     "• (%s) [%s] `%%s`0 - %s hits, last: %s`n",
                     $row['lastip'],
                     $row['uniqueid'],
@@ -78,7 +81,7 @@ if ($row['name'] != "") {
                     reltime(strtotime($row['laston']))
                 );
             }
-            output_notl("`n");
+            $output->outputNotl("`n");
         }
         if (substr($ip, $x - 1, 1) == ".") {
             $x--;


### PR DESCRIPTION
## Summary
- replace navigation and output wrapper calls in `pages/user/` with `Lotgd` class usage
- drop legacy includes and add imports for `Nav`, `Translator`, `Redirect`, and `Modules`

## Testing
- `php -l pages/user/user_.php`
- `php -l pages/user/user_debuglog.php`
- `php -l pages/user/user_del.php`
- `php -l pages/user/user_delban.php`
- `php -l pages/user/user_edit.php`
- `php -l pages/user/user_removeban.php`
- `php -l pages/user/user_save.php`
- `php -l pages/user/user_saveban.php`
- `php -l pages/user/user_savemodule.php`
- `php -l pages/user/user_searchban.php`
- `php -l pages/user/user_setupban.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6887901429f48329acca384ee7c71839