### PR TITLE
Refactor mail compose prefilled body handling

### DIFF
--- a/pages/mail/case_write.php
+++ b/pages/mail/case_write.php
@@ -20,8 +20,9 @@ function mailWrite(): void
     $forwardTo  = (int) httppost('forwardto');
     $toGet      = (string) httpget('to');
     $toPost     = (string) httppost('to');
+    $bodyGet    = (string) httpget('body'); // Prefilled request value for body text
 
-    $body  = '';
+    $body  = ''; // Loaded message body when replying or forwarding
     $row   = '';
     $msgId = 0;
 
@@ -167,7 +168,7 @@ function mailWrite(): void
         getsetting('charset', 'ISO-8859-1')
     );
     $textBody .= htmlentities(
-        Sanitize::sanitizeMb(stripslashes((string) httpget('body'))),
+        Sanitize::sanitizeMb(stripslashes($bodyGet)),
         ENT_COMPAT,
         getsetting('charset', 'ISO-8859-1')
     );


### PR DESCRIPTION
## Summary
- Capture prefilled body text from request in `$bodyGet`
- Clarify difference between loaded message body and prefilled request body
- Use `$bodyGet` when assembling message body text

## Testing
- `composer install`
- `composer test`
- `php -l pages/mail/case_write.php`


------
https://chatgpt.com/codex/tasks/task_e_68979b71b5b883299534e1bfff161896