### PR TITLE
Use Nltoappon when rendering biography text

### DIFF
--- a/bio.php
+++ b/bio.php
@@ -20,6 +20,7 @@ use Lotgd\Modules\HookHandler;
 use Lotgd\MySQL\Database;
 use Lotgd\Sanitize;
 use Lotgd\DateTime;
+use Lotgd\Nltoappon;
 
 require_once("common.php");
 
@@ -132,7 +133,7 @@ if ($target = Database::fetchAssoc($result)) {
     }
 
     if ($target['bio'] > "") {
-        $output->output("`^Bio: `@`n%s`n", soap($target['bio']));
+        $output->output("`^Bio: `@`n%s`n", Nltoappon::convert(soap($target['bio'])));
     }
 
     HookHandler::hook("bioinfo", $target);


### PR DESCRIPTION
## Summary
- import `Lotgd\Nltoappon` in `bio.php`
- convert sanitized biography text with `Nltoappon::convert` before output

## Testing
- `php -l bio.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689c61e551cc8329bec81b7d53ecf520