### PR TITLE
Refactor inn pages for namespace helpers

### DIFF
--- a/inn.php
+++ b/inn.php
@@ -1,18 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\Commentary;
 use Lotgd\Buffs;
 use Lotgd\Nav\VillageNav;
+use Lotgd\Sanitize;
+use Lotgd\Http;
+use Lotgd\Events;
 
 // addnews ready
 // translator ready
 // mail ready
 require_once("common.php");
 use Lotgd\Pvp;
-require_once("lib/sanitize.php");
-require_once("lib/http.php");
-require_once("lib/events.php");
-require_once("lib/villagenav.php");
 
 tlschema("inn");
 
@@ -21,28 +22,28 @@ $iname = getsetting("innname", LOCATION_INN);
 $vname = getsetting("villagename", LOCATION_FIELDS);
 $barkeep = getsetting('barkeep', '`tCedrik');
 
-$op = httpget('op');
+$op = Http::get('op');
 // Correctly reset the location if they fleeing the dragon
 // This needs to be done up here because a special could alter your op.
 if ($op == "fleedragon") {
     $session['user']['location'] = $vname;
 }
 
-page_header(array("%s",sanitize($iname)));
-$skipinndesc = handle_event("inn");
+page_header(["%s", Sanitize::sanitize($iname)]);
+$skipinndesc = Events::handleEvent("inn");
 
 if (!$skipinndesc) {
     checkday();
-    rawoutput("<span style='color: #9900FF'>");
-    output_notl("`c`b");
-    output($iname);
-    output_notl("`b`c");
+    $output->rawOutput("<span style='color: #9900FF'>");
+    $output->outputNotl("`c`b");
+    $output->output($iname);
+    $output->outputNotl("`b`c");
 }
 
-$subop = httpget('subop');
+$subop = Http::get('subop');
 
-$com = httpget('comscroll');
-$comment = httppost('insertcommentary');
+$com = Http::get('comscroll');
+$comment = Http::post('insertcommentary');
 
 require_once("lib/partner.php");
 $partner = get_partner();
@@ -69,7 +70,7 @@ switch ($op) {
 }
 
 if (!$skipinndesc) {
-    rawoutput("</span>");
+    $output->rawOutput("</span>");
 }
 
 page_footer();

--- a/pages/inn/inn_bartender.php
+++ b/pages/inn/inn_bartender.php
@@ -1,13 +1,18 @@
 <?php
 
