### PR TITLE
Add configurable home online list modes

### DIFF
--- a/config/configuration.php
+++ b/config/configuration.php
@@ -47,6 +47,8 @@ $setup = array(
     "homenewestplayer" => "Should the newest player be shown?,bool",
         "defaultskin" => "Which template should be the default? (ships with twig:aurora),theme",
     "listonlyonline" => "Show Warriors List with only online folks (prevent paging)?,bool",
+    "homeonline_mode" => "Online list mode,enum,0,Current online,1,Online in last timeout,2,Online in last X minutes",
+    "homeonline_minutes" => "Minutes for 'last X minutes' mode,range,1,1440,1",
     "impressum" => "Tell the world something about the person running this server. (e.g. name and address),textarea",
 
     "Beta Setup,title",

--- a/login.php
+++ b/login.php
@@ -98,7 +98,7 @@ if ($name != "") {
                 if (!is_array($session['user']['dragonpoints'])) {
                     $session['user']['dragonpoints'] = array();
                 }
-                invalidatedatacache("charlisthomepage");
+                massinvalidate('charlisthomepage');
                 invalidatedatacache("list.php-warsonline");
                 $session['user']['laston'] = date("Y-m-d H:i:s");
 
@@ -218,7 +218,7 @@ if ($name != "") {
     if ($session['user']['loggedin']) {
         $sql = "UPDATE " . db_prefix("accounts") . " SET loggedin=0 WHERE acctid = " . $session['user']['acctid'];
         db_query($sql);
-        invalidatedatacache("charlisthomepage");
+        massinvalidate('charlisthomepage');
         invalidatedatacache("list.php-warsonline");
 
         // Handle the change in number of users online

--- a/prefs.php
+++ b/prefs.php
@@ -41,7 +41,7 @@ if ($op == "suicide" && getsetting("selfdelete", 0) != 0) {
     $session['user'] = array();
     $session['loggedin'] = false;
     $session['user']['loggedin'] = false;
-    invalidatedatacache("charlisthomepage");
+    massinvalidate('charlisthomepage');
     invalidatedatacache("list.php-warsonline");
 } elseif ($op == "forcechangeemail") {
     checkday();


### PR DESCRIPTION
## Summary
- Add settings for home page online list mode and custom minute window
- Expand online character list logic to handle timeout and fixed minute modes with cache key updates
- Cover all list modes with regression tests
- Ensure online list cache is invalidated on login, logout, and account deletion to prevent stale data

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6890ef59e5a48329a8396f7aa1d77e32