### PR TITLE
Fix empty badguy during saves

### DIFF
--- a/src/Lotgd/Entity/Account.php
+++ b/src/Lotgd/Entity/Account.php
@@ -422,6 +422,8 @@ class Account
                     $value = intval($value);
                 } elseif ($type === 'float') {
                     $value = (float) $value;
+                } elseif ($type === 'string' && $value === null) {
+                    $value = '';
                 }
 
                 $this->$prop = $value;


### PR DESCRIPTION
## Summary
- handle `null` assignments in dynamic setters

The dynamic `__call()` on `Account` could assign `null` into typed string fields when older game code set session values to `null`. If `badguy` became `null` during a fight resolution, Doctrine would throw `Cannot assign null to property Lotgd\Entity\Account::$badguy of type string`. We now coerce null to an empty string in that scenario.

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6887ca0384648329a13f8ca68ff0ef51