### PR TITLE
Guard AJAX polling start until Jaxon is ready

### DIFF
--- a/async/js/ajax_polling.js
+++ b/async/js/ajax_polling.js
@@ -167,7 +167,10 @@ function clear_ajax()
 // Start polling once the DOM is ready using configuration variables
 // supplied by the server. Commentary and timeout checks only run
 // if the corresponding variables are present.
-$(function () {
+$(function startPolling() {
+    if (typeof window.JaxonLotgd === 'undefined') {
+        return setTimeout(startPolling, 250);
+    }
     set_poll_ajax();
     if (typeof lotgd_clear_delay_ms !== 'undefined') {
         window.setTimeout(clear_ajax, lotgd_clear_delay_ms);

--- a/async/maillink.php
+++ b/async/maillink.php
@@ -18,6 +18,7 @@ global $jaxon, $session, $check_mail_timeout_seconds, $start_timeout_show_second
 $s_js = $jaxon->getJs();
 $s_script = $jaxon->getScript();
 $maillink_add_pre = $s_js . $s_script;
+$maillink_add_pre .= "<script src='/async/js/ajax_polling.js' defer></script>";
 $maillink_add_after = "<script>";
 $maillink_add_after .= "var lotgd_comment_section = " . json_encode($session['last_comment_section'] ?? '') . ";";
 $maillink_add_after .= "var lotgd_lastCommentId = " . (int)($session['lastcommentid'] ?? 0) . ";";
@@ -25,5 +26,4 @@ $maillink_add_after .= "var lotgd_poll_interval_ms = " . (($check_mail_timeout_s
 $maillink_add_after .= "var lotgd_timeout_delay_ms = " . ((getsetting('LOGINTIMEOUT', 900) - ($start_timeout_show_seconds ?? 300)) * 1000) . ";";
 $maillink_add_after .= "var lotgd_clear_delay_ms = " . ((getsetting('LOGINTIMEOUT', 900) - ($clear_script_execution_seconds ?? -1)) * 1000) . ";";
 $maillink_add_after .= "</script>";
-$maillink_add_after .= "<script src='/async/js/ajax_polling.js' defer></script>";
 $maillink_add_after .= "<div id='notify'></div>";


### PR DESCRIPTION
## Summary
- Delay ajax polling start until the Jaxon client is available
- Load ajax_polling.js only after the Jaxon script in maillink bootstrap

## Testing
- `composer install`
- `composer test`
- `php -l async/maillink.php`


------
https://chatgpt.com/codex/tasks/task_e_68a444471e008329aaaee23b9281c15f