### PR TITLE
Refactor clan hall default page

### DIFF
--- a/pages/clan/clan_default.php
+++ b/pages/clan/clan_default.php
@@ -2,95 +2,96 @@
 
 declare(strict_types=1);
 
-use Lotgd\Modules;
-use Lotgd\MySQL\Database;
-use Lotgd\Translator;
-use Lotgd\Nav;
 use Lotgd\Commentary;
+use Lotgd\Modules;
+use Lotgd\Nav;
+use Lotgd\Repository\ClanRepository;
+use Lotgd\Translator;
 
-        Modules::hook("collapse{", ["name" => "clanentry"]);
-        $output->output("Having pressed the secret levers and turned the secret knobs on the lock of the door to your clan's hall, you gain entrance and chat with your clan mates.`n`n");
-        Modules::hook("}collapse");
+/**
+ * Controller for the default clan hall view.
+ */
+function renderClanDefault(): void
+{
+    global $claninfo, $output, $session, $ranks;
 
-        $sql = "SELECT name FROM " . Database::prefix("accounts")  . " WHERE acctid={$claninfo['motdauthor']}";
-        $result = Database::query($sql);
-if (Database::numRows($result) > 0) {
-    $row = Database::fetchAssoc($result);
-    $motdauthname = $row['name'];
-} else {
-    $motdauthname = Translator::translateInline("Nobody");
-}
-        $sql = "SELECT name FROM " . Database::prefix("accounts") . " WHERE acctid={$claninfo['descauthor']}";
-        $result = Database::query($sql);
-if (Database::numRows($result) > 0) {
-    $row = Database::fetchAssoc($result);
-    $descauthname = $row['name'];
-} else {
-    $descauthname = Translator::translateInline("Nobody");
-}
+    Modules::hook('collapse{', ['name' => 'clanentry']);
+    $output->output("Having pressed the secret levers and turned the secret knobs on the lock of the door to your clan's hall, you gain entrance and chat with your clan mates.`n`n");
+    Modules::hook('}collapse');
 
-if ($claninfo['clanmotd'] != '') {
-    $output->rawOutput("<div style='margin-left: 15px; padding-left: 15px;'>");
-    $output->output("`&`bCurrent MoTD:`b `#by %s`2`n", $motdauthname);
-    $output->outputNotl(nltoappon($claninfo['clanmotd']) . "`n");
-    $output->rawOutput("</div>");
-    $output->outputNotl("`n");
-}
+    // Retrieve author names for MoTD and description.
+    $motdAuthorName = ClanRepository::fetchAccountName((int) $claninfo['motdauthor']) ?? Translator::translateInline('Nobody');
+    $descAuthorName = ClanRepository::fetchAccountName((int) $claninfo['descauthor']) ?? Translator::translateInline('Nobody');
 
-        // you can modify the displayed clanchat here. more control for modules
-        $clan_commentary = Modules::hook("clan-commentary", array("section" => "clan-{$claninfo['clanid']}","clanid" => $claninfo['clanid']));
-        $clan_section_name = $clan_commentary['section'];
-            Commentary::commentDisplay("", $clan_section_name, "Speak", 25, ($claninfo['customsay'] > '' ? $claninfo['customsay'] : "says"));
-
-        Modules::hook("clanhall");
-
-if ($claninfo['clandesc'] != '') {
-    Modules::hook("collapse{", array("name" => "collapsedesc"));
-    $output->output("`n`n`&`bCurrent Description:`b `#by %s`2`n", $descauthname);
-    $output->outputNotl(nltoappon($claninfo['clandesc']));
-    Modules::hook("}collapse");
-}
-        $sql = "SELECT count(acctid) AS c, clanrank FROM " . Database::prefix("accounts") . " WHERE clanid={$claninfo['clanid']} GROUP BY clanrank ORDER BY clanrank DESC";
-        $result = Database::query($sql);
-        // begin collapse
-        Modules::hook("collapse{", array("name" => "clanmemberdet"));
-        $output->output("`n`n`bMembership Details:`b`n");
-        $leaders = 0;
-while ($row = Database::fetchAssoc($result)) {
-    $output->outputNotl((isset($ranks[$row['clanrank']]) ? $ranks[$row['clanrank']] : 'Undefined') . ": `0" . $row['c'] . "`n");
-    if ($row['clanrank'] >= CLAN_LEADER) {
-        $leaders += $row['c'];
+    /**
+     * MoTD display section.
+     */
+    if ($claninfo['clanmotd'] !== '') {
+        $output->rawOutput("<div style='margin-left: 15px; padding-left: 15px;'>");
+        $output->output("`&`bCurrent MoTD:`b `#by %s`2`n", $motdAuthorName);
+        $output->outputNotl(nltoappon($claninfo['clanmotd']) . "`n");
+        $output->rawOutput('</div>');
+        $output->outputNotl("`n");
     }
-}
-        $output->output("`n");
-        $noleader = Translator::translateInline("`^There is currently no leader!  Promoting %s`^ to leader as they are the highest ranking member (or oldest member in the event of a tie).`n`n");
-if ($leaders == 0) {
-    //There's no leader here, probably because the leader's account
-    //expired.
-    $sql = "SELECT name,acctid,clanrank FROM " . Database::prefix("accounts") . " WHERE clanid={$session['user']['clanid']} AND clanrank > " . CLAN_APPLICANT . " ORDER BY clanrank DESC, clanjoindate";
-    $result = Database::query($sql);
-    if (Database::numRows($result)) {
-        $row = Database::fetchAssoc($result);
-        $sql = "UPDATE " . Database::prefix("accounts") . " SET clanrank=" . CLAN_LEADER . " WHERE acctid={$row['acctid']}";
-        Database::query($sql);
-        $output->outputNotl($noleader, $row['name']);
-        if ($row['acctid'] == $session['user']['acctid']) {
-            //if it's the current user, we'll need to update their
-            //session in order for the db write to take effect.
-            $session['user']['clanrank'] = CLAN_LEADER;
+
+    // Display clan chat.
+    $clanCommentary = Modules::hook('clan-commentary', ['section' => "clan-{$claninfo['clanid']}", 'clanid' => $claninfo['clanid']]);
+    $clanSectionName = $clanCommentary['section'];
+    Commentary::commentDisplay('', $clanSectionName, 'Speak', 25, ($claninfo['customsay'] > '' ? $claninfo['customsay'] : 'says'));
+
+    Modules::hook('clanhall');
+
+    /**
+     * Clan description display.
+     */
+    if ($claninfo['clandesc'] !== '') {
+        Modules::hook('collapse{', ['name' => 'collapsedesc']);
+        $output->output("`n`n`&`bCurrent Description:`b `#by %s`2`n", $descAuthorName);
+        $output->outputNotl(nltoappon($claninfo['clandesc']));
+        Modules::hook('}collapse');
+    }
+
+    /**
+     * Membership summary section.
+     */
+    $members = ClanRepository::countMembersByRank((int) $claninfo['clanid']);
+    Modules::hook('collapse{', ['name' => 'clanmemberdet']);
+    $output->output("`n`n`bMembership Details:`b`n");
+    $leaders = 0;
+    foreach ($members as $row) {
+        $output->outputNotl(($ranks[$row['clanrank']] ?? 'Undefined') . ": `0" . $row['c'] . "`n");
+        if ($row['clanrank'] >= CLAN_LEADER) {
+            $leaders += $row['c'];
         }
-    } else {
-        // There are no viable leaders.  But we cannot disband the clan
-        // here.
     }
-}
-        // end collapse
-        Modules::hook("}collapse");
+    $output->output("`n");
 
-if ($session['user']['clanrank'] > CLAN_MEMBER) {
-    Nav::add("Update MoTD / Clan Desc", "clan.php?op=motd");
+    /**
+     * Leader reassignment section.
+     */
+    $noLeaderText = Translator::translateInline("`^There is currently no leader!  Promoting %s`^ to leader as they are the highest ranking member (or oldest member in the event of a tie).`n`n");
+    if ($leaders === 0) {
+        $member = ClanRepository::getHighestRankingMember((int) $session['user']['clanid']);
+        if ($member !== null) {
+            ClanRepository::promoteToLeader((int) $member['acctid']);
+            $output->outputNotl($noLeaderText, $member['name']);
+            if ((int) $member['acctid'] === (int) $session['user']['acctid']) {
+                // Update session rank for current user.
+                $session['user']['clanrank'] = CLAN_LEADER;
+            }
+        }
+    }
+    Modules::hook('}collapse');
+
+    // Navigation options.
+    if ($session['user']['clanrank'] > CLAN_MEMBER) {
+        Nav::add('Update MoTD / Clan Desc', 'clan.php?op=motd');
+    }
+    Nav::add('M?View Membership', 'clan.php?op=membership');
+    Nav::add('Online Members', 'list.php?op=clan');
+    Nav::add("Your Clan's Waiting Area", 'clan.php?op=waiting');
+    Nav::add('Withdraw From Your Clan', 'clan.php?op=withdrawconfirm');
 }
-        Nav::add("M?View Membership", "clan.php?op=membership");
-        Nav::add("Online Members", "list.php?op=clan");
-        Nav::add("Your Clan's Waiting Area", "clan.php?op=waiting");
-        Nav::add("Withdraw From Your Clan", "clan.php?op=withdrawconfirm");
+
+renderClanDefault();
+

--- a/src/Lotgd/Repository/ClanRepository.php
+++ b/src/Lotgd/Repository/ClanRepository.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Repository;
+
+use Lotgd\MySQL\Database;
+
+/**
+ * Repository with helper methods for clan-related database operations.
+ */
+class ClanRepository
+{
+    /**
+     * Fetch the account name for the given account id.
+     */
+    public static function fetchAccountName(int $acctid): ?string
+    {
+        $sql = 'SELECT name FROM ' . Database::prefix('accounts') . " WHERE acctid={$acctid}";
+        $result = Database::query($sql);
+        if (Database::numRows($result) > 0) {
+            $row = Database::fetchAssoc($result);
+            return $row['name'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Count members of a clan grouped by their rank.
+     *
+     * @return array<int, array<string, int>>
+     */
+    public static function countMembersByRank(int $clanId): array
+    {
+        $sql = 'SELECT count(acctid) AS c, clanrank FROM ' . Database::prefix('accounts') . " WHERE clanid={$clanId} GROUP BY clanrank ORDER BY clanrank DESC";
+        $result = Database::query($sql);
+        $rows = [];
+        while ($row = Database::fetchAssoc($result)) {
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Get the highest ranking member of a clan.
+     *
+     * @return array<string, int|string>|null
+     */
+    public static function getHighestRankingMember(int $clanId): ?array
+    {
+        $sql = 'SELECT name,acctid,clanrank FROM ' . Database::prefix('accounts') . ' WHERE clanid=' . $clanId . ' AND clanrank > ' . CLAN_APPLICANT . ' ORDER BY clanrank DESC, clanjoindate';
+        $result = Database::query($sql);
+        if (Database::numRows($result)) {
+            return Database::fetchAssoc($result);
+        }
+
+        return null;
+    }
+
+    /**
+     * Promote an account to clan leader.
+     */
+    public static function promoteToLeader(int $acctid): void
+    {
+        $sql = 'UPDATE ' . Database::prefix('accounts') . ' SET clanrank=' . CLAN_LEADER . " WHERE acctid={$acctid}";
+        Database::query($sql);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Wrap default clan hall display logic in `renderClanDefault` controller
- Introduce `ClanRepository` for clan-related SQL queries
- Clarify sections with descriptive variables and inline comments

## Testing
- `php -l pages/clan/clan_default.php`
- `php -l src/Lotgd/Repository/ClanRepository.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689732218f0c832984cf833f4b238f3b