### PR TITLE
Harden logdnet server loop against invalid entries

### DIFF
--- a/logdnet.php
+++ b/logdnet.php
@@ -259,9 +259,18 @@ if ($op == "") {
             }
             $i = 0;
             foreach ($servers as $val) {
-                // remove newlines from the pulled content
+                // Ensure we have a string value
+                if (!is_string($val)) {
+                    continue;
+                }
+
+                // Remove newlines from the pulled content
                 $val = trim($val);
-                $row = unserialize($val);
+                if ($val === '') {
+                    continue;
+                }
+
+                $row = @unserialize($val);
                 if (!is_array($row)) {
                     if (getsetting('logdnet_error_notify', 1)) {
                         ErrorHandler::errorNotify(E_WARNING, 'Invalid logdnet row', __FILE__, __LINE__, Backtrace::show());


### PR DESCRIPTION
## Summary
- Skip non-string and empty server entries before unserializing
- Notify only for invalid serialized rows in logdnet server list

## Testing
- `php -l logdnet.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a8e1cecfc483298079ab4dfa481c83