### PR TITLE
Restore Jaxon namespace and ensure JS script output

### DIFF
--- a/async/common/jaxon.php
+++ b/async/common/jaxon.php
@@ -19,15 +19,14 @@ use function Jaxon\jaxon;
 // Load asynchronous configuration settings
 require_once __DIR__ . '/settings.php';
 
-global $jaxon;
+global $jaxon, $s_js;
 // Get the Jaxon singleton object
 $jaxon = jaxon();
 
 // Set the Jaxon request processing URI
 $jaxon->setOption('core.request.uri', '/async/process.php');
 // Set a prefix for generated JavaScript classes so the global object is created
-// $jaxon->setOption('core.prefix.class', 'JaxonLotgd');
-$jaxon->setOption('core.prefix.class', 'Jaxon'); // or omit for default
+$jaxon->setOption('core.prefix.class', 'JaxonLotgd');
 
 // Configure the Jaxon client library and namespace
 $jaxon->setOption('js.app.export', true);
@@ -39,3 +38,7 @@ $jaxon->setOption('js.app.file', 'lotgd.jaxon');
 $jaxon->register(Jaxon::CALLABLE_CLASS, Mail::class);
 $jaxon->register(Jaxon::CALLABLE_CLASS, Commentary::class);
 $jaxon->register(Jaxon::CALLABLE_CLASS, Timeout::class);
+
+// Generate the script tag for Jaxon Javascript and make it available
+$s_js = $jaxon->getJs();
+

--- a/async/setup.php
+++ b/async/setup.php
@@ -10,13 +10,13 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/common/jaxon.php';
 
-global $jaxon;
+global $jaxon, $s_js;
 $s_css = $jaxon->getCss();
 
 if (isset($pre_headscript)) {
-    $pre_headscript .= $s_css . "<script src=\"/async/js/jquery.min.js\" defer></script>";
+    $pre_headscript .= $s_css . $s_js . "<script src=\"/async/js/jquery.min.js\" defer></script>";
 } else {
-    $pre_headscript = "";
+    $pre_headscript = $s_css . $s_js . "<script src=\"/async/js/jquery.min.js\" defer></script>";
 }
-//$pre_headscript.="ha$s_js ha";
 addnav("", "async/process.php");
+


### PR DESCRIPTION
## Summary
- Reinstate `JaxonLotgd` class prefix and generate client script tag
- Include Jaxon-generated script in async setup header

## Testing
- `php -l async/common/jaxon.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a4694dc0148329942f207e903e6f45