### PR TITLE
Specify deterministic Jaxon JS filename

### DIFF
--- a/async/common/jaxon.php
+++ b/async/common/jaxon.php
@@ -30,6 +30,7 @@ $jaxon->setOption('core.request.uri', '/async/process.php');
 $jaxon->setOption('js.app.export', true);
 $jaxon->setOption('js.app.dir', __DIR__ . '/../js');
 $jaxon->setOption('js.app.uri', '/async/js');
+$jaxon->setOption('js.app.file', 'lotgd.jaxon');
 
 // Register callable classes
 $jaxon->register(Jaxon::CALLABLE_CLASS, Mail::class);


### PR DESCRIPTION
## Summary
- Configure Jaxon to generate a deterministic JavaScript app file name

## Testing
- `composer install`
- `php -l async/common/jaxon.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a440233dc88329afa863481e593629