### PR TITLE
Verify last comment id updates after AJAX scripts

### DIFF
--- a/async/setup.php
+++ b/async/setup.php
@@ -128,7 +128,21 @@ function pollForUpdates() {
                         }
                         if (cmd.cmd === 'js' && cmd.data) {
                             try {
+                                const beforeId = window.lotgd_lastCommentId;
                                 eval(cmd.data);
+
+                                if (window.lotgd_lastCommentId === beforeId) {
+                                    const match = cmd.data.match(/lotgd_lastCommentId\s*=\s*(\d+)/);
+
+                                    if (match) {
+                                        window.lotgd_lastCommentId = parseInt(match[1], 10);
+                                        console.log('AJAX: lastCommentId parsed to', window.lotgd_lastCommentId);
+                                    } else {
+                                        console.warn('AJAX: lastCommentId unchanged after script:', cmd.data);
+                                    }
+                                } else {
+                                    console.log('AJAX: lastCommentId updated to', window.lotgd_lastCommentId);
+                                }
                             } catch (e) {
                                 console.error('AJAX: Script execution error:', e);
                             }


### PR DESCRIPTION
## Summary
- Ensure pollForUpdates verifies updates to `lotgd_lastCommentId` and parses assignment when needed

## Testing
- `php -l async/setup.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a835d6c65c8329b1beb5a15657e811