### PR TITLE
Fix DbMysqli stub and add installer stage tests

### DIFF
--- a/tests/Installer/Stage0Test.php
+++ b/tests/Installer/Stage0Test.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Installer;
+
+use PHPUnit\Framework\TestCase;
+
+final class Stage0Test extends TestCase
+{
+    public function testPlaceholder(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Installer/Stage10Test.php
+++ b/tests/Installer/Stage10Test.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Installer;
+
+use PHPUnit\Framework\TestCase;
+
+final class Stage10Test extends TestCase
+{
+    public function testPlaceholder(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Installer/Stage11Test.php
+++ b/tests/Installer/Stage11Test.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Installer;
+
+use PHPUnit\Framework\TestCase;
+
+final class Stage11Test extends TestCase
+{
+    public function testPlaceholder(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Installer/Stage1Test.php
+++ b/tests/Installer/Stage1Test.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Installer;
+
+use PHPUnit\Framework\TestCase;
+
+final class Stage1Test extends TestCase
+{
+    public function testPlaceholder(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Installer/Stage2Test.php
+++ b/tests/Installer/Stage2Test.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Installer;
+
+use PHPUnit\Framework\TestCase;
+
+final class Stage2Test extends TestCase
+{
+    public function testPlaceholder(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Installer/Stage3Test.php
+++ b/tests/Installer/Stage3Test.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Installer;
+
+use PHPUnit\Framework\TestCase;
+
+final class Stage3Test extends TestCase
+{
+    public function testPlaceholder(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Installer/Stage5Test.php
+++ b/tests/Installer/Stage5Test.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Installer;
+
+use PHPUnit\Framework\TestCase;
+
+final class Stage5Test extends TestCase
+{
+    public function testPlaceholder(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Installer/Stage6Test.php
+++ b/tests/Installer/Stage6Test.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Installer;
+
+use PHPUnit\Framework\TestCase;
+
+final class Stage6Test extends TestCase
+{
+    public function testPlaceholder(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Installer/Stage8Test.php
+++ b/tests/Installer/Stage8Test.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Installer;
+
+use PHPUnit\Framework\TestCase;
+
+final class Stage8Test extends TestCase
+{
+    public function testPlaceholder(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Stubs/DbMysqli.php
+++ b/tests/Stubs/DbMysqli.php
@@ -28,16 +28,6 @@ class DbMysqli
         return 'mysql_result';
     }
 
-    public function connect($host, $user, $pass)
-    {
-        return true;
-    }
-
-    public function selectDb($dbname)
-    {
-        return true;
-    }
-
     public function fetchAssoc($result): array
     {
         return ['ok' => true];


### PR DESCRIPTION
## Summary
- fix redeclaration in DbMysqli test stub
- add placeholder PHPUnit tests for installer stages 0,1,2,3,5,6,8,10,11

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68aae589de408329a5d5e641f539e80a