### PR TITLE
Set Jaxon class prefix and export client script

### DIFF
--- a/async/common/jaxon.php
+++ b/async/common/jaxon.php
@@ -25,6 +25,8 @@ $jaxon = jaxon();
 
 // Set the Jaxon request processing URI
 $jaxon->setOption('core.request.uri', '/async/process.php');
+// Set a prefix for generated JavaScript classes so the global object is created
+$jaxon->setOption('core.prefix.class', 'JaxonLotgd');
 
 // Configure the Jaxon client library and namespace
 $jaxon->setOption('js.app.export', true);

--- a/async/js/lotgd.jaxon.js
+++ b/async/js/lotgd.jaxon.js
@@ -1,0 +1,63 @@
+try {
+    if(typeof jaxon.config == undefined)
+        jaxon.config = {};
+}
+catch(e) {
+    jaxon = {};
+    jaxon.config = {};
+};
+
+jaxon.config.requestURI = "/async/process.php";
+jaxon.config.statusMessages = false;
+jaxon.config.waitCursor = true;
+jaxon.config.version = "Jaxon 4.x";
+jaxon.config.defaultMode = "asynchronous";
+jaxon.config.defaultMethod = "POST";
+jaxon.config.responseType = "JSON";
+
+if(JaxonLotgdLotgd.Async.Handler.Mail === undefined) {
+    JaxonLotgdLotgd.Async.Handler.Mail = {};
+}
+JaxonLotgdLotgd.Async.Handler.Mail.mailStatus = function() {
+    return jaxon.request({ jxncls: 'Lotgd.Async.Handler.Mail', jxnmthd: 'mailStatus' }, { parameters: arguments });
+};
+if(JaxonLotgdLotgd.Async.Handler.Timeout === undefined) {
+    JaxonLotgdLotgd.Async.Handler.Timeout = {};
+}
+JaxonLotgdLotgd.Async.Handler.Timeout.timeoutStatus = function() {
+    return jaxon.request({ jxncls: 'Lotgd.Async.Handler.Timeout', jxnmthd: 'timeoutStatus' }, { parameters: arguments });
+};
+if(JaxonLotgdLotgd.Async.Handler.Commentary === undefined) {
+    JaxonLotgdLotgd.Async.Handler.Commentary = {};
+}
+JaxonLotgdLotgd.Async.Handler.Commentary.commentaryText = function() {
+    return jaxon.request({ jxncls: 'Lotgd.Async.Handler.Commentary', jxnmthd: 'commentaryText' }, { parameters: arguments });
+};
+JaxonLotgdLotgd.Async.Handler.Commentary.commentaryRefresh = function() {
+    return jaxon.request({ jxncls: 'Lotgd.Async.Handler.Commentary', jxnmthd: 'commentaryRefresh' }, { parameters: arguments });
+};
+JaxonLotgdLotgd.Async.Handler.Commentary.pollUpdates = function() {
+    return jaxon.request({ jxncls: 'Lotgd.Async.Handler.Commentary', jxnmthd: 'pollUpdates' }, { parameters: arguments });
+};
+
+jaxon.dialogs = {};
+
+jaxon.dom.ready(function() {
+jaxon.command.handler.register("jquery", (args) => jaxon.cmd.script.execute(args));
+
+jaxon.command.handler.register("bags.set", (args) => {
+        for (const bag in args.data) {
+            jaxon.ajax.parameters.bags[bag] = args.data[bag];
+        }
+    });
+});
+
+    jaxon.command.handler.register("rd", (command) => {
+        const { data: sUrl, delay: nDelay } = command;
+        if (nDelay <= 0) {
+            window.location = sUrl;
+            return true;
+        }
+        window.setTimeout(() => window.location = sUrl, nDelay * 1000);
+        return true;
+    });


### PR DESCRIPTION
## Summary
- Prefix Jaxon classes with `JaxonLotgd` so the global object is created
- Export client-side Jaxon code as `async/js/lotgd.jaxon.js`

## Testing
- `composer install`
- `php -l async/common/jaxon.php`
- `composer test`
- `curl -I http://127.0.0.1:8080/async/js/lotgd.jaxon.js`
- `node -e "global.jaxon={config:{},dom:{ready:function(fn){fn();}},command:{handler:{register:function(){}}}}; global.JaxonLotgdLotgd={Async:{Handler:{}}}; const fs=require('fs'), vm=require('vm'); vm.runInThisContext(fs.readFileSync('async/js/lotgd.jaxon.js','utf8'));"`

------
https://chatgpt.com/codex/tasks/task_e_68a444307b408329902926221e40184f