### PR TITLE
Convert clan wrappers

### DIFF
--- a/pages/clan/applicant.php
+++ b/pages/clan/applicant.php
@@ -11,9 +11,9 @@ use Lotgd\Modules;
     Nav::add("Clan Options");
     $output->output("`b`c`&Clan Halls`c`b");
 if ($op == "apply") {
-        require_once("pages/clan/applicant_apply.php");
+        require("pages/clan/applicant_apply.php");
 } elseif ($op == "new") {
-        require_once("pages/clan/applicant_new.php");
+        require("pages/clan/applicant_new.php");
 } else {
     $output->output("`7You stand in the center of a great marble lobby filled with pillars.");
     $output->output("All around the walls of the lobby are various doors which lead to various clan halls.");

--- a/pages/clan/applicant_apply.php
+++ b/pages/clan/applicant_apply.php
@@ -8,6 +8,7 @@ use Lotgd\MySQL\Database;
 use Lotgd\Nltoappon;
 use Lotgd\Translator;
 use Lotgd\Modules;
+use Lotgd\Sanitize;
 
         $to = (int)Http::get('to');
 if ($to > 0) {
@@ -76,7 +77,7 @@ if ($row['c'] == 1) {
                 $output->outputNotl(
                     "&#149; <a href='clan.php?op=apply&to=%s'>%s</a> %s`n",
                     $row['clanid'],
-                    full_sanitize(htmlentities($row['clanname'], ENT_COMPAT, getsetting("charset", "ISO-8859-1"))),
+                    Sanitize::fullSanitize(htmlentities($row['clanname'], ENT_COMPAT, getsetting("charset", "ISO-8859-1"))),
                     $memb,
                     true
                 );

--- a/pages/clan/applicant_new.php
+++ b/pages/clan/applicant_new.php
@@ -78,7 +78,7 @@ if ($apply == 1) {
 /*//*/                      $args = array("ocn" => $ocn, "ocs" => $ocs, "clanname" => $clanname, "clanshort" => $clanshort);
 /*//*/                      $args = Modules::hook("process-createclan", $args);
 /*//*/                      if (isset($args['blocked']) && $args['blocked']) {
-/*//*/                          $output->outputNotl(sprintf_translate($args['blockmsg']));
+/*//*/                          $output->outputNotl(Translator::sprintfTranslate($args['blockmsg']));
 /*//*/                          clanform();
 /*//*/                          Nav::add("Return to the Lobby", "clan.php");
 /*//*/

--- a/pages/clan/clan_membership.php
+++ b/pages/clan/clan_membership.php
@@ -8,6 +8,7 @@ use Lotgd\Modules;
 use Lotgd\DebugLog;
 use Lotgd\SafeEscape;
 use Lotgd\Translator;
+use Lotgd\Sanitize;
 
         Nav::add("Clan Hall", "clan.php");
         Nav::add("Clan Options");
@@ -70,7 +71,7 @@ if ($remove > "") {
         $output->rawOutput("<tr class='trhead'><td>$rank</td><td>$name</td><td>$lev</td><td>$dk</td><td>$jd</td><td>$lo</td><td>$ops</td></tr>", true);
         $i = false;
         $tot = 0;
-                require_once("pages/clan/func.php");
+                require("pages/clan/func.php");
         $validranks = array_intersect_key($ranks, range(0, $session['user']['clanrank']));
 while ($row = Database::fetchAssoc($result)) {
     $i = !$i;
@@ -124,7 +125,7 @@ while ($row = Database::fetchAssoc($result)) {
         //new promote/demote system
         if ($row['clanrank'] == CLAN_FOUNDER && $row['login'] == $session['user']['login']) {
             $conf = Translator::translateInline("Are you really sure to step down as founder? You can NEVER rise again to that rank!");
-            $output->outputNotl("<form action='clan.php?op=membership&setrank=" . clan_previousrank($ranks, $row['clanrank']) . "&whoacctid=" . $row['acctid'] . "' METHOD='POST'><input type='submit' class='button' onClick='return confirm(\"$conf\");' value='" . sanitize($stepdown) . "'></form> | ", true);
+            $output->outputNotl("<form action='clan.php?op=membership&setrank=" . clan_previousrank($ranks, $row['clanrank']) . "&whoacctid=" . $row['acctid'] . "' METHOD='POST'><input type='submit' class='button' onClick='return confirm(\"$conf\");' value='" . Sanitize::sanitize($stepdown) . "'></form> | ", true);
             Nav::add("", "clan.php?op=membership&setrank=" . clan_previousrank($ranks, $row['clanrank']) . "&whoacctid=" . $row['acctid']);
         } elseif ($row['clanrank'] != CLAN_FOUNDER) {
             $output->rawOutput("<form action='clan.php?op=membership&whoacctid={$row['acctid']}' method='post'><select name='setrank'>");

--- a/pages/clan/clan_start.php
+++ b/pages/clan/clan_start.php
@@ -8,16 +8,16 @@ use Lotgd\Sanitize;
     Header::pageHeader("Clan Hall for %s", Sanitize::fullSanitize($claninfo['clanname']));
     Nav::add("Clan Options");
 if ($op == "") {
-        require_once("pages/clan/clan_default.php");
+        require("pages/clan/clan_default.php");
 } elseif ($op == "motd") {
-        require_once("pages/clan/clan_motd.php");
+        require("pages/clan/clan_motd.php");
 } elseif ($op == "membership") {
-        require_once("pages/clan/clan_membership.php");
+        require("pages/clan/clan_membership.php");
 } elseif ($op == "withdrawconfirm") {
     $output->output("Are you sure you want to withdraw from your clan?");
     Nav::add("Withdraw?");
     Nav::add("No", "clan.php");
     Nav::add("!?Yes", "clan.php?op=withdraw");
 } elseif ($op == "withdraw") {
-    require_once("pages/clan/clan_withdraw.php");
+    require("pages/clan/clan_withdraw.php");
 }


### PR DESCRIPTION
## Summary
- modernize pages/clan includes and helpers
- swap deprecated wrapper calls for namespaced functions
- use `$output->output()` and add missing namespaces

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6887cd5d912c832980a29f99823e6536