### PR TITLE
feat(async): add shared async settings loader

### DIFF
--- a/async/common/jaxon.php
+++ b/async/common/jaxon.php
@@ -14,24 +14,9 @@ use Lotgd\Async\Handler\Commentary;
 use Lotgd\Async\Handler\Mail;
 use Lotgd\Async\Handler\Timeout;
 use function Jaxon\jaxon;
+
 // Load asynchronous configuration settings
-$defaults = require __DIR__ . '/../../config/async.settings.php.dist';
-$customFile = __DIR__ . '/../../config/async.settings.php';
-
-if (is_readable($customFile)) {
-    $settings = array_merge($defaults, require $customFile);
-} else {
-    $settings = $defaults;
-}
-
-extract($settings, EXTR_SKIP);
-
-if ($mail_debug == 1) {
-    $check_mail_timeout_seconds = 500;  // how often check for new mail
-    $check_timeout_seconds = 5;         // how often checking for timeout
-    $start_timeout_show_seconds = 999;  // when should the counter start to display (time left)
-    $clear_script_execution_seconds = -1; // when javascript should stop checking (ddos)
-}
+require_once __DIR__ . '/settings.php';
 
 global $jaxon;
 // Get the Jaxon singleton object
@@ -41,7 +26,6 @@ $jaxon = jaxon();
 $jaxon->setOption('core.request.uri', 'async/process.php');
 
 // Register callable classes
-
 $jaxon->register(Jaxon::CALLABLE_CLASS, Mail::class);
-$jaxon->register(Jaxon::CALLABLE_CLASS, Timeout::class);
 $jaxon->register(Jaxon::CALLABLE_CLASS, Commentary::class);
+$jaxon->register(Jaxon::CALLABLE_CLASS, Timeout::class);

--- a/async/common/settings.php
+++ b/async/common/settings.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Load asynchronous configuration settings.
+ *
+ * This script loads user-defined async settings from the configuration
+ * directory. If the user configuration file does not exist, it falls
+ * back to the distributed defaults and logs a warning.
+ */
+
+$defaults = require __DIR__ . '/../../config/async.settings.php.dist';
+$customFile = __DIR__ . '/../../config/async.settings.php';
+
+if (is_readable($customFile)) {
+    $settings = array_merge($defaults, require $customFile);
+} else {
+    trigger_error(
+        'Custom asynchronous settings file missing; using defaults.',
+        E_USER_WARNING
+    );
+    $settings = $defaults;
+}
+
+extract($settings, EXTR_SKIP);
+
+if ($mail_debug == 1) {
+    $check_mail_timeout_seconds = 500;   // how often check for new mail
+    $check_timeout_seconds = 5;          // how often checking for timeout
+    $start_timeout_show_seconds = 999;   // when should the counter start to display (time left)
+    $clear_script_execution_seconds = -1; // when javascript should stop checking (ddos)
+}


### PR DESCRIPTION
## Summary
- factor async configuration into `async/common/settings.php`
- wire settings loader into Jaxon bootstrap and register async handlers

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a363e70a308329a9de19820925986f