### PR TITLE
Refactor admin pages to use namespaced API

### DIFF
--- a/companions.php
+++ b/companions.php
@@ -1,8 +1,18 @@
 <?php
+declare(strict_types=1);
 
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
 use Lotgd\Buffs;
+use Lotgd\Http;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Nav;
+use Lotgd\MySQL\Database;
+use Lotgd\DataCache;
+use Lotgd\Translator;
+use Lotgd\Settings;
+use Lotgd\Modules\HookHandler;
 
 // addnews ready
 // mail ready
@@ -10,63 +20,62 @@ use Lotgd\Buffs;
 
 // hilarious copy of mounts.php
 require_once("common.php");
-require_once("lib/http.php");
 
 SuAccess::check(SU_EDIT_MOUNTS);
 
-tlschema("companions");
+Translator::tlschema("companions");
 
-page_header("Companion Editor");
+Header::pageHeader("Companion Editor");
 
 SuperuserNav::render();
 
-addnav("Companion Editor");
-addnav("Add a companion", "companions.php?op=add");
+Nav::add("Companion Editor");
+Nav::add("Add a companion", "companions.php?op=add");
 
-$op = httpget('op');
-$id = httpget('id');
+$op = Http::get('op');
+$id = Http::get('id');
 if ($op == "deactivate") {
-    $sql = "UPDATE " . db_prefix("companions") . " SET companionactive=0 WHERE companionid='$id'";
-    db_query($sql);
+    $sql = "UPDATE " . Database::prefix("companions") . " SET companionactive=0 WHERE companionid='$id'";
+    Database::query($sql);
     $op = "";
-    httpset("op", "");
-    invalidatedatacache("companionsdata-$id");
+    Http::set("op", "");
+    DataCache::invalidatedatacache("companionsdata-$id");
 } elseif ($op == "activate") {
-    $sql = "UPDATE " . db_prefix("companions") . " SET companionactive=1 WHERE companionid='$id'";
-    db_query($sql);
+    $sql = "UPDATE " . Database::prefix("companions") . " SET companionactive=1 WHERE companionid='$id'";
+    Database::query($sql);
     $op = "";
-    httpset("op", "");
-    invalidatedatacache("companiondata-$id");
+    Http::set("op", "");
+    DataCache::invalidatedatacache("companiondata-$id");
 } elseif ($op == "del") {
     //drop the companion.
-    $sql = "DELETE FROM " . db_prefix("companions") . " WHERE companionid='$id'";
-    db_query($sql);
-    module_delete_objprefs('companions', $id);
+    $sql = "DELETE FROM " . Database::prefix("companions") . " WHERE companionid='$id'";
+    Database::query($sql);
+    HookHandler::deleteObjPrefs('companions', $id);
     $op = "";
-    httpset("op", "");
-    invalidatedatacache("companiondata-$id");
+    Http::set("op", "");
+    DataCache::invalidatedatacache("companiondata-$id");
 } elseif ($op == "take") {
-    $sql = "SELECT * FROM " . db_prefix("companions") . " WHERE companionid='$id'";
-    $result = db_query($sql);
-    if ($row = db_fetch_assoc($result)) {
+    $sql = "SELECT * FROM " . Database::prefix("companions") . " WHERE companionid='$id'";
+    $result = Database::query($sql);
+    if ($row = Database::fetchAssoc($result)) {
         $row['attack'] = $row['attack'] + $row['attackperlevel'] * $session['user']['level'];
         $row['defense'] = $row['defense'] + $row['defenseperlevel'] * $session['user']['level'];
         $row['maxhitpoints'] = $row['maxhitpoints'] + $row['maxhitpointsperlevel'] * $session['user']['level'];
         $row['hitpoints'] = $row['maxhitpoints'];
-        $row = modulehook("alter-companion", $row);
+        $row = HookHandler::moduleHook("alter-companion", $row);
         $row['abilities'] = @unserialize($row['abilities']);
         if (Buffs::applyCompanion($row['name'], $row)) {
-            output("`\$Successfully taken `^%s`\$ as companion.", $row['name']);
+            $output->output("`\$Successfully taken `^%s`\$ as companion.", $row['name']);
         } else {
-            output("`\$Companion not taken due to global limit.`0");
+            $output->output("`\$Companion not taken due to global limit.`0");
         }
     }
     $op = "";
-    httpset("op", "");
+    Http::set("op", "");
 } elseif ($op == "save") {
     $subop = httpget("subop");
     if ($subop == "") {
-        $companion = httppost('companion');
+        $companion = Http::post('companion');
         if ($companion) {
             if (!isset($companion['allowinshades'])) {
                 $companion['allowinshades'] = 0;
@@ -103,63 +112,63 @@ if ($op == "deactivate") {
                 $i++;
             }
             if ($id > "") {
-                $sql = "UPDATE " . db_prefix("companions") .
+                $sql = "UPDATE " . Database::prefix("companions") .
                     " SET $sql WHERE companionid='$id'";
             } else {
-                $sql = "INSERT INTO " . db_prefix("companions") .
+                $sql = "INSERT INTO " . Database::prefix("companions") .
                     " ($keys) VALUES ($vals)";
             }
-            db_query($sql);
-            invalidatedatacache("companiondata-$id");
-            if (db_affected_rows() > 0) {
-                output("`^Companion saved!`0`n`n");
+            Database::query($sql);
+            DataCache::invalidatedatacache("companiondata-$id");
+            if (Database::affectedRows() > 0) {
+                $output->output("`^Companion saved!`0`n`n");
             } else {
 //              if (strlen($sql) > 400) $sql = substr($sql,0,200)." ... ".substr($sql,strlen($sql)-200);
-                output("`^Companion `\$not`^ saved: `\$%s`0`n`n", $sql);
+                $output->output("`^Companion `\$not`^ saved: `\$%s`0`n`n", $sql);
             }
         }
     } elseif ($subop == "module") {
         // Save modules settings
-        $module = httpget("module");
-        $post = httpallpost();
+        $module = Http::get("module");
+        $post = Http::allPost();
         reset($post);
         foreach ($post as $key => $val) {
-            set_module_objpref("companions", $id, $key, $val, $module);
+            HookHandler::setObjPref("companions", $id, $key, $val, $module);
         }
-        output("`^Saved!`0`n");
+        $output->output("`^Saved!`0`n");
     }
     if ($id) {
         $op = "edit";
     } else {
         $op = "";
     }
-    httpset("op", $op);
+    Http::set("op", $op);
 }
 
 if ($op == "") {
-    $sql = "SELECT * FROM " . db_prefix("companions") . " ORDER BY category, name";
-    $result = db_query($sql);
+    $sql = "SELECT * FROM " . Database::prefix("companions") . " ORDER BY category, name";
+    $result = Database::query($sql);
 
-    $ops = translate_inline("Ops");
-    $name = translate_inline("Name");
-    $cost = translate_inline("Cost");
+    $ops = Translator::translateInline("Ops");
+    $name = Translator::translateInline("Name");
+    $cost = Translator::translateInline("Cost");
 
-    $edit = translate_inline("Edit");
-    $del = translate_inline("Del");
-    $take = translate_inline("Take");
-    $deac = translate_inline("Deactivate");
-    $act = translate_inline("Activate");
+    $edit = Translator::translateInline("Edit");
+    $del = Translator::translateInline("Del");
+    $take = Translator::translateInline("Take");
+    $deac = Translator::translateInline("Deactivate");
+    $act = Translator::translateInline("Activate");
 
-    rawoutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
-    rawoutput("<tr class='trhead'><td nowrap>$ops</td><td>$name</td><td>$cost</td></tr>");
+    $output->rawOutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
+    $output->rawOutput("<tr class='trhead'><td nowrap>$ops</td><td>$name</td><td>$cost</td></tr>");
     $cat = "";
     $count = 0;
 
-    while ($row = db_fetch_assoc($result)) {
+    while ($row = Database::fetchAssoc($result)) {
         if ($cat != $row['category']) {
-            rawoutput("<tr class='trlight'><td colspan='5'>");
-            output("Category: %s", $row['category']);
-            rawoutput("</td></tr>");
+            $output->rawOutput("<tr class='trlight'><td colspan='5'>");
+            $output->output("Category: %s", $row['category']);
+            $output->rawOutput("</td></tr>");
             $cat = $row['category'];
             $count = 0;
         }
@@ -168,57 +177,57 @@ if ($op == "") {
         } else {
             $companions[$row['companionid']] = 0;
         }
-        rawoutput("<tr class='" . ($count % 2 ? "trlight" : "trdark") . "'>");
-        rawoutput("<td nowrap>[ <a href='companions.php?op=edit&id={$row['companionid']}'>$edit</a> |");
-        addnav("", "companions.php?op=edit&id={$row['companionid']}");
+        $output->rawOutput("<tr class='" . ($count % 2 ? "trlight" : "trdark") . "'>");
+        $output->rawOutput("<td nowrap>[ <a href='companions.php?op=edit&id={$row['companionid']}'>$edit</a> |");
+        Nav::add("", "companions.php?op=edit&id={$row['companionid']}");
         if ($row['companionactive']) {
-            rawoutput("$del |");
+            $output->rawOutput("$del |");
         } else {
             $mconf = sprintf($conf, $companions[$row['companionid']]);
-            rawoutput("<a href='companions.php?op=del&id={$row['companionid']}'>$del</a> |");
-            addnav("", "companions.php?op=del&id={$row['companionid']}");
+            $output->rawOutput("<a href='companions.php?op=del&id={$row['companionid']}'>$del</a> |");
+            Nav::add("", "companions.php?op=del&id={$row['companionid']}");
         }
         if ($row['companionactive']) {
-            rawoutput("<a href='companions.php?op=deactivate&id={$row['companionid']}'>$deac</a> | ");
-            addnav("", "companions.php?op=deactivate&id={$row['companionid']}");
+            $output->rawOutput("<a href='companions.php?op=deactivate&id={$row['companionid']}'>$deac</a> | ");
+            Nav::add("", "companions.php?op=deactivate&id={$row['companionid']}");
         } else {
-            rawoutput("<a href='companions.php?op=activate&id={$row['companionid']}'>$act</a> | ");
-            addnav("", "companions.php?op=activate&id={$row['companionid']}");
+            $output->rawOutput("<a href='companions.php?op=activate&id={$row['companionid']}'>$act</a> | ");
+            Nav::add("", "companions.php?op=activate&id={$row['companionid']}");
         }
-        rawoutput("<a href='companions.php?op=take&id={$row['companionid']}'>$take</a> ]</td>");
-        addnav("", "companions.php?op=take&id={$row['companionid']}");
-        rawoutput("<td>");
-        output_notl("`&%s`0", $row['name']);
-        rawoutput("</td><td>");
-        output("`%%s gems`0, `^%s gold`0", $row['companioncostgems'], $row['companioncostgold']);
-        rawoutput("</td></tr>");
+        $output->rawOutput("<a href='companions.php?op=take&id={$row['companionid']}'>$take</a> ]</td>");
+        Nav::add("", "companions.php?op=take&id={$row['companionid']}");
+        $output->rawOutput("<td>");
+        $output->outputNotl("`&%s`0", $row['name']);
+        $output->rawOutput("</td><td>");
+        $output->output("`%%s gems`0, `^%s gold`0", $row['companioncostgems'], $row['companioncostgold']);
+        $output->rawOutput("</td></tr>");
         $count++;
     }
-    rawoutput("</table>");
-    output("`nIf you wish to delete a companion, you have to deactivate it first.");
+    $output->rawOutput("</table>");
+    $output->output("`nIf you wish to delete a companion, you have to deactivate it first.");
 } elseif ($op == "add") {
-    output("Add a companion:`n");
-    addnav("Companion Editor Home", "companions.php");
+    $output->output("Add a companion:`n");
+    Nav::add("Companion Editor Home", "companions.php");
     companionform(array());
 } elseif ($op == "edit") {
-    addnav("Companion Editor Home", "companions.php");
-    $sql = "SELECT * FROM " . db_prefix("companions") . " WHERE companionid='$id'";
-    $result = db_query_cached($sql, "companiondata-$id", 3600);
-    if (db_num_rows($result) <= 0) {
-        output("`iThis companion was not found.`i");
+    Nav::add("Companion Editor Home", "companions.php");
+    $sql = "SELECT * FROM " . Database::prefix("companions") . " WHERE companionid='$id'";
+    $result = Database::queryCached($sql, "companiondata-$id", 3600);
+    if (Database::numRows($result) <= 0) {
+        $output->output("`iThis companion was not found.`i");
     } else {
-        addnav("Companion properties", "companions.php?op=edit&id=$id");
-        module_editor_navs("prefs-companions", "companions.php?op=edit&subop=module&id=$id&module=");
-        $subop = httpget("subop");
+        Nav::add("Companion properties", "companions.php?op=edit&id=$id");
+        HookHandler::editorNavs("prefs-companions", "companions.php?op=edit&subop=module&id=$id&module=");
+        $subop = Http::get("subop");
         if ($subop == "module") {
-            $module = httpget("module");
-            rawoutput("<form action='companions.php?op=save&subop=module&id=$id&module=$module' method='POST'>");
-            module_objpref_edit("companions", $module, $id);
-            rawoutput("</form>");
-            addnav("", "companions.php?op=save&subop=module&id=$id&module=$module");
+            $module = Http::get("module");
+            $output->rawOutput("<form action='companions.php?op=save&subop=module&id=$id&module=$module' method='POST'>");
+            HookHandler::objprefEdit("companions", $module, $id);
+            $output->rawOutput("</form>");
+            Nav::add("", "companions.php?op=save&subop=module&id=$id&module=$module");
         } else {
-            output("Companion Editor:`n");
-            $row = db_fetch_assoc($result);
+            $output->output("Companion Editor:`n");
+            $row = Database::fetchAssoc($result);
             $row['abilities'] = @unserialize($row['abilities']);
             companionform($row);
         }
@@ -314,107 +323,107 @@ function companionform($companion)
         $companion['allowintrain'] = 0;
     }
 
-    rawoutput("<form action='companions.php?op=save&id={$companion['companionid']}' method='POST'>");
-    rawoutput("<input type='hidden' name='companion[companionactive]' value=\"" . $companion['companionactive'] . "\">");
+    $output->rawOutput("<form action='companions.php?op=save&id={$companion['companionid']}' method='POST'>");
+    $output->rawOutput("<input type='hidden' name='companion[companionactive]' value=\"" . $companion['companionactive'] . "\">");
     addnav("", "companions.php?op=save&id={$companion['companionid']}");
-    rawoutput("<table width='100%'>");
-    rawoutput("<tr><td nowrap>");
-    output("Companion Name:");
-    rawoutput("</td><td><input name='companion[name]' value=\"" . htmlentities($companion['name'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\" maxlength='50'></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Companion Dyingtext:");
-    rawoutput("</td><td><input name='companion[dyingtext]' value=\"" . htmlentities($companion['dyingtext'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\"></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Companion Description:");
-    rawoutput("</td><td><textarea cols='25' rows='5' name='companion[description]'>" . htmlentities($companion['description'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "</textarea></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Companion join text:");
-    rawoutput("</td><td><textarea cols='25' rows='5' name='companion[jointext]'>" . htmlentities($companion['jointext'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "</textarea></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Companion Category:");
-    rawoutput("</td><td><input name='companion[category]' value=\"" . htmlentities($companion['category'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\" maxlength='50'></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Companion Availability:");
-    rawoutput("</td><td nowrap>");
+    $output->rawOutput("<table width='100%'>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Companion Name:");
+    $output->rawOutput("</td><td><input name='companion[name]' value=\"" . htmlentities($companion['name'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "\" maxlength='50'></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Companion Dyingtext:");
+    $output->rawOutput("</td><td><input name='companion[dyingtext]' value=\"" . htmlentities($companion['dyingtext'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "\"></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Companion Description:");
+    $output->rawOutput("</td><td><textarea cols='25' rows='5' name='companion[description]'>" . htmlentities($companion['description'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "</textarea></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Companion join text:");
+    $output->rawOutput("</td><td><textarea cols='25' rows='5' name='companion[jointext]'>" . htmlentities($companion['jointext'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "</textarea></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Companion Category:");
+    $output->rawOutput("</td><td><input name='companion[category]' value=\"" . htmlentities($companion['category'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "\" maxlength='50'></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Companion Availability:");
+    $output->rawOutput("</td><td nowrap>");
     // Run a modulehook to find out where camps are located.  By default
     // they are located in 'Degolburg' (ie, getgamesetting('villagename'));
     // Some later module can remove them however.
-    $vname = getsetting('villagename', LOCATION_FIELDS);
-    $locs = array($vname => sprintf_translate("The Village of %s", $vname));
-    $locs = modulehook("camplocs", $locs);
-    $locs['all'] = translate_inline("Everywhere");
+    $vname = Settings::getsetting('villagename', LOCATION_FIELDS);
+    $locs = array($vname => Translator::sprintfTranslate("The Village of %s", $vname));
+    $locs = HookHandler::hook("camplocs", $locs);
+    $locs['all'] = Translator::translateInline("Everywhere");
     ksort($locs);
     reset($locs);
-    rawoutput("<select name='companion[companionlocation]'>");
+    $output->rawOutput("<select name='companion[companionlocation]'>");
     foreach ($locs as $loc => $name) {
-        rawoutput("<option value='$loc'" . ($companion['companionlocation'] == $loc ? " selected" : "") . ">$name</option>");
+        $output->rawOutput("<option value='$loc'" . ($companion['companionlocation'] == $loc ? " selected" : "") . ">$name</option>");
     }
 
-    rawoutput("<tr><td nowrap>");
-    output("Maxhitpoints / Bonus per level:");
-    rawoutput("</td><td><input name='companion[maxhitpoints]' value=\"" . htmlentities($companion['maxhitpoints'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\"> / <input name='companion[maxhitpointsperlevel]' value=\"" . htmlentities($companion['maxhitpointsperlevel'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\"></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Attack / Bonus per level:");
-    rawoutput("</td><td><input name='companion[attack]' value=\"" . htmlentities($companion['attack'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\"> / <input name='companion[attackperlevel]' value=\"" . htmlentities($companion['attackperlevel'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\"></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Defense / Bonus per level:");
-    rawoutput("</td><td><input name='companion[defense]' value=\"" . htmlentities($companion['defense'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\"> / <input name='companion[defenseperlevel]' value=\"" . htmlentities($companion['defenseperlevel'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\"></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Maxhitpoints / Bonus per level:");
+    $output->rawOutput("</td><td><input name='companion[maxhitpoints]' value=\"" . htmlentities($companion['maxhitpoints'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "\"> / <input name='companion[maxhitpointsperlevel]' value=\"" . htmlentities($companion['maxhitpointsperlevel'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "\"></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Attack / Bonus per level:");
+    $output->rawOutput("</td><td><input name='companion[attack]' value=\"" . htmlentities($companion['attack'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "\"> / <input name='companion[attackperlevel]' value=\"" . htmlentities($companion['attackperlevel'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "\"></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Defense / Bonus per level:");
+    $output->rawOutput("</td><td><input name='companion[defense]' value=\"" . htmlentities($companion['defense'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "\"> / <input name='companion[defenseperlevel]' value=\"" . htmlentities($companion['defenseperlevel'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "\"></td></tr>");
 
-    rawoutput("<tr><td nowrap>");
-    output("Fighter?:");
-    rawoutput("</td><td><input id='fighter' type='checkbox' name='companion[abilities][fight]' value='1'" . ($companion['abilities']['fight'] == true ? " checked" : "") . " onClick='document.getElementById(\"defender\").disabled=document.getElementById(\"fighter\").checked; if(document.getElementById(\"defender\").disabled==true) document.getElementById(\"defender\").checked=false;'></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Defender?:");
-    rawoutput("</td><td><input id='defender' type='checkbox' name='companion[abilities][defend]' value='1'" . ($companion['abilities']['defend'] == true ? " checked" : "") . " onClick='document.getElementById(\"fighter\").disabled=document.getElementById(\"defender\").checked; if(document.getElementById(\"fighter\").disabled==true) document.getElementById(\"fighter\").checked=false;'></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Healer level:");
-    rawoutput("</td><td valign='top'><select name='companion[abilities][heal]'>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Fighter?:");
+    $output->rawOutput("</td><td><input id='fighter' type='checkbox' name='companion[abilities][fight]' value='1'" . ($companion['abilities']['fight'] == true ? " checked" : "") . " onClick='document.getElementById(\"defender\").disabled=document.getElementById(\"fighter\").checked; if(document.getElementById(\"defender\").disabled==true) document.getElementById(\"defender\").checked=false;'></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Defender?:");
+    $output->rawOutput("</td><td><input id='defender' type='checkbox' name='companion[abilities][defend]' value='1'" . ($companion['abilities']['defend'] == true ? " checked" : "") . " onClick='document.getElementById(\"fighter\").disabled=document.getElementById(\"defender\").checked; if(document.getElementById(\"fighter\").disabled==true) document.getElementById(\"fighter\").checked=false;'></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Healer level:");
+    $output->rawOutput("</td><td valign='top'><select name='companion[abilities][heal]'>");
     for ($i = 0; $i <= 30; $i++) {
-        rawoutput("<option value='$i'" . ($companion['abilities']['heal'] == $i ? " selected" : "") . ">$i</option>");
+        $output->rawOutput("<option value='$i'" . ($companion['abilities']['heal'] == $i ? " selected" : "") . ">$i</option>");
     }
-    rawoutput("</select></td></tr>");
-    rawoutput("<tr><td colspan='2'>");
-    output("`iThis value determines the maximum amount of HP healed per round`i");
-    rawoutput("</td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Magician?:");
-    rawoutput("</td><td valign='top'><select name='companion[abilities][magic]'>");
+    $output->rawOutput("</select></td></tr>");
+    $output->rawOutput("<tr><td colspan='2'>");
+    $output->output("`iThis value determines the maximum amount of HP healed per round`i");
+    $output->rawOutput("</td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Magician?:");
+    $output->rawOutput("</td><td valign='top'><select name='companion[abilities][magic]'>");
     for ($i = 0; $i <= 30; $i++) {
-        rawoutput("<option value='$i'" . ($companion['abilities']['magic'] == $i ? " selected" : "") . ">$i</option>");
+        $output->rawOutput("<option value='$i'" . ($companion['abilities']['magic'] == $i ? " selected" : "") . ">$i</option>");
     }
-    rawoutput("</select></td></tr>");
-    rawoutput("<tr><td colspan='2'>");
-    output("`iThis value determines the maximum amount of damage caused per round`i");
-    rawoutput("</td></tr>");
+    $output->rawOutput("</select></td></tr>");
+    $output->rawOutput("<tr><td colspan='2'>");
+    $output->output("`iThis value determines the maximum amount of damage caused per round`i");
+    $output->rawOutput("</td></tr>");
 
-    rawoutput("<tr><td nowrap>");
-    output("Companion cannot die:");
-    rawoutput("</td><td><input type='checkbox' name='companion[cannotdie]' value='1'" . ($companion['cannotdie'] == true ? " checked" : "") . "></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Companion cannot be healed:");
-    rawoutput("</td><td><input type='checkbox' name='companion[cannotbehealed]' value='1'" . ($companion['cannotbehealed'] == true ? " checked" : "") . "></td></tr>");
-    rawoutput("<tr><td nowrap>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Companion cannot die:");
+    $output->rawOutput("</td><td><input type='checkbox' name='companion[cannotdie]' value='1'" . ($companion['cannotdie'] == true ? " checked" : "") . "></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Companion cannot be healed:");
+    $output->rawOutput("</td><td><input type='checkbox' name='companion[cannotbehealed]' value='1'" . ($companion['cannotbehealed'] == true ? " checked" : "") . "></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
 
-    output("Companion Cost (DKs):");
-    rawoutput("</td><td><input name='companion[companioncostdks]' value=\"" . htmlentities((int)$companion['companioncostdks'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\"></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Companion Cost (Gems):");
-    rawoutput("</td><td><input name='companion[companioncostgems]' value=\"" . htmlentities((int)$companion['companioncostgems'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\"></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Companion Cost (Gold):");
-    rawoutput("</td><td><input name='companion[companioncostgold]' value=\"" . htmlentities((int)$companion['companioncostgold'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\"></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Allow in shades:");
-    rawoutput("</td><td><input type='checkbox' name='companion[allowinshades]' value='1'" . ($companion['allowinshades'] == true ? " checked" : "") . "></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Allow in PvP:");
-    rawoutput("</td><td><input type='checkbox' name='companion[allowinpvp]' value='1'" . ($companion['allowinpvp'] == true ? " checked" : "") . "></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Allow in train:");
-    rawoutput("</td><td><input type='checkbox' name='companion[allowintrain]' value='1'" . ($companion['allowintrain'] == true ? " checked" : "") . "></td></tr>");
-    rawoutput("</table>");
-    $save = translate_inline("Save");
-    rawoutput("<input type='submit' class='button' value='$save'></form>");
+    $output->output("Companion Cost (DKs):");
+    $output->rawOutput("</td><td><input name='companion[companioncostdks]' value=\"" . htmlentities((int)$companion['companioncostdks'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "\"></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Companion Cost (Gems):");
+    $output->rawOutput("</td><td><input name='companion[companioncostgems]' value=\"" . htmlentities((int)$companion['companioncostgems'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "\"></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Companion Cost (Gold):");
+    $output->rawOutput("</td><td><input name='companion[companioncostgold]' value=\"" . htmlentities((int)$companion['companioncostgold'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "\"></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Allow in shades:");
+    $output->rawOutput("</td><td><input type='checkbox' name='companion[allowinshades]' value='1'" . ($companion['allowinshades'] == true ? " checked" : "") . "></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Allow in PvP:");
+    $output->rawOutput("</td><td><input type='checkbox' name='companion[allowinpvp]' value='1'" . ($companion['allowinpvp'] == true ? " checked" : "") . "></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Allow in train:");
+    $output->rawOutput("</td><td><input type='checkbox' name='companion[allowintrain]' value='1'" . ($companion['allowintrain'] == true ? " checked" : "") . "></td></tr>");
+    $output->rawOutput("</table>");
+    $save = Translator::translateInline("Save");
+    $output->rawOutput("<input type='submit' class='button' value='$save'></form>");
 }
 
-page_footer();
+Footer::pageFooter();

--- a/deathmessages.php
+++ b/deathmessages.php
@@ -1,130 +1,136 @@
 <?php
+declare(strict_types=1);
 
 use Lotgd\SuAccess;
 use Lotgd\Substitute;
 use Lotgd\Nav\SuperuserNav;
+use Lotgd\Http;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Nav;
+use Lotgd\Translator;
+use Lotgd\MySQL\Database;
 
 // addnews ready
 // mail ready
 // translator ready
 require_once("common.php");
-require_once("lib/http.php");
 
-tlschema("deathmessage");
+Translator::tlschema("deathmessage");
 
 SuAccess::check(SU_EDIT_CREATURES);
 
-page_header("Deathmessage Editor");
+Header::pageHeader("Deathmessage Editor");
 SuperuserNav::render();
-$op = httpget('op');
-$deathmessageid = httpget('deathmessageid');
+$op = Http::get('op');
+$deathmessageid = Http::get('deathmessageid');
 switch ($op) {
     case "edit":
-        addnav("Deathmessages");
-        addnav("Return to the Deathmessage editor", "deathmessages.php");
-        rawoutput("<form action='deathmessages.php?op=save&deathmessageid=$deathmessageid' method='POST'>", true);
-        addnav("", "deathmessages.php?op=save&deathmessageid=$deathmessageid");
+        Nav::add("Deathmessages");
+        Nav::add("Return to the Deathmessage editor", "deathmessages.php");
+        $output->rawOutput("<form action='deathmessages.php?op=save&deathmessageid=$deathmessageid' method='POST'>", true);
+        Nav::add("", "deathmessages.php?op=save&deathmessageid=$deathmessageid");
         if ($deathmessageid != "") {
-            $sql = "SELECT * FROM " . db_prefix("deathmessages") . " WHERE deathmessageid=\"$deathmessageid\"";
-            $result = db_query($sql);
-            $row = db_fetch_assoc($result);
+            $sql = "SELECT * FROM " . Database::prefix("deathmessages") . " WHERE deathmessageid=\"$deathmessageid\"";
+            $result = Database::query($sql);
+            $row = Database::fetchAssoc($result);
             $badguy = array('creaturename' => '`2The Nasty Rabbit', 'creatureweapon' => 'Rabbit Ears');
             $deathmessage = Substitute::applyArray($row['deathmessage'], array("{where}"), array("in the fields"));
-            $deathmessage = call_user_func_array("sprintf_translate", $deathmessage);
-            output("Preview: %s`0`n`n", $deathmessage);
+            $deathmessage = Translator::sprintfTranslate(...$deathmessage);
+            $output->output("Preview: %s`0`n`n", $deathmessage);
         } else {
             $row = array('deathmessageid' => 0, 'deathmessage' => "");
         }
-        output("The following codes are supported (case matters):`n");
-        output("{goodguyname}	= The player's name (also can be specified as {goodguy}`n");
-        output("{goodguyweapon}	= The player's weapon (also can be specified as {weapon}`n");
-        output("{armorname}	= The player's armor (also can be specified as {armor}`n");
-        output("{himher}	= Subjective pronoun for the player (him her)`n");
-        output("{hisher}	= Possessive pronoun for the player (his her)`n");
-        output("{heshe}		= Objective pronoun for the player (he she)`n");
-        output("{badguyname}	= The monster's name (also can be specified as {badguy}`n");
-        output("{badguyweapon}	= The monster's weapon (also can be specified as {creatureweapon}`n");
-        output("{where}         = The location like 'in the forest' or 'in the fields' or whatnot`n");
-        $save = translate_inline("Save");
-        output("`n`n`4Deathmessage: ");
-        rawoutput("<input name='deathmessage' value=\"" . HTMLEntities($row['deathmessage'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\" size='70'><br>");
-        output("Is this a Forest Deathmessage: ");
-        rawoutput("<input name='forest' " . ((int)$row['forest'] ? "checked" : "") . " value='1' type='checkbox'><br>");
-        output("Is this a Graveyard Deathmessage: ");
-        rawoutput("<input name='graveyard' " . ((int)$row['graveyard'] ? "checked" : "") . " value='1' type='checkbox'><br>");
-        output("Is a Taunt displayed along with it?");
-        rawoutput("<input name='taunt' " . ((int)$row['taunt'] ? "checked" : "") . " value='1' type='checkbox'><br>");
-        rawoutput("<input type='submit' class='button' value='$save'>");
-        rawoutput("</form>");
+        $output->output("The following codes are supported (case matters):`n");
+        $output->output("{goodguyname}	= The player's name (also can be specified as {goodguy}`n");
+        $output->output("{goodguyweapon}	= The player's weapon (also can be specified as {weapon}`n");
+        $output->output("{armorname}	= The player's armor (also can be specified as {armor}`n");
+        $output->output("{himher}	= Subjective pronoun for the player (him her)`n");
+        $output->output("{hisher}	= Possessive pronoun for the player (his her)`n");
+        $output->output("{heshe}		= Objective pronoun for the player (he she)`n");
+        $output->output("{badguyname}	= The monster's name (also can be specified as {badguy}`n");
+        $output->output("{badguyweapon}	= The monster's weapon (also can be specified as {creatureweapon}`n");
+        $output->output("{where}         = The location like 'in the forest' or 'in the fields' or whatnot`n");
+        $save = Translator::translateInline("Save");
+        $output->output("`n`n`4Deathmessage: ");
+        $output->rawOutput("<input name='deathmessage' value=\"" . HTMLEntities($row['deathmessage'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "\" size='70'><br>");
+        $output->output("Is this a Forest Deathmessage: ");
+        $output->rawOutput("<input name='forest' " . ((int)$row['forest'] ? "checked" : "") . " value='1' type='checkbox'><br>");
+        $output->output("Is this a Graveyard Deathmessage: ");
+        $output->rawOutput("<input name='graveyard' " . ((int)$row['graveyard'] ? "checked" : "") . " value='1' type='checkbox'><br>");
+        $output->output("Is a Taunt displayed along with it?");
+        $output->rawOutput("<input name='taunt' " . ((int)$row['taunt'] ? "checked" : "") . " value='1' type='checkbox'><br>");
+        $output->rawOutput("<input type='submit' class='button' value='$save'>");
+        $output->rawOutput("</form>");
         break;
     case "del":
-        $sql = "DELETE FROM " . db_prefix("deathmessages") . " WHERE deathmessageid=\"$deathmessageid\"";
-        db_query($sql);
+        $sql = "DELETE FROM " . Database::prefix("deathmessages") . " WHERE deathmessageid=\"$deathmessageid\"";
+        Database::query($sql);
         $op = "";
-        httpset("op", "");
+        Http::set("op", "");
         break;
     case "save":
-        $deathmessage = httppost('deathmessage');
-        $forest = (int) httppost('forest');
-        $graveyard = (int) httppost('graveyard');
-        $taunt = (int) httppost('taunt');
+        $deathmessage = Http::post('deathmessage');
+        $forest = (int) Http::post('forest');
+        $graveyard = (int) Http::post('graveyard');
+        $taunt = (int) Http::post('taunt');
         if ($deathmessageid != "") {
-            $sql = "UPDATE " . db_prefix("deathmessages") . " SET deathmessage=\"$deathmessage\",taunt=$taunt,forest=$forest,graveyard=$graveyard,editor=\"" . addslashes($session['user']['login']) . "\" WHERE deathmessageid=\"$deathmessageid\"";
+            $sql = "UPDATE " . Database::prefix("deathmessages") . " SET deathmessage=\"$deathmessage\",taunt=$taunt,forest=$forest,graveyard=$graveyard,editor=\"" . addslashes($session['user']['login']) . "\" WHERE deathmessageid=\"$deathmessageid\"";
         } else {
-            $sql = "INSERT INTO " . db_prefix("deathmessages") . " (deathmessage,taunt,forest,graveyard,editor) VALUES (\"$deathmessage\",$taunt,$forest,$graveyard,\"" . addslashes($session['user']['login']) . "\")";
+            $sql = "INSERT INTO " . Database::prefix("deathmessages") . " (deathmessage,taunt,forest,graveyard,editor) VALUES (\"$deathmessage\",$taunt,$forest,$graveyard,\"" . addslashes($session['user']['login']) . "\")";
         }
-        db_query($sql);
+        Database::query($sql);
         $op = "";
-        httpset("op", "");
+        Http::set("op", "");
         break;
 }
 if ($op == "") {
-    output("`i`\$Note: These messages are NEWS messages the user will trigger when he/she dies in the forest or graveyard.`0`i`n`n");
-    $sql = "SELECT * FROM " . db_prefix("deathmessages");
-    $result = db_query($sql);
-    rawoutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
-    $op = translate_inline("Ops");
-    $t = translate_inline("Deathmessage String");
-    $auth = translate_inline("Author");
-    $f = translate_inline("Forest Message");
-    $g = translate_inline("Graveyard Message");
-    $ta = translate_inline("With Taunt");
-    rawoutput("<tr class='trhead'><td nowrap>$op</td><td>$t</td><td>$f</td><td>$g</td><td>$ta</td><td>$auth</td></tr>");
+    $output->output("`i`\$Note: These messages are NEWS messages the user will trigger when he/she dies in the forest or graveyard.`0`i`n`n");
+    $sql = "SELECT * FROM " . Database::prefix("deathmessages");
+    $result = Database::query($sql);
+    $output->rawOutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
+    $op = Translator::translateInline("Ops");
+    $t = Translator::translateInline("Deathmessage String");
+    $auth = Translator::translateInline("Author");
+    $f = Translator::translateInline("Forest Message");
+    $g = Translator::translateInline("Graveyard Message");
+    $ta = Translator::translateInline("With Taunt");
+    $output->rawOutput("<tr class='trhead'><td nowrap>$op</td><td>$t</td><td>$f</td><td>$g</td><td>$ta</td><td>$auth</td></tr>");
     $i = true;
-    while ($row = db_fetch_assoc($result)) {
+    while ($row = Database::fetchAssoc($result)) {
         $i = !$i;
-        rawoutput("<tr class='" . ($i ? "trdark" : "trlight") . "'>", true);
-        rawoutput("<td nowrap>");
-        $edit = translate_inline("Edit");
-        $del = translate_inline("Del");
-        $conf = translate_inline("Are you sure you wish to delete this deathmessage?");
+        $output->rawOutput("<tr class='" . ($i ? "trdark" : "trlight") . "'>", true);
+        $output->rawOutput("<td nowrap>");
+        $edit = Translator::translateInline("Edit");
+        $del = Translator::translateInline("Del");
+        $conf = Translator::translateInline("Are you sure you wish to delete this deathmessage?");
         $id = $row['deathmessageid'];
-        rawoutput("[ <a href='deathmessages.php?op=edit&deathmessageid=$id'>$edit</a> | <a href='deathmessages.php?op=del&deathmessageid=$id' onClick='return confirm(\"$conf\");'>$del</a> ]");
-        addnav("", "deathmessages.php?op=edit&deathmessageid=$id");
-        addnav("", "deathmessages.php?op=del&deathmessageid=$id");
-        rawoutput("</td><td>");
-        output_notl("%s", $row['deathmessage']);
-        rawoutput("</td><td>");
-        output_notl("%s", deathmessages_bool($row['forest']));
-        rawoutput("</td><td>");
-        output_notl("%s", deathmessages_bool($row['graveyard']));
-        rawoutput("</td><td>");
-        output_notl("%s", deathmessages_bool($row['taunt']));
-        rawoutput("</td><td>");
-        output_notl("%s", $row['editor']);
-        rawoutput("</td></tr>");
+        $output->rawOutput("[ <a href='deathmessages.php?op=edit&deathmessageid=$id'>$edit</a> | <a href='deathmessages.php?op=del&deathmessageid=$id' onClick='return confirm(\"$conf\");'>$del</a> ]");
+        Nav::add("", "deathmessages.php?op=edit&deathmessageid=$id");
+        Nav::add("", "deathmessages.php?op=del&deathmessageid=$id");
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['deathmessage']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", deathmessages_bool($row['forest']));
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", deathmessages_bool($row['graveyard']));
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", deathmessages_bool($row['taunt']));
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['editor']);
+        $output->rawOutput("</td></tr>");
     }
-    addnav("", "deathmessages.php?c=" . httpget('c'));
-    rawoutput("</table>");
-    addnav("Deathmessages");
-    addnav("Add a new deathmessage", "deathmessages.php?op=edit");
+    Nav::add("", "deathmessages.php?c=" . Http::get('c'));
+    $output->rawOutput("</table>");
+    Nav::add("Deathmessages");
+    Nav::add("Add a new deathmessage", "deathmessages.php?op=edit");
 }
 function deathmessages_bool($value)
 {
     if ($value) {
-        return translate_inline("Yes");
+        return Translator::translateInline("Yes");
     } else {
-        return translate_inline("No");
+        return Translator::translateInline("No");
     }
 }
-page_footer();
+Footer::pageFooter();

--- a/taunt.php
+++ b/taunt.php
@@ -1,98 +1,105 @@
 <?php
+declare(strict_types=1);
 
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
 use Lotgd\Substitute;
+use Lotgd\Http;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Nav;
+use Lotgd\Translator;
+use Lotgd\MySQL\Database;
+use Lotgd\Settings;
 
 // addnews ready
 // mail ready
 // translator ready
 require_once("common.php");
-require_once("lib/http.php");
 
-tlschema("taunt");
+Translator::tlschema("taunt");
 
 SuAccess::check(SU_EDIT_CREATURES);
 
-page_header("Taunt Editor");
+Header::pageHeader("Taunt Editor");
 SuperuserNav::render();
-$op = httpget('op');
-$tauntid = httpget('tauntid');
+$op = Http::get('op');
+$tauntid = Http::get('tauntid');
 if ($op == "edit") {
-    addnav("Taunts");
-    addnav("Return to the taunt editor", "taunt.php");
-    rawoutput("<form action='taunt.php?op=save&tauntid=$tauntid' method='POST'>", true);
-    addnav("", "taunt.php?op=save&tauntid=$tauntid");
+    Nav::add("Taunts");
+    Nav::add("Return to the taunt editor", "taunt.php");
+    $output->rawOutput("<form action='taunt.php?op=save&tauntid=$tauntid' method='POST'>", true);
+    Nav::add("", "taunt.php?op=save&tauntid=$tauntid");
     if ($tauntid != "") {
-        $sql = "SELECT * FROM " . db_prefix("taunts") . " WHERE tauntid=\"$tauntid\"";
-        $result = db_query($sql);
-        $row = db_fetch_assoc($result);
+        $sql = "SELECT * FROM " . Database::prefix("taunts") . " WHERE tauntid=\"$tauntid\"";
+        $result = Database::query($sql);
+        $row = Database::fetchAssoc($result);
         $badguy = array('creaturename' => 'Baron Munchausen', 'creatureweapon' => 'Bad Puns');
         $taunt = Substitute::applyArray($row['taunt']);
-        $taunt = call_user_func_array("sprintf_translate", $taunt);
-        output("Preview: %s`0`n`n", $taunt);
+        $taunt = Translator::sprintfTranslate(...$taunt);
+        $output->output("Preview: %s`0`n`n", $taunt);
     } else {
         $row = array('tauntid' => 0, 'taunt' => "");
     }
-    output("Taunt: ");
-    rawoutput("<input name='taunt' value=\"" . HTMLEntities($row['taunt'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\" size='70'><br>");
-    output("The following codes are supported (case matters):`n");
-    output("{goodguyname}	= The player's name (also can be specified as {goodguy}`n");
-    output("{goodguyweapon}	= The player's weapon (also can be specified as {weapon}`n");
-    output("{armorname}	= The player's armor (also can be specified as {armor}`n");
-    output("{himher}	= Subjective pronoun for the player (him her)`n");
-    output("{hisher}	= Possessive pronoun for the player (his her)`n");
-    output("{heshe}		= Objective pronoun for the player (he she)`n");
-    output("{badguyname}	= The monster's name (also can be specified as {badguy}`n");
-    output("{badguyweapon}	= The monster's weapon (also can be specified as {creatureweapon}`n");
-    $save = translate_inline("Save");
-    rawoutput("<input type='submit' class='button' value='$save'>");
-    rawoutput("</form>");
+    $output->output("Taunt: ");
+    $output->rawOutput("<input name='taunt' value=\"" . HTMLEntities($row['taunt'], ENT_COMPAT, Settings::getsetting("charset", "ISO-8859-1")) . "\" size='70'><br>");
+    $output->output("The following codes are supported (case matters):`n");
+    $output->output("{goodguyname}	= The player's name (also can be specified as {goodguy}`n");
+    $output->output("{goodguyweapon}	= The player's weapon (also can be specified as {weapon}`n");
+    $output->output("{armorname}	= The player's armor (also can be specified as {armor}`n");
+    $output->output("{himher}	= Subjective pronoun for the player (him her)`n");
+    $output->output("{hisher}	= Possessive pronoun for the player (his her)`n");
+    $output->output("{heshe}		= Objective pronoun for the player (he she)`n");
+    $output->output("{badguyname}	= The monster's name (also can be specified as {badguy}`n");
+    $output->output("{badguyweapon}	= The monster's weapon (also can be specified as {creatureweapon}`n");
+    $save = Translator::translateInline("Save");
+    $output->rawOutput("<input type='submit' class='button' value='$save'>");
+    $output->rawOutput("</form>");
 } elseif ($op == "del") {
-    $sql = "DELETE FROM " . db_prefix("taunts") . " WHERE tauntid=\"$tauntid\"";
-    db_query($sql);
+    $sql = "DELETE FROM " . Database::prefix("taunts") . " WHERE tauntid=\"$tauntid\"";
+    Database::query($sql);
     $op = "";
-    httpset("op", "");
+    Http::set("op", "");
 } elseif ($op == "save") {
-    $taunt = httppost('taunt');
+    $taunt = Http::post('taunt');
     if ($tauntid != "") {
-        $sql = "UPDATE " . db_prefix("taunts") . " SET taunt=\"$taunt\",editor=\"" . addslashes($session['user']['login']) . "\" WHERE tauntid=\"$tauntid\"";
+        $sql = "UPDATE " . Database::prefix("taunts") . " SET taunt=\"$taunt\",editor=\"" . addslashes($session['user']['login']) . "\" WHERE tauntid=\"$tauntid\"";
     } else {
-        $sql = "INSERT INTO " . db_prefix("taunts") . " (taunt,editor) VALUES (\"$taunt\",\"" . addslashes($session['user']['login']) . "\")";
+        $sql = "INSERT INTO " . Database::prefix("taunts") . " (taunt,editor) VALUES (\"$taunt\",\"" . addslashes($session['user']['login']) . "\")";
     }
-    db_query($sql);
+    Database::query($sql);
     $op = "";
-    httpset("op", "");
+    Http::set("op", "");
 }
 if ($op == "") {
-    $sql = "SELECT * FROM " . db_prefix("taunts");
-    $result = db_query($sql);
-    rawoutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
-    $op = translate_inline("Ops");
-    $t = translate_inline("Taunt String");
-    $auth = translate_inline("Author");
-    rawoutput("<tr class='trhead'><td nowrap>$op</td><td>$t</td><td>$auth</td></tr>");
-    $number = db_num_rows($result);
+    $sql = "SELECT * FROM " . Database::prefix("taunts");
+    $result = Database::query($sql);
+    $output->rawOutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
+    $op = Translator::translateInline("Ops");
+    $t = Translator::translateInline("Taunt String");
+    $auth = Translator::translateInline("Author");
+    $output->rawOutput("<tr class='trhead'><td nowrap>$op</td><td>$t</td><td>$auth</td></tr>");
+    $number = Database::numRows($result);
     for ($i = 0; $i < $number; $i++) {
-        $row = db_fetch_assoc($result);
-        rawoutput("<tr class='" . ($i % 2 == 0 ? "trdark" : "trlight") . "'>", true);
-        rawoutput("<td nowrap>");
-        $edit = translate_inline("Edit");
-        $del = translate_inline("Del");
-        $conf = translate_inline("Are you sure you wish to delete this taunt?");
+        $row = Database::fetchAssoc($result);
+        $output->rawOutput("<tr class='" . ($i % 2 == 0 ? "trdark" : "trlight") . "'>", true);
+        $output->rawOutput("<td nowrap>");
+        $edit = Translator::translateInline("Edit");
+        $del = Translator::translateInline("Del");
+        $conf = Translator::translateInline("Are you sure you wish to delete this taunt?");
         $id = $row['tauntid'];
-        rawoutput("[ <a href='taunt.php?op=edit&tauntid=$id'>$edit</a> | <a href='taunt.php?op=del&tauntid=$id' onClick='return confirm(\"$conf\");'>$del</a> ]");
-        addnav("", "taunt.php?op=edit&tauntid=$id");
-        addnav("", "taunt.php?op=del&tauntid=$id");
-        rawoutput("</td><td>");
-        output_notl("%s", $row['taunt']);
-        rawoutput("</td><td>");
-        output_notl("%s", $row['editor']);
-        rawoutput("</td></tr>");
+        $output->rawOutput("[ <a href='taunt.php?op=edit&tauntid=$id'>$edit</a> | <a href='taunt.php?op=del&tauntid=$id' onClick='return confirm(\"$conf\");'>$del</a> ]");
+        Nav::add("", "taunt.php?op=edit&tauntid=$id");
+        Nav::add("", "taunt.php?op=del&tauntid=$id");
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['taunt']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("%s", $row['editor']);
+        $output->rawOutput("</td></tr>");
     }
-    addnav("", "taunt.php?c=" . httpget('c'));
-    rawoutput("</table>");
-    addnav("Taunts");
-    addnav("Add a new taunt", "taunt.php?op=edit");
+    Nav::add("", "taunt.php?c=" . Http::get('c'));
+    $output->rawOutput("</table>");
+    Nav::add("Taunts");
+    Nav::add("Add a new taunt", "taunt.php?op=edit");
 }
-page_footer();
+Footer::pageFooter();


### PR DESCRIPTION
## Summary
- use strict types in admin tools
- swap legacy calls for namespaced classes
- drop old library includes
- render output through the collector

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6887c765f1e08329abf53e226df85a0f