### PR TITLE
Remove redundant PHPDoc block

### DIFF
--- a/src/Lotgd/Commentary.php
+++ b/src/Lotgd/Commentary.php
@@ -227,9 +227,6 @@ SQL;
     }
 
     /**
-     * Clean up user supplied commentary, remove line breaks and limit colour codes.
-     */
-    /**
      * Sanitize user supplied commentary, remove line breaks and limit colour codes.
      *
      * @param string $comment Raw comment text to sanitize


### PR DESCRIPTION
## Summary
- tidy up sanitizeComment docblock in Commentary

## Testing
- `php -l src/Lotgd/Commentary.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68985b81815883298f67f618175fa812