### PR TITLE
Fix default value detection in table descriptors

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -220,7 +220,7 @@ class TableDescriptor
             if ($row['Null'] == "Yes") {
                 $item['null'] = true;
             }
-            if (isset($row['Default']) && !empty(trim($row['Default']))) {
+            if (array_key_exists('Default', $row) && $row['Default'] !== null && $row['Default'] !== 'NULL') {
                 $item['default'] = $row['Default'];
             }
             if (isset($row['Extra']) && !empty(trim($row['Extra']))) {

--- a/tests/Stubs/Database.php
+++ b/tests/Stubs/Database.php
@@ -13,6 +13,8 @@ class Database
     public static int $onlineCounter = 0;
     public static int $affected_rows = 0;
     public static string $lastSql = '';
+    public static array $describe_rows = [];
+    public static array $keys_rows = [];
     public static ?object $doctrineConnection = null;
     public static ?object $instance = null;
 
@@ -42,6 +44,16 @@ class Database
             $conn->executeQuery($sql);
             self::$affected_rows = 1;
             $last_query_result = [['ok' => true]];
+            return $last_query_result;
+        }
+
+        if (strpos($sql, 'DESCRIBE ') === 0) {
+            $last_query_result = self::$describe_rows;
+            return $last_query_result;
+        }
+
+        if (strpos($sql, 'SHOW KEYS FROM') === 0) {
+            $last_query_result = self::$keys_rows;
             return $last_query_result;
         }
 

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\MySQL\TableDescriptor;
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
+
+final class TableDescriptorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        class_exists(Database::class);
+        Database::$describe_rows = [];
+        Database::$keys_rows = [];
+    }
+
+    public function testDefaultZeroIsDetected(): void
+    {
+        Database::$describe_rows = [
+            [
+                'Field' => 'noaddskillpoints',
+                'Type' => 'tinyint unsigned',
+                'Null' => 'NO',
+                'Key' => '',
+                'Default' => '0',
+                'Extra' => '',
+            ],
+        ];
+        $descriptor = TableDescriptor::tableCreateDescriptor('dummy');
+        $this->assertSame('0', $descriptor['noaddskillpoints']['default']);
+    }
+}


### PR DESCRIPTION
## Summary
- capture default values like `0` when creating table descriptors
- update database test stub to support `DESCRIBE` and `SHOW KEYS` queries
- add regression test for descriptor default detection

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68888ff9eb88832983bd6984ad527b57