### PR TITLE
Handle advanced sprintf placeholders and stray percents

### DIFF
--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -174,20 +174,17 @@ class Translator
                 $args[$key] = self::sprintfTranslate(...$val);
             }
         }
-        preg_match_all('/(?<!%)%[a-zA-Z]/', (string) $args[0], $matches);
+        preg_match_all('/(?<!%)%(?:\d+\$)?[0-9\+\-#\.]*[a-zA-Z]/', (string) $args[0], $matches);
         $placeholderCount = count($matches[0]);
         $argCount = count($args) - 1;
         if ($placeholderCount !== $argCount) {
             if ($argCount > $placeholderCount) {
                 $args = array_slice($args, 0, $placeholderCount + 1);
             } else {
-                trigger_error(
-                    sprintf('sprintfTranslate expected %d arguments, got %d', $placeholderCount, $argCount),
-                    E_USER_WARNING
-                );
                 $args = array_pad($args, $placeholderCount + 1, '');
             }
         }
+        $args[0] = preg_replace('/(?<!%)%(?!(?:\d+\$)?[0-9\+\-#\.]*[a-zA-Z]|%)/', '%%', $args[0]);
         ob_start();
         if (is_array($args) && count($args) > 0) {
             //if it is an array

--- a/tests/Translator/SprintfTranslateTest.php
+++ b/tests/Translator/SprintfTranslateTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Translator;
+
+use Lotgd\Translator;
+use Lotgd\Tests\Stubs\DummySettings;
+use PHPUnit\Framework\TestCase;
+
+final class SprintfTranslateTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['settings'] = new DummySettings(['enabletranslation' => true]);
+        $GLOBALS['session'] = [];
+        $GLOBALS['REQUEST_URI'] = '/';
+        if (!defined('LANGUAGE')) {
+            define('LANGUAGE', 'en');
+        }
+        $GLOBALS['language'] = 'en';
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['settings'], $GLOBALS['session'], $GLOBALS['REQUEST_URI'], $GLOBALS['language']);
+    }
+
+    public function testNoArgumentPadsEmptyString(): void
+    {
+        $warnings = [];
+        set_error_handler(function (int $errno, string $errstr) use (&$warnings): bool {
+            $warnings[] = [$errno, $errstr];
+            return true;
+        }, E_USER_WARNING);
+        $result = Translator::sprintfTranslate('Value: %s');
+        restore_error_handler();
+        $this->assertSame('Value: ', $result);
+        $this->assertSame([], $warnings);
+    }
+
+    public function testSupportsPositionWidthAndLiteralPercent(): void
+    {
+        $result = Translator::sprintfTranslate('Progress: %1$s %2$02d%%', 'Done', 3);
+        $this->assertSame('Progress: Done 03%', $result);
+    }
+
+    public function testStrayPercentDoesNotCrash(): void
+    {
+        $result = Translator::sprintfTranslate('Value with stray % sign');
+        $this->assertSame('Value with stray % sign', $result);
+    }
+}
+

--- a/tests/TranslatorSprintfTranslateTest.php
+++ b/tests/TranslatorSprintfTranslateTest.php
@@ -32,7 +32,7 @@ final class TranslatorSprintfTranslateTest extends TestCase
         $this->assertSame('Hello World', $result);
     }
 
-    public function testSprintfTranslateWithMissingArgumentsLogsWarningAndPads(): void
+    public function testSprintfTranslateWithMissingArgumentsPadsWithoutWarning(): void
     {
         $warnings = [];
         set_error_handler(function (int $errno, string $errstr) use (&$warnings): bool {
@@ -42,8 +42,7 @@ final class TranslatorSprintfTranslateTest extends TestCase
         $result = Translator::sprintfTranslate('Value: %s %s', 'First');
         restore_error_handler();
         $this->assertSame('Value: First ', $result);
-        $this->assertNotEmpty($warnings);
-        $this->assertStringContainsString('expected 2 arguments, got 1', $warnings[0][1]);
+        $this->assertEmpty($warnings);
     }
 
     public function testSprintfTranslateWithExtraArgumentsDropsExtraWithoutWarning(): void


### PR DESCRIPTION
## Summary
- Improve placeholder detection in Translator::sprintfTranslate to support positional flags, width, precision and escape stray `%` signs
- Pad missing arguments with empty strings without emitting warnings
- Cover complex sprintf patterns and edge cases with new Translator tests

## Testing
- `composer install`
- `php -l src/Lotgd/Translator.php tests/Translator/SprintfTranslateTest.php tests/TranslatorSprintfTranslateTest.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a0bb2410e883299e750b0997589af8