### PR TITLE
refactor: streamline superuser warning retrieval

### DIFF
--- a/mail.php
+++ b/mail.php
@@ -10,7 +10,6 @@ use Lotgd\Mail;
 tlschema("mail");
 $args = modulehook("header-mail", array("done" => 0));
 
-$superusermessage = getsetting("superuseryommessage", "Asking an admin for gems, gold, weapons, armor, or anything else which you have not earned will not be honored.  If you are experiencing problems with the game, please use the 'Petition for Help' link instead of contacting an admin directly.");
 
 $op = httpget('op');
 $id = (int)httpget('id');

--- a/pages/mail/case_write.php
+++ b/pages/mail/case_write.php
@@ -132,7 +132,7 @@ function mailWrite(): void
 
     rawoutput("<div id='warning' style='visibility: hidden; display: none;'>");
     // superuser messages do not get translated.
-    output("`2Notice: `^%s`n", $superusermessage);
+    output("`2Notice: `^%s`n", getsetting('superuseryommessage', 'Asking an admin for gems, gold, weapons, armor, or anything else which you have not earned will not be honored. If you are experiencing problems with the game, please use the \'Petition for Help\' link instead of contacting an admin directly.'));
     // Give modules a chance to put info in here to this user
     modulehook('mail-write-notify', ['acctid_to' => $acctidTo]);
     rawoutput('</div>');


### PR DESCRIPTION
## Summary
- inline superuser message lookup during mail composition
- drop unused `$superusermessage` variable

## Testing
- `composer install`
- `php -l pages/mail/case_write.php`
- `php -l mail.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68986b9455048329b8b64b0ded706754