### PR TITLE
Handle curl_exec failures in PullUrl

### DIFF
--- a/src/Lotgd/PullUrl.php
+++ b/src/Lotgd/PullUrl.php
@@ -32,7 +32,15 @@ class PullUrl
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $val);
         curl_setopt($ch, CURLOPT_TIMEOUT, $val);
         $ret = curl_exec($ch);
+        if ($ret === false) {
+            debug(curl_error($ch));
+            curl_close($ch);
+            return false;
+        }
         curl_close($ch);
+        if (!is_string($ret)) {
+            return false;
+        }
         $val = explode("\n", $ret);
         $total = count($val);
         $cur = 0;


### PR DESCRIPTION
## Summary
- handle curl errors in PullUrl::curl

## Testing
- `composer install`
- `php -l src/Lotgd/PullUrl.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a86a447a7083299d9a612d2eb192e1