### PR TITLE
Fix installer Stage 7 to avoid failures on clean installs

### DIFF
--- a/install/data/installer_sqlstatements.php
+++ b/install/data/installer_sqlstatements.php
@@ -3,10 +3,10 @@
 $creaturefields = "(creatureid,creaturename,creaturelevel,creatureweapon,creaturelose,creaturewin,creaturegold,creatureexp,creaturehealth,creatureattack,creaturedefense,creatureaiscript,createdby,forest,graveyard,oldcreatureexp)";
 $creaturefields111 = "(creatureid,creaturename,creaturelevel,creatureweapon,creaturelose,creaturewin,creaturegold,creatureexp,creaturehealth,creatureattack,creaturedefense,creatureaiscript,createdby,forest,graveyard)";
 
-if (!isset($settings) || !$settings instanceof \Lotgd\Settings) {
-    throw new \Exception('Settings object is not initialized.');
+$defaultVillage = 'Degolburg';
+if (isset($settings) && $settings instanceof \Lotgd\Settings) {
+    $defaultVillage = $settings->getSetting('villagename', $defaultVillage);
 }
-$defaultVillage = $settings->getSetting("villagename", LOCATION_FIELDS);
 
 $sql_upgrade_statements = array(
 "-1" => array(), //needed just as a placeholder for new installs.

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -952,7 +952,9 @@ class Installer
     public function stage7(): void
     {
         global $session, $logd_version, $recommended_modules, $noinstallnavs, $stage, $DB_USEDATACACHE, $settings;
-        require(__DIR__ . "/../data/installer_sqlstatements.php");
+        if ($session['dbinfo']['upgrade'] ?? false) {
+            require __DIR__ . '/../data/installer_sqlstatements.php';
+        }
         if (Http::post("type") > "") {
             if (Http::post("type") == "install") {
                 $session['fromversion'] = "-1";
@@ -990,18 +992,23 @@ class Installer
                 }
             }
             $this->output->rawOutput("<input type='radio' value='upgrade' name='type'" . ($session['dbinfo']['upgrade'] ? " checked" : "") . ">");
-            $this->output->output(" `2Perform an upgrade from ");
+            $this->output->output(" `2Perform an upgrade" . ($session['dbinfo']['upgrade'] ? " from" : "") . " ");
             if ($version == "-1") {
                 $version = "0.9.7";
             }
-            reset($sql_upgrade_statements);
-            $this->output->rawOutput("<select name='version'>");
-            foreach ($sql_upgrade_statements as $key => $val) {
-                if ($key != "-1") {
-                    $this->output->rawOutput("<option value='$key'" . ($version == $key ? " selected" : "") . ">$key</option>");
+            if ($session['dbinfo']['upgrade']) {
+                if (!isset($sql_upgrade_statements)) {
+                    require __DIR__ . '/../data/installer_sqlstatements.php';
                 }
+                reset($sql_upgrade_statements);
+                $this->output->rawOutput("<select name='version'>");
+                foreach ($sql_upgrade_statements as $key => $val) {
+                    if ($key != "-1") {
+                        $this->output->rawOutput("<option value='$key'" . ($version == $key ? " selected" : "") . ">$key</option>");
+                    }
+                }
+                $this->output->rawOutput("</select>");
             }
-            $this->output->rawOutput("</select>");
             $this->output->rawOutput("<br><input type='radio' value='install' name='type'" . ($session['dbinfo']['upgrade'] ? "" : " checked") . ">");
             $this->output->output(" `2Perform a clean install.");
             $this->output->rawOutput("</td></tr></table>");


### PR DESCRIPTION
## Summary
- Load installer SQL statements only during upgrade flow
- Default village name to `Degolburg` when `$settings` is missing

## Testing
- `php -l install/lib/Installer.php`
- `php -l install/data/installer_sqlstatements.php`
- `composer install`
- `composer test`
- `php -r 'require "autoload.php"; function modulehook($n,$a=[],...$r){return $a;} require "install/lib/Installer.php"; $GLOBALS["session"]=["dbinfo"=>["upgrade"=>false]]; $GLOBALS["logd_version"]="1.0"; $GLOBALS["recommended_modules"]=[]; $GLOBALS["noinstallnavs"]=true; $GLOBALS["stage"]=7; $GLOBALS["DB_USEDATACACHE"]=0; $_POST=[]; $installer=new \\Lotgd\\Installer\\Installer(); $installer->stage7(); print_r(array_filter(get_included_files(), fn($f)=>str_contains($f, "installer_sqlstatements.php")));'`

------
https://chatgpt.com/codex/tasks/task_e_68aa202d1f0c8329981283fbece11344