### PR TITLE
Trim death message placeholders before substitution

### DIFF
--- a/src/Lotgd/DeathMessage.php
+++ b/src/Lotgd/DeathMessage.php
@@ -63,8 +63,10 @@ class DeathMessage
             $taunt = 1;
             $deathmessage = "`5\"`6{goodguyname}'s mother wears combat boots`5\", screams {badguyname}.";
         }
-        if (isset($extra[0]) && $extra[0] == '{where}') {
+        if (isset($extra[0]) && $extra[0] === '{where}') {
             $deathmessage = str_replace($extra[0], $extrarep[0] ?? 'UNKNOWN', $deathmessage);
+            array_shift($extra);
+            array_shift($extrarep);
         }
         $deathmessage = Substitute::applyArray($deathmessage, $extra, $extrarep);
         array_unshift($deathmessage, true, 'deathmessages');

--- a/tests/DeathMessageNewsArgumentsTest.php
+++ b/tests/DeathMessageNewsArgumentsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\AddNews;
+use Lotgd\DeathMessage;
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
+
+final class DeathMessageNewsArgumentsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        class_exists(Database::class);
+        \Lotgd\Translator::tlschema('ns');
+        Database::$lastSql = '';
+        $GLOBALS['session'] = ['user' => [
+            'acctid' => 3,
+            'sex'    => 0,
+            'weapon' => 'sword',
+            'armor'  => 'armor',
+            'name'   => 'Hero',
+        ]];
+        $GLOBALS['badguy'] = ['creatureweapon' => 'claws', 'creaturename' => 'Dragon'];
+    }
+
+    protected function tearDown(): void
+    {
+        \Lotgd\Translator::tlschema(false);
+        unset($GLOBALS['session'], $GLOBALS['badguy']);
+    }
+
+    public function testNewsArgumentsContainOnlyTemplateValues(): void
+    {
+        $where = 'in the forest';
+        $deathmessage = DeathMessage::selectArray(true, ['{where}'], [$where]);
+
+        AddNews::add('%s`n%s', $deathmessage['deathmessage'], 'taunt');
+
+        $this->assertTrue(
+            preg_match("/VALUES \('.*','.*',\d+,'([^']*)','ns'\)/", Database::$lastSql, $matches) === 1
+        );
+        $args = unserialize(stripslashes($matches[1]));
+
+        $this->assertCount(2, $args); // deathmessage array and taunt
+        $deathArgs = $args[0];
+        $this->assertSame(['`^Hero`^', 'Dragon'], array_slice($deathArgs, 3));
+    }
+}

--- a/tests/Stubs/Database.php
+++ b/tests/Stubs/Database.php
@@ -93,6 +93,14 @@ class Database
             return $last_query_result;
         }
 
+        if (preg_match("/SELECT deathmessage,taunt FROM deathmessages/", $sql)) {
+            $last_query_result = [[
+                'deathmessage' => '{goodguyname} met {badguyname} {where}.',
+                'taunt'        => 1,
+            ]];
+            return $last_query_result;
+        }
+
         if (strpos($sql, 'INSERT INTO mail') === 0) {
             if (preg_match("/\((?:'|\")?(\d+)(?:'|\")?,(?:'|\")?(\d+)(?:'|\")?,(?:'|\")?(.*?)(?:'|\")?,(?:'|\")?(.*?)(?:'|\")?,(?:'|\")?(.*?)(?:'|\")?\)/", $sql, $m)) {
                 $from = (int) $m[1];

--- a/tests/Stubs/Functions.php
+++ b/tests/Stubs/Functions.php
@@ -154,6 +154,13 @@ namespace {
         }
     }
 
+    if (!function_exists('e_rand')) {
+        function e_rand(int $min = 0, int $max = PHP_INT_MAX): int
+        {
+            return mt_rand($min, $max);
+        }
+    }
+
     if (!function_exists('soap')) {
         function soap($input, $debug = false, $skiphook = false)
         {


### PR DESCRIPTION
## Summary
- Trim the `{where}` placeholder and its value before applying `Substitute::applyArray`
- Add regression test ensuring news arguments store only required death-message values

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a06315b27c83298eeff45d15ffe626