### PR TITLE
Make dropping clanname index safe

### DIFF
--- a/migrations/Version20250724000015.php
+++ b/migrations/Version20250724000015.php
@@ -17,7 +17,7 @@ final class Version20250724000015 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE ' . Database::prefix('clans') . ' DROP INDEX clanname');
+        $this->addSql('ALTER TABLE ' . Database::prefix('clans') . ' DROP INDEX IF EXISTS clanname');
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
## Summary
- Avoid failing migration when `clanname` index is missing by using `DROP INDEX IF EXISTS`

## Testing
- `php -l migrations/Version20250724000015.php`
- `composer test`
- `vendor/bin/doctrine-migrations migrate --no-interaction --configuration=migrations.php --db-configuration=config/doctrine.php` *(fails: It was not possible to locate any configuration file / mysqli_get_server_info(): Argument #1 ($mysql) must be of type mysqli, null given)*

------
https://chatgpt.com/codex/tasks/task_e_68aac56dd4f08329a9eee2ca23273011