### PR TITLE
Refactor petition scripts to use Output object

### DIFF
--- a/petition.php
+++ b/petition.php
@@ -1,8 +1,11 @@
 <?php
+declare(strict_types=1);
 
 use Lotgd\SuAccess;
 use Lotgd\Stripslashes;
 use Lotgd\Nav\SuperuserNav;
+use Lotgd\Http;
+use Lotgd\Page\Footer;
 
 // addnews ready
 // translator ready
@@ -10,9 +13,8 @@ use Lotgd\Nav\SuperuserNav;
 define("ALLOW_ANONYMOUS", true);
 define("OVERRIDE_FORCED_NAV", true);
 require_once("common.php");
-require_once("lib/output_array.php");
-require_once("lib/http.php");
-$op = httpget('op');
+
+$op = Http::get('op');
 
 switch ($op) {
     case "primer":
@@ -26,4 +28,4 @@ switch ($op) {
             require("pages/petition/petition_default.php");
         break;
 }
-popup_footer();
+Footer::popupFooter();

--- a/viewpetition.php
+++ b/viewpetition.php
@@ -266,7 +266,7 @@ if ($op == "") {
     Nav::add("Details");
     $viewpageinfo = (int)Http::get("viewpageinfo");
     if ($viewpageinfo == 1) {
-        Nav::add("Hide Details", "viewpetition.php?op=view&id=$id}");
+        Nav::add("Hide Details", "viewpetition.php?op=view&id=$id");
     } else {
         Nav::add("D?Show Details", "viewpetition.php?op=view&id=$id&viewpageinfo=1");
     }

--- a/viewpetition.php
+++ b/viewpetition.php
@@ -1,15 +1,20 @@
 <?php
+declare(strict_types=1);
 
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
 use Lotgd\Commentary;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Nav;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // translator ready
 // addnews ready
 // mail ready
 
 require_once("common.php");
-require_once("lib/http.php");
 
 tlschema("petition");
 
@@ -31,13 +36,13 @@ $statuses = array(
     2 => "`iClosed`i",
     );
 
-$statuses = modulehook("petition-status", $statuses);
+$statuses = HookHandler::hook("petition-status", $statuses);
 $statuses = translate_inline($statuses);
 
-$op = httpget("op");
-$id = httpget("id");
+$op = Http::get("op");
+$id = Http::get("id");
 
-if (trim(httppost('insertcommentary')) != "") {
+if (trim(Http::post('insertcommentary')) != "") {
     /* Update the bug if someone adds comments as well */
     $sql = "UPDATE " . db_prefix("petitions") . " SET closeuserid='{$session['user']['acctid']}',closedate='" . date("Y-m-d H:i:s") . "' WHERE petitionid='$id'";
     db_query($sql);
@@ -53,11 +58,11 @@ if (trim(httppost('insertcommentary')) != "") {
 //  invalidatedatacache("petition_counts");
 //  $op="";
 //}
-page_header("Petition Viewer");
+Header::pageHeader("Petition Viewer");
 if ($op == "") {
     $sql = "DELETE FROM " . db_prefix("petitions") . " WHERE status=2 AND closedate<'" . date("Y-m-d H:i:s", strtotime("-7 days")) . "'";
     db_query($sql);
-    $setstat = httpget("setstat");
+    $setstat = Http::get("setstat");
     invalidatedatacache("petition_counts");
     if ($setstat != "") {
         $sql = "SELECT status FROM " . db_prefix("petitions") . " WHERE petitionid='$id'";
@@ -81,7 +86,7 @@ if ($op == "") {
     $row = db_fetch_assoc($result);
     $totalpages = ceil($row['c'] / $petitionsperpage);
 
-    $page = httpget("page");
+    $page = Http::get("page");
     if ($page == "") {
         if (isset($session['petitionPage'])) {
             $page = (int)$session['petitionPage'];
@@ -99,12 +104,12 @@ if ($op == "") {
 
     // No need to show the pages if there is only one.
     if ($totalpages != 1) {
-        addnav("Page");
+        Nav::add("Page");
         for ($x = 1; $x <= $totalpages; $x++) {
             if ($page == $x) {
-                addnav(array("`b`#Page %s`0`b", $x), "viewpetition.php?page=$x");
+                Nav::add(array("`b`#Page %s`0`b", $x), "viewpetition.php?page=$x");
             } else {
-                addnav(array("Page %s", $x), "viewpetition.php?page=$x");
+                Nav::add(array("Page %s", $x), "viewpetition.php?page=$x");
             }
         }
     }
@@ -137,8 +142,8 @@ if ($op == "") {
 		date ASC
 	LIMIT $limit";
     $result = db_query($sql);
-    addnav("Petitions");
-    addnav("Refresh", "viewpetition.php");
+    Nav::add("Petitions");
+    Nav::add("Refresh", "viewpetition.php");
     $num = translate_inline("Num");
     $ops = translate_inline("Ops");
     $from = translate_inline("From");
@@ -150,7 +155,7 @@ if ($op == "") {
     $close = translate_inline("Close");
     $mark = translate_inline("Mark");
 
-    rawoutput("<table border='0'><tr class='trhead'><td>$num</td><td>$ops</td><td>$from</td><td>$sent</td><td>$com</td><td>$last</td><td>$when</td></tr>");
+    $output->rawOutput("<table border='0'><tr class='trhead'><td>$num</td><td>$ops</td><td>$from</td><td>$sent</td><td>$com</td><td>$last</td><td>$when</td></tr>");
     $i = 0;
     $laststatus = -1;
     $catcount = array();
@@ -165,115 +170,115 @@ if ($op == "") {
         $res = db_query($sql);
         $counter = db_fetch_assoc($res);
         if (array_key_exists('status', $row) && $row['status'] != $laststatus) {
-            rawoutput("<tr class='" . ($i ? "trlight" : "trdark") . "'>");
-            rawoutput("<td colspan='7' style='background-color:#FAA000'>");
-            output_notl("%s", $statuses[$row['status']], true);
-            rawoutput("</td></tr>");
+            $output->rawOutput("<tr class='" . ($i ? "trlight" : "trdark") . "'>");
+            $output->rawOutput("<td colspan='7' style='background-color:#FAA000'>");
+            $output->outputNotl("%s", $statuses[$row['status']], true);
+            $output->rawOutput("</td></tr>");
             $i = 1;
             $laststatus = $row['status'];
         }
-        rawoutput("<tr class='" . ($i ? "trlight" : "trdark") . "'>");
-        rawoutput("<td>");
-        output_notl("%s", $row['petitionid']);
-        rawoutput("</td>");
-        rawoutput("<td nowrap>[ ");
-        rawoutput("<a href='viewpetition.php?op=view&id={$row['petitionid']}'>$view</a>", true);
-        rawoutput(" | <a href='viewpetition.php?setstat=2&id={$row['petitionid']}'>$close</a>");
-        output_notl(" | %s: ", $mark);
-        output_notl("<a href='viewpetition.php?setstat=0&id={$row['petitionid']}'>`b`&U`0`b</a>/", true);
-        output_notl("<a href='viewpetition.php?setstat=1&id={$row['petitionid']}'>`7P`0</a>/", true);
-        //output_notl("<a href='viewpetition.php?setstat=3&id={$row['petitionid']}'>`!I`0</a>/",true);
-        output_notl("<a href='viewpetition.php?setstat=4&id={$row['petitionid']}'>`^E`0</a>", true);
-        //output_notl("<a href='viewpetition.php?setstat=5&id={$row['petitionid']}'>`\$T`0</a>/",true);
-        //output_notl("<a href='viewpetition.php?setstat=6&id={$row['petitionid']}'>`%B`0</a>/",true);
-        //output_notl("<a href='viewpetition.php?setstat=7&id={$row['petitionid']}'>`#A`0</a>",true);
-        rawoutput(" ]</td>");
-        addnav("", "viewpetition.php?op=view&id={$row['petitionid']}");
-        addnav("", "viewpetition.php?setstat=2&id={$row['petitionid']}");
-        addnav("", "viewpetition.php?setstat=0&id={$row['petitionid']}");
-        addnav("", "viewpetition.php?setstat=1&id={$row['petitionid']}");
-        //addnav("","viewpetition.php?setstat=3&id={$row['petitionid']}");
-        addnav("", "viewpetition.php?setstat=4&id={$row['petitionid']}");
-        //addnav("","viewpetition.php?setstat=5&id={$row['petitionid']}");
-        //addnav("","viewpetition.php?setstat=6&id={$row['petitionid']}");
-        //addnav("","viewpetition.php?setstat=7&id={$row['petitionid']}");
-        rawoutput("<td>");
+        $output->rawOutput("<tr class='" . ($i ? "trlight" : "trdark") . "'>");
+        $output->rawOutput("<td>");
+        $output->outputNotl("%s", $row['petitionid']);
+        $output->rawOutput("</td>");
+        $output->rawOutput("<td nowrap>[ ");
+        $output->rawOutput("<a href='viewpetition.php?op=view&id={$row['petitionid']}'>$view</a>", true);
+        $output->rawOutput(" | <a href='viewpetition.php?setstat=2&id={$row['petitionid']}'>$close</a>");
+        $output->outputNotl(" | %s: ", $mark);
+        $output->outputNotl("<a href='viewpetition.php?setstat=0&id={$row['petitionid']}'>`b`&U`0`b</a>/", true);
+        $output->outputNotl("<a href='viewpetition.php?setstat=1&id={$row['petitionid']}'>`7P`0</a>/", true);
+        //$output->outputNotl("<a href='viewpetition.php?setstat=3&id={$row['petitionid']}'>`!I`0</a>/",true);
+        $output->outputNotl("<a href='viewpetition.php?setstat=4&id={$row['petitionid']}'>`^E`0</a>", true);
+        //$output->outputNotl("<a href='viewpetition.php?setstat=5&id={$row['petitionid']}'>`\$T`0</a>/",true);
+        //$output->outputNotl("<a href='viewpetition.php?setstat=6&id={$row['petitionid']}'>`%B`0</a>/",true);
+        //$output->outputNotl("<a href='viewpetition.php?setstat=7&id={$row['petitionid']}'>`#A`0</a>",true);
+        $output->rawOutput(" ]</td>");
+        Nav::add("", "viewpetition.php?op=view&id={$row['petitionid']}");
+        Nav::add("", "viewpetition.php?setstat=2&id={$row['petitionid']}");
+        Nav::add("", "viewpetition.php?setstat=0&id={$row['petitionid']}");
+        Nav::add("", "viewpetition.php?setstat=1&id={$row['petitionid']}");
+        //Nav::add("","viewpetition.php?setstat=3&id={$row['petitionid']}");
+        Nav::add("", "viewpetition.php?setstat=4&id={$row['petitionid']}");
+        //Nav::add("","viewpetition.php?setstat=5&id={$row['petitionid']}");
+        //Nav::add("","viewpetition.php?setstat=6&id={$row['petitionid']}");
+        //Nav::add("","viewpetition.php?setstat=7&id={$row['petitionid']}");
+        $output->rawOutput("<td>");
         if ($row['name'] == "") {
             $v = substr($row['body'], 0, strpos($row['body'], "[email"));
             $v = preg_replace("'\\[PHPSESSID\\] = .*'", "", $v);
             $v = preg_replace("'[^a-zA-Z0-91234567890\\[\\]= @.!,?-]'", "", $v);
             // Make sure we don't get something too large.. 50 chars max
             $v = substr($v, 0, 50);
-            output_notl("`\$%s`0", $v);
+            $output->outputNotl("`\$%s`0", $v);
         } else {
-            output_notl("`&%s`0", $row['name']);
+            $output->outputNotl("`&%s`0", $row['name']);
         }
-        rawoutput("</td>");
-        rawoutput("<td>");
-        output_notl("`7%s`0", reltime(strtotime($row['date'])));
-        rawoutput("</td>");
-        rawoutput("<td>");
-        output_notl("`#%s`0", $counter['c']);
-        rawoutput("</td>");
-        rawoutput("<td>");
-        output_notl("`^%s`0", $row['closer']);
-        rawoutput("</td>");
-        rawoutput("<td>");
+        $output->rawOutput("</td>");
+        $output->rawOutput("<td>");
+        $output->outputNotl("`7%s`0", reltime(strtotime($row['date'])));
+        $output->rawOutput("</td>");
+        $output->rawOutput("<td>");
+        $output->outputNotl("`#%s`0", $counter['c']);
+        $output->rawOutput("</td>");
+        $output->rawOutput("<td>");
+        $output->outputNotl("`^%s`0", $row['closer']);
+        $output->rawOutput("</td>");
+        $output->rawOutput("<td>");
         if ($row['closedate'] != 0) {
-            output_notl("`7%s`0", reltime(strtotime($row['closedate'])));
+            $output->outputNotl("`7%s`0", reltime(strtotime($row['closedate'])));
         }
-        rawoutput("</td>");
-        rawoutput("</tr>");
+        $output->rawOutput("</td>");
+        $output->rawOutput("</tr>");
     }
-    rawoutput("</table>");
+    $output->rawOutput("</table>");
     //navlist with counter
     if ($catcount != array()) {
-        addnav("Overview");
+        Nav::add("Overview");
     }
     foreach ($catcount as $categorynumber => $amount) {
-        addnav(array("`t%s`t(%s)",$statuses[$categorynumber],$amount), "viewpetition.php?page=" . ((int)httpget('page')));
+        Nav::add(array("`t%s`t(%s)",$statuses[$categorynumber],$amount), "viewpetition.php?page=" . ((int)Http::get('page')));
     }
 
     //end
-    output("`i(Closed petitions will automatically delete themselves when they have been closed for 7 days)`i");
-    output("`n`bKey:`b`n");
-    rawoutput("<ul><li>");
-    output("`\$T = Top Level`0 petitions are for petitions that only server operators can take care of.");
-    rawoutput("</li><li>");
-    output("`^E = Escalated`0 petitions deal with an issue you can't handle for yourself.");
-    output("Mark it escalated so someone with more permissions than you can deal with it.");
-    rawoutput("</li><li>");
-    output("`b`&U = Unhandled`0`b: No one is currently working on this problem, and it has not been dealt with yet.");
-    rawoutput("</li><li>");
-    output("P = In-Progress petitions are probably being worked on by someone else, so please leave them be unless they have been around for some time.");
-    rawoutput("</li><li>");
-    output("`%B = Bug/Suggestion`0 petitions are petitions that detail mistakes, bugs, misspellings, or suggestions for the game.");
-    rawoutput("</li><li>");
-    output("`#A = Awaiting Points`0 stuff wot is dun and needz teh points added (this is mostly for lotgd.net).");
-    rawoutput("</li><li>");
-    output("`!I = Informational`0 petitions are just around for others to view, either nothing needed to be done with them, or their issue has been dealt with, but you feel other admins could benefit from reading it.");
-    rawoutput("</li><li>");
-    output("`iClosed`i petitions are for you have dealt with an issue, these will auto delete when they have been closed for 7 days.");
-    modulehook("petitions-descriptions", array());
-    rawoutput("</li></ul>");
+    $output->output("`i(Closed petitions will automatically delete themselves when they have been closed for 7 days)`i");
+    $output->output("`n`bKey:`b`n");
+    $output->rawOutput("<ul><li>");
+    $output->output("`\$T = Top Level`0 petitions are for petitions that only server operators can take care of.");
+    $output->rawOutput("</li><li>");
+    $output->output("`^E = Escalated`0 petitions deal with an issue you can't handle for yourself.");
+    $output->output("Mark it escalated so someone with more permissions than you can deal with it.");
+    $output->rawOutput("</li><li>");
+    $output->output("`b`&U = Unhandled`0`b: No one is currently working on this problem, and it has not been dealt with yet.");
+    $output->rawOutput("</li><li>");
+    $output->output("P = In-Progress petitions are probably being worked on by someone else, so please leave them be unless they have been around for some time.");
+    $output->rawOutput("</li><li>");
+    $output->output("`%B = Bug/Suggestion`0 petitions are petitions that detail mistakes, bugs, misspellings, or suggestions for the game.");
+    $output->rawOutput("</li><li>");
+    $output->output("`#A = Awaiting Points`0 stuff wot is dun and needz teh points added (this is mostly for lotgd.net).");
+    $output->rawOutput("</li><li>");
+    $output->output("`!I = Informational`0 petitions are just around for others to view, either nothing needed to be done with them, or their issue has been dealt with, but you feel other admins could benefit from reading it.");
+    $output->rawOutput("</li><li>");
+    $output->output("`iClosed`i petitions are for you have dealt with an issue, these will auto delete when they have been closed for 7 days.");
+    HookHandler::hook("petitions-descriptions", array());
+    $output->rawOutput("</li></ul>");
 } elseif ($op == "view") {
-    addnav("Petitions");
-    addnav("Details");
-    $viewpageinfo = (int)httpget("viewpageinfo");
+    Nav::add("Petitions");
+    Nav::add("Details");
+    $viewpageinfo = (int)Http::get("viewpageinfo");
     if ($viewpageinfo == 1) {
-        addnav("Hide Details", "viewpetition.php?op=view&id=$id}");
+        Nav::add("Hide Details", "viewpetition.php?op=view&id=$id}");
     } else {
-        addnav("D?Show Details", "viewpetition.php?op=view&id=$id&viewpageinfo=1");
+        Nav::add("D?Show Details", "viewpetition.php?op=view&id=$id&viewpageinfo=1");
     }
-    addnav("Navigation");
-    addnav("V?Petition Viewer", "viewpetition.php");
+    Nav::add("Navigation");
+    Nav::add("V?Petition Viewer", "viewpetition.php");
 
-    addnav("User Ops");
+    Nav::add("User Ops");
 
-    addnav("Petition Ops");
+    Nav::add("Petition Ops");
     foreach ($statuses as $key => $val) {
         $plain = full_sanitize($val);
-        addnav(
+        Nav::add(
             array("%s?Mark %s", substr($plain, 0, 1), $val),
             "viewpetition.php?setstat=$key&id=$id"
         );
@@ -282,18 +287,18 @@ if ($op == "") {
     $sql = "SELECT " . db_prefix("accounts") . ".name," .  db_prefix("accounts") . ".login," .  db_prefix("accounts") . ".acctid," .  "author,date,closedate,status,petitionid,ip,body,pageinfo," .  "accts.name AS closer FROM " .  db_prefix("petitions") . " LEFT JOIN " .  db_prefix("accounts ") . "ON " .  db_prefix("accounts") . ".acctid=author LEFT JOIN " .  db_prefix("accounts") . " AS accts ON accts.acctid=" .  "closeuserid WHERE petitionid='$id' ORDER BY date ASC";
     $result = db_query($sql);
     $row = db_fetch_assoc($result);
-    addnav("User Ops");
+    Nav::add("User Ops");
     if (isset($row['login'])) {
-        addnav("View User Biography", "bio.php?char=" . $row['acctid']
+        Nav::add("View User Biography", "bio.php?char=" . $row['acctid']
                         . "&ret=%2Fviewpetition.php%3Fop%3Dview%26id=" . $id);
     }
     if ($row['acctid'] > 0 && $session['user']['superuser'] & SU_EDIT_USERS) {
-        addnav("User Ops");
-        addnav("R?Edit User Record", "user.php?op=edit&userid={$row['acctid']}&returnpetition=$id");
+        Nav::add("User Ops");
+        Nav::add("R?Edit User Record", "user.php?op=edit&userid={$row['acctid']}&returnpetition=$id");
     }
     if ($row['acctid'] > 0 && $session['user']['superuser'] & SU_EDIT_DONATIONS) {
-        addnav("User Ops");
-        addnav("Edit User Donations", "donators.php?op=add1&name=" . rawurlencode($row['login']) . "&ret=" . urlencode($_SERVER['REQUEST_URI']));
+        Nav::add("User Ops");
+        Nav::add("Edit User Donations", "donators.php?op=add1&name=" . rawurlencode($row['login']) . "&ret=" . urlencode($_SERVER['REQUEST_URI']));
     }
     $write = translate_inline("Write Mail");
     // We assume that petitions are handled in default language
@@ -311,29 +316,29 @@ if ($op == "") {
         $catpos = strpos($line, $category_check);
         if ($catpos !== false) {
             //cat found
-            rawoutput("<h2>");
-            output("`2Category: %s`n", substr($line, strlen($category_check) - 1));
-            rawoutput("</h2>");
+            $output->rawOutput("<h2>");
+            $output->output("`2Category: %s`n", substr($line, strlen($category_check) - 1));
+            $output->rawOutput("</h2>");
         }
     }
 
 
-    output("`@From: ");
+    $output->output("`@From: ");
     if ($row['login'] > "") {
-        rawoutput("<a href=\"mail.php?op=write&to=" . rawurlencode($row['login']) . "&body=" . rawurlencode("\n\n----- $yourpeti -----\n$reppet") . "&subject=RE:+$peti\" target=\"_blank\" onClick=\"" . popup("mail.php?op=write&to=" . rawurlencode($row['login']) . "&body=" . rawurlencode("\n\n----- $yourpeti -----\n$reppet") . "&subject=RE:+$peti") . ";return false;\"><img src='images/newscroll.GIF' width='16' height='16' alt='$write' border='0'></a>");
+        $output->rawOutput("<a href=\"mail.php?op=write&to=" . rawurlencode($row['login']) . "&body=" . rawurlencode("\n\n----- $yourpeti -----\n$reppet") . "&subject=RE:+$peti\" target=\"_blank\" onClick=\"" . popup("mail.php?op=write&to=" . rawurlencode($row['login']) . "&body=" . rawurlencode("\n\n----- $yourpeti -----\n$reppet") . "&subject=RE:+$peti") . ";return false;\"><img src='images/newscroll.GIF' width='16' height='16' alt='$write' border='0'></a>");
     }
-    output_notl("`^`b%s`b`n", $row['name']);
-    output("`@Date: `^`b%s`b (%s)`n", $row['date'], reltime(strtotime($row['date'])));
-    output("`@Status: %s`n", $statuses[$row['status']]);
+    $output->outputNotl("`^`b%s`b`n", $row['name']);
+    $output->output("`@Date: `^`b%s`b (%s)`n", $row['date'], reltime(strtotime($row['date'])));
+    $output->output("`@Status: %s`n", $statuses[$row['status']]);
     if ($row['closer'] != '') {
-        output("`@Last Update: `^%s`@ on `^%s (%s)`n", $row['closer'], $row['closedate'], reltime(strtotime($row['closedate'])));
+        $output->output("`@Last Update: `^%s`@ on `^%s (%s)`n", $row['closer'], $row['closedate'], reltime(strtotime($row['closedate'])));
     }
-    output("`@Body:`^`n");
-    output("`\$[ipaddress] `^= `#%s`^`n", $row['ip']);
+    $output->output("`@Body:`^`n");
+    $output->output("`\$[ipaddress] `^= `#%s`^`n", $row['ip']);
     $body = htmlentities(stripslashes($row['body']), ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
     $body = preg_replace("'([[:alnum:]_.-]+[@][[:alnum:]_.-]{2,}([.][[:alnum:]_.-]{2,})+)'i", "<a href='mailto:\\1?subject=RE: $peti&body=" . str_replace("+", " ", URLEncode("\n\n----- $yourpeti -----\n" . stripslashes($row['body']))) . "'>\\1</a>", $body);
     $body = preg_replace("'([\\[][[:alnum:]_.-]+[\\]])'i", "<span class='colLtRed'>\\1</span>", $body);
-    rawoutput("<span style='font-family: fixed-width'>" . nl2br($body) . "</span>");
+    $output->rawOutput("<span style='font-family: fixed-width'>" . nl2br($body) . "</span>");
     //position tracking
     if ($row['body'] != '') {
         $pos = strpos($row['body'], "[abuseplayer]") + 16;
@@ -342,18 +347,18 @@ if ($op == "") {
             $search = substr($row['body'], $pos, $endpos - $pos);
             $search = (int) $search;
             if ($search != 0) {
-                modulehook("petition-abuse", array("acctid" => $search,"abused" => $row['author']));
+                HookHandler::hook("petition-abuse", array("acctid" => $search,"abused" => $row['author']));
             }
         }
     }
     Commentary::commentDisplay("`n`@Commentary:`0`n", "pet-$id", "Add information", 200);
     if ($viewpageinfo) {
-        output("`n`n`@Page Info:`&`n");
+        $output->output("`n`n`@Page Info:`&`n");
         $row['pageinfo'] = stripslashes($row['pageinfo']);
         $body = HTMLEntities($row['pageinfo'], ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
         $body = preg_replace("'([[:alnum:]_.-]+[@][[:alnum:]_.-]{2,}([.][[:alnum:]_.-]{2,})+)'i", "<a href='mailto:\\1?subject=RE: $peti&body=" . str_replace("+", " ", URLEncode("\n\n----- $yourpeti -----\n" . $row['body'])) . "'>\\1</a>", $body);
         $body = preg_replace("'([\\[][[:alnum:]_.-]+[\\]])'i", "<span class='colLtRed'>\\1</span>", $body);
-        rawoutput("<span style='font-family: fixed-width'>" . nl2br($body) . "</span>");
+        $output->rawOutput("<span style='font-family: fixed-width'>" . nl2br($body) . "</span>");
     }
 }
 
@@ -366,8 +371,8 @@ if ($id && $op != "") {
         $previd = $prevrow['petitionid'];
         $s = $prevrow['status'];
         $status = $statuses[$s];
-        addnav("Petitions");
-        addnav(array("Previous %s",$status), "viewpetition.php?op=view&id=$previd");
+        Nav::add("Petitions");
+        Nav::add(array("Previous %s",$status), "viewpetition.php?op=view&id=$previd");
     }
     $nextsql = "SELECT p1.petitionid, p1.status FROM " . db_prefix("petitions") . " AS p1, " . db_prefix("petitions") . " AS p2
 			WHERE p1.petitionid>'$id' AND p2.petitionid='$id' AND p1.status=p2.status ORDER BY p1.petitionid ASC LIMIT 1";
@@ -377,8 +382,8 @@ if ($id && $op != "") {
         $nextid = $nextrow['petitionid'];
         $s = $nextrow['status'];
         $status = $statuses[$s];
-        addnav("Petitions");
-        addnav(array("Next %s",$status), "viewpetition.php?op=view&id=$nextid");
+        Nav::add("Petitions");
+        Nav::add(array("Next %s",$status), "viewpetition.php?op=view&id=$nextid");
     }
 }
-page_footer();
+Footer::pageFooter();


### PR DESCRIPTION
## Summary
- convert `viewpetition.php` to call `$output` methods
- replace `modulehook()` calls with `HookHandler::hook()`
- keep petition entry point using namespaced helpers

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6887b3654d2c8329913944c9d96bb52f