### PR TITLE
Fix docs headers

### DIFF
--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,3 +1,4 @@
+# Docker Environment
 
 ### docker-compose.yml
 

--- a/docs/LegacyREADME.md
+++ b/docs/LegacyREADME.md
@@ -1,3 +1,4 @@
+# Legacy README
 
 Always back up your database and existing source files before upgrading.
 
@@ -92,10 +93,3 @@ Optional Composer packages can be defined in
 `composer-merge-plugin` will automatically merge the local file with the
 main `composer.json`.
 
-# LOTGD Docker Environment
-
-This guide explains how to containerize and run the LOTGD application using Docker. The provided Docker environment is configured for development and testing purposes. Additional configurations are required for production use, particularly regarding security and SSL encryption.
-
-## Table of Contents
-
-- [Prerequisites](#prerequisites)


### PR DESCRIPTION
## Summary
- add header to Docker environment doc
- add header to legacy README and remove Docker environment section

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688927a0ae748329a0b722654047dc38