### PR TITLE
Prefix debug output with origin

### DIFF
--- a/src/Lotgd/Output.php
+++ b/src/Lotgd/Output.php
@@ -194,16 +194,29 @@ class Output
      */
     public function debug($text, $force = false)
     {
-        global $session;
+        global $session, $mostrecentmodule;
+
         $temp = $this->getBlockNewOutput();
         $this->setBlockNewOutput(false);
+
         if ($force || (isset($session['user']['superuser']) && ($session['user']['superuser'] & SU_DEBUG_OUTPUT))) {
             if (is_array($text)) {
                 $text = appoencode(DumpItem::dump($text), true);
             }
+
+            $origin = $mostrecentmodule ?? '';
+
+            if ('' === $origin) {
+                $trace  = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+                $origin = basename($trace[2]['file'] ?? '');
+            }
+
+            $text = "{$origin}: {$text}";
+
             // Toggle visibility of debug output to make the page cleaner if you want to
             $this->rawOutput("<button onclick=\"this.nextElementSibling.classList.toggle('hidden');\">Show Debug Output</button><div class='debug'>$text</div>");
         }
+
         $this->setBlockNewOutput($temp);
     }
 

--- a/tests/Stubs/Functions.php
+++ b/tests/Stubs/Functions.php
@@ -96,6 +96,20 @@ namespace {
     if (!function_exists('debug')) {
         function debug($t, $force = false): void
         {
+            global $forms_output, $mostrecentmodule;
+
+            if (is_array($t)) {
+                $t = appoencode(\Lotgd\DumpItem::dump($t), true);
+            }
+
+            $origin = $mostrecentmodule ?? '';
+
+            if ('' === $origin) {
+                $trace  = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+                $origin = basename($trace[2]['file'] ?? '');
+            }
+
+            $forms_output .= "<button onclick=\"this.nextElementSibling.classList.toggle('hidden');\">Show Debug Output</button><div class='debug'>{$origin}: {$t}</div>";
         }
     }
 


### PR DESCRIPTION
## Summary
- Prefix debug output with module or caller file name for clearer origin tracking
- Emulate prefixed debug output in test stubs

## Testing
- `composer install`
- `composer test`
- Manual debug output check for module and page scenarios

------
https://chatgpt.com/codex/tasks/task_e_6890cfe3bcd8832992b224307289b013