### PR TITLE
Remove clanname index from clans table

### DIFF
--- a/install/data/tables.php
+++ b/install/data/tables.php
@@ -646,9 +646,6 @@ function get_all_tables()
             'unique' => '1',
             'columns' => 'clanid'
             ),
-        'key-clanname' => array(
-            'name' => 'clanname', 'type' => 'key', 'columns' => 'clanname'
-            ),
         'key-clanshort' => array(
             'name' => 'clanshort', 'type' => 'key', 'columns' => 'clanshort'
             )

--- a/migrations/Version20250724000015.php
+++ b/migrations/Version20250724000015.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Lotgd\MySQL\Database;
+
+final class Version20250724000015 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove index "clanname" from clans table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE ' . Database::prefix('clans') . ' DROP INDEX clanname');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE ' . Database::prefix('clans') . ' ADD INDEX clanname (clanname)');
+    }
+}


### PR DESCRIPTION
## Summary
- Remove `key-clanname` from clan table descriptor
- Add migration to drop obsolete `clanname` index

## Testing
- `composer test`
- `vendor/bin/doctrine-migrations migrate --no-interaction` *(fails: It was not possible to locate any configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a22d72cedc8329a0945e287cc140a2