### PR TITLE
Add placeholder count check for Translator sprintfTranslate

### DIFF
--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -174,6 +174,14 @@ class Translator
                 $args[$key] = self::sprintfTranslate(...$val);
             }
         }
+        $placeholderCount = substr_count(preg_replace('/%%/', '', (string) $args[0]), '%');
+        $argCount = count($args) - 1;
+        if ($placeholderCount !== $argCount) {
+            trigger_error(sprintf('sprintfTranslate expected %d arguments, got %d', $placeholderCount, $argCount), E_USER_WARNING);
+            if ($placeholderCount > $argCount) {
+                $args = array_merge($args, array_fill(0, $placeholderCount - $argCount, ''));
+            }
+        }
         ob_start();
         if (is_array($args) && count($args) > 0) {
             //if it is an array

--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -174,7 +174,8 @@ class Translator
                 $args[$key] = self::sprintfTranslate(...$val);
             }
         }
-        $placeholderCount = substr_count(preg_replace('/%%/', '', (string) $args[0]), '%');
+        preg_match_all('/(?<!%)%[a-zA-Z]/', (string) $args[0], $matches);
+        $placeholderCount = count($matches[0]);
         $argCount = count($args) - 1;
         if ($placeholderCount !== $argCount) {
             trigger_error(sprintf('sprintfTranslate expected %d arguments, got %d', $placeholderCount, $argCount), E_USER_WARNING);

--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -180,7 +180,7 @@ class Translator
         if ($placeholderCount !== $argCount) {
             trigger_error(sprintf('sprintfTranslate expected %d arguments, got %d', $placeholderCount, $argCount), E_USER_WARNING);
             if ($placeholderCount > $argCount) {
-                $args = array_merge($args, array_fill(0, $placeholderCount - $argCount, ''));
+                $args = array_pad($args, $placeholderCount + 1, '');
             }
         }
         ob_start();

--- a/tests/TranslatorSprintfTranslateTest.php
+++ b/tests/TranslatorSprintfTranslateTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Translator;
+use Lotgd\Tests\Stubs\DummySettings;
+use PHPUnit\Framework\TestCase;
+
+final class TranslatorSprintfTranslateTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['settings'] = new DummySettings(['enabletranslation' => true]);
+        $GLOBALS['session'] = [];
+        $GLOBALS['REQUEST_URI'] = '/';
+        if (!defined('LANGUAGE')) {
+            define('LANGUAGE', 'en');
+        }
+        $GLOBALS['language'] = 'en';
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['settings'], $GLOBALS['session'], $GLOBALS['REQUEST_URI'], $GLOBALS['language']);
+    }
+
+    public function testSprintfTranslateWithMatchingArguments(): void
+    {
+        $result = Translator::sprintfTranslate('Hello %s', 'World');
+        $this->assertSame('Hello World', $result);
+    }
+
+    public function testSprintfTranslateWithMissingArgumentsLogsWarningAndPads(): void
+    {
+        $warnings = [];
+        set_error_handler(function (int $errno, string $errstr) use (&$warnings): bool {
+            $warnings[] = [$errno, $errstr];
+            return true;
+        }, E_USER_WARNING);
+        $result = Translator::sprintfTranslate('Value: %s %s', 'First');
+        restore_error_handler();
+        $this->assertSame('Value: First ', $result);
+        $this->assertNotEmpty($warnings);
+        $this->assertStringContainsString('expected 2 arguments, got 1', $warnings[0][1]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- validate placeholder counts before formatting translations
- warn and pad missing args to prevent sprintf errors
- cover matching and mismatched arg cases in tests

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a027e8de9083298fd7511fbc0bedca