### PR TITLE
Fix missing superuser mail warning

### DIFF
--- a/pages/mail/case_write.php
+++ b/pages/mail/case_write.php
@@ -11,7 +11,7 @@ use Lotgd\Translator;
  */
 function mailWrite(): void
 {
-    global $session;
+    global $session, $superusermessage;
 
     // Capture request values
     $subject    = (string) httppost('subject');


### PR DESCRIPTION
## Summary
- Expose the superuser warning message from game settings to the mail compose form

## Testing
- `php -l pages/mail/case_write.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689868a924508329ac9fedc41657bf63