### PR TITLE
Use checkbox fields for MOTD author/date options

### DIFF
--- a/src/Lotgd/Motd.php
+++ b/src/Lotgd/Motd.php
@@ -167,16 +167,16 @@ class Motd
             'motdtype'  => 'Type,viewhiddenonly',
         ];
         if ($id > 0) {
-            $form['changeauthor'] = 'Change Author,checklist';
-            $form['changedate'] = 'Change Date (force popup),checklist';
+            $form['changeauthor'] = 'Change Author,checkbox';
+            $form['changedate'] = 'Change Date (force popup),checkbox';
         }
         output('<form action="motd.php?op=save&id=' . (int)$id . '" method="post">', true);
         $defaults = [
             'motdtitle'    => $title,
             'motdbody'     => $body,
             'motdtype'     => $poll,
-            'changeauthor' => '0',
-            'changedate'   => '0',
+            'changeauthor' => 0,
+            'changedate'   => 0,
         ];
         $data = array_merge($defaults, $data);
         // The third parameter 'true' enables form preview mode.


### PR DESCRIPTION
## Summary
- Switch `changeauthor` and `changedate` form fields from checklist to checkbox and set integer defaults
- Keep `saveMotd()` reading these options as booleans via `httppost`

## Testing
- `composer install`
- `composer test`
- `php -l src/Lotgd/Motd.php`


------
https://chatgpt.com/codex/tasks/task_e_689c5fa977508329a4863a408d055ab5