### PR TITLE
feat: add fallback methods for URL pulling

### DIFF
--- a/src/Lotgd/PullUrl.php
+++ b/src/Lotgd/PullUrl.php
@@ -93,6 +93,24 @@ class PullUrl
     public static function pull(string $url)
     {
         // Prefer file() to avoid open_basedir issues.
-        return @file($url);
+        $data = @file($url);
+        if (false !== $data) {
+            return $data;
+        }
+
+        debug("file() failed for $url, trying curl()");
+        $data = self::curl($url);
+        if (false !== $data) {
+            return $data;
+        }
+
+        debug("curl() failed for $url, trying socket connection");
+        $data = self::sock($url);
+        if (false !== $data) {
+            return $data;
+        }
+
+        debug("Unable to fetch $url using available methods");
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- retry URL retrieval with cURL and socket methods if `file()` fails
- log failures to help admins debug connectivity issues

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689f7745493c832990bd2685135c81ac