### PR TITLE
Handle numeric inputs in sanitize utility

### DIFF
--- a/src/Lotgd/Sanitize.php
+++ b/src/Lotgd/Sanitize.php
@@ -9,17 +9,17 @@ class Sanitize
     /**
      * Strip game colour codes from a string.
      *
-     * @param string|null $in Input string
+     * @param string|int|float|null $in Input value
      *
      * @return string Sanitized value
      */
-    public static function sanitize(?string $in): string
+    public static function sanitize(string|int|float|null $in): string
     {
         global $output;
         if ($in == '' || $in === null) {
             return '';
         }
-        $out = preg_replace('/[`][0' . $output->getColormapEscaped() . 'bicnHw]/', '', $in);
+        $out = preg_replace('/[`][0' . $output->getColormapEscaped() . 'bicnHw]/', '', (string) $in);
         return $out;
     }
 


### PR DESCRIPTION
## Summary
- expand `Sanitize::sanitize` to accept string, integer, float, or null
- cast input to string before regex processing

## Testing
- `php -l src/Lotgd/Sanitize.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689a5a1c7a088329a77943498858875a