### PR TITLE
Refactor database calls in user pages

### DIFF
--- a/pages/user/user_.php
+++ b/pages/user/user_.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use Lotgd\Nav;
 use Lotgd\Translator;
+use Lotgd\MySQL\Database;
 
 if ($display == 1) {
     $q = "";
@@ -36,7 +37,7 @@ if ($display == 1) {
     Nav::add("", "user.php?sort=uniqueid$q");
     $rn = 0;
     $oorder = "";
-    while ($row = db_fetch_assoc($searchresult)) {
+    while ($row = Database::fetchAssoc($searchresult)) {
         $laston = relativedate($row['laston']);
         $loggedin =
             (date("U") - strtotime($row['laston']) <

--- a/pages/user/user_debuglog.php
+++ b/pages/user/user_debuglog.php
@@ -3,14 +3,15 @@ declare(strict_types=1);
 
 use Lotgd\Nav;
 use Lotgd\Translator;
+use Lotgd\MySQL\Database;
 
 if ($petition != "") {
     Nav::add("Navigation");
     Nav::add("Return to the petition", "viewpetition.php?op=view&id=$petition");
 }
-$debuglog = db_prefix('debuglog');
-$debuglog_archive = db_prefix('debuglog_archive');
-$accounts = db_prefix('accounts');
+$debuglog = Database::prefix('debuglog');
+$debuglog_archive = Database::prefix('debuglog_archive');
+$accounts = Database::prefix('accounts');
 
 
 // As mySQL cannot use two different indexes in a single query this query can take up to 25s on its own!
@@ -20,23 +21,23 @@ $accounts = db_prefix('accounts');
 // $sql = "SELECT count(id) AS c FROM $debuglog WHERE actor=$userid OR target=$userid";
 
 $sql = "SELECT COUNT(id) AS c FROM $debuglog WHERE target=$userid";
-$result = db_query($sql);
-$row = db_fetch_assoc($result);
+$result = Database::query($sql);
+$row = Database::fetchAssoc($result);
 $max = $row['c'];
 
 $sql = "SELECT COUNT(id) AS c FROM $debuglog WHERE actor=$userid";
-$result = db_query($sql);
-$row = db_fetch_assoc($result);
+$result = Database::query($sql);
+$row = Database::fetchAssoc($result);
 $max += $row['c'];
 
 $sql = "SELECT COUNT(id) AS c FROM $debuglog_archive WHERE target=$userid";
-$result = db_query($sql);
-$row = db_fetch_assoc($result);
+$result = Database::query($sql);
+$row = Database::fetchAssoc($result);
 $max = $row['c'];
 
 $sql = "SELECT COUNT(id) AS c FROM $debuglog_archive WHERE actor=$userid";
-$result = db_query($sql);
-$row = db_fetch_assoc($result);
+$result = Database::query($sql);
+$row = Database::fetchAssoc($result);
 $max += $row['c'];
 
 
@@ -86,9 +87,9 @@ if ($start > 0) {
         "user.php?op=debuglog&userid=$userid&start=$prev$returnpetition"
     );
 }
-$result = db_query($sql);
+$result = Database::query($sql);
 $odate = "";
-while ($row = db_fetch_assoc($result)) {
+while ($row = Database::fetchAssoc($result)) {
     $dom = date("D, M d", strtotime($row['date']));
     if ($odate != $dom) {
         $output->outputNotl("`n`b`@%s`0`b`n", $dom);

--- a/pages/user/user_del.php
+++ b/pages/user/user_del.php
@@ -3,12 +3,13 @@ declare(strict_types=1);
 
 use Lotgd\PlayerFunctions;
 use Lotgd\Translator;
+use Lotgd\MySQL\Database;
 
-$sql = "SELECT name,superuser from " . db_prefix("accounts") . " WHERE acctid='$userid'";
-$res = db_query($sql);
+$sql = "SELECT name,superuser from " . Database::prefix("accounts") . " WHERE acctid='$userid'";
+$res = Database::query($sql);
 PlayerFunctions::charCleanup($userid, CHAR_DELETE_MANUAL);
 $fail = false;
-while ($row = db_fetch_assoc($res)) {
+while ($row = Database::fetchAssoc($res)) {
     if ($row['superuser'] > 0 && ($session['user']['superuser'] & SU_MEGAUSER) != SU_MEGAUSER) {
         $output->output("`\$You are trying to delete a user with superuser powers. Regardless of the type, ONLY a megauser can do so due to security reasons.");
         $fail = true;
@@ -18,7 +19,7 @@ while ($row = db_fetch_assoc($res)) {
     debuglog("deleted user" . $row['name'] . "'0");
 }
 if ($fail !== true) {
-    $sql = "DELETE FROM " . db_prefix("accounts") . " WHERE acctid='$userid'";
-    db_query($sql);
-    $output->output(db_affected_rows() . " user deleted.");
+    $sql = "DELETE FROM " . Database::prefix("accounts") . " WHERE acctid='$userid'";
+    Database::query($sql);
+    $output->output(Database::affectedRows() . " user deleted.");
 }

--- a/pages/user/user_delban.php
+++ b/pages/user/user_delban.php
@@ -2,7 +2,8 @@
 declare(strict_types=1);
 
 use Lotgd\Redirect;
+use Lotgd\MySQL\Database;
 
-$sql = "DELETE FROM " . db_prefix("bans") . " WHERE ipfilter = '" . httpget("ipfilter") . "' AND uniqueid = '" . httpget("uniqueid") . "'";
-db_query($sql);
+$sql = "DELETE FROM " . Database::prefix("bans") . " WHERE ipfilter = '" . httpget("ipfilter") . "' AND uniqueid = '" . httpget("uniqueid") . "'";
+Database::query($sql);
 Redirect::redirect("user.php?op=removeban");

--- a/pages/user/user_edit.php
+++ b/pages/user/user_edit.php
@@ -6,9 +6,10 @@ use Lotgd\Forms;
 use Lotgd\Nav;
 use Lotgd\Translator;
 use Lotgd\Modules;
+use Lotgd\MySQL\Database;
 
-$result = db_query("SELECT * FROM " . db_prefix("accounts") . " WHERE acctid=" . (int)$userid);
-$row = db_fetch_assoc($result);
+$result = Database::query("SELECT * FROM " . Database::prefix("accounts") . " WHERE acctid=" . (int)$userid);
+$row = Database::fetchAssoc($result);
 $petition = httpget("returnpetition");
 if ($petition != "") {
     $returnpetition = "&returnpetition=$petition";
@@ -101,9 +102,9 @@ if (httpget("subop") == "") {
                 $data[$key] = $x[1];
             }
         }
-               $sql = "SELECT * FROM " . db_prefix("module_userprefs") . " WHERE modulename='" . db_real_escape_string($module) . "' AND userid=" . (int)$userid;
-        $result = db_query($sql);
-        while ($row = db_fetch_assoc($result)) {
+               $sql = "SELECT * FROM " . Database::prefix("module_userprefs") . " WHERE modulename='" . Database::escape($module) . "' AND userid=" . (int)$userid;
+        $result = Database::query($sql);
+        while ($row = Database::fetchAssoc($result)) {
             $data[$row['setting']] = $row['value'];
         }
         $output->rawOutput("<form action='user.php?op=savemodule&module=$module&userid=$userid$returnpetition' method='POST'>");

--- a/pages/user/user_lasthit.php
+++ b/pages/user/user_lasthit.php
@@ -2,17 +2,18 @@
 declare(strict_types=1);
 
 use Lotgd\Output;
+use Lotgd\MySQL\Database;
 
-$output = "";
-$sql = "SELECT output FROM " . db_prefix("accounts_output") . " WHERE acctid=" . (int)$userid;
-$result = db_query($sql);
-$row = db_fetch_assoc($result);
+$display = '';
+$sql = "SELECT output FROM " . Database::prefix("accounts_output") . " WHERE acctid=" . (int)$userid;
+$result = Database::query($sql);
+$row = Database::fetchAssoc($result);
 if (empty($row) || !isset($row['output']) || $row['output'] == '') {
-        $output = new Output();
-    $text = $output->appoencode("`\$This user has had his navs fixed OR has an empty page stored. Nothing can be displayed to you -_-`0");
-    $output = "<html><head><link href=\"templates/common/colors.css\" rel=\"stylesheet\" type=\"text/css\"></head><body style='background-color: #000000'>$text</body></html>";
+        $out = new Output();
+    $text = $out->appoencode("`\$This user has had his navs fixed OR has an empty page stored. Nothing can be displayed to you -_-`0");
+    $display = "<html><head><link href=\"templates/common/colors.css\" rel=\"stylesheet\" type=\"text/css\"></head><body style='background-color: #000000'>$text</body></html>";
 } else {
-    $output = gzuncompress($row['output']);
+    $display = gzuncompress($row['output']);
 }
-echo str_replace(".focus();", ".blur();", str_replace("<iframe src=", "<iframe Xsrc=", $output));
+$output->rawOutput(str_replace('.focus();', '.blur();', str_replace('<iframe src=', '<iframe Xsrc=', $display)));
 exit(0);

--- a/pages/user/user_removeban.php
+++ b/pages/user/user_removeban.php
@@ -3,32 +3,31 @@ declare(strict_types=1);
 
 use Lotgd\Nav;
 use Lotgd\Translator;
+use Lotgd\MySQL\Database;
 
 $subop = httpget("subop");
 $none = Translator::translateInline('NONE');
 if ($subop == "xml") {
     header("Content-Type: text/xml");
-    $sql = "SELECT DISTINCT " . db_prefix("accounts") . ".name FROM " . db_prefix("bans") . ", " . db_prefix("accounts") . " WHERE (ipfilter='" . addslashes(httpget("ip")) . "' AND " .
-        db_prefix("bans") . ".uniqueid='" .
+    $sql = "SELECT DISTINCT " . Database::prefix("accounts") . ".name FROM " . Database::prefix("bans") . ", " . Database::prefix("accounts") . " WHERE (ipfilter='" . addslashes(httpget("ip")) . "' AND " .
+        Database::prefix("bans") . ".uniqueid='" .
         addslashes(httpget("id")) . "') AND ((substring(" .
-        db_prefix("accounts") . ".lastip,1,length(ipfilter))=ipfilter " .
-        "AND ipfilter<>'') OR (" .  db_prefix("bans") . ".uniqueid=" .
-        db_prefix("accounts") . ".uniqueid AND " .
-        db_prefix("bans") . ".uniqueid<>''))";
-    $r = db_query($sql);
-    echo "<xml>";
-    while ($ro = db_fetch_assoc($r)) {
-        echo "<name name=\"";
-        echo urlencode(appoencode("`0{$ro['name']}"));
-        echo "\"/>";
+        Database::prefix("accounts") . ".lastip,1,length(ipfilter))=ipfilter " .
+        "AND ipfilter<>'') OR (" .  Database::prefix("bans") . ".uniqueid=" .
+        Database::prefix("accounts") . ".uniqueid AND " .
+        Database::prefix("bans") . ".uniqueid<>''))";
+    $r = Database::query($sql);
+    $output->rawOutput("<xml>");
+    while ($ro = Database::fetchAssoc($r)) {
+        $output->rawOutput("<name name=\"" . urlencode(appoencode("`0{$ro['name']}")) . "\"/>");
     }
-    if (db_num_rows($r) == 0) {
-        echo "<name name=\"$none\"/>";
+    if (Database::numRows($r) == 0) {
+        $output->rawOutput("<name name=\"$none\"/>");
     }
-    echo "</xml>";
+    $output->rawOutput("</xml>");
     exit();
 }
-    db_query("DELETE FROM " . db_prefix("bans") . " WHERE banexpire < \"" . date("Y-m-d") . "\" AND banexpire>'0000-00-00'");
+    Database::query("DELETE FROM " . Database::prefix("bans") . " WHERE banexpire < \"" . date("Y-m-d") . "\" AND banexpire>'0000-00-00'");
 $duration =  httpget("duration");
 if (httpget('notbefore')) {
     $operator = ">=";
@@ -81,8 +80,8 @@ Nav::add("1 year", "user.php?op=removeban&duration=1+year&notbefore=1");
 Nav::add("2 years", "user.php?op=removeban&duration=2+years&notbefore=1");
 Nav::add("4 years", "user.php?op=removeban&duration=4+years&notbefore=1");
 
-$sql = "SELECT * FROM " . db_prefix("bans") . " $since ORDER BY banexpire ASC";
-$result = db_query($sql);
+$sql = "SELECT * FROM " . Database::prefix("bans") . " $since ORDER BY banexpire ASC";
+$result = Database::query($sql);
 $output->rawOutput("<script language='JavaScript'>
 function getUserInfo(ip,id,divid){
 	var filename='user.php?op=removeban&subop=xml&ip='+ip+'&id='+id;
@@ -116,7 +115,7 @@ $aff = Translator::translateInline("Affects");
 $l = Translator::translateInline("Last");
     $output->rawOutput("<tr class='trhead'><td>$ops</td><td>$bauth</td><td>$ipd</td><td>$dur</td><td>$mssg</td><td>$aff</td><td>$l</td></tr>");
 $i = 0;
-while ($row = db_fetch_assoc($result)) {
+while ($row = Database::fetchAssoc($result)) {
     $liftban = Translator::translateInline("Lift&nbsp;ban");
     $showuser = Translator::translateInline("Click&nbsp;to&nbsp;show&nbsp;users");
     $output->rawOutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'>");

--- a/pages/user/user_save.php
+++ b/pages/user/user_save.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use Lotgd\Names;
 use Lotgd\Nav;
+use Lotgd\MySQL\Database;
 
 $sql = "";
 $updates = 0;
@@ -195,14 +196,14 @@ foreach ($post as $key => $val) {
     }
 }
     $sql = substr($sql, 0, strlen($sql) - 1);
-$sql = "UPDATE " . db_prefix("accounts") . " SET " . $sql . " WHERE acctid=\"$userid\"";
+$sql = "UPDATE " . Database::prefix("accounts") . " SET " . $sql . " WHERE acctid=\"$userid\"";
     $petition = httpget("returnpetition");
 if ($petition != "") {
     Nav::add("", "viewpetition.php?op=view&id=$petition");
 }
 Nav::add("", "user.php");
 if ($updates > 0) {
-    db_query($sql);
+    Database::query($sql);
     debug("Updated $updates fields in the user record with:\n$sql");
     $output->output("%s fields in the user's record were updated.", $updates);
 } else {

--- a/pages/user/user_saveban.php
+++ b/pages/user/user_saveban.php
@@ -2,8 +2,9 @@
 declare(strict_types=1);
 
 use Lotgd\Cookies;
+use Lotgd\MySQL\Database;
 
-$sql = "INSERT INTO " . db_prefix("bans") . " (banner,";
+$sql = "INSERT INTO " . Database::prefix("bans") . " (banner,";
 $type = httppost("type");
 if ($type == "ip") {
     $sql .= "ipfilter";
@@ -45,22 +46,22 @@ if ($type == "ip") {
     }
 }
 if ($sql != "") {
-    $result = db_query($sql);
-    $output->output("%s ban rows entered.`n`n", db_affected_rows($result));
-    $output->outputNotl("%s", db_error(LINK));
+    $result = Database::query($sql);
+    $output->output("%s ban rows entered.`n`n", Database::affectedRows($result));
+    $output->outputNotl("%s", Database::error());
     debuglog("entered a ban: " .  ($type == "ip" ?  "IP: " . httppost("ip") : "ID: " . httppost("id")) . " Ends after: $duration  Reason: \"" .  httppost("reason") . "\"");
     /* log out affected players */
-    $sql = "SELECT acctid FROM " . db_prefix('accounts') . " WHERE $key='$key_value'";
-    $result = db_query($sql);
+    $sql = "SELECT acctid FROM " . Database::prefix('accounts') . " WHERE $key='$key_value'";
+    $result = Database::query($sql);
     $acctids = array();
-    while ($row = db_fetch_assoc($result)) {
+    while ($row = Database::fetchAssoc($result)) {
         $acctids[] = $row['acctid'];
     }
     if ($acctids != array()) {
-        $sql = " UPDATE " . db_prefix('accounts') . " SET loggedin=0 WHERE acctid IN (" . implode(",", $acctids) . ")";
-        $result = db_query($sql);
+        $sql = " UPDATE " . Database::prefix('accounts') . " SET loggedin=0 WHERE acctid IN (" . implode(",", $acctids) . ")"; 
+        $result = Database::query($sql);
         if ($result) {
-            $output->output("`\$%s people have been logged out!`n`n`0", db_affected_rows($result));
+            $output->output("`\$%s people have been logged out!`n`n`0", Database::affectedRows($result));
         } else {
             $output->output("`\$Nobody was logged out. Acctids (%s) did not return rows!`n`n`0", implode(",", $acctids));
         }

--- a/pages/user/user_savemodule.php
+++ b/pages/user/user_savemodule.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Lotgd\Translator;
+use Lotgd\MySQL\Database;
 
 //save module settings.
 $userid = (int)httpget('userid');
@@ -18,12 +19,12 @@ if (isset($post['validation_error']) && $post['validation_error']) {
     $output->outputNotl("`n");
     foreach ($post as $key => $val) {
         $output->output("`\$Setting '`2%s`\$' to '`2%s`\$'`n", $key, htmlspecialchars($val, ENT_QUOTES, 'UTF-8'));
-               $sql = "REPLACE INTO " . db_prefix("module_userprefs") .
+               $sql = "REPLACE INTO " . Database::prefix("module_userprefs") .
                        " (modulename,userid,setting,value) VALUES ('" .
-                       db_real_escape_string($module) . "',$userid,'" .
-                       db_real_escape_string($key) . "','" .
-                       db_real_escape_string($val) . "')";
-        db_query($sql);
+                       Database::escape($module) . "',$userid,'" .
+                       Database::escape($key) . "','" .
+                       Database::escape($val) . "')";
+        Database::query($sql);
     }
     $output->output("`^Preferences for module %s saved.`n", $module);
 }

--- a/pages/user/user_setupban.php
+++ b/pages/user/user_setupban.php
@@ -3,10 +3,11 @@ declare(strict_types=1);
 
 use Lotgd\Nav;
 use Lotgd\Translator;
+use Lotgd\MySQL\Database;
 
-$sql = "SELECT name,lastip,uniqueid FROM " . db_prefix("accounts") . " WHERE acctid=\"$userid\"";
-$result = db_query($sql);
-$row = db_fetch_assoc($result);
+$sql = "SELECT name,lastip,uniqueid FROM " . Database::prefix("accounts") . " WHERE acctid=\"$userid\"";
+$result = Database::query($sql);
+$row = Database::fetchAssoc($result);
 if ($row['name'] != "") {
     $output->output("Setting up ban information based on `\$%s`0", $row['name']);
 }
@@ -41,9 +42,9 @@ if ($row['name'] != "") {
     $name = $row['name'];
     $output->output("`0To help locate similar users to `@%s`0, here are some other users who are close:`n", $name);
     $output->output("`bSame ID (%s):`b`n", $id);
-    $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . db_prefix("accounts") . " WHERE uniqueid='" . addslashes($id) . "' ORDER BY lastip";
-    $result = db_query($sql);
-    while ($row = db_fetch_assoc($result)) {
+    $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . Database::prefix("accounts") . " WHERE uniqueid='" . addslashes($id) . "' ORDER BY lastip";
+    $result = Database::query($sql);
+    while ($row = Database::fetchAssoc($result)) {
         $output->output(
             "`0• (%s) `%%s`0 - %s hits, last: %s`n",
             $row['lastip'],
@@ -61,16 +62,16 @@ if ($row['name'] != "") {
             break;
         }
         $thisip = substr($ip, 0, $x);
-        $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . db_prefix("accounts") . " WHERE lastip LIKE '$thisip%' AND NOT (lastip LIKE '$oip') ORDER BY uniqueid";
+        $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . Database::prefix("accounts") . " WHERE lastip LIKE '$thisip%' AND NOT (lastip LIKE '$oip') ORDER BY uniqueid";
         //$output->output("$sql`n");
-        $result = db_query($sql);
-        if (db_num_rows($result) > 0) {
+        $result = Database::query($sql);
+        if (Database::numRows($result) > 0) {
             $output->output("• IP Filter: %s ", $thisip);
             $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
             $output->output("Use this filter");
             $output->rawOutput("</a>");
             $output->outputNotl("`n");
-            while ($row = db_fetch_assoc($result)) {
+            while ($row = Database::fetchAssoc($result)) {
                 $output->output("&nbsp;&nbsp;", true);
                 $output->output(
                     "• (%s) [%s] `%%s`0 - %s hits, last: %s`n",

--- a/pages/user/user_special.php
+++ b/pages/user/user_special.php
@@ -1,20 +1,22 @@
 <?php
 declare(strict_types=1);
 
+use Lotgd\MySQL\Database;
+
 if (httppost("newday") != "") {
 #   $offset = "-".(24 / (int)getsetting("daysperday",4))." hours";
 #   $newdate = date("Y-m-d H:i:s",strtotime($offset));
 #   $sql = "UPDATE " . db_prefix("accounts") . " SET lasthit='$newdate' WHERE acctid='$userid'";
-       $sql = "UPDATE " . db_prefix("accounts") . " SET lasthit='" . DATETIME_DATEMIN . "' WHERE acctid=" . (int)$userid;
-    db_query($sql);
+       $sql = "UPDATE " . Database::prefix("accounts") . " SET lasthit='" . DATETIME_DATEMIN . "' WHERE acctid=" . (int)$userid;
+    Database::query($sql);
 } elseif (httppost("fixnavs") != "") {
-       $sql = "UPDATE " . db_prefix("accounts") . " SET allowednavs='', restorepage='', specialinc='' WHERE acctid=" . (int)$userid;
-    db_query($sql);
-       $sql = "DELETE FROM " . db_prefix("accounts_output") . " WHERE acctid=" . (int)$userid . ";";
-    db_query($sql);
+       $sql = "UPDATE " . Database::prefix("accounts") . " SET allowednavs='', restorepage='', specialinc='' WHERE acctid=" . (int)$userid;
+    Database::query($sql);
+       $sql = "DELETE FROM " . Database::prefix("accounts_output") . " WHERE acctid=" . (int)$userid . ";";
+    Database::query($sql);
 } elseif (httppost("clearvalidation") != "") {
-       $sql = "UPDATE " . db_prefix("accounts") . " SET emailvalidation='' WHERE acctid=" . (int)$userid;
-    db_query($sql);
+       $sql = "UPDATE " . Database::prefix("accounts") . " SET emailvalidation='' WHERE acctid=" . (int)$userid;
+    Database::query($sql);
 }
 $op = "edit";
 httpset("op", "edit");


### PR DESCRIPTION
## Summary
- replace legacy db_* functions with `Lotgd\MySQL\Database` methods
- ensure output uses the global collector
- clean up user last hit display logic

## Testing
- `php -l pages/user/user_.php pages/user/user_debuglog.php pages/user/user_del.php pages/user/user_delban.php pages/user/user_edit.php pages/user/user_lasthit.php pages/user/user_removeban.php pages/user/user_save.php pages/user/user_saveban.php pages/user/user_savemodule.php pages/user/user_searchban.php pages/user/user_setupban.php pages/user/user_special.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6887cd6143f8832992e3a7be4a9eeea8