### PR TITLE
Refactor mail compose handler into function

### DIFF
--- a/pages/mail/case_write.php
+++ b/pages/mail/case_write.php
@@ -304,7 +304,7 @@ function renderResizeScripts(): void
  */
 function renderSizeCountScript(): void
 {
-    $sizeMsg = '`#Max message size is `@%s`#, you have `^XX`# characters left.`';
+    $sizeMsg = '`#Max message size is `@%s`#, you have `^XX`# characters left.';
     $sizeMsg = Translator::translateInline($sizeMsg);
     $sizeMsg = sprintf($sizeMsg, getsetting('mailsizelimit', 1024));
 

--- a/pages/mail/case_write.php
+++ b/pages/mail/case_write.php
@@ -6,201 +6,330 @@ use Lotgd\Mail;
 use Lotgd\Sanitize;
 use Lotgd\Translator;
 
-$subject = httppost('subject');
-$body = "";
-$row = "";
-$replyto = (int)httpget('replyto');
-$forwardto = (int) httppost('forwardto');
-if ($replyto > 0) {
-    $msgid = $replyto;
-} else {
-    $msgid = $forwardto;
-}
-if ($msgid > 0) {
-    $row = Mail::getMessage($session['user']['acctid'], $msgid);
-    if ($row) {
-        if ((!isset($row['login']) || $row['login'] === '') && $forwardto == 0) {
-            output("You cannot reply to a system message.`n`nPress the \"Back\" button in your browser to get back.");
-            $row = [];
-            popup_footer();
+/**
+ * Display the mail compose form.
+ */
+function mailWrite(): void
+{
+    global $session;
+
+    // Capture request values
+    $subject    = (string) httppost('subject');
+    $subjectGet = (string) httpget('subject');
+    $replyTo    = (int) httpget('replyto');
+    $forwardTo  = (int) httppost('forwardto');
+    $toGet      = (string) httpget('to');
+    $toPost     = (string) httppost('to');
+
+    $body  = '';
+    $row   = '';
+    $msgId = 0;
+
+    if ($replyTo > 0) {
+        // Reply path
+        $msgId = $replyTo;
+    } elseif ($forwardTo > 0) {
+        // Forward path
+        $msgId = $forwardTo;
+    }
+
+    if ($msgId > 0) {
+        $row = Mail::getMessage($session['user']['acctid'], $msgId);
+
+        if ($row) {
+            if ((!isset($row['login']) || $row['login'] === '') && $forwardTo == 0) {
+                output("You cannot reply to a system message.`n`nPress the \"Back\" button in your browser to get back.");
+                $row = [];
+                popup_footer();
+            }
+
+            if ($forwardTo > 0) {
+                $row['login'] = '';
+            }
+
+            if (isset($row['login']) && $row['login'] !== '') {
+                $row['superuser'] = getSuperuserFlag($row['login']);
+            }
+        } else {
+            output("Eek, no such message was found!`n");
         }
-        if ($forwardto > 0) {
-            $row['login'] = '';
+    }
+
+    if ($toGet !== '') {
+        $temp = getAccountByLogin($toGet);
+
+        if ($temp === null) {
+            output("Could not find that person.`n");
+        } else {
+            $row = $temp;
         }
-        if (isset($row['login']) && $row['login'] !== '') {
-            $sql = "SELECT superuser FROM " . db_prefix('accounts')
-                . " WHERE login = '" . addslashes($row['login']) . "'";
-            $result = db_query($sql);
-            $acct = db_fetch_assoc($result);
-            $row['superuser'] = $acct['superuser'] ?? 0;
+    }
+
+    if (is_array($row)) {
+        if (isset($row['subject']) && $row['subject']) {
+            if ((int) $row['msgfrom'] === 0) {
+                $row['name'] = Translator::translateInline('`i`^System`0`i');
+
+                // No translation for subject if it's not an array
+                $rowSubject = @unserialize($row['subject']);
+                if ($rowSubject !== false) {
+                    $row['subject'] = Translator::sprintfTranslate(...$rowSubject);
+                }
+
+                // No translation for body if it's not an array
+                $rowBody = @unserialize($row['body']);
+                if ($rowBody !== false) {
+                    $row['body'] = Translator::sprintfTranslate(...$rowBody);
+                }
+            }
+
+            $subject = $row['subject'];
+            if (strncmp($subject, 'RE: ', 4) !== 0) {
+                $subject = "RE: $subject";
+            }
+        }
+
+        if (isset($row['body']) && $row['body']) {
+            $body = "\n\n---" . Translator::sprintfTranslate(
+                'Original Message from %s(%s)',
+                Sanitize::sanitize($row['name']),
+                date('Y-m-d H:i:s', strtotime($row['sent']))
+            ) . "---\n" . $row['body'];
+        }
+    }
+
+    rawoutput("<form action='mail.php?op=send' method='post'>");
+    rawoutput("<input type='hidden' name='returnto' value=\"$msgId\">");
+
+    $superusers = [];
+    $acctidTo   = 0; // only for hook right now
+
+    if (isset($row['login']) && $row['login'] !== '' && $forwardTo == 0) {
+        output_notl(
+            "<input type='hidden' name='to' id='to' value=\"" .
+            htmlentities($row['login'], ENT_COMPAT, getsetting('charset', 'ISO-8859-1')) .
+            "\">",
+            true
+        );
+        output('`2To: `^%s`n', $row['name']);
+        if (($row['superuser'] & SU_GIVES_YOM_WARNING) && !($row['superuser'] & SU_OVERRIDE_YOM_WARNING)) {
+            $superusers[] = $row['login'];
         }
     } else {
-        output("Eek, no such message was found!`n");
+        renderRecipientSelection($toPost, $superusers, $acctidTo, $row);
     }
+
+    renderSuperuserScript($superusers);
+
+    output('`2Subject:');
+    rawoutput(
+        "<input name='subject' value=\"" .
+        htmlentities($subject, ENT_COMPAT, getsetting('charset', 'ISO-8859-1')) .
+        htmlentities(stripslashes($subjectGet), ENT_COMPAT, getsetting('charset', 'ISO-8859-1')) .
+        "\"><br>"
+    );
+
+    rawoutput("<div id='warning' style='visibility: hidden; display: none;'>");
+    // superuser messages do not get translated.
+    output("`2Notice: `^%s`n", $superusermessage);
+    // Give modules a chance to put info in here to this user
+    modulehook('mail-write-notify', ['acctid_to' => $acctidTo]);
+    rawoutput('</div>');
+
+    output('`2Body:`n');
+    renderResizeScripts();
+
+    $prefs = &$session['user']['prefs'];
+    if (!isset($prefs['mailwidth']) || $prefs['mailwidth'] === '') {
+        $prefs['mailwidth'] = 60;
+    }
+    if (!isset($prefs['mailheight']) || $prefs['mailheight'] === '') {
+        $prefs['mailheight'] = 9;
+    }
+
+    $cols = max(10, $prefs['mailwidth']);
+    $rows = max(10, $prefs['mailheight']);
+
+    rawoutput(
+        "<table style='border:0;cellspacing:10'><tr><td><input type='button' onClick=\"increase(textarea1,1);\" value='+' accesskey='+'></td><td><input type='button' onClick=\"increase(textarea1,-1);\" value='-' accesskey='-'></td><td><input type='button' onClick=\"cincrease(textarea1,-1);\" value='<-'></td><td><input type='button' onClick=\"cincrease(textarea1,1);\" value='->' accesskey='-'></td></tr></table>"
+    );
+
+    // substr is necessary if you have chars that take up more than 1 byte.
+    $textBody = htmlentities(
+        str_replace(
+            '`n',
+            "\n",
+            Sanitize::sanitizeMb(
+                substr($body, 0, (int) getsetting('mailsizelimit', 1024, getsetting('charset', 'ISO-8859-1')))
+            )
+        ),
+        ENT_COMPAT,
+        getsetting('charset', 'ISO-8859-1')
+    );
+    $textBody .= htmlentities(
+        Sanitize::sanitizeMb(stripslashes((string) httpget('body'))),
+        ENT_COMPAT,
+        getsetting('charset', 'ISO-8859-1')
+    );
+
+    rawoutput(
+        "<textarea id='textarea1' class='input' onKeyUp='sizeCount(this);' name='body' cols='$cols' rows='$rows'>$textBody</textarea>"
+    );
+
+    $send     = Translator::translateInline('Send');
+    $sendClose = Translator::translateInline('Send and Close');
+    $sendBack  = Translator::translateInline('Send and back to main Mailbox');
+    rawoutput(
+        "<table border='0' cellpadding='0' cellspacing='0' width='100%'><tr><td><input type='submit' class='button' value='$send'></td><td style='width:20px;'></td><td><input type='submit' class='button' value='$sendClose' name='sendclose'></td><td><input type='submit' class='button' value='$sendBack' name='sendback'></td><td align='right'><div id='sizemsg'></div></td></tr></table>"
+    );
+    rawoutput('</form>');
+
+    renderSizeCountScript();
 }
-$to = httpget('to');
-if ($to) {
-    $sql = "SELECT login,name, superuser FROM " . db_prefix("accounts") . " WHERE login=\"$to\"";
+
+/**
+ * Get the superuser flag for a login.
+ */
+function getSuperuserFlag(string $login): int
+{
+    $sql    = 'SELECT superuser FROM ' . db_prefix('accounts') . " WHERE login = '" . addslashes($login) . "'";
     $result = db_query($sql);
-    if (!($row = db_fetch_assoc($result))) {
-        output("Could not find that person.`n");
-    }
+    $acct   = db_fetch_assoc($result);
+
+    return $acct['superuser'] ?? 0;
 }
-if (is_array($row)) {
-    if (isset($row['subject']) && $row['subject']) {
-        if ((int)$row['msgfrom'] == 0) {
-            $row['name'] = Translator::translateInline("`i`^System`0`i");
-            // No translation for subject if it's not an array
-            $row_subject = @unserialize($row['subject']);
-            if ($row_subject !== false) {
-                $row['subject'] = Translator::sprintfTranslate(...$row_subject);
-            }
-            // No translation for body if it's not an array
-            $row_body = @unserialize($row['body']);
-            if ($row_body !== false) {
-                $row['body'] = Translator::sprintfTranslate(...$row_body);
-            }
-        }
-        $subject = $row['subject'];
-        if (strncmp($subject, "RE: ", 4) !== 0) {
-            $subject = "RE: $subject";
-        }
-    }
-    if (isset($row['body']) && $row['body']) {
-        $body = "\n\n---" . Translator::sprintfTranslate("Original Message from %s(%s)", Sanitize::sanitize($row['name']), date("Y-m-d H:i:s", strtotime($row['sent']))) . "---\n" . $row['body'];
-    }
-}
-rawoutput("<form action='mail.php?op=send' method='post'>");
-rawoutput("<input type='hidden' name='returnto' value=\"" . ((string)$msgid) . "\">");
-$superusers = array();
-$acctid_to = 0; //only for hook right now
-if (isset($row['login']) && $row['login'] != "" && $forwardto == 0) {
-    output_notl("<input type='hidden' name='to' id='to' value=\"" . htmlentities($row['login'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\">", true);
-    output("`2To: `^%s`n", $row['name']);
-    if (($row['superuser'] & SU_GIVES_YOM_WARNING) && !($row['superuser'] & SU_OVERRIDE_YOM_WARNING)) {
-        array_push($superusers, $row['login']);
-    }
-} else {
-        rawoutput("<label for='to'>");
-        output("`2To: ");
-        rawoutput("</label>");
-    $to = httppost('to');
-    $sql = "SELECT acctid,login,name,superuser FROM " . db_prefix('accounts') . " WHERE login = '" . addslashes($to) . "' AND locked = 0";
+
+/**
+ * Fetch account information by login.
+ */
+function getAccountByLogin(string $login): ?array
+{
+    $sql    = 'SELECT login,name, superuser FROM ' . db_prefix('accounts') . " WHERE login=\"$login\"";
     $result = db_query($sql);
-    $db_num_rows = db_num_rows($result);
-    if ($db_num_rows != 1) {
-        $string = "%";
-        $to_len = strlen($to);
-        for ($x = 0; $x < $to_len; ++$x) {
-            $string .= $to[$x] . "%";
+    $row    = db_fetch_assoc($result);
+
+    return $row ?: null;
+}
+
+/**
+ * Render recipient selection or input field.
+ */
+function renderRecipientSelection(string $to, array &$superusers, int &$acctidTo, array &$row): void
+{
+    rawoutput("<label for='to'>");
+    output('`2To: ');
+    rawoutput('</label>');
+
+    $sql   = 'SELECT acctid,login,name,superuser FROM ' . db_prefix('accounts') .
+        " WHERE login = '" . addslashes($to) . "' AND locked = 0";
+    $result    = db_query($sql);
+    $dbNumRows = db_num_rows($result);
+
+    if ($dbNumRows !== 1) {
+        $string = '%';
+        $toLen  = strlen($to);
+        for ($x = 0; $x < $toLen; ++$x) {
+            $string .= $to[$x] . '%';
         }
-        $sql = "SELECT login,name,superuser FROM " . db_prefix("accounts") . " WHERE name LIKE '" . addslashes($string) . "' AND locked=0 ORDER by login='$to' DESC, name='$to' DESC, login";
-        $result = db_query($sql);
-        $db_num_rows = db_num_rows($result);
+        $sql       = 'SELECT login,name,superuser FROM ' . db_prefix('accounts') . " WHERE name LIKE '" . addslashes($string) . "' AND locked=0 ORDER by login='$to' DESC, name='$to' DESC, login";
+        $result    = db_query($sql);
+        $dbNumRows = db_num_rows($result);
     }
-    if ($db_num_rows == 1) {
+
+    if ($dbNumRows == 1) {
         $row = db_fetch_assoc($result);
-        output_notl("<input type='hidden' id='to' name='to' value=\"" . htmlentities($row['login'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\">", true);
+        output_notl(
+            "<input type='hidden' id='to' name='to' value=\"" .
+            htmlentities($row['login'], ENT_COMPAT, getsetting('charset', 'ISO-8859-1')) .
+            "\">",
+            true
+        );
         output_notl("`^{$row['name']}`n");
         if (($row['superuser'] & SU_GIVES_YOM_WARNING) && !($row['superuser'] & SU_OVERRIDE_YOM_WARNING)) {
-            array_push($superusers, $row['login']);
+            $superusers[] = $row['login'];
         }
-        $acctid_to = $row['acctid'];
-    } elseif ($db_num_rows == 0) {
+        $acctidTo = $row['acctid'];
+    } elseif ($dbNumRows == 0) {
         output("`\$No one was found who matches \"%s\".`n", stripslashes($to));
-        output("`@Please try again.`n");
+        output('`@Please try again.`n');
         httpset('prepop', $to, true);
-        rawoutput("</form>");
-                require("pages/mail/case_address.php");
+        rawoutput('</form>');
+        require 'pages/mail/case_address.php';
         popup_footer();
     } else {
         output_notl("<select name='to' id='to' onchange='check_su_warning();'>", true);
-        $superusers = array();
+        $superusers = [];
+
         while ($row = db_fetch_assoc($result)) {
-            output_notl("<option value=\"" . htmlentities($row['login'], ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\">", true);
-            output_notl("%s", Sanitize::fullSanitize($row['name']));
+            output_notl(
+                "<option value=\"" . htmlentities($row['login'], ENT_COMPAT, getsetting('charset', 'ISO-8859-1')) . "\">",
+                true
+            );
+            output_notl('%s', Sanitize::fullSanitize($row['name']));
             if (($row['superuser'] & SU_GIVES_YOM_WARNING) && !($row['superuser'] & SU_OVERRIDE_YOM_WARNING)) {
-                array_push($superusers, $row['login']);
+                $superusers[] = $row['login'];
             }
         }
-        output_notl("</select>`n", true);
+        output_notl('</select>`n', true);
     }
 }
-rawoutput("<script type='text/javascript'>var superusers = new Array();");
-foreach ($superusers as $val) {
-    rawoutput("	superusers['" . addslashes($val) . "'] = true;");
-}
-rawoutput("</script>");
-output("`2Subject:");
-rawoutput("<input name='subject' value=\"" . htmlentities((string)$subject, ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . htmlentities(stripslashes((string)httpget('subject')), ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\"><br>");
-rawoutput("<div id='warning' style='visibility: hidden; display: none;'>");
-//superuser messages do not get translated.
-output("`2Notice: `^%s`n", $superusermessage);
-// Give modules a chance to put info in here to this user
-modulehook("mail-write-notify", array("acctid_to" => $acctid_to));
-rawoutput("</div>");
-output("`2Body:`n");
-rawoutput("<script type=\"text/javascript\">function increase(target, value){  if (target.rows + value > 3 && target.rows + value < 50) target.rows = target.rows + value;}</script>");
-rawoutput("<script type=\"text/javascript\">function cincrease(target, value){  if (target.cols + value > 3 && target.cols + value < 150) target.cols = target.cols + value;}</script>");
-$key = 1;
-$keyout = 'body';
-$prefs=&$session['user']['prefs'];
-if (!isset($prefs['mailwidth']) || $prefs['mailwidth'] == "") {
-    $prefs['mailwidth'] = 60;
-}
-if (!isset($prefs['mailheight']) || $prefs['mailheight'] == "") {
-    $prefs['mailheight'] = 9;
+
+/**
+ * Render javascript with superuser list.
+ */
+function renderSuperuserScript(array $superusers): void
+{
+    rawoutput("<script type='text/javascript'>var superusers = new Array();");
+    foreach ($superusers as $val) {
+        rawoutput(" superusers['" . addslashes($val) . "'] = true;");
+    }
+    rawoutput('</script>');
 }
 
-$cols = max(10, $prefs['mailwidth']);
-$rows = max(10, $prefs['mailheight']);
-rawoutput("<table style='border:0;cellspacing:10'><tr><td><input type='button' onClick=\"increase(textarea$key,1);\" value='+' accesskey='+'></td><td><input type='button' onClick=\"increase(textarea$key,-1);\" value='-' accesskey='-'></td>");
-rawoutput("<td><input type='button' onClick=\"cincrease(textarea$key,-1);\" value='<-'></td><td><input type='button' onClick=\"cincrease(textarea$key,1);\" value='->' accesskey='-'></td></tr></table>");
-//substr is necessary if you have chars that take up more than 1 byte. That breaks the entire HTMLentities up and it returns nothing
-rawoutput("<textarea id='textarea$key' class='input' onKeyUp='sizeCount(this);' name='$keyout' cols='$cols' rows='$rows'>" . htmlentities(str_replace("`n", "\n", Sanitize::sanitizeMb(substr($body, 0, (int)getsetting("mailsizelimit", 1024, getsetting("charset", "ISO-8859-1"))))), ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . htmlentities(Sanitize::sanitizeMb(stripslashes((string)httpget('body'))), ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "</textarea>");
-//rawoutput("<textarea name='body' id='textarea' class='input' cols='60' rows='9' onKeyUp='sizeCount(this);'>".htmlentities($body, ENT_COMPAT, getsetting("charset", "ISO-8859-1")).htmlentities(stripslashes(httpget('body')), ENT_COMPAT, getsetting("charset", "ISO-8859-1"))."</textarea><br>");
-$send = Translator::translateInline("Send");
-$sendclose = Translator::translateInline("Send and Close");
-$sendback = Translator::translateInline("Send and back to main Mailbox");
-rawoutput("<table border='0' cellpadding='0' cellspacing='0' width='100%'><tr><td><input type='submit' class='button' value='$send'></td><td style='width:20px;'></td><td><input type='submit' class='button' value='$sendclose' name='sendclose'></td><td><input type='submit' class='button' value='$sendback' name='sendback'></td><td align='right'><div id='sizemsg'></div></td></tr></table>");
-rawoutput("</form>");
-$sizemsg = "`#Max message size is `@%s`#, you have `^XX`# characters left.";
-$sizemsg = Translator::translateInline($sizemsg);
-$sizemsg = sprintf($sizemsg, getsetting("mailsizelimit", 1024));
-$sizemsgover = "`\$Max message size is `@%s`\$, you are over by `^XX`\$ characters!";
-$sizemsgover = Translator::translateInline($sizemsgover);
-$sizemsgover = sprintf($sizemsgover, getsetting("mailsizelimit", 1024));
-$sizemsg = explode("XX", $sizemsg);
-$sizemsgover = explode("XX", $sizemsgover);
-$usize1 = addslashes("<span>" . appoencode($sizemsg[0]) . "</span>");
-$usize2 = addslashes("<span>" . appoencode($sizemsg[1]) . "</span>");
-$osize1 = addslashes("<span>" . appoencode($sizemsgover[0]) . "</span>");
-$osize2 = addslashes("<span>" . appoencode($sizemsgover[1]) . "</span>");
-rawoutput("
-<script type='text/javascript'>
-	var maxlen = " . getsetting("mailsizelimit", 1024) . ";
-	function sizeCount(box){
-		if (box==null) return;
-		var len = box.value.length;
-		var msg = '';
-		if (len <= maxlen){
-			msg = '$usize1'+(maxlen-len)+'$usize2';
-		}else{
-			msg = '$osize1'+(len-maxlen)+'$osize2';
-		}
-		document.getElementById('sizemsg').innerHTML = msg;
-	}
-	sizeCount(document.getElementById('textarea'));
-		function check_su_warning(){
-		var to = document.getElementById('to');
-		var warning = document.getElementById('warning');
-		if (superusers[to.value]){
-			warning.style.visibility = 'visible';
-			warning.style.display = 'inline';
-		}else{
-			warning.style.visibility = 'hidden';
-			warning.style.display = 'none';
-		}
-	}
-	check_su_warning();
-</script>");
+/**
+ * Render textarea resize helper scripts.
+ */
+function renderResizeScripts(): void
+{
+    rawoutput(
+        "<script type=\"text/javascript\">function increase(target, value){  if (target.rows + value > 3 && target.rows + value < 50) target.rows = target.rows + value;}</script>"
+    );
+    rawoutput(
+        "<script type=\"text/javascript\">function cincrease(target, value){  if (target.cols + value > 3 && target.cols + value < 150) target.cols = target.cols + value;}</script>"
+    );
+}
+
+/**
+ * Render character counting and warning scripts.
+ */
+function renderSizeCountScript(): void
+{
+    $sizeMsg = '`#Max message size is `@%s`#, you have `^XX`# characters left.`';
+    $sizeMsg = Translator::translateInline($sizeMsg);
+    $sizeMsg = sprintf($sizeMsg, getsetting('mailsizelimit', 1024));
+
+    $sizeMsgOver = '`$Max message size is `@%s`$, you are over by `^XX`$ characters!`';
+    $sizeMsgOver = Translator::translateInline($sizeMsgOver);
+    $sizeMsgOver = sprintf($sizeMsgOver, getsetting('mailsizelimit', 1024));
+
+    $sizeMsg    = explode('XX', $sizeMsg);
+    $sizeMsgOver = explode('XX', $sizeMsgOver);
+
+    $usize1 = addslashes('<span>' . appoencode($sizeMsg[0]) . '</span>');
+    $usize2 = addslashes('<span>' . appoencode($sizeMsg[1]) . '</span>');
+    $osize1 = addslashes('<span>' . appoencode($sizeMsgOver[0]) . '</span>');
+    $osize2 = addslashes('<span>' . appoencode($sizeMsgOver[1]) . '</span>');
+    $maxlen = getsetting('mailsizelimit', 1024);
+
+    rawoutput("<script type='text/javascript'>");
+    rawoutput(
+        "var maxlen = $maxlen;" .
+        "function sizeCount(box){if(box==null) return;var len = box.value.length;var msg='';if(len <= maxlen){msg='$usize1'+(maxlen-len)+'$usize2';}else{msg='$osize1'+(len-maxlen)+'$osize2';}document.getElementById('sizemsg').innerHTML = msg;}" .
+        "function check_su_warning(){var to = document.getElementById('to');var warning = document.getElementById('warning');if(superusers[to.value]){warning.style.visibility='visible';warning.style.display='inline';}else{warning.style.visibility='hidden';warning.style.display='none';}}" .
+        'check_su_warning();'
+    );
+    rawoutput('</script>');
+}
+
+mailWrite();
+

--- a/pages/mail/case_write.php
+++ b/pages/mail/case_write.php
@@ -308,7 +308,7 @@ function renderSizeCountScript(): void
     $sizeMsg = Translator::translateInline($sizeMsg);
     $sizeMsg = sprintf($sizeMsg, getsetting('mailsizelimit', 1024));
 
-    $sizeMsgOver = '`$Max message size is `@%s`$, you are over by `^XX`$ characters!`';
+    $sizeMsgOver = '`$Max message size is `@%s`$, you are over by `^XX`$ characters!';
     $sizeMsgOver = Translator::translateInline($sizeMsgOver);
     $sizeMsgOver = sprintf($sizeMsgOver, getsetting('mailsizelimit', 1024));
 

--- a/pages/mail/case_write.php
+++ b/pages/mail/case_write.php
@@ -204,7 +204,7 @@ function getSuperuserFlag(string $login): int
  */
 function getAccountByLogin(string $login): ?array
 {
-    $sql    = 'SELECT login,name, superuser FROM ' . db_prefix('accounts') . " WHERE login=\"$login\"";
+    $sql    = 'SELECT login,name, superuser FROM ' . db_prefix('accounts') . " WHERE login='" . addslashes($login) . "'";
     $result = db_query($sql);
     $row    = db_fetch_assoc($result);
 


### PR DESCRIPTION
## Summary
- Refactor mail compose page into `mailWrite()`
- Capture request variables once and reuse
- Extract SQL and HTML blocks into helper functions

## Testing
- `php -l pages/mail/case_write.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6897793a5d5083299ea2680e2d597655