### PR TITLE
Use namespaced API in graveyard pages

### DIFF
--- a/pages/graveyard/case_battle_search.php
+++ b/pages/graveyard/case_battle_search.php
@@ -4,31 +4,36 @@ declare(strict_types=1);
 use Lotgd\Battle;
 use Lotgd\BellRand;
 use Lotgd\PlayerFunctions;
+use Lotgd\Modules\HookHandler;
+use Lotgd\Nav;
+use Lotgd\Http;
+use Lotgd\Page\Footer;
+use Lotgd\MySQL\Database;
 
 if ($session['user']['gravefights'] <= 0) {
-    output("`\$`bYour soul can bear no more torment in this afterlife.`b`0");
-    $op = "";
-    httpset('op', "");
+    $output->output("`\$`bYour soul can bear no more torment in this afterlife.`b`0");
+    $op = '';
+    Http::set('op', '');
 } else {
-       Battle::suspendCompanions("allowinshades", true);
-    if (module_events("graveyard", getsetting("gravechance", 0)) != 0) {
-        if (!checknavs()) {
+    Battle::suspendCompanions('allowinshades', true);
+    if (HookHandler::moduleEvents('graveyard', (int) getsetting('gravechance', 0)) != 0) {
+        if (! Nav::checkNavs()) {
             // If we're going back to the graveyard, make sure to reset
             // the special and the specialmisc
             $session['user']['specialinc'] = "";
             $session['user']['specialmisc'] = "";
             $skipgraveyardtext = true;
-            $op = "";
-            httpset("op", "");
+            $op = '';
+            Http::set('op', '');
         } else {
-            page_footer();
+            Footer::pageFooter();
         }
     } else {
         $session['user']['gravefights']--;
             $battle = true;
-            $sql = "SELECT * FROM " . db_prefix("creatures") . " WHERE graveyard=1 ORDER BY rand(" . e_rand() . ") LIMIT 1";
-        $result = db_query($sql);
-        $badguy = db_fetch_assoc($result);
+            $sql = "SELECT * FROM " . Database::prefix('creatures') . " WHERE graveyard=1 ORDER BY rand(" . e_rand() . ") LIMIT 1";
+        $result = Database::query($sql);
+        $badguy = Database::fetchAssoc($result);
         $level = $session['user']['level'];
         $shift = 0;
         if ($level < 5) {
@@ -61,7 +66,7 @@ if ($session['user']['gravefights'] <= 0) {
 
 
         //no multifights currently, so this hook passes the badguy to modify
-        $attackstack = modulehook("graveyardfight-start", $attackstack);
+        $attackstack = HookHandler::hook('graveyardfight-start', $attackstack);
 
         $session['user']['badguy'] = createstring($attackstack);
     }

--- a/pages/graveyard/case_default.php
+++ b/pages/graveyard/case_default.php
@@ -1,23 +1,36 @@
 <?php
 declare(strict_types=1);
 
-if (!$skipgraveyardtext) {
-    output("`)`c`bThe Graveyard`b`c");
-    output("Your spirit wanders into a lonely graveyard, overgrown with sickly weeds which seem to grab at your spirit as you float past them.");
-    output("Around you are the remains of many broken tombstones, some lying on their faces, some shattered to pieces.");
-    output("You can almost hear the wails of the souls trapped within each plot lamenting their fates.`n`n");
-    output("In the center of the graveyard is an ancient looking mausoleum which has been worn by the effects of untold years.");
-    output("A sinister looking gargoyle adorns the apex of its roof; its eyes seem to follow  you, and its mouth gapes with sharp stone teeth.");
-    output("The plaque above the door reads `\$%s`), Overlord of Death`).", $deathoverlord);
-    modulehook("graveyard-desc");
+use Lotgd\Nav;
+use Lotgd\Modules\HookHandler;
+
+if (! $skipgraveyardtext) {
+    $output->output("`)`c`bThe Graveyard`b`c");
+    $output->output(
+        "Your spirit wanders into a lonely graveyard, overgrown with sickly weeds which seem to grab at your spirit as you float past them."
+    );
+    $output->output(
+        "Around you are the remains of many broken tombstones, some lying on their faces, some shattered to pieces."
+    );
+    $output->output(
+        "You can almost hear the wails of the souls trapped within each plot lamenting their fates.`n`n"
+    );
+    $output->output(
+        "In the center of the graveyard is an ancient looking mausoleum which has been worn by the effects of untold years."
+    );
+    $output->output(
+        "A sinister looking gargoyle adorns the apex of its roof; its eyes seem to follow  you, and its mouth gapes with sharp stone teeth."
+    );
+    $output->output("The plaque above the door reads `\$%s`), Overlord of Death`).", $deathoverlord);
+    HookHandler::hook('graveyard-desc');
 }
-addnav("S?Return to the Shades", "shades.php");
+Nav::add('S?Return to the Shades', 'shades.php');
 if ($session['user']['gravefights']) {
-    addnav("Torment");
-    addnav("Look for Something to Torment", "graveyard.php?op=search");
+    Nav::add('Torment');
+    Nav::add('Look for Something to Torment', 'graveyard.php?op=search');
 }
-addnav("Places");
-addnav("W?List Warriors", "list.php");
-addnav("M?Enter the Mausoleum", "graveyard.php?op=enter");
-modulehook("graveyard");
-module_display_events("graveyard", "graveyard.php");
+Nav::add('Places');
+Nav::add('W?List Warriors', 'list.php');
+Nav::add('M?Enter the Mausoleum', 'graveyard.php?op=enter');
+HookHandler::hook('graveyard');
+HookHandler::displayEvents('graveyard', 'graveyard.php');

--- a/pages/graveyard/case_enter.php
+++ b/pages/graveyard/case_enter.php
@@ -1,18 +1,21 @@
 <?php
 declare(strict_types=1);
 
-output("`)`b`cThe Mausoleum`c`b");
+use Lotgd\Nav;
+use Lotgd\Modules\HookHandler;
 
-output("You enter the mausoleum and find yourself in a cold, stark marble chamber.");
-output("The air around you carries the chill of death itself.");
-output("From the darkness, two black eyes stare into your soul.");
-output("A clammy grasp seems to clutch your mind, and fill it with the words of the Overlord of Death, `\$%s`) himself.`n`n", $deathoverlord);
+$output->output('`)`b`cThe Mausoleum`c`b');
 
-output("\"`7Your mortal coil has forsaken you.  Now you turn to me.  There are those within this land that have eluded my grasp and possess a life beyond life.  To prove your worth to me and earn my favor, go out and torment their souls.  Should you gain enough of my favor, I will reward you.`)\"");
-addnav("G?Return to the Graveyard", "graveyard.php");
-addnav("Places");
-addnav("S?Land of the Shades", "shades.php");
-addnav("Souls");
-addnav(array("Question `\$%s`0 about the worth of your soul",$deathoverlord), "graveyard.php?op=question");
-addnav(array("Restore Your Soul (%s favor)", $favortoheal), "graveyard.php?op=restore");
-modulehook("mausoleum");
+$output->output('You enter the mausoleum and find yourself in a cold, stark marble chamber.');
+$output->output('The air around you carries the chill of death itself.');
+$output->output('From the darkness, two black eyes stare into your soul.');
+$output->output('A clammy grasp seems to clutch your mind, and fill it with the words of the Overlord of Death, `\$%s`) himself.`n`n', $deathoverlord);
+
+$output->output("\"`7Your mortal coil has forsaken you.  Now you turn to me.  There are those within this land that have eluded my grasp and possess a life beyond life.  To prove your worth to me and earn my favor, go out and torment their souls.  Should you gain enough of my favor, I will reward you.`)\"");
+Nav::add('G?Return to the Graveyard', 'graveyard.php');
+Nav::add('Places');
+Nav::add('S?Land of the Shades', 'shades.php');
+Nav::add('Souls');
+Nav::add(["Question `\$%s`0 about the worth of your soul", $deathoverlord], 'graveyard.php?op=question');
+Nav::add(["Restore Your Soul (%s favor)", $favortoheal], 'graveyard.php?op=restore');
+HookHandler::hook('mausoleum');

--- a/pages/graveyard/case_question.php
+++ b/pages/graveyard/case_question.php
@@ -1,12 +1,15 @@
 <?php
 declare(strict_types=1);
 
-addnav("G?Return to the Graveyard", "graveyard.php");
-addnav("Places");
-addnav("S?Land of the Shades", "shades.php");
-addnav("Souls");
+use Lotgd\Nav;
+use Lotgd\Modules\HookHandler;
+
+Nav::add('G?Return to the Graveyard', 'graveyard.php');
+Nav::add('Places');
+Nav::add('S?Land of the Shades', 'shades.php');
+Nav::add('Souls');
 if ($favortoheal > 0) {
-    addnav(array("Restore Your Soul (%s favor)",$favortoheal), "graveyard.php?op=restore");
+    Nav::add(['Restore Your Soul (%s favor)', $favortoheal], 'graveyard.php?op=restore');
 }
 
 
@@ -24,7 +27,7 @@ $default_actions[] = array(
     );
 
 //build navigation
-$actions = modulehook("deathoverlord_actions", $default_actions);
+$actions = HookHandler::hook('deathoverlord_actions', $default_actions);
 
 
 foreach ($actions as $key => $row) {
@@ -69,19 +72,19 @@ if ($length > 0) {
     }
 }
 $highest = str_replace("{deathoverlord}", $deathoverlord, $highest);
-output_notl($highest . "`n`n");
+$output->outputNotl($highest . "`n`n");
 
 
-addnav(array("%s Favors",sanitize($deathoverlord)));
+Nav::add(["%s Favors", sanitize($deathoverlord)]);
 for ($i = 0; $i < $length; $i++) {
     $linktext[$i] = str_replace("{deathoverlord}", $deathoverlord, $linktext[$i]);
-    addnav(array("%s`) (%s favors)",$linktext[$i],$favorcostlist[$i]), $linklist[$i]);
+    Nav::add(["%s`) (%s favors)", $linktext[$i], $favorcostlist[$i]], $linklist[$i]);
     if (isset($textlist[$i]) && $textlist[$i] != "") {
         $textlist[$i] = str_replace("{deathoverlord}", $deathoverlord, $textlist[$i]);
-        output_notl($textlist[$i]);
+        $output->outputNotl($textlist[$i]);
     }
 }
-addnav("Other");
-modulehook("ramiusfavors");
+Nav::add('Other');
+HookHandler::hook('ramiusfavors');
 
-output("`n`nYou have `6%s`) favor with `\$%s`).", $session['user']['deathpower'], $deathoverlord);
+$output->output("`n`nYou have `6%s`) favor with `\$%s`).", $session['user']['deathpower'], $deathoverlord);

--- a/pages/graveyard/case_restore.php
+++ b/pages/graveyard/case_restore.php
@@ -1,21 +1,23 @@
 <?php
 declare(strict_types=1);
 
-output("`)`b`cThe Mausoleum`c`b");
+use Lotgd\Nav;
+
+$output->output('`)`b`cThe Mausoleum`c`b');
 if ($session['user']['soulpoints'] < $max) {
     if ($session['user']['deathpower'] >= $favortoheal) {
-        output("`\$%s`) calls you weak for needing restoration, but as you have enough favor with him, he grants your request at the cost of `4%s`) favor.", $deathoverlord, $favortoheal);
+        $output->output("`\$%s`) calls you weak for needing restoration, but as you have enough favor with him, he grants your request at the cost of `4%s`) favor.", $deathoverlord, $favortoheal);
         $session['user']['deathpower'] -= $favortoheal;
         $session['user']['soulpoints'] = $max;
     } else {
-        output("`\$%s`) curses you and throws you from the Mausoleum, you must gain more favor with him before he will grant restoration.", $deathoverlord);
+        $output->output("`\$%s`) curses you and throws you from the Mausoleum, you must gain more favor with him before he will grant restoration.", $deathoverlord);
     }
 } else {
-    output("`\$%s`) sighs and mumbles something about, \"`7just 'cause they're dead, does that mean they don't have to think?`)\"`n`n", $deathoverlord);
-    output("Perhaps you'd like to actually `ineed`i restoration before you ask for it.");
+    $output->output("`\$%s`) sighs and mumbles something about, \"`7just 'cause they're dead, does that mean they don't have to think?`)\"`n`n", $deathoverlord);
+    $output->output("Perhaps you'd like to actually `ineed`i restoration before you ask for it.");
 }
-addnav("G?Return to the Graveyard", "graveyard.php");
-addnav("Places");
-addnav("S?Land of the Shades", "shades.php");
-addnav("Souls");
-addnav(array("Question `\$%s`0 about the worth of your soul",$deathoverlord), "graveyard.php?op=question");
+Nav::add('G?Return to the Graveyard', 'graveyard.php');
+Nav::add('Places');
+Nav::add('S?Land of the Shades', 'shades.php');
+Nav::add('Souls');
+Nav::add(["Question `\$%s`0 about the worth of your soul", $deathoverlord], 'graveyard.php?op=question');

--- a/pages/graveyard/case_resurrection.php
+++ b/pages/graveyard/case_resurrection.php
@@ -1,7 +1,9 @@
 <?php
 declare(strict_types=1);
 
-output("`\$%s`0 waves his skeletal arms as he begins to command the very fabric of life.`n`n", $deathoverlord);
+use Lotgd\Nav;
+
+$output->output("`\$%s`0 waves his skeletal arms as he begins to command the very fabric of life.`n`n", $deathoverlord);
 // Note to translators.  The text spoken by Ramius here is backwards
 // English.  You might choose to maintain it in tact, or you might choose
 // to translate it to your language, and reverse the letters that way.  A
@@ -12,9 +14,9 @@ output("`\$%s`0 waves his skeletal arms as he begins to command the very fabric 
 // power over death is mine
 // your life ego grant tu again
 // for ego know tu shall return to me again
-output("\"`)Noitcerruser evah llahs ut...`\$\"  The air begins to crackle around you.`n`n");
-output("\"`)Tnavres o htaed eht morf esir.`\$\" Your soul begins to burn with the pain of a thousand frosty fires.`n`n");
-output("\"`)Enim si htaed revo rewop.`\$\" Gradually you begin to become aware that the fires are dimming and are replaced by the blinding pain last known by your body before it fell.`n`n");
-output("\"`)Niaga ut tnarg oge efil ruoy.`\$\" You begin to look around you, and you watch as your muscles knit themselves back together.`n`n");
-output("\"`)Niaga em ot nruter llahs ut wonk oge rof.`\$\" With a gasp, you laboriously again draw your first breath.");
-addnav("Continue", "newday.php?resurrection=true");
+$output->output("\"`)Noitcerruser evah llahs ut...`\$\"  The air begins to crackle around you.`n`n");
+$output->output("\"`)Tnavres o htaed eht morf esir.`\$\" Your soul begins to burn with the pain of a thousand frosty fires.`n`n");
+$output->output("\"`)Enim si htaed revo rewop.`\$\" Gradually you begin to become aware that the fires are dimming and are replaced by the blinding pain last known by your body before it fell.`n`n");
+$output->output("\"`)Niaga ut tnarg oge efil ruoy.`\$\" You begin to look around you, and you watch as your muscles knit themselves back together.`n`n");
+$output->output("\"`)Niaga em ot nruter llahs ut wonk oge rof.`\$\" With a gasp, you laboriously again draw your first breath.");
+Nav::add('Continue', 'newday.php?resurrection=true');


### PR DESCRIPTION
## Summary
- update graveyard page scripts to use Lotgd namespaced APIs
- keep strict types and adjust imports accordingly

## Testing
- `php -l pages/graveyard/case_default.php`
- `php -l pages/graveyard/case_enter.php`
- `php -l pages/graveyard/case_question.php`
- `php -l pages/graveyard/case_restore.php`
- `php -l pages/graveyard/case_resurrection.php`
- `php -l pages/graveyard/case_battle_search.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6887cd5e6550832981bd5fed278dad94