### PR TITLE
Initialize mail link variables before async include

### DIFF
--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -637,10 +637,13 @@ class PageParts
         $mailHtml = '';
         if (isset($session['user']['acctid']) && $session['user']['acctid'] > 0 && $session['user']['loggedin']) {
             if (getsetting('ajax', 0) == 1 && isset($session['user']['prefs']['ajax']) && $session['user']['prefs']['ajax']) {
-                if (file_exists('async/maillink.php')) {
-                    require 'async/maillink.php';
+                $maillink_add_pre = '';
+                $maillink_add_after = '';
+                $asyncFile = __DIR__ . '/../../async/maillink.php';
+                if (file_exists($asyncFile)) {
+                    require $asyncFile;
                 }
-                $mailHtml = $maillink_add_pre . "<div id='maillink'>" . self::mailLink() . "</div>" . $maillink_add_after;
+                $mailHtml = ($maillink_add_pre ?? '') . "<div id='maillink'>" . self::mailLink() . "</div>" . ($maillink_add_after ?? '');
             } else {
                 $mailHtml = self::mailLink();
             }

--- a/tests/AssembleMailLinkTest.php
+++ b/tests/AssembleMailLinkTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\PageParts;
+use Lotgd\Tests\Stubs\Database;
+use Lotgd\Tests\Stubs\DummySettings;
+use PHPUnit\Framework\TestCase;
+
+final class AssembleMailLinkTest extends TestCase
+{
+    private string $asyncFile;
+    private string $backupFile;
+
+    protected function setUp(): void
+    {
+        $this->asyncFile = dirname(__DIR__) . '/async/maillink.php';
+        $this->backupFile = $this->asyncFile . '.bak';
+        Database::$queryCacheResults = [];
+    }
+
+    protected function tearDown(): void
+    {
+        global $session, $settings;
+        unset($session, $settings);
+        Database::$queryCacheResults = [];
+        if (is_file($this->backupFile)) {
+            if (is_file($this->asyncFile)) {
+                unlink($this->asyncFile);
+            }
+            rename($this->backupFile, $this->asyncFile);
+        }
+    }
+
+    public function testWithoutAjax(): void
+    {
+        global $session, $settings;
+        $session = ['user' => ['acctid' => 1, 'loggedin' => true, 'prefs' => []]];
+        $settings = new DummySettings(['ajax' => 0]);
+        Database::$queryCacheResults['mail-1'] = [['seencount' => 0, 'notseen' => 0]];
+        [$header] = PageParts::assembleMailLink('{mail}', '');
+        $this->assertStringContainsString("<a href='mail.php'", $header);
+        $this->assertStringNotContainsString("<div id='maillink'>", $header);
+    }
+
+    public function testWithAjax(): void
+    {
+        global $session, $settings;
+        $session = ['user' => ['acctid' => 1, 'loggedin' => true, 'prefs' => ['ajax' => 1]]];
+        $settings = new DummySettings(['ajax' => 1]);
+        Database::$queryCacheResults['mail-1'] = [['seencount' => 0, 'notseen' => 0]];
+        if (file_exists($this->asyncFile)) {
+            rename($this->asyncFile, $this->backupFile);
+        }
+        file_put_contents($this->asyncFile, "<?php\n\$maillink_add_pre='PRE';\n\$maillink_add_after='AFTER';\n");
+        [$header] = PageParts::assembleMailLink('{mail}', '');
+        $this->assertStringContainsString("PRE<div id='maillink'>", $header);
+        $this->assertStringContainsString("</div>AFTER", $header);
+    }
+}

--- a/tests/Stubs/Database.php
+++ b/tests/Stubs/Database.php
@@ -18,6 +18,7 @@ class Database
     public static array $keys_rows = [];
     public static ?object $doctrineConnection = null;
     public static ?object $instance = null;
+    public static array $queryCacheResults = [];
 
     public static function prefix(string $name, bool $force = false): string
     {
@@ -259,7 +260,7 @@ class Database
     {
         self::$lastSql = $sql;
         self::$lastCacheName = $name;
-        return [];
+        return self::$queryCacheResults[$name] ?? [];
     }
 
     public static function getDoctrineConnection()


### PR DESCRIPTION
## Summary
- Ensure `assembleMailLink` always defines wrapper variables and loads async script via an absolute path
- Support cached query stubbing for tests and add coverage for AJAX/non-AJAX mail links

## Testing
- `php -l src/Lotgd/PageParts.php`
- `php -l tests/Stubs/Database.php`
- `php -l tests/AssembleMailLinkTest.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a38068a9dc83299fffc6f4d3f24469