### PR TITLE
Guard mail link bootstrap to avoid forced navigation

### DIFF
--- a/async/maillink.php
+++ b/async/maillink.php
@@ -7,8 +7,11 @@ declare(strict_types=1);
  * interface. It injects Jaxon scripts and variables required by the
  * asynchronous mail and commentary polling.
  */
- 
-require_once __DIR__ . '/common/bootstrap.php';
+
+// Only bootstrap the application when this script is executed directly.
+if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
+    require_once __DIR__ . '/common/bootstrap.php';
+}
 require_once __DIR__ . '/common/jaxon.php';
 
 global $jaxon, $session;


### PR DESCRIPTION
## Summary
- Only load async bootstrap when maillink.php runs directly
- Prevent forced navigation from triggering when maillink.php is included

## Testing
- `composer install`
- `php -l async/maillink.php`
- `composer test`
- `php -r '$_SERVER["SCRIPT_FILENAME"]="other.php"; include "async/maillink.php"; echo "loaded";'` *(fails: Call to undefined function getsetting(), verifying bootstrap not invoked when included)*

------
https://chatgpt.com/codex/tasks/task_e_68a43535571c832980466976835b1986