### PR TITLE
Handle missing sort order parameter in mail inbox

### DIFF
--- a/pages/mail/case_default.php
+++ b/pages/mail/case_default.php
@@ -21,7 +21,7 @@ function mailDefault(): void
     $session['message'] = '';
 
     $sortOrder = httpget('sortorder');
-    if ($sortOrder === '') {
+    if ($sortOrder === false || $sortOrder === '') {
         $sortOrder = 'date';
     }
     $order = match ($sortOrder) {


### PR DESCRIPTION
## Summary
- Ensure `renderMailTableHeader` always receives a string sort order

## Testing
- `composer install --no-interaction --no-progress`
- `php -l pages/mail/case_default.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6898619e12f08329ac770b6f4fa37519