### PR TITLE
Use autoloaded PullUrl in logdnet image

### DIFF
--- a/images/logdnet.php
+++ b/images/logdnet.php
@@ -6,6 +6,7 @@
 session_start();
 //unset($_SESSION['logdnet']);
 //session_register("session");
+require_once __DIR__ . '/../autoload.php';
 if (isset($_GET['op']) && $_GET['op'] == "register") {
     if (
         !isset($_SESSION['logdnet']) || !isset($_SESSION['logdnet']['']) ||
@@ -31,8 +32,7 @@ if (isset($_GET['op']) && $_GET['op'] == "register") {
             "&l=" . $l . // primary language of this server -- you may change
                       // this if it turns out to be inaccurate.
             "";
-        require_once("../lib/pullurl.php");
-        $info = @pullurl($url);
+        $info = @\Lotgd\PullUrl::pull($url);
         if ($info !== false) {
             $info = base64_decode(join("", $info));
             $_SESSION['logdnet'] = unserialize($info);


### PR DESCRIPTION
## Summary
- Require Composer autoloader in `images/logdnet.php`
- Replace legacy `pullurl` helper with `Lotgd\PullUrl::pull`

## Testing
- `php -l images/logdnet.php`
- `composer install`
- `composer test`
- `php -r 'chdir("images"); $_GET=["op"=>"register","a"=>"http://test","c"=>1,"l"=>"en","d"=>"desc","e"=>"admin@example.com","v"=>"1.0","u"=>"http://central/"]; include "logdnet.php";' | head -c 20 | od -An -t x1`


------
https://chatgpt.com/codex/tasks/task_e_6895b26c7eac8329908ac37c7f14dcda