### PR TITLE
Add async configuration template for Ajax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 
 /.vs
 config/composer.local.json
+config/async.settings.php
 .phpunit.result.cache
 dbconnect.php

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Features of this fork include:
 - mail notifications that auto-refresh via Ajax
 - incremental chat updates via `commentary_refresh` to load new messages without reloading the page
 - Ajax requests are rate limited to roughly one per second; faster requests
-  receive an HTTP 429 response. Adjust $ajax_rate_limit_seconds in
-  `ext/ajax_settings.php` to change the threshold
+  receive an HTTP 429 response. When enabling Ajax features, copy
+  `config/async.settings.php.dist` to `config/async.settings.php` and adjust
+  `$ajax_rate_limit_seconds` as needed.
 - Composer integration for third-party modules
   - after modifying Composer settings, run `composer dump-autoload` to recognize new namespaces
   - after running `composer install` or `composer dump-autoload`, include `autoload.php` to load all dependencies

--- a/config/async.settings.php.dist
+++ b/config/async.settings.php.dist
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Default asynchronous settings for Ajax polling.
+ *
+ * Copy this file to `config/async.settings.php` and modify values as needed.
+ */
+
+return [
+    // Debug flag: set to 1 for extended debug intervals.
+    'mail_debug' => 0,
+
+    // Prevent session timeout while the browser remains open.
+    'never_timeout_if_browser_open' => 0,
+
+    // Minimum time in seconds between Ajax requests from the same session.
+    'ajax_rate_limit_seconds' => 1.0,
+
+    // Interval settings when mail_debug is disabled.
+    'check_mail_timeout_seconds' => 10,
+    'check_timeout_seconds' => 5,
+    'start_timeout_show_seconds' => 300,
+    'clear_script_execution_seconds' => -1,
+];

--- a/ext/ajax_settings.php
+++ b/ext/ajax_settings.php
@@ -3,27 +3,27 @@
 declare(strict_types=1);
 
 /**
- * Configuration values controlling the AJAX polling behaviour for
- * mail checks, timeouts and intervals. Adjust these values to tune
- * the client-side update frequency.
+ * Load asynchronous configuration for Ajax features.
+ *
+ * Values are read from `config/async.settings.php` if present,
+ * otherwise the defaults from `config/async.settings.php.dist` are used.
+ * Copy the `.dist` file to `config/async.settings.php` to customize these settings.
  */
 
-$mail_debug = 0; //debug
-$never_timeout_if_browser_open = 0;
+$defaults = require __DIR__ . '/../config/async.settings.php.dist';
+$customFile = __DIR__ . '/../config/async.settings.php';
 
-// Minimum time in seconds between Ajax requests from the same session.
-$ajax_rate_limit_seconds = 1.0; // adjust to allow faster or slower polling
-
-if ($mail_debug == 0) {
-    $check_mail_timeout_seconds = 10;   // how often check for new mail
-    $check_timeout_seconds = 5;         // how often checking for timeout
-    $start_timeout_show_seconds = 300;      //when should the counter start to display (time left)
-    $clear_script_execution_seconds = -1;   //  when javascript should stop checking (ddos)
+if (is_readable($customFile)) {
+    $settings = array_merge($defaults, require $customFile);
+} else {
+    $settings = $defaults;
 }
-//test
+
+extract($settings, EXTR_SKIP);
+
 if ($mail_debug == 1) {
     $check_mail_timeout_seconds = 500;  // how often check for new mail
     $check_timeout_seconds = 5;         // how often checking for timeout
-    $start_timeout_show_seconds = 999;  //when should the counter start to display (time left)
-    $clear_script_execution_seconds = -1;   //  when javascript should stop checking (ddos)
+    $start_timeout_show_seconds = 999;  // when should the counter start to display (time left)
+    $clear_script_execution_seconds = -1; // when javascript should stop checking (ddos)
 }


### PR DESCRIPTION
## Summary
- provide `config/async.settings.php.dist` with default Ajax polling values
- load async settings from config and ignore site-specific overrides
- document copying the config when enabling Ajax

## Testing
- `php -l config/async.settings.php.dist`
- `php -l ext/ajax_settings.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a34b3375788329ab73321a3b5f5f2b