### PR TITLE
Use namespaced APIs in bans pages

### DIFF
--- a/pages/bans/case_.php
+++ b/pages/bans/case_.php
@@ -1,71 +1,76 @@
 <?php
+declare(strict_types=1);
+
+use Lotgd\MySQL\Database;
+use Lotgd\Translator;
+use Lotgd\Nav;
 
 if ($display == 1) {
     $q = "";
     if ($query) {
         $q = "&q=$query";
     }
-    $ops = translate_inline("Ops");
-    $acid = translate_inline("AcctID");
-    $login = translate_inline("Login");
-    $nm = translate_inline("Name");
-    $lev = translate_inline("Level");
-    $lon = translate_inline("Last On");
-    $hits = translate_inline("Hits");
-    $lip = translate_inline("Last IP");
-    $lid = translate_inline("Last ID");
-    $ban = translate_inline("Ban");
-        rawoutput("<table>");
-    rawoutput("<tr class='trhead'><td>$ops</td><td><a href='bans.php?sort=acctid$q'>$acid</a></td><td><a href='bans.php?sort=login$q'>$login</a></td><td><a href='bans.php?sort=name$q'>$nm</a></td><td><a href='bans.php?sort=level$q'>$lev</a></td><td><a href='bans.php?sort=laston$q'>$lon</a></td><td><a href='bans.php?sort=gentimecount$q'>$hits</a></td><td><a href='bans.php?sort=lastip$q'>$lip</a></td><td><a href='bans.php?sort=uniqueid$q'>$lid</a></td></tr>");
-    addnav("", "bans.php?sort=acctid$q");
-    addnav("", "bans.php?sort=login$q");
-    addnav("", "bans.php?sort=name$q");
-    addnav("", "bans.php?sort=level$q");
-    addnav("", "bans.php?sort=laston$q");
-    addnav("", "bans.php?sort=gentimecount$q");
-    addnav("", "bans.php?sort=lastip$q");
-    addnav("", "bans.php?sort=uniqueid$q");
+    $ops = Translator::translateInline("Ops");
+    $acid = Translator::translateInline("AcctID");
+    $login = Translator::translateInline("Login");
+    $nm = Translator::translateInline("Name");
+    $lev = Translator::translateInline("Level");
+    $lon = Translator::translateInline("Last On");
+    $hits = Translator::translateInline("Hits");
+    $lip = Translator::translateInline("Last IP");
+    $lid = Translator::translateInline("Last ID");
+    $ban = Translator::translateInline("Ban");
+        $output->rawOutput("<table>");
+    $output->rawOutput("<tr class='trhead'><td>$ops</td><td><a href='bans.php?sort=acctid$q'>$acid</a></td><td><a href='bans.php?sort=login$q'>$login</a></td><td><a href='bans.php?sort=name$q'>$nm</a></td><td><a href='bans.php?sort=level$q'>$lev</a></td><td><a href='bans.php?sort=laston$q'>$lon</a></td><td><a href='bans.php?sort=gentimecount$q'>$hits</a></td><td><a href='bans.php?sort=lastip$q'>$lip</a></td><td><a href='bans.php?sort=uniqueid$q'>$lid</a></td></tr>");
+    Nav::add("", "bans.php?sort=acctid$q");
+    Nav::add("", "bans.php?sort=login$q");
+    Nav::add("", "bans.php?sort=name$q");
+    Nav::add("", "bans.php?sort=level$q");
+    Nav::add("", "bans.php?sort=laston$q");
+    Nav::add("", "bans.php?sort=gentimecount$q");
+    Nav::add("", "bans.php?sort=lastip$q");
+    Nav::add("", "bans.php?sort=uniqueid$q");
     $rn = 0;
     $oorder = "";
-    while ($row = db_fetch_assoc($searchresult)) {
+    while ($row = Database::fetchAssoc($searchresult)) {
         $laston = relativedate($row['laston']);
         $loggedin =
             (date("U") - strtotime($row['laston']) <
              getsetting("LOGINTIMEOUT", 900) && $row['loggedin']);
         if ($loggedin) {
-            $laston = translate_inline("`#Online`0");
+            $laston = Translator::translateInline("`#Online`0");
         }
         $row['laston'] = $laston;
         if ($row[$order] != $oorder) {
             $rn++;
         }
         $oorder = $row[$order];
-        rawoutput("<tr class='" . ($rn % 2 ? "trlight" : "trdark") . "'>");
-        rawoutput("<td nowrap>");
-        rawoutput("[ <a href='bans.php?op=setupban&userid={$row['acctid']}'>$ban</a> ]");
-        addnav("", "bans.php?op=setupban&userid={$row['acctid']}");
-        rawoutput("</td><td>");
-        output_notl("%s", $row['acctid']);
-        rawoutput("</td><td>");
-        output_notl("%s", $row['login']);
-        rawoutput("</td><td>");
-        output_notl("`&%s`0", $row['name']);
-        rawoutput("</td><td>");
-        output_notl("`^%s`0", $row['level']);
-        rawoutput("</td><td>");
-        output_notl("%s", $row['laston']);
-        rawoutput("</td><td>");
-        output_notl("%s", $row['gentimecount']);
-        rawoutput("</td><td>");
-        output_notl("%s", $row['lastip']);
-        rawoutput("</td><td>");
-        output_notl("%s", $row['uniqueid']);
-        rawoutput("</td>");
+        $output->rawOutput("<tr class='" . ($rn % 2 ? "trlight" : "trdark") . "'>");
+        $output->rawOutput("<td nowrap>");
+        $output->rawOutput("[ <a href='bans.php?op=setupban&userid={$row['acctid']}'>$ban</a> ]");
+        Nav::add("", "bans.php?op=setupban&userid={$row['acctid']}");
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['acctid']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['login']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("`&%s`0", $row['name']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("`^%s`0", $row['level']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['laston']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['gentimecount']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['lastip']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['uniqueid']);
+        $output->rawOutput("</td>");
         $gentimecount += $row['gentimecount'];
         $gentime += $row['gentime'];
     }
-    rawoutput("</table>");
-    output("Total hits: %s`n", $gentimecount);
-    output("Total CPU time: %s seconds`n", round($gentime, 3));
-    output("Average page gen time is %s seconds`n", round($gentime / max($gentimecount, 1), 4));
+    $output->rawOutput("</table>");
+    $output->output("Total hits: %s`n", $gentimecount);
+    $output->output("Total CPU time: %s seconds`n", round($gentime, 3));
+    $output->output("Average page gen time is %s seconds`n", round($gentime / max($gentimecount, 1), 4));
 }

--- a/pages/bans/case_delban.php
+++ b/pages/bans/case_delban.php
@@ -1,5 +1,10 @@
 <?php
+declare(strict_types=1);
 
-$sql = "DELETE FROM " . db_prefix("bans") . " WHERE ipfilter = '" . httpget("ipfilter") . "' AND uniqueid = '" . httpget("uniqueid") . "'";
-db_query($sql);
-redirect("bans.php?op=removeban");
+use Lotgd\Http;
+use Lotgd\MySQL\Database;
+use Lotgd\Redirect;
+
+$sql = 'DELETE FROM ' . Database::prefix('bans') . " WHERE ipfilter = '" . Http::get('ipfilter') . "' AND uniqueid = '" . Http::get('uniqueid') . "'";
+Database::query($sql);
+Redirect::redirect('bans.php?op=removeban');

--- a/pages/bans/case_removeban.php
+++ b/pages/bans/case_removeban.php
@@ -1,32 +1,38 @@
 <?php
+declare(strict_types=1);
 
-$subop = httpget("subop");
-$none = translate_inline('NONE');
+use Lotgd\MySQL\Database;
+use Lotgd\Translator;
+use Lotgd\Nav;
+use Lotgd\Http;
+
+$subop = Http::get('subop');
+$none = Translator::translateInline('NONE');
 if ($subop == "xml") {
     header("Content-Type: text/xml");
-    $sql = "SELECT DISTINCT " . db_prefix("accounts") . ".name FROM " . db_prefix("bans") . ", " . db_prefix("accounts") . " WHERE (ipfilter='" . addslashes(httpget("ip")) . "' AND " .
-        db_prefix("bans") . ".uniqueid='" .
-        addslashes(httpget("id")) . "') AND ((substring(" .
-        db_prefix("accounts") . ".lastip,1,length(ipfilter))=ipfilter " .
-        "AND ipfilter<>'') OR (" .  db_prefix("bans") . ".uniqueid=" .
-        db_prefix("accounts") . ".uniqueid AND " .
-        db_prefix("bans") . ".uniqueid<>''))";
-    $r = db_query($sql);
+    $sql = "SELECT DISTINCT " . Database::prefix("accounts") . ".name FROM " . Database::prefix("bans") . ", " . Database::prefix("accounts") . " WHERE (ipfilter='" . addslashes(Http::get("ip")) . "' AND " .
+        Database::prefix("bans") . ".uniqueid='" .
+        addslashes(Http::get("id")) . "') AND ((substring(" .
+        Database::prefix("accounts") . ".lastip,1,length(ipfilter))=ipfilter " .
+        "AND ipfilter<>'') OR (" .  Database::prefix("bans") . ".uniqueid=" .
+        Database::prefix("accounts") . ".uniqueid AND " .
+        Database::prefix("bans") . ".uniqueid<>''))";
+    $r = Database::query($sql);
     echo "<xml>";
-    while ($ro = db_fetch_assoc($r)) {
+    while ($ro = Database::fetchAssoc($r)) {
         echo "<name name=\"";
         echo urlencode(appoencode("`0{$ro['name']}"));
         echo "\"/>";
     }
-    if (db_num_rows($r) == 0) {
+    if (Database::numRows($r) == 0) {
         echo "<name name=\"$none\"/>";
     }
     echo "</xml>";
     exit();
 }
-db_query("DELETE FROM " . db_prefix("bans") . " WHERE banexpire < \"" . date("Y-m-d H:m:s") . "\" AND banexpire<'" . DATETIME_DATEMAX . "'");
-$duration =  httpget("duration");
-if (httpget('notbefore')) {
+Database::query("DELETE FROM " . Database::prefix("bans") . " WHERE banexpire < \"" . date("Y-m-d H:m:s") . "\" AND banexpire<'" . DATETIME_DATEMAX . "'");
+$duration =  Http::get("duration");
+if (Http::get('notbefore')) {
     $operator = ">=";
 } else {
     $operator = "<=";
@@ -34,52 +40,52 @@ if (httpget('notbefore')) {
 
 if ($duration == "") {
     $since = " WHERE banexpire $operator '" . date("Y-m-d H:i:s", strtotime("+2 weeks")) . "' AND banexpire < '" . DATETIME_DATEMAX . "'";
-        output("`bShowing bans that will expire within 2 weeks.`b`n`n");
+        $output->output("`bShowing bans that will expire within 2 weeks.`b`n`n");
 } else {
     if ($duration == "forever") {
         $since = " WHERE banexpire='" . DATETIME_DATEMAX . "'";
-        output("`bShowing all permanent bans`b`n`n");
+        $output->output("`bShowing all permanent bans`b`n`n");
     } elseif ($duration == "all") {
         $since = "";
-        output("`bShowing all bans`b`n`n");
+        $output->output("`bShowing all bans`b`n`n");
     } else {
         $since = " WHERE banexpire $operator '" . date("Y-m-d H:i:s", strtotime("+" . $duration)) . "' AND banexpire < '" . DATETIME_DATEMAX . "'";
-        output("`bShowing bans that will expire within %s.`b`n`n", $duration);
+        $output->output("`bShowing bans that will expire within %s.`b`n`n", $duration);
     }
 }
-addnav("Perma-Bans");
-addnav("Show", "bans.php?op=removeban&duration=forever");
-addnav("Will Expire Within");
-addnav("1 week", "bans.php?op=removeban&duration=1+week");
-addnav("2 weeks", "bans.php?op=removeban&duration=2+weeks");
-addnav("3 weeks", "bans.php?op=removeban&duration=3+weeks");
-addnav("4 weeks", "bans.php?op=removeban&duration=4+weeks");
-addnav("2 months", "bans.php?op=removeban&duration=2+months");
-addnav("3 months", "bans.php?op=removeban&duration=3+months");
-addnav("4 months", "bans.php?op=removeban&duration=4+months");
-addnav("5 months", "bans.php?op=removeban&duration=5+months");
-addnav("6 months", "bans.php?op=removeban&duration=6+months");
-addnav("1 year", "bans.php?op=removeban&duration=1+year");
-addnav("2 years", "bans.php?op=removeban&duration=2+years");
-addnav("4 years", "bans.php?op=removeban&duration=4+years");
-addnav("Show all", "bans.php?op=removeban&duration=all");
-addnav("Will Expire not before");
-addnav("1 week", "bans.php?op=removeban&duration=1+week&notbefore=1");
-addnav("2 weeks", "bans.php?op=removeban&duration=2+weeks&notbefore=1");
-addnav("3 weeks", "bans.php?op=removeban&duration=3+weeks&notbefore=1");
-addnav("4 weeks", "bans.php?op=removeban&duration=4+weeks&notbefore=1");
-addnav("2 months", "bans.php?op=removeban&duration=2+months&notbefore=1");
-addnav("3 months", "bans.php?op=removeban&duration=3+months&notbefore=1");
-addnav("4 months", "bans.php?op=removeban&duration=4+months&notbefore=1");
-addnav("5 months", "bans.php?op=removeban&duration=5+months&notbefore=1");
-addnav("6 months", "bans.php?op=removeban&duration=6+months&notbefore=1");
-addnav("1 year", "bans.php?op=removeban&duration=1+year&notbefore=1");
-addnav("2 years", "bans.php?op=removeban&duration=2+years&notbefore=1");
-addnav("4 years", "bans.php?op=removeban&duration=4+years&notbefore=1");
+Nav::add("Perma-Bans");
+Nav::add("Show", "bans.php?op=removeban&duration=forever");
+Nav::add("Will Expire Within");
+Nav::add("1 week", "bans.php?op=removeban&duration=1+week");
+Nav::add("2 weeks", "bans.php?op=removeban&duration=2+weeks");
+Nav::add("3 weeks", "bans.php?op=removeban&duration=3+weeks");
+Nav::add("4 weeks", "bans.php?op=removeban&duration=4+weeks");
+Nav::add("2 months", "bans.php?op=removeban&duration=2+months");
+Nav::add("3 months", "bans.php?op=removeban&duration=3+months");
+Nav::add("4 months", "bans.php?op=removeban&duration=4+months");
+Nav::add("5 months", "bans.php?op=removeban&duration=5+months");
+Nav::add("6 months", "bans.php?op=removeban&duration=6+months");
+Nav::add("1 year", "bans.php?op=removeban&duration=1+year");
+Nav::add("2 years", "bans.php?op=removeban&duration=2+years");
+Nav::add("4 years", "bans.php?op=removeban&duration=4+years");
+Nav::add("Show all", "bans.php?op=removeban&duration=all");
+Nav::add("Will Expire not before");
+Nav::add("1 week", "bans.php?op=removeban&duration=1+week&notbefore=1");
+Nav::add("2 weeks", "bans.php?op=removeban&duration=2+weeks&notbefore=1");
+Nav::add("3 weeks", "bans.php?op=removeban&duration=3+weeks&notbefore=1");
+Nav::add("4 weeks", "bans.php?op=removeban&duration=4+weeks&notbefore=1");
+Nav::add("2 months", "bans.php?op=removeban&duration=2+months&notbefore=1");
+Nav::add("3 months", "bans.php?op=removeban&duration=3+months&notbefore=1");
+Nav::add("4 months", "bans.php?op=removeban&duration=4+months&notbefore=1");
+Nav::add("5 months", "bans.php?op=removeban&duration=5+months&notbefore=1");
+Nav::add("6 months", "bans.php?op=removeban&duration=6+months&notbefore=1");
+Nav::add("1 year", "bans.php?op=removeban&duration=1+year&notbefore=1");
+Nav::add("2 years", "bans.php?op=removeban&duration=2+years&notbefore=1");
+Nav::add("4 years", "bans.php?op=removeban&duration=4+years&notbefore=1");
 
-$sql = "SELECT * FROM " . db_prefix("bans") . " $since ORDER BY banexpire ASC";
-$result = db_query($sql);
-rawoutput("<script language='JavaScript'>
+$sql = "SELECT * FROM " . Database::prefix("bans") . " $since ORDER BY banexpire ASC";
+$result = Database::query($sql);
+$output->rawOutput("<script language='JavaScript'>
 function getUserInfo(ip,id,divid){
 	var filename='bans.php?op=removeban&subop=xml&ip='+ip+'&id='+id;
 	//set up the DOM object
@@ -102,30 +108,30 @@ function getUserInfo(ip,id,divid){
 }
 </script>
 ");
-rawoutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
-$ops = translate_inline("Ops");
-$bauth = translate_inline("Ban Author");
-$ipd = translate_inline("IP/ID");
-$dur = translate_inline("Duration");
-$mssg = translate_inline("Message");
-$aff = translate_inline("Affects");
-$l = translate_inline("Last");
-    rawoutput("<tr class='trhead'><td>$ops</td><td>$bauth</td><td>$ipd</td><td>$dur</td><td>$mssg</td><td>$aff</td><td>$l</td></tr>");
+$output->rawOutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
+$ops = Translator::translateInline("Ops");
+$bauth = Translator::translateInline("Ban Author");
+$ipd = Translator::translateInline("IP/ID");
+$dur = Translator::translateInline("Duration");
+$mssg = Translator::translateInline("Message");
+$aff = Translator::translateInline("Affects");
+$l = Translator::translateInline("Last");
+    $output->rawOutput("<tr class='trhead'><td>$ops</td><td>$bauth</td><td>$ipd</td><td>$dur</td><td>$mssg</td><td>$aff</td><td>$l</td></tr>");
 $i = 0;
-while ($row = db_fetch_assoc($result)) {
-    $liftban = translate_inline("Lift&nbsp;ban");
-    $showuser = translate_inline("Click&nbsp;to&nbsp;show&nbsp;users");
-    rawoutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'>");
-    rawoutput("<td><a href='bans.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']) . "'>");
-    output_notl("%s", $liftban, true);
-    rawoutput("</a>");
-    addnav("", "bans.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']));
-    rawoutput("</td><td>");
-    output_notl("`&%s`0", $row['banner']);
-    rawoutput("</td><td>");
-    output_notl("%s", $row['ipfilter']);
-    output_notl("%s", $row['uniqueid']);
-    rawoutput("</td><td>");
+while ($row = Database::fetchAssoc($result)) {
+    $liftban = Translator::translateInline("Lift&nbsp;ban");
+    $showuser = Translator::translateInline("Click&nbsp;to&nbsp;show&nbsp;users");
+    $output->rawOutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'>");
+    $output->rawOutput("<td><a href='bans.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']) . "'>");
+    $output->outputNotl("%s", $liftban, true);
+    $output->rawOutput("</a>");
+    Nav::add("", "bans.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']));
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("`&%s`0", $row['banner']);
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("%s", $row['ipfilter']);
+    $output->outputNotl("%s", $row['uniqueid']);
+    $output->rawOutput("</td><td>");
         // "43200" used so will basically round to nearest day rather than floor number of days
 
     $expire = sprintf_translate(
@@ -133,32 +139,32 @@ while ($row = db_fetch_assoc($result)) {
         round((strtotime($row['banexpire']) + 43200 - strtotime("now")) / 86400, 0)
     );
     if (substr($expire, 0, 2) == "1 ") {
-        $expire = translate_inline("1 day");
+        $expire = Translator::translateInline("1 day");
     }
     if (date("Y-m-d", strtotime($row['banexpire'])) == date("Y-m-d")) {
-        $expire = translate_inline("Today");
+        $expire = Translator::translateInline("Today");
     }
     if (
         date("Y-m-d", strtotime($row['banexpire'])) ==
             date("Y-m-d", strtotime("1 day"))
     ) {
-        $expire = translate_inline("Tomorrow");
+        $expire = Translator::translateInline("Tomorrow");
     }
     if ($row['banexpire'] == DATETIME_DATEMAX) {
-        $expire = translate_inline("Never");
+        $expire = Translator::translateInline("Never");
     }
-    output_notl("%s", $expire);
-    rawoutput("</td><td>");
-    output_notl("%s", $row['banreason']);
-    rawoutput("</td><td>");
+    $output->outputNotl("%s", $expire);
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("%s", $row['banreason']);
+    $output->rawOutput("</td><td>");
     $file = "bans.php?op=removeban&subop=xml&ip={$row['ipfilter']}&id={$row['uniqueid']}";
-    rawoutput("<div id='user$i'><a href='$file' target='_blank' onClick=\"getUserInfo('{$row['ipfilter']}','{$row['uniqueid']}',$i); return false;\">");
-    output_notl("%s", $showuser, true);
-    rawoutput("</a></div>");
-    addnav("", $file);
-    rawoutput("</td><td>");
-    output_notl("%s", relativedate($row['lasthit']));
-    rawoutput("</td></tr>");
+    $output->rawOutput("<div id='user$i'><a href='$file' target='_blank' onClick=\"getUserInfo('{$row['ipfilter']}','{$row['uniqueid']}',$i); return false;\">");
+    $output->outputNotl("%s", $showuser, true);
+    $output->rawOutput("</a></div>");
+    Nav::add("", $file);
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("%s", relativedate($row['lasthit']));
+    $output->rawOutput("</td></tr>");
     $i++;
 }
-rawoutput("</table>");
+$output->rawOutput("</table>");

--- a/pages/bans/case_saveban.php
+++ b/pages/bans/case_saveban.php
@@ -50,7 +50,7 @@ if ($sql != "") {
     $result = Database::query($sql);
     global $output;
     $output->output("%s ban rows entered.`n`n", Database::affectedRows($result));
-    $output->outputNotl(Database::error());
+    $output->outputNotl(Database::error($result));
     debuglog("entered a ban: " .  ($type == "ip" ?  "IP: " . httppost("ip") : "ID: " . httppost("id")) . " Ends after: $duration  Reason: \"" .  httppost("reason") . "\"");
     /* log out affected players */
     $sql = "SELECT acctid FROM " . Database::prefix('accounts') . " WHERE $key='$key_value'";

--- a/pages/bans/case_saveban.php
+++ b/pages/bans/case_saveban.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
 
 use Lotgd\Cookies;
+use Lotgd\MySQL\Database;
 
-$sql = "INSERT INTO " . db_prefix("bans") . " (banner,";
+$sql = 'INSERT INTO '.Database::prefix('bans').' (banner,';
 $type = httppost("type");
 if ($type == "ip") {
     $sql .= "ipfilter";
@@ -32,38 +34,40 @@ if ($type == "ip") {
         substr($_SERVER['REMOTE_ADDR'], 0, strlen(httppost("ip"))) ==
             httppost("ip")
     ) {
-        $sql = "";
-        output("You don't really want to ban yourself now do you??");
-        output("That's your own IP address!");
+        $sql = '';
+        global $output;
+        $output->output("You don't really want to ban yourself now do you??");
+        $output->output("That's your own IP address!");
     }
 } else {
     if (Cookies::getLgi() == httppost("id")) {
-            $sql = "";
-            output("You don't really want to ban yourself now do you??");
-            output("That's your own ID!");
+            $sql = '';
+            $output->output("You don't really want to ban yourself now do you??");
+            $output->output("That's your own ID!");
     }
 }
 if ($sql != "") {
-    $result = db_query($sql);
-    output("%s ban rows entered.`n`n", db_affected_rows($result));
-    output_notl("%s", db_error(LINK));
+    $result = Database::query($sql);
+    global $output;
+    $output->output("%s ban rows entered.`n`n", Database::affectedRows($result));
+    $output->outputNotl(Database::error());
     debuglog("entered a ban: " .  ($type == "ip" ?  "IP: " . httppost("ip") : "ID: " . httppost("id")) . " Ends after: $duration  Reason: \"" .  httppost("reason") . "\"");
     /* log out affected players */
-    $sql = "SELECT acctid FROM " . db_prefix('accounts') . " WHERE $key='$key_value'";
-    $result = db_query($sql);
+    $sql = "SELECT acctid FROM " . Database::prefix('accounts') . " WHERE $key='$key_value'";
+    $result = Database::query($sql);
     $acctids = array();
-    while ($row = db_fetch_assoc($result)) {
+    while ($row = Database::fetchAssoc($result)) {
         $acctids[] = $row['acctid'];
     }
     if ($acctids != array()) {
-        $sql = " UPDATE " . db_prefix('accounts') . " SET loggedin=0 WHERE acctid IN (" . implode(",", $acctids) . ")";
-        $result = db_query($sql);
+        $sql = ' UPDATE ' . Database::prefix('accounts') . ' SET loggedin=0 WHERE acctid IN (' . implode(',', $acctids) . ')';
+        $result = Database::query($sql);
         if ($result) {
-            output("`\$%s people have been logged out!`n`n`0", db_affected_rows($result));
+            $output->output("`\$%s people have been logged out!`n`n`0", Database::affectedRows($result));
         } else {
-            output("`\$Nobody was logged out. Acctids (%s) did not return rows!`n`n`0", implode(",", $acctids));
+            $output->output("`\$Nobody was logged out. Acctids (%s) did not return rows!`n`n`0", implode(',', $acctids));
         }
     } else {
-        output("`\$No account-ids found for that IP/ID!`n`n`0");
+        $output->output("`\$No account-ids found for that IP/ID!`n`n`0");
     }
 }

--- a/pages/bans/case_searchban.php
+++ b/pages/bans/case_searchban.php
@@ -1,24 +1,31 @@
 <?php
+declare(strict_types=1);
 
-$subop = httpget("subop");
-$none = translate_inline('NONE');
+use Lotgd\MySQL\Database;
+use Lotgd\Translator;
+use Lotgd\Nav;
+use Lotgd\Http;
+use Lotgd\UserLookup;
+
+$subop = Http::get('subop');
+$none = Translator::translateInline('NONE');
 if ($subop == "xml") {
     header("Content-Type: text/xml");
-    $sql = "SELECT DISTINCT " . db_prefix("accounts") . ".name FROM " . db_prefix("bans") . ", " . db_prefix("accounts") . " WHERE (ipfilter='" . addslashes(httpget("ip")) . "' AND " .
-        db_prefix("bans") . ".uniqueid='" .
+    $sql = "SELECT DISTINCT " . Database::prefix("accounts") . ".name FROM " . Database::prefix("bans") . ", " . Database::prefix("accounts") . " WHERE (ipfilter='" . addslashes(httpget("ip")) . "' AND " .
+        Database::prefix("bans") . ".uniqueid='" .
         addslashes(httpget("id")) . "') AND ((substring(" .
-        db_prefix("accounts") . ".lastip,1,length(ipfilter))=ipfilter " .
-        "AND ipfilter<>'') OR (" .  db_prefix("bans") . ".uniqueid=" .
-        db_prefix("accounts") . ".uniqueid AND " .
-        db_prefix("bans") . ".uniqueid<>''))";
-    $r = db_query($sql);
+        Database::prefix("accounts") . ".lastip,1,length(ipfilter))=ipfilter " .
+        "AND ipfilter<>'') OR (" .  Database::prefix("bans") . ".uniqueid=" .
+        Database::prefix("accounts") . ".uniqueid AND " .
+        Database::prefix("bans") . ".uniqueid<>''))";
+    $r = Database::query($sql);
     echo "<xml>";
-    while ($ro = db_fetch_assoc($r)) {
+    while ($ro = Database::fetchAssoc($r)) {
         echo "<name name=\"";
         echo urlencode(appoencode("`0{$ro['name']}"));
         echo "\"/>";
     }
-    if (db_num_rows($r) == 0) {
+    if (Database::numRows($r) == 0) {
         echo "<name name=\"$none\"/>";
     }
     echo "</xml>";
@@ -29,40 +36,39 @@ $operator = "<=";
 
 $target = httppost('target');
 $since = 'WHERE 0';
-$submit = translate_inline("Search");
+$submit = Translator::translateInline("Search");
 if ($target == '') {
-    rawoutput("<form action='bans.php?op=searchban' method='POST'>");
-    addnav("", "bans.php?op=searchban");
-    output("Search banned user by name: ");
-    rawoutput("<input name='target' value='$target'>");
-    rawoutput("<input type='submit' class='button' value='$submit'></from><br><br>");
+    $output->rawOutput("<form action='bans.php?op=searchban' method='POST'>");
+    Nav::add("", "bans.php?op=searchban");
+    $output->output("Search banned user by name: ");
+    $output->rawOutput("<input name='target' value='$target'>");
+    $output->rawOutput("<input type='submit' class='button' value='$submit'></from><br><br>");
 } elseif (is_numeric($target)) {
     //none
     $sql = "SELECT lastip,uniqueid FROM accounts WHERE acctid=" . $target;
-    $result = db_query($sql);
-    $row = db_fetch_assoc($result);
+    $result = Database::query($sql);
+    $row = Database::fetchAssoc($result);
     $since = "WHERE ipfilter LIKE '%" . $row['lastip'] . "%' OR uniqueid LIKE '%" . $row['uniqueid'] . "%'";
 } else {
-    require_once("lib/lookup_user.php");
-    $names = lookup_user($target);
+    $names = UserLookup::lookup($target);
     if ($names[0] !== false) {
-        rawoutput("<form action='bans.php?op=searchban' method='POST'>");
-        addnav("", "bans.php?op=searchban");
-                rawoutput("<label for='target'>");
-                output("Search banned user by name: ");
-                rawoutput("</label>");
-                rawoutput("<select name='target' id='target'>");
-        while ($row = db_fetch_assoc($names[0])) {
-            rawoutput("<option value='" . $row['acctid'] . "'>" . $row['login'] . "</option>");
+        $output->rawOutput("<form action='bans.php?op=searchban' method='POST'>");
+        Nav::add("", "bans.php?op=searchban");
+                $output->rawOutput("<label for='target'>");
+                $output->output("Search banned user by name: ");
+                $output->rawOutput("</label>");
+                $output->rawOutput("<select name='target' id='target'>");
+        while ($row = Database::fetchAssoc($names[0])) {
+            $output->rawOutput("<option value='" . $row['acctid'] . "'>" . $row['login'] . "</option>");
         }
-        rawoutput("</select>");
-        rawoutput("<input type='submit' class='button' value='$submit'></from><br><br>");
+        $output->rawOutput("</select>");
+        $output->rawOutput("<input type='submit' class='button' value='$submit'></from><br><br>");
     }
 }
 
-$sql = "SELECT * FROM " . db_prefix("bans") . " $since ORDER BY banexpire ASC";
-$result = db_query($sql);
-rawoutput("<script language='JavaScript'>
+$sql = "SELECT * FROM " . Database::prefix("bans") . " $since ORDER BY banexpire ASC";
+$result = Database::query($sql);
+$output->rawOutput("<script language='JavaScript'>
 function getUserInfo(ip,id,divid){
 	var filename='bans.php?op=removeban&subop=xml&ip='+ip+'&id='+id;
 	//set up the DOM object
@@ -85,30 +91,30 @@ function getUserInfo(ip,id,divid){
 }
 </script>
 ");
-rawoutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
-$ops = translate_inline("Ops");
-$bauth = translate_inline("Ban Author");
-$ipd = translate_inline("IP/ID");
-$dur = translate_inline("Duration");
-$mssg = translate_inline("Message");
-$aff = translate_inline("Affects");
-$l = translate_inline("Last");
-    rawoutput("<tr class='trhead'><td>$ops</td><td>$bauth</td><td>$ipd</td><td>$dur</td><td>$mssg</td><td>$aff</td><td>$l</td></tr>");
+$output->rawOutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
+$ops = Translator::translateInline("Ops");
+$bauth = Translator::translateInline("Ban Author");
+$ipd = Translator::translateInline("IP/ID");
+$dur = Translator::translateInline("Duration");
+$mssg = Translator::translateInline("Message");
+$aff = Translator::translateInline("Affects");
+$l = Translator::translateInline("Last");
+    $output->rawOutput("<tr class='trhead'><td>$ops</td><td>$bauth</td><td>$ipd</td><td>$dur</td><td>$mssg</td><td>$aff</td><td>$l</td></tr>");
 $i = 0;
-while ($row = db_fetch_assoc($result)) {
-    $liftban = translate_inline("Lift&nbsp;ban");
-    $showuser = translate_inline("Click&nbsp;to&nbsp;show&nbsp;users");
-    rawoutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'>");
-    rawoutput("<td><a href='bans.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']) . "'>");
-    output_notl("%s", $liftban, true);
-    rawoutput("</a>");
-    addnav("", "bans.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']));
-    rawoutput("</td><td>");
-    output_notl("`&%s`0", $row['banner']);
-    rawoutput("</td><td>");
-    output_notl("%s", $row['ipfilter']);
-    output_notl("%s", $row['uniqueid']);
-    rawoutput("</td><td>");
+while ($row = Database::fetchAssoc($result)) {
+    $liftban = Translator::translateInline("Lift&nbsp;ban");
+    $showuser = Translator::translateInline("Click&nbsp;to&nbsp;show&nbsp;users");
+    $output->rawOutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'>");
+    $output->rawOutput("<td><a href='bans.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']) . "'>");
+    $output->outputNotl("%s", $liftban, true);
+    $output->rawOutput("</a>");
+    Nav::add("", "bans.php?op=delban&ipfilter=" . URLEncode($row['ipfilter']) . "&uniqueid=" . URLEncode($row['uniqueid']));
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("`&%s`0", $row['banner']);
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("%s", $row['ipfilter']);
+    $output->outputNotl("%s", $row['uniqueid']);
+    $output->rawOutput("</td><td>");
         // "43200" used so will basically round to nearest day rather than floor number of days
 
     $expire = sprintf_translate(
@@ -116,32 +122,32 @@ while ($row = db_fetch_assoc($result)) {
         round((strtotime($row['banexpire']) + 43200 - strtotime("now")) / 86400, 0)
     );
     if (substr($expire, 0, 2) == "1 ") {
-        $expire = translate_inline("1 day");
+        $expire = Translator::translateInline("1 day");
     }
     if (date("Y-m-d", strtotime($row['banexpire'])) == date("Y-m-d")) {
-        $expire = translate_inline("Today");
+        $expire = Translator::translateInline("Today");
     }
     if (
         date("Y-m-d", strtotime($row['banexpire'])) ==
             date("Y-m-d", strtotime("1 day"))
     ) {
-        $expire = translate_inline("Tomorrow");
+        $expire = Translator::translateInline("Tomorrow");
     }
     if ($row['banexpire'] == DATETIME_DATEMAX) {
-        $expire = translate_inline("Never");
+        $expire = Translator::translateInline("Never");
     }
-    output_notl("%s", $expire);
-    rawoutput("</td><td>");
-    output_notl("%s", $row['banreason']);
-    rawoutput("</td><td>");
+    $output->outputNotl("%s", $expire);
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("%s", $row['banreason']);
+    $output->rawOutput("</td><td>");
     $file = "bans.php?op=removeban&subop=xml&ip={$row['ipfilter']}&id={$row['uniqueid']}";
-    rawoutput("<div id='user$i'><a href='$file' target='_blank' onClick=\"getUserInfo('{$row['ipfilter']}','{$row['uniqueid']}',$i); return false;\">");
-    output_notl("%s", $showuser, true);
-    rawoutput("</a></div>");
-    addnav("", $file);
-    rawoutput("</td><td>");
-    output_notl("%s", relativedate($row['lasthit']));
-    rawoutput("</td></tr>");
+    $output->rawOutput("<div id='user$i'><a href='$file' target='_blank' onClick=\"getUserInfo('{$row['ipfilter']}','{$row['uniqueid']}',$i); return false;\">");
+    $output->outputNotl("%s", $showuser, true);
+    $output->rawOutput("</a></div>");
+    Nav::add("", $file);
+    $output->rawOutput("</td><td>");
+    $output->outputNotl("%s", relativedate($row['lasthit']));
+    $output->rawOutput("</td></tr>");
     $i++;
 }
-rawoutput("</table>");
+$output->rawOutput("</table>");

--- a/pages/bans/case_searchban.php
+++ b/pages/bans/case_searchban.php
@@ -11,9 +11,9 @@ $subop = Http::get('subop');
 $none = Translator::translateInline('NONE');
 if ($subop == "xml") {
     header("Content-Type: text/xml");
-    $sql = "SELECT DISTINCT " . Database::prefix("accounts") . ".name FROM " . Database::prefix("bans") . ", " . Database::prefix("accounts") . " WHERE (ipfilter='" . addslashes(httpget("ip")) . "' AND " .
+    $sql = "SELECT DISTINCT " . Database::prefix("accounts") . ".name FROM " . Database::prefix("bans") . ", " . Database::prefix("accounts") . " WHERE (ipfilter='" . addslashes(Http::get('ip')) . "' AND " .
         Database::prefix("bans") . ".uniqueid='" .
-        addslashes(httpget("id")) . "') AND ((substring(" .
+        addslashes(Http::get('id')) . "') AND ((substring(" .
         Database::prefix("accounts") . ".lastip,1,length(ipfilter))=ipfilter " .
         "AND ipfilter<>'') OR (" .  Database::prefix("bans") . ".uniqueid=" .
         Database::prefix("accounts") . ".uniqueid AND " .

--- a/pages/bans/case_setupban.php
+++ b/pages/bans/case_setupban.php
@@ -1,48 +1,53 @@
 <?php
+declare(strict_types=1);
 
-$sql = "SELECT name,lastip,uniqueid FROM " . db_prefix("accounts") . " WHERE acctid=" . (int)$userid;
-$result = db_query($sql);
-$row = db_fetch_assoc($result);
+use Lotgd\MySQL\Database;
+use Lotgd\Translator;
+use Lotgd\Nav;
+
+$sql = 'SELECT name,lastip,uniqueid FROM ' . Database::prefix('accounts') . ' WHERE acctid=' . (int) $userid;
+$result = Database::query($sql);
+$row = Database::fetchAssoc($result);
 if ($row['name'] != "") {
-    output("Setting up ban information based on `\$%s`0", $row['name']);
+    $output->output("Setting up ban information based on `\$%s`0", $row['name']);
 }
-rawoutput("<form action='bans.php?op=saveban' method='POST'>");
-output("Set up a new ban by IP or by ID.`n");
-output("`qWe recommended ID as this bans all users who are sitting on THAT machine with THAT browser. A cookie can be deleted, but the char stays locked anyway, regardless of that.`n`n");
-output("If you ban via IP and if you have several different users behind a NAT(sharing IPs, many big providers do this currently), you will ban much more users. However, you can ban multichars from different PCs too.`n`0");
-rawoutput("<input type='radio' value='ip' id='ipradio' name='type'>");
-output("IP: ");
-rawoutput("<input name='ip' id='ip' value=\"" . HTMLEntities($row['lastip'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\">");
-output_notl("`n");
-rawoutput("<input type='radio' value='id' name='type' checked>");
-output("ID: ");
-rawoutput("<input name='id' value=\"" . HTMLEntities($row['uniqueid'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\">");
-output("`nDuration: ");
-rawoutput("<input name='duration' id='duration' size='3' value='14'>");
-output("Days (0 for permanent)`n");
+$output->rawOutput("<form action='bans.php?op=saveban' method='POST'>");
+$output->output("Set up a new ban by IP or by ID.`n");
+$output->output("`qWe recommended ID as this bans all users who are sitting on THAT machine with THAT browser. A cookie can be deleted, but the char stays locked anyway, regardless of that.`n`n");
+$output->output("If you ban via IP and if you have several different users behind a NAT(sharing IPs, many big providers do this currently), you will ban much more users. However, you can ban multichars from different PCs too.`n`0");
+$output->rawOutput("<input type='radio' value='ip' id='ipradio' name='type'>");
+$output->output("IP: ");
+$output->rawOutput("<input name='ip' id='ip' value=\"" . HTMLEntities($row['lastip'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\">");
+$output->outputNotl("`n");
+$output->rawOutput("<input type='radio' value='id' name='type' checked>");
+$output->output("ID: ");
+$output->rawOutput("<input name='id' value=\"" . HTMLEntities($row['uniqueid'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\">");
+$output->output("`nDuration: ");
+$output->rawOutput("<input name='duration' id='duration' size='3' value='14'>");
+$output->output("Days (0 for permanent)`n");
 $reason = httpget("reason");
 if ($reason == "") {
-    $reason = translate_inline("Don't mess with me.");
+    $reason = Translator::translateInline("Don't mess with me.");
 }
-output("Reason for the ban: ");
-rawoutput("<input name='reason' size=50 value=\"$reason\">");
-output_notl("`n");
-$pban = translate_inline("Post ban");
-$conf = translate_inline("Are you sure you wish to issue a permanent ban?");
-rawoutput("<input type='submit' class='button' value='$pban' onClick='if (document.getElementById(\"duration\").value==0) {return confirm(\"$conf\");} else {return true;}'>");
-rawoutput("</form>");
-output("For an IP ban, enter the beginning part of the IP you wish to ban if you wish to ban a range, or simply a full IP to ban a single IP`n`n");
-addnav("", "bans.php?op=saveban");
+$output->output("Reason for the ban: ");
+$output->rawOutput("<input name='reason' size=50 value=\"$reason\">");
+$output->outputNotl("`n");
+$pban = Translator::translateInline("Post ban");
+$conf = Translator::translateInline("Are you sure you wish to issue a permanent ban?");
+$output->rawOutput("<input type='submit' class='button' value='$pban' onClick='if (document.getElementById(\"duration\").value==0) {return confirm(\"$conf\");} else {return true;}'>");
+$output->rawOutput("</form>");
+$output->output("For an IP ban, enter the beginning part of the IP you wish to ban if you wish to ban a range, or simply a full IP to ban a single IP`n`n");
+Nav::add("", "bans.php?op=saveban");
 if ($row['name'] != "") {
     $id = $row['uniqueid'];
     $ip = $row['lastip'];
     $name = $row['name'];
-    output("`0To help locate similar users to `@%s`0, here are some other users who are close:`n", $name);
-    output("`bSame ID (%s):`b`n", $id);
-    $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . db_prefix("accounts") . " WHERE uniqueid='" . addslashes($id) . "' ORDER BY lastip";
-    $result = db_query($sql);
-    while ($row = db_fetch_assoc($result)) {
-        output(
+    $output->output("`0To help locate similar users to `@%s`0, here are some other users who are close:`n", $name);
+    $output->output("`bSame ID (%s):`b`n", $id);
+    $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . Database::prefix("accounts") . " WHERE uniqueid='" . addslashes($id) . "' ORDER BY lastip";
+    $result = Database::query($sql);
+    while ($row = Database::fetchAssoc($result)) {
+        $output->output(
             "`0* (%s) `%%s`0 - %s hits, last: %s`n",
             $row['lastip'],
             $row['name'],
@@ -50,27 +55,27 @@ if ($row['name'] != "") {
             reltime(strtotime($row['laston']))
         );
     }
-    output_notl("`n");
+    $output->outputNotl("`n");
         $oip = "";
     $dots = 0;
-    output("`bSimilar IP's`b`n");
+    $output->output("`bSimilar IP's`b`n");
     for ($x = strlen($ip); $x > 0; $x--) {
         if ($dots > 1) {
             break;
         }
         $thisip = substr($ip, 0, $x);
-        $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . db_prefix("accounts") . " WHERE lastip LIKE '$thisip%' AND NOT (lastip LIKE '$oip') ORDER BY uniqueid";
-        //output("$sql`n");
-        $result = db_query($sql);
-        if (db_num_rows($result) > 0) {
-            output("IP Filter: %s ", $thisip);
-            rawoutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
-            output("Use this filter");
-            rawoutput("</a>");
-            output_notl("`n");
-            while ($row = db_fetch_assoc($result)) {
-                output("&nbsp;&nbsp;", true);
-                output(
+        $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . Database::prefix("accounts") . " WHERE lastip LIKE '$thisip%' AND NOT (lastip LIKE '$oip') ORDER BY uniqueid";
+        //$output->output("$sql`n");
+        $result = Database::query($sql);
+        if (Database::numRows($result) > 0) {
+            $output->output("IP Filter: %s ", $thisip);
+            $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
+            $output->output("Use this filter");
+            $output->rawOutput("</a>");
+            $output->outputNotl("`n");
+            while ($row = Database::fetchAssoc($result)) {
+                $output->output("&nbsp;&nbsp;", true);
+                $output->output(
                     "(%s) [%s] `%%s`0 - %s hits, last: %s`n",
                     $row['lastip'],
                     $row['uniqueid'],
@@ -79,7 +84,7 @@ if ($row['name'] != "") {
                     reltime(strtotime($row['laston']))
                 );
             }
-            output_notl("`n");
+            $output->outputNotl("`n");
         }
         if (substr($ip, $x - 1, 1) == ".") {
             $x--;


### PR DESCRIPTION
## Summary
- switch bans page cases to use namespaced Lotgd classes
- drop old include for lookup_user and rely on `Lotgd\UserLookup`
- add strict types and imports for new APIs

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68879029e5b88329a9232ed5c2d67de4