### PR TITLE
Load bootstrap in async mail link

### DIFF
--- a/async/maillink.php
+++ b/async/maillink.php
@@ -7,10 +7,11 @@ declare(strict_types=1);
  * interface. It injects Jaxon scripts and variables required by the
  * asynchronous mail and commentary polling.
  */
-
+ 
+require_once __DIR__ . '/common/bootstrap.php';
 require_once __DIR__ . '/common/jaxon.php';
 
-global $jaxon;
+global $jaxon, $session;
 $s_js = $jaxon->getJs();
 $s_script = $jaxon->getScript();
 $maillink_add_pre = $s_js . $s_script;


### PR DESCRIPTION
## Summary
- require async bootstrap before loading Jaxon in maillink script
- ensure mail link script has access to session and settings

## Testing
- `composer install`
- `php -l async/maillink.php`
- `composer test`
- `php -r 'require "async/common/bootstrap.php"; var_dump(isset($session), function_exists("getsetting"));'`


------
https://chatgpt.com/codex/tasks/task_e_68a373e33300832994a4d8011b11ec6e