### PR TITLE
Log mail send failures

### DIFF
--- a/src/Lotgd/Mail.php
+++ b/src/Lotgd/Mail.php
@@ -155,6 +155,7 @@ class Mail
             $mail->Send();
             return true;
         } catch (Exception $e) {
+            error_log($mail->ErrorInfo);
             debug(sprintf('Error sending notification mail: %s', $mail->ErrorInfo), true);
             return false;
         }


### PR DESCRIPTION
## Summary
- Ensure mail failures are recorded by logging PHPMailer errors

## Testing
- `composer test`
- `php -l src/Lotgd/Mail.php`


------
https://chatgpt.com/codex/tasks/task_e_689731f799a883299c2bfe3705a128b8