### PR TITLE
Handle float seconds in DateTime::readableTime

### DIFF
--- a/src/Lotgd/DateTime.php
+++ b/src/Lotgd/DateTime.php
@@ -21,10 +21,12 @@ class DateTime
 
     /**
      * Convert a duration in seconds to a readable string.
+     *
+     * Accepts seconds as a float but ignores the fractional part.
      */
-    public static function readableTime(int $date, bool $short = true): string
+    public static function readableTime(float $date, bool $short = true): string
     {
-        $x = abs($date);
+        $x = (int) abs($date);
         $d = (int)($x / 86400);
         $x %= 86400;
         $h = (int)($x / 3600);

--- a/tests/DateTimeTest.php
+++ b/tests/DateTimeTest.php
@@ -23,6 +23,12 @@ final class DateTimeTest extends TestCase
         $this->assertSame('2 days, 3 hours', DateTime::readableTime($seconds, false));
     }
 
+    public function testReadableTimeAcceptsFloat(): void
+    {
+        $seconds = 61.7; // 1 minute and 1 second (fraction ignored)
+        $this->assertSame('1m1s', DateTime::readableTime($seconds));
+    }
+
     public function testRelTimeShortFormat(): void
     {
         $diff = 3600 + 60; // 1 hour and 1 minute


### PR DESCRIPTION
## Summary
- allow DateTime::readableTime to accept float durations
- add regression test for float input

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689c5fa5dd688329b66f4305d695c074