### PR TITLE
Refactor mail pages to namespaced APIs

### DIFF
--- a/pages/mail/case_address.php
+++ b/pages/mail/case_address.php
@@ -1,10 +1,13 @@
 <?php
+declare(strict_types=1);
+
+use Lotgd\Translator;
 
 output_notl("<form action='mail.php?op=write' method='post'>", true);
 output("`b`2Address:`b`n");
-$to = translate_inline("To: ");
-$forwardto = translate_inline("Forward To: ");
-$search = htmlentities(translate_inline("Search"), ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
+$to = Translator::translateInline("To: ");
+$forwardto = Translator::translateInline("Forward To: ");
+$search = htmlentities(Translator::translateInline("Search"), ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
 $id = (int) httpget('id');
 $forwardlink = '';
 if ($id > 0) {

--- a/pages/mail/case_default.php
+++ b/pages/mail/case_default.php
@@ -1,6 +1,10 @@
 <?php
+declare(strict_types=1);
 
 use Lotgd\Mail;
+use Lotgd\PlayerFunctions;
+use Lotgd\Sanitize;
+use Lotgd\Translator;
 
 output("`b`iMail Box`i`b");
 if (isset($session['message'])) {
@@ -27,10 +31,10 @@ $newdirection = (int)!$sorting_direction;
 $rows = Mail::getInbox($session['user']['acctid'], $order, $direction);
 $db_num_rows = count($rows);
 if ($db_num_rows > 0) {
-    $no_subject = translate_inline("`i(No Subject)`i");
-    $subject = translate_inline("Subject");
-    $from = translate_inline("Sender");
-    $date = translate_inline("SendDate");
+    $no_subject = Translator::translateInline("`i(No Subject)`i");
+    $subject = Translator::translateInline("Subject");
+    $from = Translator::translateInline("Sender");
+    $date = Translator::translateInline("SendDate");
     $arrow = ($sorting_direction ? "arrow_down.png" : "arrow_up.png");
 
     rawoutput("<form action='mail.php?op=process' onsubmit=\"return confirm('Do you really want to delete/move/process those entries?');\" method='post'><table>");
@@ -48,7 +52,7 @@ if ($db_num_rows > 0) {
         }
     }
 
-        $user_statuslist = mass_is_player_online($userlist);
+        $user_statuslist = PlayerFunctions::massIsPlayerOnline($userlist);
 
     foreach ($rows as $row) {
         rawoutput("<tr>");
@@ -57,7 +61,7 @@ if ($db_num_rows > 0) {
         rawoutput("<td>");
         $status_image = "";
         if ((int)$row['msgfrom'] == 0) {
-            $row['name'] = translate_inline("`i`^System`0`i");
+            $row['name'] = Translator::translateInline("`i`^System`0`i");
             // Only translate the subject if it's an array, ie, it came from the game.
             if (isset($row['subject'])) {
                 $row_subject = \Lotgd\Serialization::safeUnserialize($row['subject']);
@@ -65,10 +69,10 @@ if ($db_num_rows > 0) {
                 $row_subject = "";
             }
             if ($row_subject !== false && $row_subject != null && is_array($row_subject)) {
-                $row['subject'] = call_user_func_array("sprintf_translate", $row_subject);
+                $row['subject'] = Translator::sprintfTranslate(...$row_subject);
             }
         } elseif ($row['name'] == '') {
-            $row['name'] = translate_inline("`i`^Deleted User`0`i");
+            $row['name'] = Translator::translateInline("`i`^Deleted User`0`i");
         } else {
             //get status
             $online = $user_statuslist[$row['acctid']];
@@ -76,7 +80,7 @@ if ($db_num_rows > 0) {
             $status_image = "<img src='images/$status.gif' alt='$status'>";
         }
         //collect sanitized names plus message IDs for later use
-        $sname = sanitize($row['name']);
+        $sname = Sanitize::sanitize($row['name']);
         if (!isset($from_list[$sname])) {
             $from_list[$sname] = "'" . $row['messageid'] . "'";
         } else {
@@ -97,8 +101,8 @@ if ($db_num_rows > 0) {
 						var elements = document.getElementsByName(\"msg[]\");
 						var max = elements.length;
 						var Zaehler=0;
-						var checktext='" . translate_inline("Check all") . "';
-						var unchecktext='" . translate_inline("Uncheck all") . "';
+                                                var checktext='" . Translator::translateInline("Check all") . "';
+                                                var unchecktext='" . Translator::translateInline("Uncheck all") . "';
 						var check = false;
 						for (Zaehler=0;Zaehler<max;Zaehler++) {
 							if (elements[Zaehler].checked==true) {
@@ -137,7 +141,7 @@ if ($db_num_rows > 0) {
     }
     $script .= "var container = new Array($add);
 			var who = document.getElementById('check_name_select').value;
-			var unchecktext='" . translate_inline("Uncheck all") . "';
+                        var unchecktext='" . Translator::translateInline("Uncheck all") . "';
 			for (var i=0;i<container[who].length;i++) {
 				document.getElementById(container[who][i]).checked=true;
 			}
@@ -145,9 +149,9 @@ if ($db_num_rows > 0) {
 		}
 					</script>";
     rawoutput($script);
-    $checkall = htmlentities(translate_inline("Check All"), ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
-    $delchecked = htmlentities(translate_inline("Delete Checked"), ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
-    $checknames = htmlentities(translate_inline("`vCheck by Name"), ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
+    $checkall = htmlentities(Translator::translateInline("Check All"), ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
+    $delchecked = htmlentities(Translator::translateInline("Delete Checked"), ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
+    $checknames = htmlentities(Translator::translateInline("`vCheck by Name"), ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
         output_notl("<label for='check_name_select'>" . $checknames . "</label> <select onchange='check_name()' id='check_name_select'>" . $option . "</select><br>", true);
     rawoutput("<input type='button' id='button_check' value=\"$checkall\" class='button' onClick='check_all()'>");
     rawoutput("<input type='submit' class='button' value=\"$delchecked\">");

--- a/pages/mail/case_read.php
+++ b/pages/mail/case_read.php
@@ -1,40 +1,44 @@
 <?php
+declare(strict_types=1);
 
 use Lotgd\Mail;
+use Lotgd\PlayerFunctions;
+use Lotgd\Sanitize;
+use Lotgd\Translator;
 
 $row = Mail::getMessage($session['user']['acctid'], $id);
 if ($row) {
-    $reply = translate_inline("Reply");
-    $del = translate_inline("Delete");
-    $forward = translate_inline("Forward");
-    $unread = translate_inline("Mark Unread");
-    $report = translate_inline("Report to Admin");
-    $prev = translate_inline("< Previous");
-    $next = translate_inline("Next >");
+    $reply = Translator::translateInline("Reply");
+    $del = Translator::translateInline("Delete");
+    $forward = Translator::translateInline("Forward");
+    $unread = Translator::translateInline("Mark Unread");
+    $report = Translator::translateInline("Report to Admin");
+    $prev = Translator::translateInline("< Previous");
+    $next = Translator::translateInline("Next >");
     $problem = "Abusive Email Report:\nFrom: {$row['name']}\nSubject: {$row['subject']}\nSent: {$row['sent']}\nID: {$row['messageid']}\nBody:\n{$row['body']}";
     $problemplayer = (int)$row['msgfrom'];
     $status_image = "";
     if ((int)$row['msgfrom'] == 0) {
-        $row['name'] = translate_inline("`i`^System`0`i");
+        $row['name'] = Translator::translateInline("`i`^System`0`i");
         // No translation for subject if it's not an array
                 $row_subject = \Lotgd\Serialization::safeUnserialize($row['subject']);
         if ($row_subject !== false && is_array($row_subject)) {
-            $row['subject'] = call_user_func_array("sprintf_translate", $row_subject);
+            $row['subject'] = Translator::sprintfTranslate(...$row_subject);
         } else {
             $row['subject'] = $row_subject;
         }
         // No translation for body if it's not an array
                 $row_body = \Lotgd\Serialization::safeUnserialize($row['body']);
         if ($row_body !== false && is_array($row_body)) {
-            $row['body'] = call_user_func_array("sprintf_translate", $row_body);
+            $row['body'] = Translator::sprintfTranslate(...$row_body);
         } else {
             $row['body'] = $row_body;
         }
     } elseif ($row['name'] == "") {
-        $row['name'] = translate_inline("`^Deleted User");
+        $row['name'] = Translator::translateInline("`^Deleted User");
     } else {
         //get status
-        $online = (int)is_player_online($row['acctid']);
+        $online = (int)PlayerFunctions::isPlayerOnline($row['acctid']);
         $status = ($online ? "online" : "offline");
         $status_image = "<img src='images/$status.gif' alt='$status'>";
     }
@@ -65,7 +69,7 @@ if ($row) {
         rawoutput(htmlentities($next, ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "</td>");
     }
     rawoutput("</tr></table><br/>");
-    output_notl(sanitize_mb(str_replace("\n", "`n", $row['body'])));
+    output_notl(Sanitize::sanitizeMb(str_replace("\n", "`n", $row['body'])));
         Mail::markRead($session['user']['acctid'], $id);
     rawoutput("<table width='50%' border='0' cellpadding='0' cellspacing='5'><tr>
 		<td><a href='mail.php?op=write&replyto={$row['messageid']}' class='motd'>$reply</a></td>

--- a/pages/mail/case_send.php
+++ b/pages/mail/case_send.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;


### PR DESCRIPTION
## Summary
- modernize `pages/mail` handlers
- use `Lotgd\` classes for translation, sanitization and player status
- drop obsolete includes

## Testing
- `composer install`
- `composer test`
- `php -l pages/mail/case_send.php`
- `php -l pages/mail/case_address.php`
- `php -l pages/mail/case_default.php`
- `php -l pages/mail/case_read.php`
- `php -l pages/mail/case_write.php`


------
https://chatgpt.com/codex/tasks/task_e_68879017dd7c832980f779960ab9d305