### PR TITLE
Initialize Jaxon in async maillink snippet

### DIFF
--- a/async/maillink.php
+++ b/async/maillink.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
  * asynchronous mail and commentary polling.
  */
 
+require_once __DIR__ . '/common/jaxon.php';
+
 global $jaxon;
 $s_js = $jaxon->getJs();
 $s_script = $jaxon->getScript();


### PR DESCRIPTION
## Summary
- include `common/jaxon.php` in `async/maillink.php` so Jaxon is initialized before generating scripts
- review `async/setup.php` and `async/process.php` for redundant paths; both already use common bootstrap routines

## Testing
- `php -l async/maillink.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a3655d71d48329beab53bea9d5617b