### PR TITLE
refactor: remove unused response import

### DIFF
--- a/async/common/jaxon.php
+++ b/async/common/jaxon.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 use Jaxon\Jaxon;                      // Use the jaxon core class
-use Jaxon\Response\Response;          // and the Response class
 use Lotgd\Async\Handler\Commentary;
 use Lotgd\Async\Handler\Mail;
 use Lotgd\Async\Handler\Timeout;


### PR DESCRIPTION
## Summary
- remove unused Jaxon response import from async bootstrap

## Testing
- `php -l async/common/jaxon.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a375b8680c8329a1ec9210db55efa7