### PR TITLE
Encode Jaxon parameters in polling

### DIFF
--- a/async/setup.php
+++ b/async/setup.php
@@ -97,8 +97,8 @@ function pollForUpdates() {
     const formData = new URLSearchParams();
     formData.append('jxncls', 'Lotgd.Async.Handler.Commentary');
     formData.append('jxnmthd', 'pollUpdates');
-    formData.append('jxnargs[0]', lotgd_comment_section || 'superuser');
-    formData.append('jxnargs[1]', String(lotgd_lastCommentId || 0));
+    formData.append('jxnargs[0]', 'S' + (lotgd_comment_section || 'superuser'));
+    formData.append('jxnargs[1]', 'N' + String(lotgd_lastCommentId || 0));
     formData.append('jxnr', Math.random().toString().substring(2));
     
     fetch('/async/process.php', {


### PR DESCRIPTION
## Summary
- Ensure Jaxon parameters include type prefixes before sending AJAX commentary poll requests

## Testing
- `php -l async/setup.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a83c8effec83298cd3e6c5c0252889