### PR TITLE
Cast debug log values to string before sanitization

### DIFF
--- a/pages/user/user_debuglog.php
+++ b/pages/user/user_debuglog.php
@@ -100,14 +100,14 @@ while ($row = Database::fetchAssoc($result)) {
     $time = date("H:i:s", strtotime($row['date'])) . " (" . reltime(strtotime($row['date'])) . ")";
     $output->outputNotl(
         "`#%s (%s) `^%s - `&%s`7 %s`0",
-        Sanitize::sanitize($row['field']),
-        Sanitize::sanitize($row['value']),
+        Sanitize::sanitize((string)$row['field']),
+        Sanitize::sanitize((string)$row['value']),
         $time,
-        Sanitize::sanitize($row['actorname']),
-        Sanitize::sanitize($row['message'])
+        Sanitize::sanitize((string)$row['actorname']),
+        Sanitize::sanitize((string)$row['message'])
     );
     if ($row['target']) {
-        $output->output(" \-- Recipient = `\$%s`0", Sanitize::sanitize($row['targetname']));
+        $output->output(" \-- Recipient = `\$%s`0", Sanitize::sanitize((string)$row['targetname']));
     }
     $output->outputNotl("`n");
 }


### PR DESCRIPTION
## Summary
- cast debug log fields to strings before calling `Sanitize::sanitize`

## Testing
- `php -l pages/user/user_debuglog.php`
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689a4f7a9d5c83298d8d345a25dcacd4