### PR TITLE
Add null default test for table descriptor

### DIFF
--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -46,7 +46,12 @@ final class TableDescriptorTest extends TestCase
             ],
         ];
         $descriptor = TableDescriptor::tableCreateDescriptor('dummy');
-        $this->assertArrayHasKey('default', $descriptor['somecolumn']);
-        $this->assertNull($descriptor['somecolumn']['default']);
+        $expected = [
+            'name' => 'somecolumn',
+            'type' => 'int',
+            'default' => null,
+        ];
+
+        $this->assertSame($expected, $descriptor['somecolumn']);
     }
 }


### PR DESCRIPTION
## Summary
- add a unit test ensuring table descriptor handles `'NULL'` default values

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6888bb0aa06483299e116bbaa97d8872