### PR TITLE
Add MOTD preview support

### DIFF
--- a/motd.php
+++ b/motd.php
@@ -39,13 +39,20 @@ if ($op == "vote") {
     exit();
 }
 if (($op == "save" || $op == "savenew") && ($session['user']['superuser'] & SU_POST_MOTD)) {
-    if ($op == "save") {
-            Motd::saveMotd((int)$id);
+    if (httppost('preview')) {
+        $title = httppost('motdtitle');
+        $body = nltoappon((string) httppost('motdbody'));
+        Motd::motdItem($title, $body, $session['user']['name'], date('Y-m-d H:i:s'), (int) $id);
+        Motd::motdForm((int) $id, $_POST);
     } else {
+        if ($op == "save") {
+            Motd::saveMotd((int) $id);
+        } else {
             Motd::savePoll();
-    }
+        }
         header("Location: motd.php");
         exit();
+    }
 }
 if ($op == "add" || $op == "addpoll" || $op == "del") {
     if ($session['user']['superuser'] & SU_POST_MOTD) {

--- a/src/Lotgd/Motd.php
+++ b/src/Lotgd/Motd.php
@@ -179,6 +179,7 @@ class Motd
             'changedate'   => '0',
         ];
         $data = array_merge($defaults, $data);
+        // The third parameter 'true' enables form preview mode.
         Forms::showForm($form, $data, true);
         $preview = Translator::translateInline('Preview');
         $save = Translator::translateInline('Save');

--- a/src/Lotgd/Motd.php
+++ b/src/Lotgd/Motd.php
@@ -145,7 +145,7 @@ class Motd
     /**
      * Display edit form for a MOTD record.
      */
-    public static function motdForm(int $id): void
+    public static function motdForm(int $id, array $data = []): void
     {
         require_once 'lib/showform.php';
         $sql = 'SELECT motdtitle,motdbody,motdtype FROM ' . Database::prefix('motd') . " WHERE motditem='$id'";
@@ -160,19 +160,30 @@ class Motd
             $body = '';
             $poll = '0';
         }
-        $form = array(
+        $form = [
             'Motd,title',
             'motdtitle' => 'Title,string,50',
             'motdbody'  => 'Body,textarea,37',
             'motdtype'  => 'Type,viewhiddenonly',
-        );
+        ];
         if ($id > 0) {
             $form['changeauthor'] = 'Change Author,checklist';
             $form['changedate'] = 'Change Date (force popup),checklist';
         }
         output('<form action="motd.php?op=save&id=' . (int)$id . '" method="post">', true);
-        $data = ['motdtitle' => $title, 'motdbody' => $body, 'motdtype' => $poll, 'changeauthor' => '0', 'changedate' => '0'];
-        Forms::showForm($form, $data);
+        $defaults = [
+            'motdtitle'    => $title,
+            'motdbody'     => $body,
+            'motdtype'     => $poll,
+            'changeauthor' => '0',
+            'changedate'   => '0',
+        ];
+        $data = array_merge($defaults, $data);
+        Forms::showForm($form, $data, true);
+        $preview = Translator::translateInline('Preview');
+        $save = Translator::translateInline('Save');
+        rawoutput("<input type='submit' name='preview' class='button' value='$preview'>");
+        rawoutput("<input type='submit' class='button' value='$save'>");
         rawoutput('</form>');
     }
 


### PR DESCRIPTION
## Summary
- Allow editing form to prepopulate values and include Preview/Save buttons
- Add preview handling to `motd.php` for MOTD submissions

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689af37dc9508329b9ec91e7f1996719