### PR TITLE
Avoid marking migrations on fresh installs

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1487,11 +1487,13 @@ class Installer
         ];
 
         $from = $session['fromversion'] ?? '-1';
-        foreach ($map as $ver => $id) {
-            if ($from === '-1' || version_compare($from, $ver, '<')) {
-                $v = new Version($id);
-                if (! $executed->hasMigration($v)) {
-                    $storage->complete(new ExecutionResult($v));
+        if ($from !== '-1') {
+            foreach ($map as $ver => $id) {
+                if (version_compare($from, $ver, '<')) {
+                    $v = new Version($id);
+                    if (! $executed->hasMigration($v)) {
+                        $storage->complete(new ExecutionResult($v));
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Skip adding prior migrations when session fromversion is `-1`

## Testing
- `php -l install/lib/Installer.php`
- `composer install`
- `composer test`
- `php -r 'require "autoload.php"; $session=["fromversion"=>"-1"]; $inst=new \\Lotgd\\Installer\\Installer(); $ref=new ReflectionClass($inst); $m=$ref->getMethod("runMigrations"); $m->setAccessible(true); $m->invoke($inst);'` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2260b7cc8329bc4de53b9a108fc9