### PR TITLE
Fix debug log pagination across archive tables

### DIFF
--- a/pages/user/user_debuglog.php
+++ b/pages/user/user_debuglog.php
@@ -34,7 +34,7 @@ $max += $row['c'];
 $sql = "SELECT COUNT(id) AS c FROM $debuglog_archive WHERE target=$userid";
 $result = Database::query($sql);
 $row = Database::fetchAssoc($result);
-$max = $row['c'];
+$max += $row['c'];
 
 $sql = "SELECT COUNT(id) AS c FROM $debuglog_archive WHERE actor=$userid";
 $result = Database::query($sql);


### PR DESCRIPTION
## Summary
- Accumulate debug log counts from both main and archive tables for accurate pagination

## Testing
- `composer test`
- `php -l pages/user/user_debuglog.php`


------
https://chatgpt.com/codex/tasks/task_e_6899b52763b88329bcbe2ad7ce73e70b