### PR TITLE
Fix missing globals in commentary and clan membership

### DIFF
--- a/pages/clan/clan_membership.php
+++ b/pages/clan/clan_membership.php
@@ -16,7 +16,7 @@ use Lotgd\Sanitize;
  */
 function clanMembership(): void
 {
-    global $output, $session, $claninfo, $apply_short;
+    global $output, $session, $claninfo, $apply_short, $ranks;
 
     Nav::add('Clan Hall', 'clan.php');
     Nav::add('Clan Options');

--- a/src/Lotgd/Commentary.php
+++ b/src/Lotgd/Commentary.php
@@ -872,6 +872,8 @@ SQL;
      */
     public static function talkLine(string $section, string $talkline, int $limit, $schema, int $counttoday, string $message): void
     {
+        global $session;
+
         $args = modulehook("insertcomment", array("section" => $section));
         if (
             array_key_exists("mute", $args) && $args['mute'] &&


### PR DESCRIPTION
## Summary
- Declare session variable within `Commentary::talkLine` to prevent undefined variable errors
- Expose global clan ranks in `clanMembership` to avoid undefined variable notices

## Testing
- `php -l pages/clan/clan_membership.php`
- `php -l src/Lotgd/Commentary.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6898dadccf3c83298390398187f729fe