### PR TITLE
Refactor wrapper calls to Lotgd API

### DIFF
--- a/pages/bans/case_setupban.php
+++ b/pages/bans/case_setupban.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Nav;
+use Lotgd\Http;
 
 $sql = 'SELECT name,lastip,uniqueid FROM ' . Database::prefix('accounts') . ' WHERE acctid=' . (int) $userid;
 $result = Database::query($sql);
@@ -25,7 +26,7 @@ $output->rawOutput("<input name='id' value=\"" . HTMLEntities($row['uniqueid'] ?
 $output->output("`nDuration: ");
 $output->rawOutput("<input name='duration' id='duration' size='3' value='14'>");
 $output->output("Days (0 for permanent)`n");
-$reason = httpget("reason");
+$reason = (string) Http::get("reason");
 if ($reason == "") {
     $reason = Translator::translateInline("Don't mess with me.");
 }

--- a/pages/mail/case_address.php
+++ b/pages/mail/case_address.php
@@ -4,20 +4,22 @@ declare(strict_types=1);
 use Lotgd\Translator;
 use Lotgd\Http;
 
-output_notl("<form action='mail.php?op=write' method='post'>", true);
-output("`b`2Address:`b`n");
+global $output;
+
+$output->outputNotl("<form action='mail.php?op=write' method='post'>", true);
+$output->output("`b`2Address:`b`n");
 $to = Translator::translateInline("To: ");
 $forwardto = Translator::translateInline("Forward To: ");
 $search = htmlentities(Translator::translateInline("Search"), ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
-$id = (int) httpget('id');
+$id = (int) Http::get('id');
 $forwardlink = '';
 if ($id > 0) {
     $to = $forwardto;
     $forwardlink = "<input type='hidden' name='forwardto' value='$id'>";
 }
 $preop = (string) Http::get('preop');
-output_notl("`2$to <input name='to' id='to' value=\"" . htmlentities($preop, ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\">", true);
-output_notl("<input type='submit' class='button' value=\"$search\">", true);
-rawoutput($forwardlink);
-rawoutput("</form>");
-rawoutput("<script type='text/javascript'>document.getElementById(\"to\").focus();</script>");
+$output->outputNotl("`2$to <input name='to' id='to' value=\"" . htmlentities($preop, ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\">", true);
+$output->outputNotl("<input type='submit' class='button' value=\"$search\">", true);
+$output->rawOutput($forwardlink);
+$output->rawOutput("</form>");
+$output->rawOutput("<script type='text/javascript'>document.getElementById(\"to\").focus();</script>");

--- a/pvp.php
+++ b/pvp.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 // translator ready
 // addnews ready
@@ -7,8 +8,12 @@ require_once("common.php");
 use Lotgd\FightNav;
 use Lotgd\Pvp;
 use Lotgd\Battle;
-require_once("lib/http.php");
-require_once("lib/villagenav.php");
+use Lotgd\AddNews;
+use Lotgd\Nav;
+use Lotgd\Nav\VillageNav;
+use Lotgd\Http;
+
+global $output;
 
 tlschema("pvp");
 
@@ -16,8 +21,8 @@ $iname = getsetting("innname", LOCATION_INN);
 $battle = false;
 
 page_header("PvP Combat!");
-$op = httpget('op');
-$act = httpget('act');
+$op = Http::get('op');
+$act = Http::get('act');
 
 if ($op == "" && $act != "attack") {
     checkday();
@@ -28,13 +33,13 @@ if ($op == "" && $act != "attack") {
     );
     $args = modulehook("pvpstart", $args);
     tlschema($args['schemas']['atkmsg']);
-    output($args['atkmsg'], $session['user']['playerfights']);
+    $output->output($args['atkmsg'], $session['user']['playerfights']);
     tlschema();
-    addnav("L?Refresh List of Warriors", "pvp.php");
+    Nav::add("L?Refresh List of Warriors", "pvp.php");
         Pvp::listTargets();
-    villagenav();
+    VillageNav::render();
 } elseif ($act == "attack") {
-    $name = httpget('name');
+    $name = Http::get('name');
         $badguy = Pvp::setupTarget($name);
     $options['type'] = "pvp";
     $failedattack = false;
@@ -53,25 +58,25 @@ if ($op == "" && $act != "attack") {
     }
 
     if ($failedattack) {
-        if (httpget('inn') > "") {
-            addnav("Return to Listing", "inn.php?op=bartender&act=listupstairs");
+        if (Http::get('inn') > "") {
+            Nav::add("Return to Listing", "inn.php?op=bartender&act=listupstairs");
         } else {
-            addnav("Return to Listing", "pvp.php");
+            Nav::add("Return to Listing", "pvp.php");
         }
     }
 }
 
 if ($op == "run") {
-    output("Your pride prevents you from running");
+    $output->output("Your pride prevents you from running");
     $op = "fight";
-    httpset('op', $op);
+    Http::set('op', $op);
 }
 
-$skill = httpget('skill');
+$skill = Http::get('skill');
 if ($skill != "") {
-    output("Your honor prevents you from using any special ability");
+    $output->output("Your honor prevents you from using any special ability");
     $skill = "";
-    httpset('skill', $skill);
+    Http::set('skill', $skill);
 }
 if ($op == "fight" || $op == "run") {
     $battle = true;
@@ -93,14 +98,14 @@ if ($battle) {
         }
 
         $op = "";
-        httpset('op', $op);
+        Http::set('op', $op);
         if ($killedin == $iname) {
-            addnav("Return to the inn", "inn.php");
+            Nav::add("Return to the inn", "inn.php");
         } else {
-            villagenav();
+            VillageNav::render();
         }
         if ($session['user']['hitpoints'] <= 0) {
-            output("`n`n`&Using a bit of cloth nearby, you manage to staunch your wounds so that you do not die as well.");
+            $output->output("`n`n`&Using a bit of cloth nearby, you manage to staunch your wounds so that you do not die as well.");
             $session['user']['hitpoints'] = 1;
         }
     } elseif ($defeat) {
@@ -120,7 +125,7 @@ if ($battle) {
         }
     } else {
         $extra = "";
-        if (httpget('inn')) {
+        if (Http::get('inn')) {
             $extra = "?inn=1";
         }
                 FightNav::fightnav(false, false, "pvp.php$extra");


### PR DESCRIPTION
## Summary
- replace legacy output and navigation calls
- use `Lotgd\Http` in ban and mail pages
- update PvP page to use namespaced helpers

## Testing
- `php -l pages/mail/case_address.php`
- `php -l pages/bans/case_setupban.php`
- `php -l pvp.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6887c7642598832987d30b1d7f061ed2