### PR TITLE
Handle extra arguments in Translator::sprintfTranslate

### DIFF
--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -178,8 +178,13 @@ class Translator
         $placeholderCount = count($matches[0]);
         $argCount = count($args) - 1;
         if ($placeholderCount !== $argCount) {
-            trigger_error(sprintf('sprintfTranslate expected %d arguments, got %d', $placeholderCount, $argCount), E_USER_WARNING);
-            if ($placeholderCount > $argCount) {
+            if ($argCount > $placeholderCount) {
+                $args = array_slice($args, 0, $placeholderCount + 1);
+            } else {
+                trigger_error(
+                    sprintf('sprintfTranslate expected %d arguments, got %d', $placeholderCount, $argCount),
+                    E_USER_WARNING
+                );
                 $args = array_pad($args, $placeholderCount + 1, '');
             }
         }

--- a/tests/TranslatorSprintfTranslateTest.php
+++ b/tests/TranslatorSprintfTranslateTest.php
@@ -45,5 +45,18 @@ final class TranslatorSprintfTranslateTest extends TestCase
         $this->assertNotEmpty($warnings);
         $this->assertStringContainsString('expected 2 arguments, got 1', $warnings[0][1]);
     }
+
+    public function testSprintfTranslateWithExtraArgumentsDropsExtraWithoutWarning(): void
+    {
+        $warnings = [];
+        set_error_handler(function (int $errno, string $errstr) use (&$warnings): bool {
+            $warnings[] = [$errno, $errstr];
+            return true;
+        }, E_USER_WARNING);
+        $result = Translator::sprintfTranslate('Values: %s and %s', 'First', 'Second', 'Third');
+        restore_error_handler();
+        $this->assertSame('Values: First and Second', $result);
+        $this->assertEmpty($warnings);
+    }
 }
 


### PR DESCRIPTION
## Summary
- drop additional arguments beyond available placeholders in `Translator::sprintfTranslate`
- test that extra sprintf args don't trigger warnings or produce output

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a0632420bc8329bbc9cb63ca17675a