### PR TITLE
Fix level setter for string input

### DIFF
--- a/src/Lotgd/Entity/Account.php
+++ b/src/Lotgd/Entity/Account.php
@@ -371,9 +371,9 @@ class Account
         return $this->level;
     }
 
-    public function setLevel(int $level): self
+    public function setLevel(int|string $level): self
     {
-        $this->level = $level;
+        $this->level = (int) $level;
         return $this;
     }
 

--- a/tests/AccountsDoctrineTest.php
+++ b/tests/AccountsDoctrineTest.php
@@ -58,4 +58,13 @@ final class AccountsDoctrineTest extends TestCase
         $entity = Accounts::getAccountEntity();
         $this->assertTrue($entity->getAlive());
     }
+
+    public function testSaveUserCastsIntegerFields(): void
+    {
+        $GLOBALS['session']['user']['level'] = '3';
+        $GLOBALS['baseaccount']['level'] = 1;
+        Accounts::saveUser();
+        $entity = Accounts::getAccountEntity();
+        $this->assertSame(3, $entity->getLevel());
+    }
 }


### PR DESCRIPTION
## Summary
- allow `Account::setLevel` to accept string input and cast to int
- test integer casting in `Accounts` when saving user

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6887c73b9364832990c2811a18930fd7