### PR TITLE
Safely unserialize session data

### DIFF
--- a/src/Lotgd/ForcedNavigation.php
+++ b/src/Lotgd/ForcedNavigation.php
@@ -26,14 +26,17 @@ class ForcedNavigation
                 global $baseaccount;
                 $baseaccount = $session['user'];
                 self::$baseAccount = $session['user'];
-                $session['bufflist'] = unserialize($session['user']['bufflist']);
+                $session['bufflist'] = Serialization::safeUnserialize($session['user']['bufflist']);
                 if (!is_array($session['bufflist'])) {
                     $session['bufflist'] = [];
                 }
-                $session['user']['dragonpoints'] = unserialize($session['user']['dragonpoints']);
-                $session['user']['prefs'] = unserialize($session['user']['prefs']);
+                $session['user']['dragonpoints'] = Serialization::safeUnserialize($session['user']['dragonpoints']);
                 if (!is_array($session['user']['dragonpoints'])) {
                     $session['user']['dragonpoints'] = [];
+                }
+                $session['user']['prefs'] = Serialization::safeUnserialize($session['user']['prefs']);
+                if (!is_array($session['user']['prefs'])) {
+                    $session['user']['prefs'] = [];
                 }
                 $allowednavs = Serialization::safeUnserialize($session['user']['allowednavs']);
                 if (is_array($allowednavs)) {

--- a/src/Lotgd/ForcedNavigation.php
+++ b/src/Lotgd/ForcedNavigation.php
@@ -6,6 +6,7 @@ namespace Lotgd;
 
 use Lotgd\Translator;
 use Lotgd\MySQL\Database;
+use Lotgd\Serialization;
 
 class ForcedNavigation
 {


### PR DESCRIPTION
## Summary
- Use Serialization::safeUnserialize for `bufflist`, `dragonpoints`, and `prefs`
- Default session arrays to empty arrays when deserialization fails

## Testing
- `php -l src/Lotgd/ForcedNavigation.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689cb4026ed083299a4b79d3fa1e7fd6