### PR TITLE
Add configurable home online list modes

### DIFF
--- a/config/configuration.php
+++ b/config/configuration.php
@@ -47,6 +47,8 @@ $setup = array(
     "homenewestplayer" => "Should the newest player be shown?,bool",
         "defaultskin" => "Which template should be the default? (ships with twig:aurora),theme",
     "listonlyonline" => "Show Warriors List with only online folks (prevent paging)?,bool",
+    "homeonline_mode" => "Online list mode,enum,0,Current online,1,Online in last timeout,2,Online in last X minutes",
+    "homeonline_minutes" => "Minutes for 'last X minutes' mode,range,1,1440,1",
     "impressum" => "Tell the world something about the person running this server. (e.g. name and address),textarea",
 
     "Beta Setup,title",


### PR DESCRIPTION
## Summary
- Add settings for home page online list mode and custom minute window
- Expand online character list logic to handle timeout and fixed minute modes with cache key updates
- Cover all list modes with regression tests

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6890ef59e5a48329a8396f7aa1d77e32