### PR TITLE
Remove obsolete docker-compose snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,30 +314,6 @@ CMD ["apache2-foreground"]
 ### docker-compose.yml
 
 ```yaml
-version: '3.8'
-
-services:
-  web:
-    build: .
-    ports:
-      - "80:80"
-    depends_on:
-      - db
-    networks:
-      - lotgd-network
-
-  db:
-    image: mysql:5.7
-    restart: always
-    environment:
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-    volumes:
-      - db_data:/var/lib/mysql
-    networks:
-      - lotgd-network
 
 volumes:
   db_data:


### PR DESCRIPTION
## Summary
- delete lines from README that duplicated docker-compose services
- keep only volume and network definitions

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68890890a2ec832984254c8bfd376400