### PR TITLE
Refactor bans pages to use Http wrappers

### DIFF
--- a/pages/bans/case_saveban.php
+++ b/pages/bans/case_saveban.php
@@ -3,36 +3,37 @@ declare(strict_types=1);
 
 use Lotgd\Cookies;
 use Lotgd\MySQL\Database;
+use Lotgd\Http;
 
 $sql = 'INSERT INTO '.Database::prefix('bans').' (banner,';
-$type = httppost("type");
+$type = (string) Http::post('type');
 if ($type == "ip") {
     $sql .= "ipfilter";
     $key = "lastip";
-    $key_value = httppost('ip');
+    $key_value = Http::post('ip');
 } else {
     $sql .= "uniqueid";
     $key = "uniqueid";
-    $key_value = httppost('id');
+    $key_value = Http::post('id');
 }
 $sql .= ",banexpire,banreason) VALUES ('" . addslashes($session['user']['name']) . "',";
 if ($type == "ip") {
-    $sql .= "\"" . httppost("ip") . "\"";
+    $sql .= "\"" . Http::post('ip') . "\"";
 } else {
-    $sql .= "\"" . httppost("id") . "\"";
+    $sql .= "\"" . Http::post('id') . "\"";
 }
-$duration = (int)httppost("duration");
+$duration = (int) Http::post('duration');
 if ($duration == 0) {
     $duration = DATETIME_DATEMAX;
 } else {
     $duration = date("Y-m-d", strtotime("+$duration days"));
 }
     $sql .= ",\"$duration\",";
-$sql .= "\"" . httppost("reason") . "\")";
+$sql .= "\"" . Http::post('reason') . "\")";
 if ($type == "ip") {
     if (
-        substr($_SERVER['REMOTE_ADDR'], 0, strlen(httppost("ip"))) ==
-            httppost("ip")
+        substr($_SERVER['REMOTE_ADDR'], 0, strlen((string) Http::post('ip'))) ==
+            Http::post('ip')
     ) {
         $sql = '';
         global $output;
@@ -40,7 +41,7 @@ if ($type == "ip") {
         $output->output("That's your own IP address!");
     }
 } else {
-    if (Cookies::getLgi() == httppost("id")) {
+    if (Cookies::getLgi() == Http::post('id')) {
             $sql = '';
             $output->output("You don't really want to ban yourself now do you??");
             $output->output("That's your own ID!");
@@ -51,7 +52,7 @@ if ($sql != "") {
     global $output;
     $output->output("%s ban rows entered.`n`n", Database::affectedRows($result));
     $output->outputNotl(Database::error($result));
-    debuglog("entered a ban: " .  ($type == "ip" ?  "IP: " . httppost("ip") : "ID: " . httppost("id")) . " Ends after: $duration  Reason: \"" .  httppost("reason") . "\"");
+    debuglog('entered a ban: ' . ($type == 'ip' ? 'IP: ' . Http::post('ip') : 'ID: ' . Http::post('id')) . " Ends after: $duration  Reason: \"" . Http::post('reason') . '\"');
     /* log out affected players */
     $sql = "SELECT acctid FROM " . Database::prefix('accounts') . " WHERE $key='$key_value'";
     $result = Database::query($sql);

--- a/pages/bans/case_searchban.php
+++ b/pages/bans/case_searchban.php
@@ -34,7 +34,7 @@ if ($subop == "xml") {
 $operator = "<=";
 
 
-$target = httppost('target');
+$target = Http::post('target');
 $since = 'WHERE 0';
 $submit = Translator::translateInline("Search");
 if ($target == '') {


### PR DESCRIPTION
## Summary
- use `Lotgd\Http` for posted values in bans pages
- keep strict mode and update debug logging

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6887cd5d2ef48329b25b67853debe707