### PR TITLE
Port AJAX server handlers to async

### DIFF
--- a/async/common/jaxon.php
+++ b/async/common/jaxon.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Common bootstrap for AJAX operations. This file configures the
+ * Jaxon library and registers callable functions used by the client
+ * side scripts.
+ */
+
+require_once __DIR__ . '/../../autoload.php';
+
+use Jaxon\Jaxon;
+use function Jaxon\jaxon;
+
+require_once __DIR__ . '/../server.php';
+
+global $jaxon;
+// Get the Jaxon singleton object
+$jaxon = jaxon();
+
+// Set the Jaxon request processing URI
+$jaxon->setOption('core.request.uri', 'async/process.php');
+
+// Register callable functions
+$jaxon->register(Jaxon::CALLABLE_FUNCTION, 'mail_status');
+$jaxon->register(Jaxon::CALLABLE_FUNCTION, 'commentary_text');
+$jaxon->register(Jaxon::CALLABLE_FUNCTION, 'timeout_status');
+$jaxon->register(Jaxon::CALLABLE_FUNCTION, 'commentary_refresh');
+$jaxon->register(Jaxon::CALLABLE_FUNCTION, 'poll_updates');

--- a/tests/Ajax/CommentaryTest.php
+++ b/tests/Ajax/CommentaryTest.php
@@ -61,7 +61,7 @@ namespace {
 STUBS
         );
 
-        require_once __DIR__ . '/../../ext/ajax_server.php';
+        require_once __DIR__ . '/../../async/server.php';
     }
 
     public function testCommentaryTextSetsInnerHtml(): void

--- a/tests/Ajax/MailStatusTest.php
+++ b/tests/Ajax/MailStatusTest.php
@@ -71,7 +71,7 @@ namespace Lotgd\Tests\Ajax {
             $maillink_tabtext = '';
             $db_result = [['lastid' => 0]];
 
-            require_once __DIR__ . '/../../ext/ajax_server.php';
+            require_once __DIR__ . '/../../async/server.php';
         }
 
         public function testUnreadMailTriggersNotify(): void

--- a/tests/Ajax/TimeoutStatusTest.php
+++ b/tests/Ajax/TimeoutStatusTest.php
@@ -38,7 +38,7 @@ namespace Lotgd\Tests\Ajax {
                 }
             };
 
-            require_once __DIR__ . '/../../ext/ajax_server.php';
+            require_once __DIR__ . '/../../async/server.php';
         }
 
         public function testTimeoutWarningIsReturned(): void


### PR DESCRIPTION
## Summary
- Implement async Jaxon handlers for mail status, timeouts, commentary, and polling
- Load async handlers during Jaxon bootstrap
- Update Ajax tests to use real implementations

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a358f7eabc83299bbfd495e34bb7bd