### PR TITLE
Propagate template hook changes

### DIFF
--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -265,7 +265,10 @@ class Template
             if ($fieldname != "") {
                 $template[$fieldname] = substr($val, strpos($val, "-->") + 3);
                 if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
-                    modulehook("template-{$fieldname}", ['content' => $template[$fieldname]]);
+                    $args = modulehook("template-{$fieldname}", ['content' => $template[$fieldname]]);
+                    if (is_array($args) && array_key_exists('content', $args)) {
+                        $template[$fieldname] = $args['content'];
+                    }
                 }
             }
         }

--- a/tests/Stubs/Functions.php
+++ b/tests/Stubs/Functions.php
@@ -63,6 +63,11 @@ namespace {
     if (!function_exists('modulehook')) {
         function modulehook($name, $data = [], $allowinactive = false, $only = false)
         {
+            global $modulehook_returns;
+            if (isset($modulehook_returns[$name])) {
+                return array_merge($data, $modulehook_returns[$name]);
+            }
+
             return $data;
         }
     }

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -39,4 +39,22 @@ final class TemplateTest extends TestCase
 
         $this->assertSame('twig:aurora', $result);
     }
+
+    public function testLoadTemplateAppliesModuleHookChanges(): void
+    {
+        global $modulehook_returns;
+
+        $path = dirname(__DIR__) . '/templates/test_template.htm';
+        file_put_contents($path, "<!--!test-->original");
+        $modulehook_returns = ['template-test' => ['content' => 'modified']];
+
+        try {
+            $result = Template::loadTemplate('test_template.htm');
+        } finally {
+            unlink($path);
+            unset($modulehook_returns);
+        }
+
+        $this->assertSame('modified', $result['test']);
+    }
 }


### PR DESCRIPTION
## Summary
- Apply module hook results when loading legacy templates
- Allow tests to override modulehook output
- Add regression test for template hook handling

## Testing
- `composer install`
- `composer test`
- `php -r 'define("DB_NODB", true); $_COOKIE["template"]="legacy:modern.htm"; $_SERVER["REQUEST_URI"]="/modules.php"; include "modules.php";'`

------
https://chatgpt.com/codex/tasks/task_e_6895c90506a88329a8a559d915cb19a1