### PR TITLE
Guard LoGDnet listing by settings

### DIFF
--- a/logdnet.php
+++ b/logdnet.php
@@ -247,11 +247,12 @@ if ($op == "") {
     require_once("lib/pullurl.php");
     $servers = array();
     $u = getsetting("logdnetserver", "http://logdnet.logd.com/");
+    $logdnet = getsetting('logdnet', 0);
     if (!preg_match("/\/$/", $u)) {
         $u = $u . "/";
         savesetting("logdnetserver", $u);
     }
-    if ($u != "") {
+    if ($logdnet && $u != "") {
         try {
             $servers = pullurl($u . "logdnet.php?op=net");
             if (!$servers) {
@@ -337,8 +338,12 @@ if ($op == "") {
                 );
             }
         }
+    } elseif (!$logdnet) {
+        rawoutput("<tr><td colspan='2'>");
+        output("LoGDnet server listings are currently disabled.");
+        rawoutput("</td></tr>");
     } else {
-        rawoutput("<tr><td colspan='2')>");
+        rawoutput("<tr><td colspan='2'>");
         output("Sorry, no logdnet host server was defined in the game settings");
         rawoutput("</td></tr>");
     }


### PR DESCRIPTION
## Summary
- Skip remote LoGDnet requests when the feature is disabled or the host is not configured
- Display a friendly message when LoGDnet is turned off

## Testing
- `composer install`
- `php -l logdnet.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e3842f8c83299e92fed1c0f7e345