### PR TITLE
Add NULL default detection in TableDescriptor

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -220,8 +220,12 @@ class TableDescriptor
             if ($row['Null'] == "Yes") {
                 $item['null'] = true;
             }
-            if (array_key_exists('Default', $row) && $row['Default'] !== null && $row['Default'] !== 'NULL') {
-                $item['default'] = $row['Default'];
+            if (array_key_exists('Default', $row)) {
+                if ($row['Default'] === null || $row['Default'] === 'NULL') {
+                    $item['default'] = null;
+                } else {
+                    $item['default'] = $row['Default'];
+                }
             }
             if (isset($row['Extra']) && !empty(trim($row['Extra']))) {
                 $item['extra'] = $row['Extra'];

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -32,4 +32,21 @@ final class TableDescriptorTest extends TestCase
         $descriptor = TableDescriptor::tableCreateDescriptor('dummy');
         $this->assertSame('0', $descriptor['noaddskillpoints']['default']);
     }
+
+    public function testDefaultNullIsDetected(): void
+    {
+        Database::$describe_rows = [
+            [
+                'Field' => 'somecolumn',
+                'Type' => 'int',
+                'Null' => 'YES',
+                'Key' => '',
+                'Default' => 'NULL',
+                'Extra' => '',
+            ],
+        ];
+        $descriptor = TableDescriptor::tableCreateDescriptor('dummy');
+        $this->assertArrayHasKey('default', $descriptor['somecolumn']);
+        $this->assertNull($descriptor['somecolumn']['default']);
+    }
 }


### PR DESCRIPTION
## Summary
- detect `NULL` default values when building a table descriptor
- add test for default NULL values

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6888b837e1cc8329b22bd2c5db9a28fa