### PR TITLE
refactor: isolate commentary pagination

### DIFF
--- a/src/Lotgd/Commentary.php
+++ b/src/Lotgd/Commentary.php
@@ -387,7 +387,7 @@ class Commentary
     private static function fetchCommentBuffer(string $section, int $limit, int $com, int $cid, string $real_request_uri): array
     {
         $sql = self::buildCommentFetchSql($section, $limit, $com, $cid);
-        $useCache = $cid === 0 && $com === 0 && strstr($real_request_uri, '/moderate.php') !== $real_request_uri;
+        $useCache = $cid === 0 && $com === 0 && strstr($real_request_uri, '/moderate.php') === false;
 
         if ($useCache) {
             $result = Database::queryCached($sql, "comments-{$section}");


### PR DESCRIPTION
## Summary
- centralize commentary pagination and SQL assembly
- prepare `viewCommentary` for cleaner request handling

## Testing
- `php -l src/Lotgd/Commentary.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689771f5d3148329b458838441ebbde8