### PR TITLE
Ensure JaxonLotgd exists before loading script

### DIFF
--- a/async/setup.php
+++ b/async/setup.php
@@ -17,8 +17,11 @@ $s_script = $jaxon->getScript();
 
 $pre_headscript = ($pre_headscript ?? '')
     . $jaxon->getCss()
-    . $s_js
-    . "<script src='/async/js/lotgd.jaxon.js'></script>"
+    . $s_js;
+
+$pre_headscript .= "<script>window.JaxonLotgd = window.JaxonLotgd || {Async:{Handler:{}}};</script>";
+
+$pre_headscript .= "<script src='/async/js/lotgd.jaxon.js'></script>"
     . $s_script
     . "<script src='/async/js/jquery.min.js' defer></script>"
     . "<script src='/async/js/ajax_polling.js' defer></script>";


### PR DESCRIPTION
## Summary
- Guarantee global object exists before `lotgd.jaxon.js` executes

## Testing
- `php -l async/setup.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a4eb2b9ca48329a0b3d9b97d51ba99