### PR TITLE
Translate defeat locations via forestdefeat

### DIFF
--- a/lib/forestoutcomes.php
+++ b/lib/forestoutcomes.php
@@ -3,10 +3,17 @@
 // Legacy wrapper for \Lotgd\Forest\Outcomes class
 
 use Lotgd\Forest\Outcomes;
+use Lotgd\Translator;
 
-require_once("lib/output.php");
-require_once("lib/nav.php");
-require_once("lib/playerfunctions.php");
+if (!function_exists('output')) {
+    require_once 'lib/output.php';
+}
+if (!function_exists('addnav')) {
+    require_once 'lib/nav.php';
+}
+if (!function_exists('restore_buff_fields')) {
+    require_once 'lib/playerfunctions.php';
+}
 
 function forestvictory($enemies, $denyflawless = false): void
 {
@@ -15,11 +22,10 @@ function forestvictory($enemies, $denyflawless = false): void
 
 function forestdefeat($enemies, $where = 'in the forest'): void
 {
-    // Normalize $where to ensure it is always a string
     if (is_array($where)) {
-        $where = implode(', ', $where); // Convert array to string
+        $where = Translator::sprintfTranslate(...$where);
     } elseif (!is_string($where)) {
-        $where = 'in the forest'; // Fallback to default value
+        $where = 'in the forest';
     }
     Outcomes::defeat($enemies, $where);
 }

--- a/modules/cities/run.php
+++ b/modules/cities/run.php
@@ -200,9 +200,10 @@ if ($battle) {
             "runmodule.php?module=cities&city=" . urlencode($city) . "&d=$danger&continue=1"
         );
     } elseif ($defeat) {
-            Outcomes::defeat($newenemies, sprintf("travelling to %s", $city));
+        require_once 'lib/forestoutcomes.php';
+        forestdefeat($newenemies, ['travelling to %s', $city]);
     } else {
         FightNav::fightnav(true, true, "runmodule.php?module=cities&city=" . urlencode($city) . "&d=$danger");
     }
-            page_footer();
+    page_footer();
 }

--- a/tests/ForestDefeatLocationTest.php
+++ b/tests/ForestDefeatLocationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Forest;
+
+class Outcomes
+{
+    public static string $lastWhere;
+
+    public static function defeat($enemies, $where): void
+    {
+        self::$lastWhere = $where;
+    }
+}
+
+namespace Lotgd\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../lib/forestoutcomes.php';
+
+final class ForestDefeatLocationTest extends TestCase
+{
+    public function testArrayWhereIsTranslated(): void
+    {
+        \forestdefeat([], ['travelling to %s', 'Gotham']);
+        $this->assertSame('travelling to Gotham', \Lotgd\Forest\Outcomes::$lastWhere);
+    }
+}
+


### PR DESCRIPTION
## Summary
- use `Translator::sprintfTranslate` when `forestdefeat` receives array location data
- pass defeat location as translation template in cities module
- add regression test for translated defeat locations

## Testing
- `php -l lib/forestoutcomes.php`
- `php -l modules/cities/run.php`
- `php -l tests/ForestDefeatLocationTest.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a029de7608832984cc9d917b8ffe24