### PR TITLE
Ignore hidden directories in theme selector

### DIFF
--- a/src/Lotgd/Forms.php
+++ b/src/Lotgd/Forms.php
@@ -319,43 +319,7 @@ JS;
         $entityId = HTMLEntities($fieldId, ENT_QUOTES, getsetting('charset', 'ISO-8859-1'));
         switch ($info[1]) {
             case 'theme':
-                $skins = [];
-                $handle = opendir('templates');
-                if ($handle === false) {
-                    error_log('Unable to open templates directory');
-                } else {
-                    while (false !== ($file = readdir($handle))) {
-                        if (strpos($file, '.htm') !== false) {
-                            $value = 'legacy:' . $file;
-                            $skins[$value] = substr($file, 0, strpos($file, '.htm'));
-                        }
-                    }
-                    closedir($handle);
-                }
-
-                $handle = opendir('templates_twig');
-                if ($handle === false) {
-                    error_log('Unable to open templates_twig directory');
-                } else {
-                    while (false !== ($dir = readdir($handle))) {
-                        if ($dir === '.' || $dir === '..') {
-                            continue;
-                        }
-                        if (is_dir("templates_twig/$dir")) {
-                            $name = $dir;
-                            $configPath = "templates_twig/$dir/config.json";
-                            if (file_exists($configPath)) {
-                                $cfg = json_decode((string) file_get_contents($configPath), true);
-                                if (json_last_error() === JSON_ERROR_NONE && isset($cfg['name'])) {
-                                    $name = $cfg['name'];
-                                }
-                            }
-                            $value = 'twig:' . $dir;
-                            $skins[$value] = $name;
-                        }
-                    }
-                    closedir($handle);
-                }
+                $skins = Template::getAvailableTemplates();
 
                 if (count($skins) == 0) {
                     output('None available');

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -196,21 +196,27 @@ class Template
         $handle = opendir('templates_twig');
         if ($handle !== false) {
             while (false !== ($dir = readdir($handle))) {
-                if ($dir === '.' || $dir === '..') {
+                if ($dir === '.' || $dir === '..' || str_starts_with($dir, '.')) {
                     continue;
                 }
-                if (is_dir("templates_twig/$dir")) {
-                    $name = $dir;
-                    $configPath = "templates_twig/$dir/config.json";
-                    if (file_exists($configPath)) {
-                        $cfg = json_decode((string) file_get_contents($configPath), true);
-                        if (json_last_error() === JSON_ERROR_NONE && isset($cfg['name'])) {
-                            $name = $cfg['name'];
-                        }
-                    }
-                    $value = 'twig:' . $dir;
-                    $skins[$value] = $name;
+
+                if (!is_dir("templates_twig/$dir")) {
+                    continue;
                 }
+
+                $configPath = "templates_twig/$dir/config.json";
+                if (!is_file($configPath)) {
+                    continue;
+                }
+
+                $name = $dir;
+                $cfg = json_decode((string) file_get_contents($configPath), true);
+                if (json_last_error() === JSON_ERROR_NONE && isset($cfg['name'])) {
+                    $name = $cfg['name'];
+                }
+
+                $value = 'twig:' . $dir;
+                $skins[$value] = $name;
             }
             closedir($handle);
         }

--- a/tests/FormsTest.php
+++ b/tests/FormsTest.php
@@ -29,4 +29,26 @@ final class FormsTest extends TestCase
         $this->assertStringContainsString("type='checkbox' name='flag' value='1'", $forms_output);
         $this->assertStringNotContainsString('checked', $forms_output);
     }
+
+    public function testThemeFieldSkipsInvalidDirectories(): void
+    {
+        global $forms_output;
+
+        $base = dirname(__DIR__) . '/templates_twig';
+        $tempDir = $base . '/test_no_config';
+        $hiddenDir = $base . '/.git';
+
+        mkdir($tempDir);
+        mkdir($hiddenDir);
+
+        try {
+            Forms::showForm(['skin' => 'Skin,theme'], ['skin' => 'aurora']);
+        } finally {
+            rmdir($tempDir);
+            rmdir($hiddenDir);
+        }
+
+        $this->assertStringNotContainsString("value='twig:test_no_config'", $forms_output);
+        $this->assertStringNotContainsString("value='twig:.git'", $forms_output);
+    }
 }

--- a/tests/TemplateHelperTest.php
+++ b/tests/TemplateHelperTest.php
@@ -32,4 +32,24 @@ final class TemplateHelperTest extends TestCase
     {
         $this->assertFalse(Template::isValidTemplate('nonexistent-template'));
     }
+
+    public function testDirectoriesWithoutConfigAreIgnored(): void
+    {
+        $base = dirname(__DIR__) . '/templates_twig';
+        $tempDir = $base . '/test_no_config';
+        $hiddenDir = $base . '/.git';
+
+        mkdir($tempDir);
+        mkdir($hiddenDir);
+
+        try {
+            $templates = Template::getAvailableTemplates();
+        } finally {
+            rmdir($tempDir);
+            rmdir($hiddenDir);
+        }
+
+        $this->assertArrayNotHasKey('twig:test_no_config', $templates);
+        $this->assertArrayNotHasKey('twig:.git', $templates);
+    }
 }


### PR DESCRIPTION
## Summary
- call `Template::getAvailableTemplates()` in `Forms::renderField` for theme options
- add test verifying invalid directories are skipped

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6888fee322cc83298a00a7c999af49d2