### PR TITLE
fix: correct commentary_text return type

### DIFF
--- a/ext/ajax_server.php
+++ b/ext/ajax_server.php
@@ -134,7 +134,7 @@ function timeout_status($args = false): Response
  * @param array|bool $args Parameter array from the client
  * @return Response
  */
-function commentary_text($args = false): Reponse
+function commentary_text($args = false): Response
 {
     global $session;
     if ($args === false || !is_array($args)) {


### PR DESCRIPTION
## Summary
- fix typo in `commentary_text` return type

## Testing
- `composer test`
- `php -l ext/ajax_server.php`


------
https://chatgpt.com/codex/tasks/task_e_68a20aeaa220832985cfc61b4f3eadd9