### PR TITLE
Fix datacache write failure handling

### DIFF
--- a/src/Lotgd/DataCache.php
+++ b/src/Lotgd/DataCache.php
@@ -65,13 +65,23 @@ class DataCache
         if ($settings->getSetting('usedatacache', 0)) {
             $fullname = self::makecachetempname($name);
             self::$cache[$name] = $data;
-            $fp = fopen($fullname, 'w');
-            if ($fp) {
-                fwrite($fp, json_encode($data));
-                fclose($fp);
+
+            $encoded = json_encode($data);
+            if ($encoded === false) {
+                return false;
             }
-            return true;
+
+            $fp = @fopen($fullname, 'w');
+            if ($fp === false) {
+                return false;
+            }
+
+            $written = fwrite($fp, $encoded);
+            fclose($fp);
+
+            return $written !== false;
         }
+
         return false;
     }
 

--- a/tests/DataCacheTest.php
+++ b/tests/DataCacheTest.php
@@ -67,4 +67,21 @@ final class DataCacheTest extends TestCase
         $this->assertFileDoesNotExist(DataCache::makecachetempname($prefix . '2'));
         $this->assertFileExists(DataCache::makecachetempname('other'));
     }
+
+    public function testUpdateCacheFailureOnBadPath(): void
+    {
+        $invalidPath = '/nonexistent/' . uniqid();
+        $GLOBALS['settings']->saveSetting('datacachepath', $invalidPath);
+
+        $this->assertFalse(DataCache::updatedatacache('failpath', ['x' => 1]));
+        $this->assertFileDoesNotExist(DataCache::makecachetempname('failpath'));
+    }
+
+    public function testUpdateCacheFailureOnJsonError(): void
+    {
+        $resource = tmpfile();
+        $this->assertFalse(DataCache::updatedatacache('failjson', $resource));
+        fclose($resource);
+        $this->assertFileDoesNotExist(DataCache::makecachetempname('failjson'));
+    }
 }


### PR DESCRIPTION
## Summary
- handle json encode and fopen errors when writing datacache
- add tests for datacache write failures

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6889295f252c8329a27a7808f15906b5