### PR TITLE
Translate PvP system mails before sending

### DIFF
--- a/src/Lotgd/Pvp.php
+++ b/src/Lotgd/Pvp.php
@@ -167,7 +167,11 @@ class Pvp
             reltime((int) $badguy['fightstartdate'])
         ];
 
-        Mail::systemMail($badguy['acctid'], Translator::sprintfTranslate(['`2You were killed while in %s`2', $killedloc]), $mailmessage);
+        Mail::systemMail(
+            $badguy['acctid'],
+            Translator::sprintfTranslate(['`2You were killed while in %s`2', $killedloc]),
+            Translator::sprintfTranslate(...$mailmessage)
+        );
 
         $sql = "UPDATE " . Database::prefix('accounts') . " SET alive=0, goldinbank=(goldinbank+IF(gold<{$badguy['creaturegold']},gold-{$badguy['creaturegold']},0)),gold=IF(gold<{$badguy['creaturegold']},0,gold-{$badguy['creaturegold']}), experience=IF(experience>=$lostexp,experience-$lostexp,0) WHERE acctid=" . (int) $badguy['acctid'];
         debuglog($sql, (int) $badguy['acctid'], $session['user']['acctid']);
@@ -222,7 +226,11 @@ class Pvp
             $msg .= 'You received `^%s`2 experience and `^%s`2 gold';
         }
         $msg .= '!`n%s`n`0';
-        Mail::systemMail($badguy['acctid'], ['`2You were successful while you were in %s`2', $killedloc], [$msg, $session['user']['name'], $killedloc, $wonexp, $winamount, $args['pvpmsgadd']]);
+        Mail::systemMail(
+            $badguy['acctid'],
+            Translator::sprintfTranslate(['`2You were successful while you were in %s`2', $killedloc]),
+            Translator::sprintfTranslate($msg, $session['user']['name'], $killedloc, $wonexp, $winamount, $args['pvpmsgadd'])
+        );
 
         if ($row['level'] >= $badguy['creaturelevel']) {
             $sql = "UPDATE " . Database::prefix('accounts') . " SET gold=gold+" . $winamount . ", experience=experience+" . $wonexp . " WHERE acctid=" . (int) $badguy['acctid'];


### PR DESCRIPTION
## Summary
- Translate PvP defeat and victory system mail messages before sending to ensure strings are passed to `Mail::systemMail`

## Testing
- `php -l src/Lotgd/Pvp.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689a5e9566d883298f42a1759d4150b5