### PR TITLE
Refactor root pages to namespaced helpers

### DIFF
--- a/account.php
+++ b/account.php
@@ -1,7 +1,12 @@
 <?php
+declare(strict_types=1);
 
 use Lotgd\DateTime;
 use Lotgd\Commentary;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Nav;
+use Lotgd\Nav\VillageNav;
 
 // translator ready
 // addnews ready
@@ -11,16 +16,15 @@ require_once("common.php");
 
 tlschema("account");
 
-page_header("Account Information");
+Header::pageHeader("Account Information");
 Commentary::addCommentary();
-checkday();
+DateTime::checkDay();
 
 output("`\$Some stats concerning your account. Note that this in the timezone of the server.`0`n`n");
-addnav("Navigation");
-require_once("lib/villagenav.php");
-villagenav();
-addnav("Actions");
-addnav("Refresh", "account.php");
+Nav::add("Navigation");
+VillageNav::render();
+Nav::add("Actions");
+Nav::add("Refresh", "account.php");
 
 $user = $session['user'];
 
@@ -32,7 +36,10 @@ $stats[] = array("title" => "Last Comment posted:","value" => $user['recentcomme
 $stats[] = array("title" => "Last PvP happened:","value" => $user['pvpflag']);
 $stats[] = array("title" => "Dragonkills:","value" => $user['dragonkills']);
 $stats[] = array("title" => "Total Pages generated for you:","value" => $user['gentimecount']);
-$stats[] = array("title" => "How long did these pages take to generate:","value" => readabletime($user['gentime']));
+$stats[] = array(
+    "title" => "How long did these pages take to generate:",
+    "value" => DateTime::readableTime($user['gentime'])
+);
 $stats[] = array("title" => "You are Account Number:","value" => ($user['acctid'] - 1));
 //Add the count summary for DKs
 $dksummary = "";
@@ -66,4 +73,4 @@ rawoutput("</table>");
 
 tlschema();
 
-page_footer();
+Footer::pageFooter();

--- a/badnav.php
+++ b/badnav.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * \file badnav.php
@@ -8,18 +9,24 @@
 
 // translator ready
 use Lotgd\Accounts;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Nav\VillageNav;
+use Lotgd\Nav;
+use Lotgd\DateTime;
+use Lotgd\Translator;
+use Lotgd\Redirect;
 
 // addnews ready
 // mail ready
 define("OVERRIDE_FORCED_NAV", true);
 require_once("common.php");
-require_once("lib/villagenav.php");
 
 tlschema("badnav");
 
 if ($session['user']['loggedin'] && $session['loggedin']) {
     if (isset($session['output']) && strpos($session['output'], "<!--CheckNewDay()-->")) {
-        checkday();
+        DateTime::checkDay();
     }
     foreach ($session['allowednavs'] as $key => $val) {
         //hack-tastic.
@@ -53,18 +60,18 @@ if ($session['user']['loggedin'] && $session['loggedin']) {
             count($session['allowednavs']) == 0 || $row['output'] == ""
     ) {
         $session['allowednavs'] = array();
-        page_header("Your Navs Are Corrupted");
+        Header::pageHeader("Your Navs Are Corrupted");
         if ($session['user']['alive']) {
-            villagenav();
+            VillageNav::render();
             output(
                 "Your navs are corrupted, please return to %s.",
                 $session['user']['location']
             );
         } else {
-            addnav("Return to Shades", "shades.php");
+            Nav::add("Return to Shades", "shades.php");
             output("Your navs are corrupted, please return to the Shades.");
         }
-        page_footer();
+        Footer::pageFooter();
     }
     echo $row['output'];
     $session['debug'] = "";
@@ -72,6 +79,6 @@ if ($session['user']['loggedin'] && $session['loggedin']) {
     Accounts::saveUser();
 } else {
     $session = array();
-    translator_setup();
-    redirect("index.php");
+    Translator::translatorSetup();
+    Redirect::redirect("index.php");
 }

--- a/badword.php
+++ b/badword.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * \file badword.php
@@ -8,34 +9,37 @@
 
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
+use Lotgd\Http;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Nav;
 
 // translator ready
 // addnews ready
 // mail ready
 require_once("common.php");
-require_once("lib/http.php");
 
 SuAccess::check(SU_EDIT_COMMENTS);
 
 tlschema("badword");
 
-$op = httpget('op');
+$op = Http::get('op');
 //yuck, this page is a mess, but it gets the job done.
-page_header("Bad word editor");
+Header::pageHeader("Bad word editor");
 
 SuperuserNav::render();
-addnav("Bad Word Editor");
+Nav::add("Bad Word Editor");
 
-addnav("Refresh the list", "badword.php");
+Nav::add("Refresh the list", "badword.php");
 output("`7Here you can edit the words that the game filters.  Using * at the start or end of a word will be a wildcard matching anything else attached to the word.  These words are only filtered if bad word filtering is turned on in the game settings page.`n`n`0");
 
 $test = translate_inline("Test");
 rawoutput("<form action='badword.php?op=test' method='POST'>");
-addnav("", "badword.php?op=test");
+Nav::add("", "badword.php?op=test");
 output("`7Test a word:`0");
 rawoutput("<input name='word'><input type='submit' class='button' value='$test'></form>");
 if ($op == "test") {
-    $word = httppost("word");
+    $word = Http::post("word");
     $return = soap($word, true);
     if ($return == $word) {
         output("`7\"%s\" does not trip any filters.`0`n`n", $word);
@@ -52,11 +56,11 @@ output("`7 (bad word exceptions)`0`n");
 $add = translate_inline("Add");
 $remove = translate_inline("Remove");
 rawoutput("<form action='badword.php?op=addgood' method='POST'>");
-addnav("", "badword.php?op=addgood");
+Nav::add("", "badword.php?op=addgood");
 output("`7Add a word:`0");
 rawoutput("<input name='word'><input type='submit' class='button' value='$add'></form>");
 rawoutput("<form action='badword.php?op=removegood' method='POST'>");
-addnav("", "badword.php?op=removegood");
+Nav::add("", "badword.php?op=removegood");
 output("`7Remove a word:`0");
 rawoutput("<input name='word'><input type='submit' class='button' value='$remove'></form>");
 
@@ -66,7 +70,7 @@ $result = db_query($sql);
 $row = db_fetch_assoc($result);
 $words = explode(" ", $row['words']);
 if ($op == "addgood") {
-    $newregexp = stripslashes(httppost('word'));
+    $newregexp = stripslashes(Http::post('word'));
 
     // not sure if the line below should appear, as the strings in the good
     // word list have different behaviour than those in the nasty word list,
@@ -89,7 +93,7 @@ if ($op == "addgood") {
 }
 if ($op == "removegood") {
     // false if not found
-    $removekey = array_search(stripslashes(httppost('word')), $words);
+    $removekey = array_search(stripslashes(Http::post('word')), $words);
     // $removekey can be 0
     if ($removekey !== false) {
         unset($words[$removekey]);
@@ -114,11 +118,11 @@ rawoutput("</font>");
 output_notl("`n");
 
 rawoutput("<form action='badword.php?op=add' method='POST'>");
-addnav("", "badword.php?op=add");
+Nav::add("", "badword.php?op=add");
 output("`7Add a word:`0");
 rawoutput("<input name='word'><input type='submit' class='button' value='$add'></form>");
 rawoutput("<form action='badword.php?op=remove' method='POST'>");
-addnav("", "badword.php?op=remove");
+Nav::add("", "badword.php?op=remove");
 output("`7Remove a word:`0");
 rawoutput("<input name='word'><input type='submit' class='button' value='$remove'></form>");
 
@@ -129,7 +133,7 @@ $words = explode(" ", $row['words']);
 reset($words);
 
 if ($op == "add") {
-    $newregexp = stripslashes(httppost('word'));
+    $newregexp = stripslashes(Http::post('word'));
 
     // automagically escapes all unescaped single quote characters
     $newregexp = preg_replace('/(?<!\\\\)\'/', '\\\'', $newregexp);
@@ -148,7 +152,7 @@ if ($op == "add") {
 }
 if ($op == "remove") {
     // false if not found
-    $removekey = array_search(stripslashes(httppost('word')), $words);
+    $removekey = array_search(stripslashes(Http::post('word')), $words);
     // $removekey can be 0
     if ($removekey !== false) {
         unset($words[$removekey]);
@@ -166,7 +170,7 @@ if ($op == "add" || $op == "remove") {
     db_query($sql);
     invalidatedatacache("nastywordlist");
 }
-page_footer();
+Footer::pageFooter();
 
 function show_word_list($words)
 {

--- a/bans.php
+++ b/bans.php
@@ -1,24 +1,29 @@
 <?php
+declare(strict_types=1);
 
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
 use Lotgd\DateTime;
+use Lotgd\Http;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Nav;
+use Lotgd\UserLookup;
 
 //addnews ready
 // mail ready
 require_once("common.php");
-require_once("lib/sanitize.php");
 use Lotgd\Names;
 
 tlschema("bans");
 SuAccess::check(SU_EDIT_BANS);
 
-$op = httpget('op');
-$userid = httpget("userid");
+$op = Http::get('op');
+$userid = Http::get("userid");
 
-page_header("Ban Editor");
+Header::pageHeader("Ban Editor");
 
-$sort = httpget('sort');
+$sort = Http::get('sort');
 
 $gentime = 0;
 $gentimecount = 0;
@@ -28,17 +33,16 @@ if ($sort != "") {
     $order = "$sort";
 }
 $display = 0;
-$query = httppost('q');
+$query = Http::post('q');
 if ($query === false) {
-    $query = httpget('q');
+    $query = Http::get('q');
 }
 if (!$query && $sort) {
     $query = "%";
 }
 
 if ($op == "search" || $op == "") {
-    require_once("lib/lookup_user.php");
-    list($searchresult, $err) = lookup_user($query, $order);
+    list($searchresult, $err) = UserLookup::lookupUser($query, $order);
     $op = "";
     if ($err) {
         output($err);
@@ -58,15 +62,15 @@ $se = translate_inline("Search");
 rawoutput("<input type='submit' class='button' value='$se'>");
 rawoutput("</form>");
 rawoutput("<script language='JavaScript'>document.getElementById('q').focus();</script>");
-addnav("", "bans.php?op=search");
+Nav::add("", "bans.php?op=search");
 
 
 
 SuperuserNav::render();
-addnav("Bans");
-addnav("Add a ban", "bans.php?op=setupban");
-addnav("List/Remove bans", "bans.php?op=removeban");
-addnav("Search for banned user", "bans.php?op=searchban");
+Nav::add("Bans");
+Nav::add("Add a ban", "bans.php?op=setupban");
+Nav::add("List/Remove bans", "bans.php?op=removeban");
+Nav::add("Search for banned user", "bans.php?op=searchban");
 
 
 switch ($op) {
@@ -89,4 +93,4 @@ switch ($op) {
             output("From here, you can issue bans for players from being able to play.`n`nBased on the ID = cookie on the machine AND/OR on the IP they accessed the char last the ban takes effect.`n`nNote: Locked chars stay locked, even after they delete their cookie / change their IP.`n`nHowever, they can make new chars and login in that case. You cannot control this.");
             require("pages/bans/case_.php");
 }
-page_footer();
+Footer::pageFooter();

--- a/bio.php
+++ b/bio.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 // addnews ready
 // translator ready
@@ -9,18 +10,24 @@
 * @see village.php
 * @see prefs.php
 */
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Nav;
+use Lotgd\Sanitize;
+use Lotgd\DateTime;
+use Lotgd\Http;
+
 require_once("common.php");
-require_once("lib/sanitize.php");
 
 tlschema("bio");
 
-checkday();
+DateTime::checkDay();
 
-$ret = httpget('ret');
+$ret = Http::get('ret');
 if ($ret == "") {
     $return = "/list.php";
 } else {
-    $return = cmd_sanitize($ret);
+    $return = Sanitize::cmdSanitize($ret);
 }
 
 $char = httpget('char');
@@ -39,15 +46,15 @@ if ($target = db_fetch_assoc($result)) {
     $id = $target['acctid'];
     $target['return_link'] = $return;
 
-    page_header("Character Biography: %s", full_sanitize($target['name']));
+    Header::pageHeader("Character Biography: %s", Sanitize::fullSanitize($target['name']));
 
     tlschema("nav");
-    addnav("Return");
+    Nav::add("Return");
     tlschema();
 
     if ($session['user']['superuser'] & SU_EDIT_USERS) {
-        addnav("Superuser");
-        addnav("Edit User", "user.php?op=edit&userid=$id");
+        Nav::add("Superuser");
+        Nav::add("Edit User", "user.php?op=edit&userid=$id");
     }
 
     modulehook("biotop", $target);
@@ -154,49 +161,49 @@ if ($target = db_fetch_assoc($result)) {
             );
             $odate = $row['newsdate'];
         }
-        output_notl("`@" . sanitize_mb($news) . "`0`n");
+        output_notl("`@" . Sanitize::sanitizeMb($news) . "`0`n");
     }
     tlschema();
 
     if ($ret == "") {
         $return = substr($return, strrpos($return, "/") + 1);
         tlschema("nav");
-        addnav("Return");
-        addnav("Return to the warrior list", $return);
+        Nav::add("Return");
+        Nav::add("Return to the warrior list", $return);
         tlschema();
     } else {
         $return = substr($return, strrpos($return, "/") + 1);
         tlschema("nav");
-        addnav("Return");
+        Nav::add("Return");
         if ($return == "list.php") {
-            addnav("Return to the warrior list", $return);
+            Nav::add("Return to the warrior list", $return);
         } else {
-            addnav("Return whence you came", $return);
+            Nav::add("Return whence you came", $return);
         }
         tlschema();
     }
 
     modulehook("bioend", $target);
-    page_footer();
+    Footer::pageFooter();
 } else {
-    page_header("Character has been deleted");
+    Header::pageHeader("Character has been deleted");
     output("This character is already deleted.");
     if ($ret == "") {
         $return = substr($return, strrpos($return, "/") + 1);
         tlschema("nav");
-        addnav("Return");
-        addnav("Return to the warrior list", $return);
+        Nav::add("Return");
+        Nav::add("Return to the warrior list", $return);
         tlschema();
     } else {
         $return = substr($return, strrpos($return, "/") + 1);
         tlschema("nav");
-        addnav("Return");
+        Nav::add("Return");
         if ($return == "list.php") {
-            addnav("Return to the warrior list", $return);
+            Nav::add("Return to the warrior list", $return);
         } else {
-            addnav("Return whence you came", $return);
+            Nav::add("Return whence you came", $return);
         }
         tlschema();
     }
-    page_footer();
+    Footer::pageFooter();
 }

--- a/bio.php
+++ b/bio.php
@@ -30,7 +30,7 @@ if ($ret == "") {
     $return = Sanitize::cmdSanitize($ret);
 }
 
-$char = httpget('char');
+$char = Http::get('char');
 //Legacy support
 if (is_numeric($char)) {
     $where = "acctid = $char";

--- a/bios.php
+++ b/bios.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * \file bios.php
@@ -9,18 +10,21 @@
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
 use Lotgd\Mail;
+use Lotgd\Http;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Nav;
 
 // translator ready
 // addnews ready
 // mail ready
 require_once("common.php");
-require_once("lib/http.php");
 
 tlschema("bio");
 SuAccess::check(SU_EDIT_COMMENTS);
 
-$op = httpget('op');
-$userid = (int)httpget('userid');
+$op = Http::get('op');
+$userid = (int)Http::get('userid');
 if ($op == "block") {
        $sql = "UPDATE " . db_prefix("accounts") . " SET bio='`iBlocked for inappropriate usage`i',biotime='9999-12-31 23:59:59' WHERE acctid=$userid";
     $subj = array("Your bio has been blocked");
@@ -37,7 +41,7 @@ if ($op == "unblock") {
 }
 $sql = "SELECT name,acctid,bio,biotime FROM " . db_prefix("accounts") . " WHERE biotime<'9999-12-31' AND bio>'' ORDER BY biotime DESC LIMIT 100";
 $result = db_query($sql);
-page_header("User Bios");
+Header::pageHeader("User Bios");
 $block = translate_inline("Block");
 output("`b`&Player Bios:`0`b`n");
 while ($row = db_fetch_assoc($result)) {
@@ -45,19 +49,19 @@ while ($row = db_fetch_assoc($result)) {
         rawoutput("<img src='images/new.gif' alt='&gt;' width='3' height='5' align='absmiddle'> ");
     }
     output_notl("`![<a href='bios.php?op=block&userid={$row['acctid']}'>$block</a>]", true);
-    addnav("", "bios.php?op=block&userid={$row['acctid']}");
+    Nav::add("", "bios.php?op=block&userid={$row['acctid']}");
     output_notl("`&%s`0: `^%s`0`n", $row['name'], soap($row['bio']));
 }
 db_free_result($result);
 SuperuserNav::render();
 
-addnav("Moderation");
+Nav::add("Moderation");
 
 if ($session['user']['superuser'] & SU_EDIT_COMMENTS) {
-    addnav("Return to Comment Moderation", "moderate.php");
+    Nav::add("Return to Comment Moderation", "moderate.php");
 }
 
-addnav("Refresh", "bios.php");
+Nav::add("Refresh", "bios.php");
 $sql = "SELECT name,acctid,bio,biotime FROM " . db_prefix("accounts") . " WHERE biotime>'9000-01-01' AND bio>'' ORDER BY biotime DESC LIMIT 100";
 $result = db_query($sql);
 output("`n`n`b`&Blocked Bios:`0`b`n");
@@ -67,8 +71,8 @@ for ($i = 0; $i < $number; $i++) {
     $row = db_fetch_assoc($result);
 
     output_notl("`![<a href='bios.php?op=unblock&userid={$row['acctid']}'>$unblock</a>]", true);
-    addnav("", "bios.php?op=unblock&userid={$row['acctid']}");
+    Nav::add("", "bios.php?op=unblock&userid={$row['acctid']}");
     output_notl("`&%s`0: `^%s`0`n", $row['name'], soap($row['bio']));
 }
 db_free_result($result);
-page_footer();
+Footer::pageFooter();


### PR DESCRIPTION
## Summary
- refactor wrapper function calls in multiple root pages
- drop redundant `require_once` statements for wrapper libraries
- use `Lotgd\` APIs for navigation, HTTP and rendering

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6887b35ff558832985d8e8a2baa8859f