### PR TITLE
Add Doctrine documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,9 @@ the installer fails or reports problems.
 Additional information about the navigation helper API can be found in
 [docs/Nav.md](docs/Nav.md).
 
+Doctrine usage and migration instructions are documented in
+[docs/Doctrine.md](docs/Doctrine.md).
+
 ---
 
 ## Contributing & Support

--- a/docs/Doctrine.md
+++ b/docs/Doctrine.md
@@ -1,0 +1,51 @@
+# Doctrine Namespace
+
+The `\Lotgd\Doctrine` namespace integrates Doctrine ORM into the game. It reads
+connection settings from `dbconnect.php` and exposes a helper to create an
+`EntityManager` for database operations.
+
+## Obtaining an EntityManager
+
+Call `Lotgd\Doctrine\Bootstrap::getEntityManager()` to create a configured
+`EntityManager` instance. This method sets up annotation metadata and caching
+based on your database configuration.
+
+```php
+use Lotgd\Doctrine\Bootstrap;
+
+$entityManager = Bootstrap::getEntityManager();
+```
+
+## Entities and Repositories
+
+Entity classes live under `src/Lotgd/Entity`. Each entity usually has a
+corresponding repository class in `src/Lotgd/Repository`. You can retrieve these
+repositories from the entity manager.
+
+```php
+$repo = $entityManager->getRepository(Lotgd\Entity\Account::class);
+```
+
+## Running Migrations
+
+Schema migrations reside in the `migrations/` directory. Execute them with the
+Doctrine migration tool:
+
+```bash
+vendor/bin/doctrine-migrations migrate
+```
+
+The command reads its configuration from `config/doctrine.php`.
+
+## Persisting an Account
+
+Account changes are persisted through Doctrine when calling
+`Lotgd\Accounts::saveUser()`. This method loads the current `Account` entity,
+updates it with session data and flushes the entity manager.
+
+```php
+Lotgd\Accounts::saveUser();
+```
+
+This keeps the `$session['user']` array in sync with the database using the
+entity defined in `src/Lotgd/Entity/Account.php`.

--- a/docs/Namespaces.md
+++ b/docs/Namespaces.md
@@ -88,6 +88,12 @@ Database related classes reside in the `MySQL` sub‑namespace:
 - **DbMysqli** – thin wrapper over `mysqli` used by `Database` to perform actual queries.
 - **TableDescriptor** – synchronises schema definitions and can generate `CREATE TABLE` statements.
 
+## \Lotgd\Doctrine
+
+Integrates the Doctrine ORM. The `Bootstrap` class creates the `EntityManager` used by
+entities in `src/Lotgd/Entity`. See [Doctrine.md](Doctrine.md) for details on
+using repositories and running migrations.
+
 ## \Lotgd\Nav
 
 Contains the navigation builder used throughout the game. See `docs/Nav.md` for detailed usage of `NavigationItem`, `NavigationSection` and related helpers. Additional classes include `VillageNav` for the village page and `SuperuserNav` for the admin menu.


### PR DESCRIPTION
## Summary
- add a new Doctrine.md document covering usage of Doctrine ORM
- reference Doctrine docs from the README
- document `Lotgd\Doctrine` namespace in Namespaces.md

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6888b14a3ad08329b373f63ae8b87e9a