### PR TITLE
Handle missing allowednavs in Accounts::saveUser

### DIFF
--- a/src/Lotgd/Accounts.php
+++ b/src/Lotgd/Accounts.php
@@ -76,7 +76,7 @@ class Accounts
             // Ensure that any temporary stat modifications are removed.
             Buffs::restoreBuffFields();
 
-            $session['user']['allowednavs'] = serialize($session['allowednavs']);
+            $session['user']['allowednavs'] = serialize($session['allowednavs'] ?? []);
             $session['user']['bufflist']    = serialize($session['bufflist']);
             // legacy support, allows boolean values for alive
             $session['user']['alive']       = (int) $session['user']['alive'];

--- a/tests/AccountsDoctrineTest.php
+++ b/tests/AccountsDoctrineTest.php
@@ -94,4 +94,21 @@ final class AccountsDoctrineTest extends TestCase
         $entity = Accounts::getAccountEntity();
         $this->assertSame(1.5, $entity->getGentime());
     }
+
+    public function testSaveUserHandlesMissingAllowednavs(): void
+    {
+        unset($GLOBALS['session']['allowednavs']);
+        set_error_handler(static function (int $errno, string $errstr): bool {
+            throw new \ErrorException($errstr, 0, $errno);
+        });
+
+        try {
+            Accounts::saveUser();
+        } finally {
+            restore_error_handler();
+        }
+
+        $entity = Accounts::getAccountEntity();
+        $this->assertNotNull($entity);
+    }
 }


### PR DESCRIPTION
## Summary
- guard against undefined `allowednavs` in `Accounts::saveUser`
- add regression test ensuring missing `allowednavs` does not trigger notices

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6898bb076688832982b2b83264555044