### PR TITLE
Handle missing database connection during installation

### DIFF
--- a/installer.php
+++ b/installer.php
@@ -56,11 +56,18 @@ chdir(__DIR__);
 
 require_once("common.php");
 if (file_exists("dbconnect.php")) {
-       require_once("dbconnect.php");
+    require_once("dbconnect.php");
 }
 
-// Load settings
-$settings = new Settings();
+// Load settings only when a database connection is available
+$settings = null;
+if (!defined('DB_NODB') || !DB_NODB) {
+    try {
+        $settings = new Settings();
+    } catch (\Throwable $th) {
+        $settings = null;
+    }
+}
 
 $noinstallnavs = false;
 


### PR DESCRIPTION
## Summary
- Instantiate game settings only when a database connection exists during installation
- Pass `null` for settings when no database, letting donation markup skip setting lookups

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68aa336ef99c8329ab3e08c98d7c7508