### PR TITLE
Use absolute Jaxon request URI

### DIFF
--- a/async/common/jaxon.php
+++ b/async/common/jaxon.php
@@ -25,7 +25,7 @@ global $jaxon;
 $jaxon = jaxon();
 
 // Set the Jaxon request processing URI
-$jaxon->setOption('core.request.uri', 'async/process.php');
+$jaxon->setOption('core.request.uri', '/async/process.php');
 
 // Register callable classes
 $jaxon->register(Jaxon::CALLABLE_CLASS, Mail::class);


### PR DESCRIPTION
## Summary
- Ensure Jaxon request URI uses absolute path so AJAX calls work from subdirectories

## Testing
- `composer install`
- `composer test`
- `php -l async/common/jaxon.php`


------
https://chatgpt.com/codex/tasks/task_e_68a373e290c88329a37d29e25bbebbea