### PR TITLE
Handle parenthesized SQL keywords

### DIFF
--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -100,6 +100,9 @@ class Database
         if (self::$doctrine || $bootstrapExists) {
             $conn = self::$doctrine ?? self::getDoctrineConnection();
             $trim = ltrim($sql);
+            while ($trim !== '' && $trim[0] === '(') {
+                $trim = ltrim(substr($trim, 1));
+            }
             $keyword = strtolower(strtok($trim, " \t\n\r"));
             $readOps = ['select', 'show', 'describe', 'desc', 'explain', 'pragma', 'optimize', 'analyze'];
             if (in_array($keyword, $readOps, true)) {

--- a/tests/DatabaseDoctrineTest.php
+++ b/tests/DatabaseDoctrineTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lotgd\Tests;
 
+use Lotgd\Tests\Stubs\DoctrineResult;
 use Lotgd\MySQL\Database;
 use Lotgd\Tests\Stubs\DbMysqli;
 use PHPUnit\Framework\TestCase;
@@ -57,6 +58,13 @@ final class DatabaseDoctrineTest extends TestCase
         $result = Database::query('SELECT 1');
 
         $this->assertSame(1, Database::numRows($result));
+    }
+
+    public function testUnionQueryWrappedInParenthesesReturnsDoctrineResult(): void
+    {
+        $result = Database::query('(SELECT 1) UNION (SELECT 2)');
+
+        $this->assertInstanceOf(DoctrineResult::class, $result);
     }
 
     public function testAffectedRowsAfterStatement(): void


### PR DESCRIPTION
## Summary
- ensure `Database::query` inspects the first SQL keyword after any leading parentheses
- cover UNION queries wrapped in parentheses so they return a Doctrine result

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6899b523a9b483299af1eb29235faed5