### PR TITLE
Handle positional placeholders in sprintfTranslate

### DIFF
--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -176,12 +176,21 @@ class Translator
         }
         preg_match_all('/(?<!%)%(?:\d+\$)?[0-9\+\-#\.]*[a-zA-Z]/', (string) $args[0], $matches);
         $placeholderCount = count($matches[0]);
+
+        $maxPosition = 0;
+        foreach ($matches[0] as $placeholder) {
+            if (preg_match('/(\d+)\$/', $placeholder, $posMatch)) {
+                $maxPosition = max($maxPosition, (int) $posMatch[1]);
+            }
+        }
+        $expected = max($placeholderCount, $maxPosition);
+
         $argCount = count($args) - 1;
-        if ($placeholderCount !== $argCount) {
-            if ($argCount > $placeholderCount) {
-                $args = array_slice($args, 0, $placeholderCount + 1);
+        if ($expected !== $argCount) {
+            if ($argCount > $expected) {
+                $args = array_slice($args, 0, $expected + 1);
             } else {
-                $args = array_pad($args, $placeholderCount + 1, '');
+                $args = array_pad($args, $expected + 1, '');
             }
         }
         $args[0] = preg_replace('/(?<!%)%(?!(?:\d+\$)?[0-9\+\-#\.]*[a-zA-Z]|%)/', '%%', $args[0]);

--- a/tests/Translator/SprintfTranslateTest.php
+++ b/tests/Translator/SprintfTranslateTest.php
@@ -45,6 +45,19 @@ final class SprintfTranslateTest extends TestCase
         $this->assertSame('Progress: Done 03%', $result);
     }
 
+    public function testNonSequentialPositionWithMissingArgumentPads(): void
+    {
+        $warnings = [];
+        set_error_handler(function (int $errno, string $errstr) use (&$warnings): bool {
+            $warnings[] = [$errno, $errstr];
+            return true;
+        }, E_USER_WARNING);
+        $result = Translator::sprintfTranslate('%1$s %3$s', 'First');
+        restore_error_handler();
+        $this->assertSame('First ', $result);
+        $this->assertSame([], $warnings);
+    }
+
     public function testStrayPercentDoesNotCrash(): void
     {
         $result = Translator::sprintfTranslate('Value with stray % sign');


### PR DESCRIPTION
## Summary
- handle numeric placeholder positions when translating sprintf strings
- add regression test for non-sequential placeholders

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c472b06c83299d753ad696685d1f