### PR TITLE
Use Translator::sprintfTranslate for clan system mails

### DIFF
--- a/pages/clan/applicant_apply.php
+++ b/pages/clan/applicant_apply.php
@@ -23,11 +23,12 @@ if ($to > 0) {
     $session['user']['clanjoindate'] = date("Y-m-d H:i:s");
     $sql = "SELECT acctid FROM " . Database::prefix("accounts") . " WHERE clanid='{$session['user']['clanid']}' AND clanrank>=" . CLAN_OFFICER;
     $result = Database::query($sql);
-    $sql = "DELETE FROM " .  Database::prefix("mail") . " WHERE msgfrom=0 AND seen=0 AND subject='" . Database::escape(serialize($apply_subj)) . "'";
+    $applySubj = Translator::sprintfTranslate(...$apply_subj);
+    $msg = Translator::sprintfTranslate("`^You have a new clan applicant!  `&%s`^ has completed a membership application for your clan!", $session['user']['name']);
+    $sql = "DELETE FROM " .  Database::prefix("mail") . " WHERE msgfrom=0 AND seen=0 AND subject='" . Database::escape($applySubj) . "'";
     Database::query($sql);
     while ($row = Database::fetchAssoc($result)) {
-        $msg = array("`^You have a new clan applicant!  `&%s`^ has completed a membership application for your clan!",$session['user']['name']);
-        Mail::systemMail($row['acctid'], $apply_subj, $msg);
+        Mail::systemMail($row['acctid'], $applySubj, $msg);
     }
 
     // send reminder mail if clan of choice has a description
@@ -40,7 +41,15 @@ if ($to > 0) {
         $subject = "Clan Application Reminder";
         $mail = "`&Did you remember to read the description of the clan of your choice before applying?  Note that some clans may have requirements that you have to fulfill before you can become a member.  If you are not accepted into the clan of your choice anytime soon, it may be because you have not fulfilled these requirements.  For your convenience, the description of the clan you are applying to is reproduced below.`n`n`c`#%s`@ <`^%s`@>`0`c`n%s";
 
-        Mail::systemMail($session['user']['acctid'], array($subject), array($mail, $row['clanname'], $row['clanshort'], addslashes(Nltoappon::convert($row['clandesc']))));
+        $subject = Translator::sprintfTranslate($subject);
+        $mail = Translator::sprintfTranslate(
+            $mail,
+            $row['clanname'],
+            $row['clanshort'],
+            addslashes(Nltoappon::convert($row['clandesc']))
+        );
+
+        Mail::systemMail($session['user']['acctid'], $subject, $mail);
     }
 } else {
     $order = (int)Http::get('order');

--- a/pages/clan/clan_withdraw.php
+++ b/pages/clan/clan_withdraw.php
@@ -8,6 +8,7 @@ use Lotgd\MySQL\Database;
 use Lotgd\Nav;
 use Lotgd\DebugLog;
 use Lotgd\GameLog;
+use Lotgd\Translator;
 
         Modules::hook("clan-withdraw", array('clanid' => $session['user']['clanid'], 'clanrank' => $session['user']['clanrank'], 'acctid' => $session['user']['acctid']));
 if ($session['user']['clanrank'] >= CLAN_LEADER) {
@@ -50,12 +51,14 @@ if ($session['user']['clanrank'] >= CLAN_LEADER) {
 }
         $sql = "SELECT acctid FROM " . Database::prefix("accounts") . " WHERE clanid='{$session['user']['clanid']}' AND clanrank>=" . CLAN_OFFICER . " AND acctid<>'{$session['user']['acctid']}'";
         $result = Database::query($sql);
-        $withdraw_subj = array("`\$Clan Withdraw: `&%s`0",$session['user']['name']);
-        $msg = array("`^One of your clan members has resigned their membership.  `&%s`^ has surrendered their position within your clan!",$session['user']['name']);
-        $sql = "DELETE FROM " . Database::prefix("mail") . " WHERE msgfrom=0 AND seen=0 AND subject='" . addslashes(serialize($withdraw_subj)) . "'"; //addslashes for names with ' inside
+        $withdraw_subj = array("`\$Clan Withdraw: `&%s`0", $session['user']['name']);
+        $withdraw_msg = array("`^One of your clan members has resigned their membership.  `&%s`^ has surrendered their position within your clan!", $session['user']['name']);
+        $withdrawSubj = Translator::sprintfTranslate(...$withdraw_subj);
+        $withdrawMsg = Translator::sprintfTranslate(...$withdraw_msg);
+        $sql = "DELETE FROM " . Database::prefix("mail") . " WHERE msgfrom=0 AND seen=0 AND subject='" . Database::escape($withdrawSubj) . "'";
         Database::query($sql);
 while ($row = Database::fetchAssoc($result)) {
-    Mail::systemMail($row['acctid'], $withdraw_subj, $msg);
+    Mail::systemMail($row['acctid'], $withdrawSubj, $withdrawMsg);
 }
 
         DebugLog::add($session['user']['login'] . " has withdrawn from his/her clan no. " . $session['user']['clanid']);


### PR DESCRIPTION
## Summary
- Convert array-based subjects and bodies to strings before calling `Mail::systemMail` in clan applicant and withdraw pages
- Escape withdraw mail subject via `Database::escape`

## Testing
- `php -l pages/clan/applicant_apply.php`
- `php -l pages/clan/clan_withdraw.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689a62fe9a088329955799c3f5c2700a