### PR TITLE
Add configurable LoGDnet error notifications

### DIFF
--- a/logdnet.php
+++ b/logdnet.php
@@ -263,7 +263,7 @@ if ($op == "") {
                 $val = trim($val);
                 $row = unserialize($val);
                 if (!is_array($row)) {
-                    if (getsetting('logdnet_error_notify', 0)) {
+                    if (getsetting('logdnet_error_notify', 1)) {
                         ErrorHandler::errorNotify(E_WARNING, 'Invalid logdnet row', __FILE__, __LINE__, Backtrace::show());
                     }
                     continue;
@@ -318,7 +318,7 @@ if ($op == "") {
                 $i++;
             }
         } catch (\Throwable $e) {
-            if (getsetting('logdnet_error_notify', 0)) {
+            if (getsetting('logdnet_error_notify', 1)) {
                 ErrorHandler::errorNotify(
                     E_WARNING,
                     $e->getMessage(),

--- a/src/Lotgd/Config/configuration.php
+++ b/src/Lotgd/Config/configuration.php
@@ -279,7 +279,7 @@ $setup = array(
         "serverdesc" => "Server Description (75 chars max)",
         "meta_description" => "Default HTML meta description,text",
         "logdnetserver" => "Master LoGDnet Server (default http://logd.net/)",
-        "logdnet_error_notify" => "Notify on LoGDnet errors?,bool",
+        "logdnet_error_notify" => "Report errors about LoGDnet via error_notify?,bool|1",
     "curltimeout" => "How long we wait for responses from that server (in seconds),range,1,10,1|2",
 
     "Game day Setup,title",


### PR DESCRIPTION
## Summary
- allow enabling error_notify for LoGDnet failures via new setting
- default LoGDnet error notifications to on
- remove misplaced settings default file

## Testing
- `composer install`
- `php -l logdnet.php src/Lotgd/Config/configuration.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a82010eaa483299dec1d565c7262b9