### PR TITLE
fix: use compound bitwise OR

### DIFF
--- a/sha1.js
+++ b/sha1.js
@@ -52,7 +52,7 @@ function sha1_vm_test()
 function core_sha1(x, len)
 {
   /* append padding */
-    x[len >> 5] |  = 0x80 << (24 - len % 32);
+    x[len >> 5] |= 0x80 << (24 - len % 32);
     x[((len + 64 >> 9) << 4) + 15] = len;
 
     var w = Array(80);
@@ -171,7 +171,7 @@ function str2binb(str)
     var bin = Array();
     var mask = (1 << chrsz) - 1;
     for (var i = 0; i < str.length * chrsz; i += chrsz) {
-        bin[i >> 5] |  = (str.charCodeAt(i / chrsz) & mask) << (32 - chrsz - i % 32);
+        bin[i >> 5] |= (str.charCodeAt(i / chrsz) & mask) << (32 - chrsz - i % 32);
     }
     return bin;
 }


### PR DESCRIPTION
## Summary
- fix SHA-1 implementation to use compound bitwise OR assignment

## Testing
- `node -e "const fs=require('fs');eval(fs.readFileSync('sha1.js','utf8'));console.log('sha1_vm_test:',sha1_vm_test());console.log('hex_sha1 abc:',hex_sha1('abc'));"`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689f5552f1148329aa93dd8e3de0c445