### PR TITLE
Use default Jaxon prefix

### DIFF
--- a/async/common/jaxon.php
+++ b/async/common/jaxon.php
@@ -25,8 +25,8 @@ $jaxon = jaxon();
 
 // Set the Jaxon request processing URI
 $jaxon->setOption('core.request.uri', '/async/process.php');
-// Set a prefix for generated JavaScript classes so the global object is created
-$jaxon->setOption('core.prefix.class', 'JaxonLotgd');
+// Use the default prefix for generated JavaScript classes
+$jaxon->setOption('core.prefix.class', 'Jaxon');
 
 // Configure the Jaxon client library and namespace
 $jaxon->setOption('js.app.export', true);


### PR DESCRIPTION
## Summary
- Use default `Jaxon` prefix in async Jaxon bootstrap
- Ensure Jaxon JavaScript client options are exported to app file

## Testing
- `php -l async/common/jaxon.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a5804b289c8329ac84f03cb1ffbc7f