### PR TITLE
Hash long cache keys in DataCache

### DIFF
--- a/src/Lotgd/DataCache.php
+++ b/src/Lotgd/DataCache.php
@@ -145,7 +145,14 @@ class DataCache
         }
         $name = rawurlencode($name);
         $name = str_replace('_', '-', $name);
-        $name = DATACACHE_FILENAME_PREFIX . preg_replace("'[^A-Za-z0-9.-]'", '', $name);
+        $name = preg_replace("'[^A-Za-z0-9.-]'", '', $name);
+
+        if (strlen($name) > 200) {
+            // Preserve a short prefix but replace the rest with a hash when the key is too long
+            $name = substr($name, 0, 40) . '-' . sha1($name);
+        }
+
+        $name = DATACACHE_FILENAME_PREFIX . $name;
         $fullname = self::$path . '/' . $name;
         $fullname = preg_replace("'//'", '/', $fullname);
         $fullname = preg_replace("'\\\\'", '\\', $fullname);

--- a/tests/DataCacheTest.php
+++ b/tests/DataCacheTest.php
@@ -77,6 +77,17 @@ final class DataCacheTest extends TestCase
         $this->assertFileDoesNotExist(DataCache::makecachetempname('failpath'));
     }
 
+    public function testLongCacheKeyIsHashed(): void
+    {
+        $longKey = str_repeat('a', 250);
+        $data = ['foo' => 'bar'];
+
+        $this->assertTrue(DataCache::updatedatacache($longKey, $data));
+        $expected = DATACACHE_FILENAME_PREFIX . substr($longKey, 0, 40) . '-' . sha1($longKey);
+        $this->assertSame($expected, basename(DataCache::makecachetempname($longKey)));
+        $this->assertSame($data, DataCache::datacache($longKey));
+    }
+
     public function testUpdateCacheFailureOnJsonError(): void
     {
         $resource = tmpfile();


### PR DESCRIPTION
## Summary
- Shorten cache filenames over 200 characters by hashing while keeping a small prefix
- Test DataCache with extremely long keys

## Testing
- `php -l src/Lotgd/DataCache.php tests/DataCacheTest.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689cb3f6324083298fbe2b987f35e858