### PR TITLE
Fix missing brace in sanitizeComment

### DIFF
--- a/src/Lotgd/Commentary.php
+++ b/src/Lotgd/Commentary.php
@@ -205,6 +205,7 @@ class Commentary
      * @return string Sanitized comment text
      */
     private static function sanitizeComment(string $comment): string
+    {
         $commentary = str_replace('`n', '', soap($comment));
         $colorcount = 0;
         $length = strlen($commentary);


### PR DESCRIPTION
## Summary
- add missing opening brace to `sanitizeComment` and indent its body

## Testing
- `php -l src/Lotgd/Commentary.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68976a4ffe208329bdf1f970b6427fd3