### PR TITLE
Fallback to mysqli when db config missing

### DIFF
--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -92,12 +92,13 @@ class Database
         }
         self::$dbinfo['queriesthishit']++;
         $starttime = DateTime::getMicroTime();
-        static $bootstrapExists = null;
-        if ($bootstrapExists === null) {
-            $bootstrapExists = class_exists(\Lotgd\Doctrine\Bootstrap::class);
+        static $configExists = null;
+        if ($configExists === null) {
+            $rootDir = dirname(__DIR__, 3);
+            $configExists = file_exists($rootDir . '/dbconnect.php');
         }
 
-        if (self::$doctrine || $bootstrapExists) {
+        if (self::$doctrine || $configExists) {
             $conn = self::$doctrine ?? self::getDoctrineConnection();
             $trim = ltrim($sql);
             while ($trim !== '' && $trim[0] === '(') {


### PR DESCRIPTION
## Summary
- Only initialize Doctrine DBAL when a Doctrine connection exists or `dbconnect.php` is present
- Prevent installer Stage 4 from crashing when database configuration is missing

## Testing
- `php -l src/Lotgd/MySQL/Database.php`
- `composer test`
- `php -r 'require "vendor/autoload.php"; define("IS_INSTALLER", true); $session=["dbinfo"=>["DB_HOST"=>"127.0.0.1","DB_USER"=>"test","DB_PASS"=>"","DB_NAME"=>"lotgdtest","DB_USEDATACACHE"=>false,"DB_DATACACHEPATH"=>""]]; require "install/lib/Installer.php"; $inst=new Lotgd\\Installer\\Installer(); $inst->stage4(); echo "STAGE4 DONE\n";'`

------
https://chatgpt.com/codex/tasks/task_e_68aa1ee2ad34832991e9cfac791431a4