### PR TITLE
Support array parameters for system mail

### DIFF
--- a/src/Lotgd/Mail.php
+++ b/src/Lotgd/Mail.php
@@ -19,8 +19,16 @@ class Mail
     /**
      * Send a system generated mail to a user.
      */
-    public static function systemMail(int $to, string $subject, string $body, int $from = 0, bool $noemail = false): void
+    public static function systemMail(int $to, string|array $subject, string|array $body, int $from = 0, bool $noemail = false): void
     {
+        if (is_array($subject)) {
+            $subject = Translator::sprintfTranslate(...$subject);
+        }
+
+        if (is_array($body)) {
+            $body = Translator::sprintfTranslate(...$body);
+        }
+
         $sql = 'SELECT prefs,emailaddress FROM ' . Database::prefix('accounts') . " WHERE acctid='$to'";
         $result = Database::query($sql);
         $row = Database::fetchAssoc($result);


### PR DESCRIPTION
## Summary
- Allow `systemMail` to accept strings or arrays for subject and body
- Translate array inputs via `Translator::sprintfTranslate`

## Testing
- `php -l src/Lotgd/Mail.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689a5cda4c1883298abdf8d289dea1fb