### PR TITLE
Ensure Jaxon uses Composer autoload

### DIFF
--- a/async/common/jaxon.php
+++ b/async/common/jaxon.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
  * side scripts.
  */
 
+require_once __DIR__ . '/../../vendor/autoload.php';
+
 use Jaxon\Jaxon;                      // Use the jaxon core class
 use Jaxon\Response\Response;          // and the Response class
 use Lotgd\Async\Handler\Commentary;


### PR DESCRIPTION
## Summary
- Load Composer autoloader in async/common/jaxon.php so Jaxon classes are available

## Testing
- `php -l async/common/jaxon.php`
- `php async/setup.php`
- `php async/maillink.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a36ee4c8a883299156be8a9fbb22b9