### PR TITLE
Add error handling and optional notifications for logdnet fetch

### DIFF
--- a/src/Lotgd/Config/configuration.php
+++ b/src/Lotgd/Config/configuration.php
@@ -279,6 +279,7 @@ $setup = array(
         "serverdesc" => "Server Description (75 chars max)",
         "meta_description" => "Default HTML meta description,text",
         "logdnetserver" => "Master LoGDnet Server (default http://logd.net/)",
+        "logdnet_error_notify" => "Notify on LoGDnet errors?,bool",
     "curltimeout" => "How long we wait for responses from that server (in seconds),range,1,10,1|2",
 
     "Game day Setup,title",


### PR DESCRIPTION
## Summary
- Wrap logdnet server fetch and iteration in try/catch
- Skip invalid serialized entries and notify when `logdnet_error_notify` is enabled
- Expose `logdnet_error_notify` configuration option

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a81e0328cc8329a51eea91029911ee