### PR TITLE
Show mail and warning errors via forced debug output

### DIFF
--- a/src/Lotgd/ErrorHandler.php
+++ b/src/Lotgd/ErrorHandler.php
@@ -82,9 +82,9 @@ class ErrorHandler
             case E_WARNING:
             case E_USER_WARNING:
                 Translator::tlschema('errorhandler');
+                debug(sprintf('PHP Warning: "%s" in %s at %s.', $errstr, $errfile, $errline), true);
+                Translator::tlschema();
                 if (isset($session['user']['superuser']) && ($session['user']['superuser'] & SU_DEBUG_OUTPUT) == SU_DEBUG_OUTPUT) {
-                    output("PHP Warning: \"%s\"`nin `b%s`b at `b%s`b.`n", $errstr, $errfile, $errline, true);
-                    Translator::tlschema();
                     $backtrace = Backtrace::show();
                     rawoutput($backtrace);
                 } else {

--- a/src/Lotgd/Mail.php
+++ b/src/Lotgd/Mail.php
@@ -155,7 +155,7 @@ class Mail
             $mail->Send();
             return true;
         } catch (Exception $e) {
-            output("`\$An error has been encountered, please report this: %s`n`n", $mail->ErrorInfo);
+            debug(sprintf('Error sending notification mail: %s', $mail->ErrorInfo), true);
             return false;
         }
     }


### PR DESCRIPTION
## Summary
- Display mail delivery failures using `debug(..., true)` for clearer context
- Report PHP warnings through forced debug output so all users can see them

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6890cfd9913c8329ad5346ee7806145d