### PR TITLE
Simplify mail link script for polling

### DIFF
--- a/async/maillink.php
+++ b/async/maillink.php
@@ -4,23 +4,22 @@ declare(strict_types=1);
 
 /**
  * Prepares the mail link JavaScript code snippets used by the
- * interface. It injects Jaxon scripts and variables required by the
- * asynchronous mail and commentary polling.
+ * interface. It sets variables required by the asynchronous mail and
+ * commentary polling.
  */
 
 // Only bootstrap the application when this script is executed directly.
 if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     require_once __DIR__ . '/common/bootstrap.php';
 }
-require_once __DIR__ . '/common/jaxon.php';
 
-global $jaxon, $session, $check_mail_timeout_seconds, $start_timeout_show_seconds, $clear_script_execution_seconds;
-$s_js = $jaxon->getJs();
-$s_script = $jaxon->getScript();
-$maillink_add_pre = $s_js;
-$maillink_add_pre .= "<script src='/async/js/lotgd.jaxon.js'></script>";
-$maillink_add_pre .= $s_script;
-$maillink_add_pre .= "<script src='/async/js/ajax_polling.js' defer></script>";
+// Ensure asynchronous settings are loaded so polling timeouts are defined.
+if (!isset($check_mail_timeout_seconds)) {
+    require_once __DIR__ . '/common/settings.php';
+}
+
+global $session, $check_mail_timeout_seconds, $start_timeout_show_seconds, $clear_script_execution_seconds;
+
 $maillink_add_after = "<script>";
 $maillink_add_after .= "var lotgd_comment_section = " . json_encode($session['last_comment_section'] ?? '') . ";";
 $maillink_add_after .= "var lotgd_lastCommentId = " . (int)($session['lastcommentid'] ?? 0) . ";";


### PR DESCRIPTION
## Summary
- remove Jaxon requirement and related script generation from async/maillink.php
- build polling variables and notify div only
- ensure async settings load before building mail link script

## Testing
- `php -l async/maillink.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a48d1d2fa88329a041135269578371