### PR TITLE
Fix SMTP auth setting and add error notification test

### DIFF
--- a/src/Lotgd/Mail.php
+++ b/src/Lotgd/Mail.php
@@ -105,7 +105,7 @@ class Mail
         $host = getsetting('gamemailhost', 'localhost');
         $mailusername = getsetting('gamemailusername', '');
         $mailpassword = getsetting('gamemailpassword', '');
-        $smtpauth = getsetting('gamailsmtpauth', false);
+        $smtpauth = getsetting('gamemailsmtpauth', false);
         $smtpsecure = getsetting('gamemailsmtpsecure', 'tls');
         $port = getsetting('gamemailsmtpport', '587');
 

--- a/tests/ErrorHandlerNotifyTest.php
+++ b/tests/ErrorHandlerNotifyTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\ErrorHandler;
+use Lotgd\Tests\Stubs\DummySettings;
+use Lotgd\Tests\Stubs\PHPMailer;
+use PHPUnit\Framework\TestCase;
+
+final class ErrorHandlerNotifyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $settings, $mail_sent_count, $output;
+
+        $mail_sent_count = 0;
+        $settings = new DummySettings([
+            'notify_on_error' => 1,
+            'notify_address' => 'admin@example.com',
+            'gameadminemail' => 'admin@example.com',
+            'usedatacache' => 0,
+        ]);
+
+        // Ensure the PHPMailer stub is loaded so Mail::send uses it
+        new PHPMailer();
+
+        // Provide minimal output handler for debug()
+        $output = new class {
+            public function appoencode($data, $priv)
+            {
+                return $data;
+            }
+        };
+    }
+
+    public function testErrorNotificationIsSent(): void
+    {
+        ErrorHandler::errorNotify(E_ERROR, 'Test error', 'file.php', 42, '<trace>');
+
+        $this->assertSame(1, $GLOBALS['mail_sent_count']);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Fix SMTP auth setting key in mail sending
- Test error notifications are sent when configured

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689731ef41f88329ab2f5f06eb364bf1