### PR TITLE
Preserve temporary error handler when pulling URLs

### DIFF
--- a/src/Lotgd/PullUrl.php
+++ b/src/Lotgd/PullUrl.php
@@ -101,7 +101,7 @@ class PullUrl
     public static function pull(string $url)
     {
         // Prefer file() to avoid open_basedir issues.
-        set_error_handler(static function (): bool {
+        set_error_handler(static function ($errno, $errstr, $errfile, $errline): bool {
             return true;
         });
         $data = file($url);

--- a/src/Lotgd/PullUrl.php
+++ b/src/Lotgd/PullUrl.php
@@ -101,20 +101,24 @@ class PullUrl
     public static function pull(string $url)
     {
         // Prefer file() to avoid open_basedir issues.
-        $data = @file($url);
-        if (false !== $data) {
+        set_error_handler(static function (): bool {
+            return true;
+        });
+        $data = file($url);
+        restore_error_handler();
+        if ($data !== false) {
             return $data;
         }
 
-        debug("file() failed for $url, trying curl()");
+        debug('file() failed: ' . $url);
         $data = self::curl($url);
-        if (false !== $data) {
+        if ($data !== false) {
             return $data;
         }
 
         debug("curl() failed for $url, trying socket connection");
         $data = self::sock($url);
-        if (false !== $data) {
+        if ($data !== false) {
             return $data;
         }
 

--- a/src/Lotgd/PullUrl.php
+++ b/src/Lotgd/PullUrl.php
@@ -110,7 +110,7 @@ class PullUrl
             return $data;
         }
 
-        debug('file() failed: ' . $url);
+        debug("file() failed for $url, trying curl()");
         $data = self::curl($url);
         if ($data !== false) {
             return $data;


### PR DESCRIPTION
## Summary
- Wrap initial `file()` fetch with temporary error handler to suppress warnings
- Log failure before falling back to curl and socket methods

## Testing
- `composer install`
- `php -l src/Lotgd/PullUrl.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a876ec3eb08329b750561f9e4cdd21