### PR TITLE
Notify admins on uncaught exceptions

### DIFF
--- a/src/Lotgd/ErrorHandler.php
+++ b/src/Lotgd/ErrorHandler.php
@@ -189,8 +189,14 @@ class ErrorHandler
      */
     public static function handleException(\Throwable $exception): void
     {
+        global $settings;
+
         $trace = Backtrace::show($exception->getTrace());
         self::renderError($exception->getMessage(), $exception->getFile(), $exception->getLine(), $trace);
+
+        if ($settings->getSetting('notify_on_error', 0)) {
+            self::errorNotify(E_ERROR, $exception->getMessage(), $exception->getFile(), $exception->getLine(), $trace);
+        }
     }
 
     /**

--- a/tests/ErrorHandlerExceptionNotifyTest.php
+++ b/tests/ErrorHandlerExceptionNotifyTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\ErrorHandler;
+use Lotgd\Tests\Stubs\DummySettings;
+use Lotgd\Tests\Stubs\PHPMailer;
+use PHPUnit\Framework\TestCase;
+
+final class ErrorHandlerExceptionNotifyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $settings, $mail_sent_count, $output;
+
+        $mail_sent_count = 0;
+        $settings = new DummySettings([
+            'notify_on_error' => 1,
+            'notify_address' => 'admin@example.com',
+            'gameadminemail' => 'admin@example.com',
+            'usedatacache' => 0,
+        ]);
+
+        // Ensure the PHPMailer stub is loaded so Mail::send uses it
+        new PHPMailer();
+
+        // Provide minimal output handler for debug()
+        $output = new class {
+            public function appoencode($data, $priv)
+            {
+                return $data;
+            }
+        };
+    }
+
+    public function testTypeErrorTriggersNotification(): void
+    {
+        try {
+            strlen([]);
+        } catch (\TypeError $e) {
+            ob_start();
+            @ErrorHandler::handleException($e);
+            ob_end_clean();
+        }
+
+        $this->assertSame(1, $GLOBALS['mail_sent_count']);
+    }
+}


### PR DESCRIPTION
## Summary
- send error notification when `handleException` processes an uncaught exception
- cover exception notifications with PHPUnit

## Testing
- `php -l src/Lotgd/ErrorHandler.php`
- `php -l tests/ErrorHandlerExceptionNotifyTest.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a98b1294048329a1dc0f7aae60296f