### PR TITLE
Refactor mail send handler

### DIFF
--- a/pages/mail/case_send.php
+++ b/pages/mail/case_send.php
@@ -2,44 +2,125 @@
 
 declare(strict_types=1);
 
-use Lotgd\SuAccess;
-use Lotgd\Nav\SuperuserNav;
 use Lotgd\Mail;
 
-$to = httppost('to');
-$sql = "SELECT acctid FROM " . db_prefix("accounts") . " WHERE login='$to'";
-$result = db_query($sql);
-$return = (int) httppost("returnto");
-if (db_num_rows($result) > 0) {
-        $row1 = db_fetch_assoc($result);
-        $checkUnread = (bool)getsetting("onlyunreadmails", true);
-    if (Mail::isInboxFull($row1['acctid'], $checkUnread)) {
-            output("`\$You cannot send that person mail, their mailbox is full!`0`n`n");
-    } else {
-        $subject = str_replace("`n", "", (string)httppost('subject'));
-        $body = str_replace("`n", "\n", (string)httppost('body'));
-        $body = str_replace("\r\n", "\n", $body);
-        $body = str_replace("\r", "\n", $body);
-        $body = addslashes(substr(stripslashes($body), 0, (int)getsetting("mailsizelimit", 1024)));
-        Mail::systemMail($row1['acctid'], $subject, $body, (int)$session['user']['acctid']);
-        invalidatedatacache("mail-{$row1['acctid']}");
-        output("Your message was sent!`n");
-        if (httppost('sendclose')) {
-            rawoutput("<script language='javascript'>window.close();</script>");
-        }
-        if (httppost('sendback')) {
-            $return = 0;
-        }
+/**
+ * Handle sending of in-game mail.
+ *
+ * @return void
+ */
+function MailSend(): void
+{
+    global $session, $op, $id;
+
+    // Capture and validate input values once
+    $to = (string) httppost('to');
+    $subject = (string) httppost('subject');
+    $body = (string) httppost('body');
+    $sendClose = (bool) httppost('sendclose');
+    $sendBack = (bool) httppost('sendback');
+    $return = (int) httppost('returnto');
+
+    if ($to === '' || $subject === '' || $body === '') {
+        output('Missing required fields.`n');
+
+        return;
     }
-} else {
-    output("Could not find the recipient, please try again.`n");
+
+    $sql = 'SELECT acctid FROM ' . db_prefix('accounts') . " WHERE login='$to'";
+    $result = db_query($sql);
+
+    if (db_num_rows($result) <= 0) {
+        output('Could not find the recipient, please try again.`n');
+
+        return;
+    }
+
+    $row = db_fetch_assoc($result);
+    $checkUnread = (bool) getsetting('onlyunreadmails', true);
+
+    if (Mail::isInboxFull($row['acctid'], $checkUnread)) {
+        output('`$You cannot send that person mail, their mailbox is full!`0`n`n');
+
+        return;
+    }
+
+    $subject = sanitizeSubject($subject);
+    $body = sanitizeBody($body);
+
+    Mail::systemMail($row['acctid'], $subject, $body, (int) $session['user']['acctid']);
+    invalidatedatacache("mail-{$row['acctid']}");
+    output('Your message was sent!`n');
+
+    if ($sendClose) {
+        rawoutput("<script language='javascript'>window.close();</script>");
+    }
+
+    if ($sendBack) {
+        $return = 0;
+    }
+
+    if ($return > 0) {
+        $op = 'read';
+        httpset('op', 'read');
+        $id = $return;
+        httpset('id', $id);
+    } else {
+        $op = '';
+        httpset('op', '');
+    }
 }
-if ($return > 0) {
-    $op = "read";
-    httpset('op', 'read');
-    $id = $return;
-    httpset('id', $id);
-} else {
-    $op = "";
-    httpset('op', "");
+
+/**
+ * Remove game newline codes from the subject.
+ */
+function sanitizeSubject(string $subject): string
+{
+    return str_replace('`n', '', $subject);
 }
+
+/**
+ * Sanitize the message body.
+ */
+function sanitizeBody(string $body): string
+{
+    // Replace game-specific newline markers.
+    $body = replaceGameNewlines($body);
+
+    // Normalize Windows and Mac line endings to Unix style.
+    $body = normalizeLineEndings($body);
+
+    // Truncate to the configured limit and escape for storage.
+    return escapeAndTruncateBody($body);
+}
+
+/**
+ * Replace `n codes with actual newlines.
+ */
+function replaceGameNewlines(string $body): string
+{
+    return str_replace('`n', "\n", $body);
+}
+
+/**
+ * Normalize line endings to Unix style.
+ */
+function normalizeLineEndings(string $body): string
+{
+    $body = str_replace("\r\n", "\n", $body);
+
+    return str_replace("\r", "\n", $body);
+}
+
+/**
+ * Strip slashes, truncate to limit and escape for storage.
+ */
+function escapeAndTruncateBody(string $body): string
+{
+    $limit = (int) getsetting('mailsizelimit', 1024);
+
+    return addslashes(substr(stripslashes($body), 0, $limit));
+}
+
+MailSend();
+


### PR DESCRIPTION
## Summary
- encapsulate mail sending logic inside `MailSend` handler with input validation
- extract body sanitation into documented helper functions
- format `case_send.php` to PSR-12 and add PHPDoc block

## Testing
- `php -l pages/mail/case_send.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68973220cc308329b265768a67cbe32f