### PR TITLE
Handle missing session in mail_status

### DIFF
--- a/ext/ajax_server.php
+++ b/ext/ajax_server.php
@@ -47,6 +47,11 @@ function mail_status($args = false): Response
         $new = maillink();
         $tabtext = maillinktabtext();
 
+        if (!isset($session['user']['acctid'])) {
+            error_log('mail_status: session user acctid not set');
+            return jaxon()->newResponse();
+        }
+
         // Get the highest message ID for the current user there is
         $sql = "SELECT MAX(messageid) AS lastid FROM " . db_prefix('mail') . " WHERE msgto=\"" . $session['user']['acctid'] . "\"";
         $result = db_query($sql);


### PR DESCRIPTION
## Summary
- Avoid querying mail when the user session has timed out in `mail_status`

## Testing
- `composer test`
- `php -l ext/ajax_server.php`


------
https://chatgpt.com/codex/tasks/task_e_68a209d629c883299b6542176c31f230