### PR TITLE
Refactor mail address into function

### DIFF
--- a/pages/mail/case_address.php
+++ b/pages/mail/case_address.php
@@ -5,22 +5,42 @@ declare(strict_types=1);
 use Lotgd\Translator;
 use Lotgd\Http;
 
-global $output;
-
-$output->outputNotl("<form action='mail.php?op=write' method='post'>", true);
-$output->output("`b`2Address:`b`n");
-$to = Translator::translateInline("To: ");
-$forwardto = Translator::translateInline("Forward To: ");
-$search = htmlentities(Translator::translateInline("Search"), ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
 $id = (int) Http::get('id');
-$forwardlink = '';
-if ($id > 0) {
-    $to = $forwardto;
-    $forwardlink = "<input type='hidden' name='forwardto' value='$id'>";
-}
 $preop = (string) Http::get('preop');
-$output->outputNotl("`2$to <input name='to' id='to' value=\"" . htmlentities($preop, ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "\">", true);
-$output->outputNotl("<input type='submit' class='button' value=\"$search\">", true);
-$output->rawOutput($forwardlink);
-$output->rawOutput("</form>");
-$output->rawOutput("<script type='text/javascript'>document.getElementById(\"to\").focus();</script>");
+
+/**
+ * Render the address form for mail.
+ *
+ * @param int    $id    Forward recipient ID if provided.
+ * @param string $preop Prepopulated value for "to" field.
+ */
+function mailAddress(int $id, string $preop): void
+{
+    global $output;
+
+    $output->outputNotl("<form action='mail.php?op=write' method='post'>", true);
+    $output->output("`b`2Address:`b`n");
+    $to = Translator::translateInline("To: ");
+    $forwardto = Translator::translateInline("Forward To: ");
+    $search = htmlentities(Translator::translateInline("Search"), ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
+    $forwardlink = '';
+
+    if ($id > 0) {
+        $to = $forwardto;
+        $forwardlink = "<input type='hidden' name='forwardto' value='$id'>";
+    }
+
+    $output->outputNotl(
+        "`2$to <input name='to' id='to' value=\""
+        . htmlentities($preop, ENT_COMPAT, getsetting("charset", "ISO-8859-1"))
+        . "\">",
+        true
+    );
+    $output->outputNotl("<input type='submit' class='button' value=\"$search\">", true);
+    $output->rawOutput($forwardlink);
+    $output->rawOutput("</form>");
+    $output->rawOutput("<script type='text/javascript'>document.getElementById(\"to\").focus();</script>");
+}
+
+mailAddress($id, $preop);
+


### PR DESCRIPTION
## Summary
- refactor mail address page logic into reusable `mailAddress()` function
- fetch `id` and `preop` from `Http::get` and pass to new function

## Testing
- `php -l pages/mail/case_address.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68985b80069883298f8f108ea45262b8