### PR TITLE
Update docs with maintenance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ Follow these steps to set up the game:
 
 You can also run the project using Docker. See [docs/Docker.md](docs/Docker.md) for details.
 
+## Maintenance
+
+Regular upkeep tasks:
+
+- Run `composer update` to update dependencies.
+- Run `composer test` to execute the unit tests.
+- Schedule `cron.php` via cron for automated jobs.
+- Configure SMTP settings in `config/configuration.php`.
+
+## Further Reading
+
+For details on key components:
+
+- [docs/Nav.md](docs/Nav.md)
+- [docs/Doctrine.md](docs/Doctrine.md)
+
 ## Twig Templates
 
 Twig templates reside in the `templates_twig/` directory. Each template should

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -123,16 +123,6 @@ The root `.htaccess` file configures custom error pages, disables directory list
 Installer errors are saved to `install/errors/install.log`. Check this file if
 the installer fails or reports problems.
 
-## Documentation
-
-Additional information about the navigation helper API can be found in
-[docs/Nav.md](docs/Nav.md).
-
-Doctrine usage and migration instructions are documented in
-[docs/Doctrine.md](docs/Doctrine.md).
-
----
-
 ## Contributing & Support
 
 Found a bug or have a feature request? Open an issue on GitHub.


### PR DESCRIPTION
## Summary
- add Maintenance section with cron and SMTP notes
- move doc links from Docker file to README under new Further Reading

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6889133f448c8329a05d8ae239e3c529