-$act = httpget('act');
+declare(strict_types=1);
+
+use Lotgd\Http;
+use Lotgd\Sanitize;
+
+$act = Http::get('act');
 if ($act == "") {
-    output("%s`0 looks at you sort-of sideways like.", $barkeep);
-    output("He never was the sort who would trust a man any farther than he could throw them, which gave dwarves a decided advantage, except in provinces where dwarf tossing was made illegal.");
-    output("%s`0 polishes a glass, holds it up to the light of the door as another patron opens it to stagger out into the street.", $barkeep);
-    output("He then makes a face, spits on the glass and goes back to polishing it.");
-    output("\"`%What d'ya want?`0\" he asks gruffly.");
-    addnav_notl(sanitize($barkeep));
+    $output->output("%s`0 looks at you sort-of sideways like.", $barkeep);
+    $output->output("He never was the sort who would trust a man any farther than he could throw them, which gave dwarves a decided advantage, except in provinces where dwarf tossing was made illegal.");
+    $output->output("%s`0 polishes a glass, holds it up to the light of the door as another patron opens it to stagger out into the street.", $barkeep);
+    $output->output("He then makes a face, spits on the glass and goes back to polishing it.");
+    $output->output("\"`%What d'ya want?`0\" he asks gruffly.");
+    addnav_notl(Sanitize::sanitize($barkeep));
     addnav("Bribe", "inn.php?op=bartender&act=bribe");
     addnav("Drinks");
     modulehook("ale", array());
@@ -15,11 +20,11 @@ if ($act == "") {
     $g1 = $session['user']['level'] * 10;
     $g2 = $session['user']['level'] * 50;
     $g3 = $session['user']['level'] * 100;
-    $type = httpget('type');
+    $type = Http::get('type');
     if ($type == "") {
-        output("While you know that you won't always get what you want, sometimes the way to a man's information is through your purse.");
-        output("It's also always been said that more is better.`n`n");
-        output("How much would you like to offer him?");
+        $output->output("While you know that you won't always get what you want, sometimes the way to a man's information is through your purse.");
+        $output->output("It's also always been said that more is better.`n`n");
+        $output->output("How much would you like to offer him?");
         addnav("1 gem", "inn.php?op=bartender&act=bribe&type=gem&amt=1");
         addnav("2 gems", "inn.php?op=bartender&act=bribe&type=gem&amt=2");
         addnav("3 gems", "inn.php?op=bartender&act=bribe&type=gem&amt=3");
@@ -27,11 +32,11 @@ if ($act == "") {
         addnav(array("%s gold", $g2), "inn.php?op=bartender&act=bribe&type=gold&amt=$g2");
         addnav(array("%s gold", $g3), "inn.php?op=bartender&act=bribe&type=gold&amt=$g3");
     } else {
-        $amt = httpget('amt');
+        $amt = Http::get('amt');
         if ($type == "gem") {
             if ($session['user']['gems'] < $amt) {
                 $try = false;
-                output("You don't have %s gems!", $amt);
+                $output->output("You don't have %s gems!", $amt);
             } else {
                 $chance = $amt * 30;
                 $session['user']['gems'] -= $amt;
@@ -40,7 +45,7 @@ if ($act == "") {
             }
         } else {
             if ($session['user']['gold'] < $amt) {
-                output("You don't have %s gold!", $amt);
+                $output->output("You don't have %s gold!", $amt);
                 $try = false;
             } else {
                 $try = true;
@@ -53,7 +58,7 @@ if ($act == "") {
         }
         if ($try) {
             if (e_rand(0, 100) < $chance) {
-                output("%s`0 leans over the counter toward you.  \"`%What can I do for you, kid?`0\" he asks.", $barkeep);
+                $output->output("%s`0 leans over the counter toward you.  \"`%What can I do for you, kid?`0\" he asks.", $barkeep);
                 addnav("What do you want?");
                 modulehook("bartenderbribe", array());
                 if (getsetting("pvp", 1)) {
@@ -64,66 +69,66 @@ if ($act == "") {
                     addnav("Switch specialty", "inn.php?op=bartender&act=specialty");
                 }
             } else {
-                output("%s`0 begins to wipe down the counter top, an act that really needed doing a long time ago.", $barkeep);
+                $output->output("%s`0 begins to wipe down the counter top, an act that really needed doing a long time ago.", $barkeep);
                 if ($type == "gem") {
                     if ($amt == 1) {
-                        output("When he's finished, your gem is gone.");
+                        $output->output("When he's finished, your gem is gone.");
                     } else {
-                        output("When he's finished, your gems are gone.");
+                        $output->output("When he's finished, your gems are gone.");
                     }
                 } else {
-                    output("When he's finished, your gold is gone.");
+                    $output->output("When he's finished, your gold is gone.");
                 }
-                output("You inquire about the loss, and he stares blankly back at you.");
+                $output->output("You inquire about the loss, and he stares blankly back at you.");
                 addnav(array("B?Talk to %s`0 again",$barkeep), "inn.php?op=bartender");
             }
         } else {
-            output("`n`n%s`0 stands there staring at you blankly.", $barkeep);
+            $output->output("`n`n%s`0 stands there staring at you blankly.", $barkeep);
             addnav(array("B?Talk to %s`0 the Barkeep",$barkeep), "inn.php?op=bartender");
         }
     }
 } elseif ($act == "listupstairs") {
     addnav("Refresh the list", "inn.php?op=bartender&act=listupstairs");
-    output("%s`0 lays out a set of keys on the counter top, and tells you which key opens whose room.  The choice is yours, you may sneak in and attack any one of them.", $barkeep);
+    $output->output("%s`0 lays out a set of keys on the counter top, and tells you which key opens whose room.  The choice is yours, you may sneak in and attack any one of them.", $barkeep);
     pvplist($iname, "pvp.php", "?act=attack&inn=1");
 } elseif ($act == "colors") {
-    output("%s`0 leans on the bar.  \"`%So you want to know about colors, do you?`0\" he asks.", $barkeep);
-    output("You are about to answer when you realize the question was posed in the rhetoric.");
-    output("%s`0 continues, \"`%To do colors, here's what you need to do.", $barkeep);
-    output(" First, you use a &#0096; mark (found right above the tab key) followed by 1, 2, 3, 4, 5, 6, 7, !, @, #, $, %, ^, &.", true);
-    output("Each of those corresponds with a color to look like this:");
-    output_notl("`n`1&#0096;1 `2&#0096;2 `3&#0096;3 `4&#0096;4 `5&#0096;5 `6&#0096;6 `7&#0096;7 ", true);
-    output_notl("`n`!&#0096;! `@&#0096;@ `#&#0096;# `\$&#0096;\$ `%&#0096;% `^&#0096;^ `&&#0096;& `n", true);
-    output("`% Got it?`0\"  You can practice below:");
-    rawoutput("<form action=\"$REQUEST_URI\" method='POST'>", true);
-    $testtext = httppost('testtext');
-    output("You entered %s`n", prevent_colors(HTMLEntities($testtext, ENT_COMPAT, getsetting("charset", "ISO-8859-1"))), true);
-    output("It looks like %s`n", $testtext);
+    $output->output("%s`0 leans on the bar.  \"`%So you want to know about colors, do you?`0\" he asks.", $barkeep);
+    $output->output("You are about to answer when you realize the question was posed in the rhetoric.");
+    $output->output("%s`0 continues, \"`%To do colors, here's what you need to do.", $barkeep);
+    $output->output(" First, you use a &#0096; mark (found right above the tab key) followed by 1, 2, 3, 4, 5, 6, 7, !, @, #, $, %, ^, &.", true);
+    $output->output("Each of those corresponds with a color to look like this:");
+    $output->outputNotl("`n`1&#0096;1 `2&#0096;2 `3&#0096;3 `4&#0096;4 `5&#0096;5 `6&#0096;6 `7&#0096;7 ", true);
+    $output->outputNotl("`n`!&#0096;! `@&#0096;@ `#&#0096;# `\$&#0096;\$ `%&#0096;% `^&#0096;^ `&&#0096;& `n", true);
+    $output->output("`% Got it?`0\"  You can practice below:");
+    $output->rawOutput("<form action=\"$REQUEST_URI\" method='POST'>", true);
+    $testtext = Http::post('testtext');
+    $output->output("You entered %s`n", prevent_colors(HTMLEntities($testtext, ENT_COMPAT, getsetting("charset", "ISO-8859-1"))), true);
+    $output->output("It looks like %s`n", $testtext);
     $try = translate_inline("Try");
-    rawoutput("<input name='testtext' id='input'>");
-    rawoutput("<input type='submit' class='button' value='$try'>");
-    rawoutput("</form>");
-    rawoutput("<script language='javascript'>document.getElementById('input').focus();</script>");
-        output("`0`n`nThese colors can be used in your name, and in any conversations you have.");
+    $output->rawOutput("<input name='testtext' id='input'>");
+    $output->rawOutput("<input type='submit' class='button' value='$try'>");
+    $output->rawOutput("</form>");
+    $output->rawOutput("<script language='javascript'>document.getElementById('input').focus();</script>");
+        $output->output("`0`n`nThese colors can be used in your name, and in any conversations you have.");
     addnav("", $REQUEST_URI);
 } elseif ($act == "specialty") {
-    $specialty = httpget('specialty');
+    $specialty = Http::get('specialty');
     if ($specialty == "") {
-        output("\"`2I want to change my specialty,`0\" you announce to %s`0.`n`n", $barkeep);
-        output("With out a word, %s`0 grabs you by the shirt, pulls you over the counter, and behind the barrels behind him.", $barkeep);
-        output("There, he rotates the tap on a small keg labeled \"Fine Swill XXX\"`n`n");
-        output("You look around for the secret door that you know must be opening nearby when %s`0 rotates the tap back, and lifts up a freshly filled foamy mug of what is apparently his fine swill, blue-green tint and all.`n`n", $barkeep);
-        output("\"`3What?  Were you expecting a secret room?`0\" he asks.  \"`3Now then, you must be more careful about how loudly you say that you want to change your specialty, not everyone looks favorably on that sort of thing.`n`n");
-        output("`0\"`3What new specialty did you have in mind?`0\"");
+        $output->output("\"`2I want to change my specialty,`0\" you announce to %s`0.`n`n", $barkeep);
+        $output->output("With out a word, %s`0 grabs you by the shirt, pulls you over the counter, and behind the barrels behind him.", $barkeep);
+        $output->output("There, he rotates the tap on a small keg labeled \"Fine Swill XXX\"`n`n");
+        $output->output("You look around for the secret door that you know must be opening nearby when %s`0 rotates the tap back, and lifts up a freshly filled foamy mug of what is apparently his fine swill, blue-green tint and all.`n`n", $barkeep);
+        $output->output("\"`3What?  Were you expecting a secret room?`0\" he asks.  \"`3Now then, you must be more careful about how loudly you say that you want to change your specialty, not everyone looks favorably on that sort of thing.`n`n");
+        $output->output("`0\"`3What new specialty did you have in mind?`0\"");
         $specialities = modulehook("specialtynames");
         foreach ($specialities as $key => $name) {
-            addnav($name, cmd_sanitize($REQUEST_URI) . "&specialty=$key");
+            addnav($name, Sanitize::cmdSanitize($REQUEST_URI) . "&specialty=$key");
         }
     } else {
-        output("\"`3Ok then,`0\" %s`0 says, \"`3You're all set.`0\"`n`n\"`2That's it?`0\" you ask him.`n`n", $barkeep);
-        output("\"`3Yep.  What'd you expect, some sort of fancy arcane ritual???`0\"  %s`0 begins laughing loudly.", $barkeep);
-        output("\"`3You're all right, kid... just don't ever play poker, eh?`0`n`n");
-        output("\"`3Oh, one more thing.  Your old use points and skill level still apply to that skill, you'll have to build up some points in this one to be very good at it.`0\"");
+        $output->output("\"`3Ok then,`0\" %s`0 says, \"`3You're all set.`0\"`n`n\"`2That's it?`0\" you ask him.`n`n", $barkeep);
+        $output->output("\"`3Yep.  What'd you expect, some sort of fancy arcane ritual???`0\"  %s`0 begins laughing loudly.", $barkeep);
+        $output->output("\"`3You're all right, kid... just don't ever play poker, eh?`0`n`n");
+        $output->output("\"`3Oh, one more thing.  Your old use points and skill level still apply to that skill, you'll have to build up some points in this one to be very good at it.`0\"");
         $session['user']['specialty'] = $specialty;
     }
 }

--- a/pages/inn/inn_default.php
+++ b/pages/inn/inn_default.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+use Lotgd\Http;
+
 if ($com == "" && !$comment && $op != "fleedragon") {
     if (module_events("inn", getsetting("innchance", 0)) != 0) {
         if (checknavs()) {
@@ -9,7 +13,7 @@ if ($com == "" && !$comment && $op != "fleedragon") {
             $session['user']['specialinc'] = "";
             $session['user']['specialmisc'] = "";
             $op = "";
-            httpset("op", "");
+            Http::set("op", "");
         }
     }
 }
@@ -27,26 +31,26 @@ addnav("Get a room (log out)", "inn.php?op=room");
 
 if (!$skipinndesc) {
     if ($op == "strolldown") {
-        output("You stroll down the stairs of the inn, once again ready for adventure!`n");
+        $output->output("You stroll down the stairs of the inn, once again ready for adventure!`n");
     } elseif ($op == "fleedragon") {
-        output("You pelt into the inn as if the Devil himself is at your heels.  Slowly you catch your breath and look around.`n");
-        output("%s`0 catches your eye and then looks away in disgust at your cowardice!`n`n", $partner);
-        output("You `\$lose`0 a charm point.`n`n");
+        $output->output("You pelt into the inn as if the Devil himself is at your heels.  Slowly you catch your breath and look around.`n");
+        $output->output("%s`0 catches your eye and then looks away in disgust at your cowardice!`n`n", $partner);
+        $output->output("You `\$lose`0 a charm point.`n`n");
         if ($session['user']['charm'] > 0) {
             $session['user']['charm']--;
         }
     } else {
-        output("You duck into a dim tavern that you know well.");
-        output("The pungent aroma of pipe tobacco fills the air.`n");
+        $output->output("You duck into a dim tavern that you know well.");
+        $output->output("The pungent aroma of pipe tobacco fills the air.`n");
     }
 
-    output("You wave to several patrons that you know.");
+    $output->output("You wave to several patrons that you know.");
     if ($session['user']['sex']) {
-        output("You give a special wave and wink to %s`0 who is tuning his harp by the fire.", $partner);
+        $output->output("You give a special wave and wink to %s`0 who is tuning his harp by the fire.", $partner);
     } else {
-        output("You give a special wave and wink to %s`0 who is serving drinks to some locals.", $partner);
+        $output->output("You give a special wave and wink to %s`0 who is serving drinks to some locals.", $partner);
     }
-    output("%s`0 the innkeep stands behind his counter, chatting with someone.", $barkeep);
+    $output->output("%s`0 the innkeep stands behind his counter, chatting with someone.", $barkeep);
 
     $chats = array(
         translate_inline("dragons"),
@@ -58,8 +62,8 @@ if (!$skipinndesc) {
     );
     $chats = modulehook("innchatter", $chats);
     $talk = $chats[e_rand(0, count($chats) - 1)];
-    output("You can't quite make out what he is saying, but it's something about %s`0.`n`n", $talk);
-    output("The clock on the mantle reads `6%s`0.`n", getgametime());
+    $output->output("You can't quite make out what he is saying, but it's something about %s`0.`n`n", $talk);
+    $output->output("The clock on the mantle reads `6%s`0.`n", getgametime());
     modulehook("inn-desc", array());
 }
 modulehook("inn", array());

--- a/pages/inn/inn_room.php
+++ b/pages/inn/inn_room.php
@@ -1,9 +1,14 @@
 <?php
 
-$config = unserialize($session['user']['donationconfig']);
+declare(strict_types=1);
+
+use Lotgd\Http;
+use Lotgd\Serialization;
+
+$config = Serialization::safeUnserialize($session['user']['donationconfig']);
 use Lotgd\Accounts;
 $expense = round(($session['user']['level'] * (10 + log($session['user']['level']))), 0);
-$pay = httpget('pay');
+$pay = Http::get('pay');
 if ($pay) {
     if (
         $pay == 2 || $session['user']['gold'] >= $expense ||
@@ -33,17 +38,17 @@ if ($pay) {
         $session = array();
         redirect("index.php");
     } else {
-        output("\"Aah, so that's how it is,\" %s`0 says as he puts the key he had retrieved back on to its hook behind his counter.", $barkeep);
-        output("Perhaps you'd like to get sufficient funds before you attempt to engage in local commerce.");
+        $output->output("\"Aah, so that's how it is,\" %s`0 says as he puts the key he had retrieved back on to its hook behind his counter.", $barkeep);
+        $output->output("Perhaps you'd like to get sufficient funds before you attempt to engage in local commerce.");
     }
 } else {
     if ($session['user']['boughtroomtoday']) {
-        output("You already paid for a room for the day.");
+        $output->output("You already paid for a room for the day.");
         addnav("Go to room", "inn.php?op=room&pay=1");
     } else {
         modulehook("innrooms");
-        output("You stroll over to the bartender and request a room.");
-        output("He eyes you up and says, \"It will cost `\$%s`0 gold for the night in a standard room.", $expense);
+        $output->output("You stroll over to the bartender and request a room.");
+        $output->output("He eyes you up and says, \"It will cost `\$%s`0 gold for the night in a standard room.", $expense);
         $fee = getsetting("innfee", "5%");
         if (strpos($fee, "%")) {
             $bankexpense = $expense + round($expense * $fee / 100, 0);
@@ -51,27 +56,27 @@ if ($pay) {
             $bankexpense = $expense + $fee;
         }
         if ($session['user']['goldinbank'] >= $bankexpense && $bankexpense != $expense) {
-            output("And since you are such a fine person, I'll even offer you a rate of `\$%s`0 gold if you pay direct from the bank.", $bankexpense);
+            $output->output("And since you are such a fine person, I'll even offer you a rate of `\$%s`0 gold if you pay direct from the bank.", $bankexpense);
             if (strpos($fee, "%")) {
-                output("That includes a %s transaction fee.", $fee);
+                $output->output("That includes a %s transaction fee.", $fee);
             } else {
-                output(
+                $output->output(
                     "That includes a transaction fee of %s gold.",
                     $fee
                 );
             }
         }
         $bodyguards = array("Butch","Bruce","Alfonozo","Guido","Bruno","Bubba","Al","Chuck","Brutus","Nunzio","Terrance","Mitch","Rocco","Spike","Gregor","Sven","Draco");
-        output("`n`n\"Also, let me tell you about our new 'Bodyguard Assistance Program' &#151; BAP.  You see, you hire one of my guards here, and they'll protect you should anyone happen to, er, pick the locks of your room,\" he says as he gestures to a series of men sitting at one of the inn's tables drinking ale.", true);
-        output("They range in size from a skinny shifty-eyed fellow who appears barely able to lift his stein to a great bear of a fellow.");
-        output("This bruiser has a tattoo of a heart with \"Mom\" written across it on his huge bicep, and goes to take a sip from his ale, but instead crushes his stein, squirting it all over the skinny fellow who doesn't voice any objection for obvious reasons.");
-        output("\"We call it the BAP program because when someone tries to sneak into your room, BAP BAP BAP, our guys go to work.");
-        output("There's only two conditions: you pay your fee up front, and the guard you choose gets to keep a portion of the rewards from any fights.\"");
-        output("`n`nNot wanting to part with your money when the fields offer a place to sleep, you debate the issue.");
-        output("You realize, however, that the inn is a considerably safer place to sleep.");
-        output("It is far harder for vagabonds to get you in your room while you sleep.");
-        output("Also, those bodyguards sound pretty safe to you.");
-        //output("`n`bNote, bodyguard levels not yet implemented`b`n");
+        $output->output("`n`n\"Also, let me tell you about our new 'Bodyguard Assistance Program' &#151; BAP.  You see, you hire one of my guards here, and they'll protect you should anyone happen to, er, pick the locks of your room,\" he says as he gestures to a series of men sitting at one of the inn's tables drinking ale.", true);
+        $output->output("They range in size from a skinny shifty-eyed fellow who appears barely able to lift his stein to a great bear of a fellow.");
+        $output->output("This bruiser has a tattoo of a heart with \"Mom\" written across it on his huge bicep, and goes to take a sip from his ale, but instead crushes his stein, squirting it all over the skinny fellow who doesn't voice any objection for obvious reasons.");
+        $output->output("\"We call it the BAP program because when someone tries to sneak into your room, BAP BAP BAP, our guys go to work.");
+        $output->output("There's only two conditions: you pay your fee up front, and the guard you choose gets to keep a portion of the rewards from any fights.\"");
+        $output->output("`n`nNot wanting to part with your money when the fields offer a place to sleep, you debate the issue.");
+        $output->output("You realize, however, that the inn is a considerably safer place to sleep.");
+        $output->output("It is far harder for vagabonds to get you in your room while you sleep.");
+        $output->output("Also, those bodyguards sound pretty safe to you.");
+        //$output->output("`n`bNote, bodyguard levels not yet implemented`b`n");
         addnav(array("Give him %s gold", $expense), "inn.php?op=room&pay=1");
         if ($session['user']['goldinbank'] >= $bankexpense) {
             addnav(array("Pay %s gold from bank", $bankexpense), "inn.php?op=room&pay=2");


### PR DESCRIPTION
## Summary
- use Http, Events, Sanitize, and VillageNav namespaces directly
- replace legacy output() wrappers with `$output` calls
- use safe `Serialization::safeUnserialize` in the inn room

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68879025563483298226b55eb5b9fefe