### PR TITLE
Switch graveyard battle to PlayerFunctions class

### DIFF
--- a/pages/graveyard/case_battle_search.php
+++ b/pages/graveyard/case_battle_search.php
@@ -1,7 +1,9 @@
 <?php
+declare(strict_types=1);
 
 use Lotgd\Battle;
 use Lotgd\BellRand;
+use Lotgd\PlayerFunctions;
 
 if ($session['user']['gravefights'] <= 0) {
     output("`\$`bYour soul can bear no more torment in this afterlife.`b`0");
@@ -44,9 +46,8 @@ if ($session['user']['gravefights'] <= 0) {
                 $badguy['creatureaiscript'] = "require('" . $aiscriptfile . "');";
             }
         }
-        require_once("lib/playerfunctions.php");
-        $atk = get_player_attack();
-        $def = get_player_defense();
+        $atk = PlayerFunctions::getPlayerAttack();
+        $def = PlayerFunctions::getPlayerDefense();
         //$badguy['creatureattack']*=1.7+round($atk/(10 + round(($session['user']['level'] - 1) )));
         //$badguy['creaturedefense']*=1.6+round($def/(10 + round(($session['user']['level'] - 1))));
         $modificator = 1.5;

--- a/pages/graveyard/case_default.php
+++ b/pages/graveyard/case_default.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 if (!$skipgraveyardtext) {
     output("`)`c`bThe Graveyard`b`c");

--- a/pages/graveyard/case_enter.php
+++ b/pages/graveyard/case_enter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 output("`)`b`cThe Mausoleum`c`b");
 

--- a/pages/graveyard/case_question.php
+++ b/pages/graveyard/case_question.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 addnav("G?Return to the Graveyard", "graveyard.php");
 addnav("Places");

--- a/pages/graveyard/case_restore.php
+++ b/pages/graveyard/case_restore.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 output("`)`b`cThe Mausoleum`c`b");
 if ($session['user']['soulpoints'] < $max) {

--- a/pages/graveyard/case_resurrection.php
+++ b/pages/graveyard/case_resurrection.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 output("`\$%s`0 waves his skeletal arms as he begins to command the very fabric of life.`n`n", $deathoverlord);
 // Note to translators.  The text spoken by Ramius here is backwards


### PR DESCRIPTION
## Summary
- remove legacy `require_once` in graveyard battle search
- call `PlayerFunctions` methods directly
- enable strict types for all graveyard pages

## Testing
- `for f in pages/graveyard/*.php; do php -l "$f"; done`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688790261e388329aa232b5fa31f9a47