### PR TITLE
Limit translation namespace cache key length

### DIFF
--- a/src/Lotgd/Sanitize.php
+++ b/src/Lotgd/Sanitize.php
@@ -6,6 +6,8 @@ namespace Lotgd;
 
 class Sanitize
 {
+    public const URI_MAX_LENGTH = 200;
+
     /**
      * Strip game colour codes from a string.
      *
@@ -165,6 +167,9 @@ class Sanitize
         $uri = self::cmdSanitize($uri);
         if (substr($uri, -1) == '?') {
             $uri = substr($uri, 0, -1);
+        }
+        if (strlen($uri) > self::URI_MAX_LENGTH) {
+            $uri = substr($uri, 0, self::URI_MAX_LENGTH);
         }
         return $uri;
     }

--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -291,7 +291,11 @@ class Translator
         if (isset($settings) && !$settings->getSetting("cachetranslations", 0)) {
             $result = Database::query($sql);
         } else {
-            $result = Database::queryCached($sql, "translations-" . $namespace . "-" . $language, 600);
+            $cacheNamespace = $namespace;
+            if (strlen($cacheNamespace) > Sanitize::URI_MAX_LENGTH) {
+                $cacheNamespace = sha1($cacheNamespace);
+            }
+            $result = Database::queryCached($sql, "translations-" . $cacheNamespace . "-" . $language, 600);
             //store it for 10 Minutes, normally you don't need to refresh this often
         }
         $out = array();

--- a/tests/SanitizeExtraTest.php
+++ b/tests/SanitizeExtraTest.php
@@ -52,6 +52,13 @@ final class SanitizeExtraTest extends TestCase
         $this->assertSame('page.php', Sanitize::translatorPage($clean));
     }
 
+    public function testTranslatorUriMaxLength(): void
+    {
+        $uri = 'page.php?op=' . str_repeat('a', 500);
+        $clean = Sanitize::translatorUri($uri);
+        $this->assertLessThanOrEqual(Sanitize::URI_MAX_LENGTH, strlen($clean));
+    }
+
     public function testModulenameSanitize(): void
     {
         $this->assertSame('ModuleName', Sanitize::modulenameSanitize('Module!Name'));

--- a/tests/Stubs/Database.php
+++ b/tests/Stubs/Database.php
@@ -13,6 +13,7 @@ class Database
     public static int $onlineCounter = 0;
     public static int $affected_rows = 0;
     public static string $lastSql = '';
+    public static string $lastCacheName = '';
     public static array $describe_rows = [];
     public static array $keys_rows = [];
     public static ?object $doctrineConnection = null;
@@ -248,6 +249,8 @@ class Database
 
     public static function queryCached(string $sql, string $name, int $duration = 900): array
     {
+        self::$lastSql = $sql;
+        self::$lastCacheName = $name;
         return [];
     }
 

--- a/tests/TranslatorNamespaceTest.php
+++ b/tests/TranslatorNamespaceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Translator;
+use Lotgd\Sanitize;
+use Lotgd\DataCache;
+use Lotgd\Tests\Stubs\CacheDummySettings;
+use PHPUnit\Framework\TestCase;
+
+final class TranslatorNamespaceTest extends TestCase
+{
+    private string $cacheDir;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = sys_get_temp_dir() . '/lotgd_cache_' . uniqid();
+        mkdir($this->cacheDir, 0700, true);
+        $GLOBALS['settings'] = new CacheDummySettings([
+            'datacachepath' => $this->cacheDir,
+            'usedatacache'  => 1,
+        ]);
+        $GLOBALS['session'] = [];
+        if (!defined('LANGUAGE')) {
+            define('LANGUAGE', 'en');
+        }
+        $GLOBALS['language'] = 'en';
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->cacheDir . '/*') as $file) {
+            unlink($file);
+        }
+        rmdir($this->cacheDir);
+        unset($GLOBALS['settings'], $GLOBALS['session'], $GLOBALS['language']);
+    }
+
+    public function testLongNamespaceUsesShortCacheKey(): void
+    {
+        $longNamespace = str_repeat('a', 500);
+        Translator::translateLoadNamespace($longNamespace, 'en');
+        $cacheName = \Lotgd\MySQL\Database::$lastCacheName;
+        $expectedNamespace = strlen($longNamespace) > Sanitize::URI_MAX_LENGTH
+            ? sha1($longNamespace)
+            : $longNamespace;
+        $expected = 'translations-' . $expectedNamespace . '-en';
+        $this->assertSame($expected, $cacheName);
+        $cacheFile = DataCache::makecachetempname($cacheName);
+        $this->assertLessThan(255, strlen($cacheFile));
+        $this->assertTrue(DataCache::updatedatacache($cacheName, ['ok' => true]));
+        $this->assertFileExists($cacheFile);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Truncate URIs using a new `Sanitize::URI_MAX_LENGTH` and limit translator cache keys
- Hash overly long namespaces before caching translations
- Cover long-namespace scenarios with unit tests

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689cb3fb2ac88329827b067c6f78631c