### PR TITLE
Ignore non-template directories in template selector

### DIFF
--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -196,21 +196,27 @@ class Template
         $handle = opendir('templates_twig');
         if ($handle !== false) {
             while (false !== ($dir = readdir($handle))) {
-                if ($dir === '.' || $dir === '..') {
+                if ($dir === '.' || $dir === '..' || str_starts_with($dir, '.')) {
                     continue;
                 }
-                if (is_dir("templates_twig/$dir")) {
-                    $name = $dir;
-                    $configPath = "templates_twig/$dir/config.json";
-                    if (file_exists($configPath)) {
-                        $cfg = json_decode((string) file_get_contents($configPath), true);
-                        if (json_last_error() === JSON_ERROR_NONE && isset($cfg['name'])) {
-                            $name = $cfg['name'];
-                        }
-                    }
-                    $value = 'twig:' . $dir;
-                    $skins[$value] = $name;
+
+                if (!is_dir("templates_twig/$dir")) {
+                    continue;
                 }
+
+                $configPath = "templates_twig/$dir/config.json";
+                if (!is_file($configPath)) {
+                    continue;
+                }
+
+                $name = $dir;
+                $cfg = json_decode((string) file_get_contents($configPath), true);
+                if (json_last_error() === JSON_ERROR_NONE && isset($cfg['name'])) {
+                    $name = $cfg['name'];
+                }
+
+                $value = 'twig:' . $dir;
+                $skins[$value] = $name;
             }
             closedir($handle);
         }

--- a/tests/TemplateHelperTest.php
+++ b/tests/TemplateHelperTest.php
@@ -32,4 +32,24 @@ final class TemplateHelperTest extends TestCase
     {
         $this->assertFalse(Template::isValidTemplate('nonexistent-template'));
     }
+
+    public function testDirectoriesWithoutConfigAreIgnored(): void
+    {
+        $base = dirname(__DIR__) . '/templates_twig';
+        $tempDir = $base . '/test_no_config';
+        $hiddenDir = $base . '/.git';
+
+        mkdir($tempDir);
+        mkdir($hiddenDir);
+
+        try {
+            $templates = Template::getAvailableTemplates();
+        } finally {
+            rmdir($tempDir);
+            rmdir($hiddenDir);
+        }
+
+        $this->assertArrayNotHasKey('twig:test_no_config', $templates);
+        $this->assertArrayNotHasKey('twig:.git', $templates);
+    }
 }


### PR DESCRIPTION
## Summary
- ignore hidden folders and missing config.json in Template::getAvailableTemplates
- ensure template scanning ignores directories without config in tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6888fee322cc83298a00a7c999af49d2