### PR TITLE
Handle missing session in AJAX timeout_status

### DIFF
--- a/ext/ajax_server.php
+++ b/ext/ajax_server.php
@@ -89,6 +89,10 @@ function timeout_status($args = false): Response
             return jaxon()->newResponse();
         };
         global $session;
+        if (!isset($session['user'])) {
+            error_log('timeout_status: session user not set');
+            return jaxon()->newResponse();
+        }
         $warning = '';
         if ($never_timeout_if_browser_open == 1) {
             $session['user']['laston'] = date("Y-m-d H:i:s"); // set to now


### PR DESCRIPTION
## Summary
- Safeguard `timeout_status` against undefined session user and log the condition

## Testing
- `php -l ext/ajax_server.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689f7747930083298c2f2d1b79a9e251