### PR TITLE
Add defaults for asynchronous mail polling timing

### DIFF
--- a/async/maillink.php
+++ b/async/maillink.php
@@ -18,13 +18,21 @@ if (!isset($check_mail_timeout_seconds)) {
     require_once __DIR__ . '/common/settings.php';
 }
 
-global $session, $check_mail_timeout_seconds, $start_timeout_show_seconds, $clear_script_execution_seconds;
+global $session,
+    $check_mail_timeout_seconds,
+    $start_timeout_show_seconds,
+    $clear_script_execution_seconds,
+    $s_js;
+
+$check_mail_timeout_seconds ??= 60;
+$start_timeout_show_seconds ??= 1;
+$clear_script_execution_seconds ??= 86400;
 
 $maillink_add_after = "<script>";
 $maillink_add_after .= "var lotgd_comment_section = " . json_encode($session['last_comment_section'] ?? '') . ";";
 $maillink_add_after .= "var lotgd_lastCommentId = " . (int)($session['lastcommentid'] ?? 0) . ";";
-$maillink_add_after .= "var lotgd_poll_interval_ms = " . (($check_mail_timeout_seconds ?? 10) * 1000) . ";";
-$maillink_add_after .= "var lotgd_timeout_delay_ms = " . ((getsetting('LOGINTIMEOUT', 900) - ($start_timeout_show_seconds ?? 300)) * 1000) . ";";
-$maillink_add_after .= "var lotgd_clear_delay_ms = " . ((getsetting('LOGINTIMEOUT', 900) - ($clear_script_execution_seconds ?? -1)) * 1000) . ";";
+$maillink_add_after .= "var lotgd_poll_interval_ms = " . ($check_mail_timeout_seconds * 1000) . ";";
+$maillink_add_after .= "var lotgd_timeout_delay_ms = " . ((getsetting('LOGINTIMEOUT', 900) - $start_timeout_show_seconds) * 1000) . ";";
+$maillink_add_after .= "var lotgd_clear_delay_ms = " . ((getsetting('LOGINTIMEOUT', 900) - $clear_script_execution_seconds) * 1000) . ";";
 $maillink_add_after .= "</script>";
 $maillink_add_after .= "<div id='notify'></div>";


### PR DESCRIPTION
## Summary
- include `$s_js` in mail link globals
- default mail polling timeout variables and use them directly when generating JS

## Testing
- `php -l async/maillink.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a5804fb7cc8329bc99812c0f330b9d