### PR TITLE
Use temp directory when DB_DATACACHEPATH is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To run Legend of the Green Dragon on a typical web host you will need:
 ## Getting Started
 1. Clone the repository.
 2. Run `composer install`.
-3. Open `installer.php` in your browser and follow the prompts.
+3. Open `installer.php` in your browser and follow the prompts. When asked for a cache directory, set `DB_DATACACHEPATH` to a writable path such as `data/cache`.
 4. (Optional) Use Docker—see [docs/Docker.md](docs/Docker.md).
 
 ## Maintenance
@@ -261,6 +261,10 @@ Build the Docker containers and start the environment:
 ```bash
 docker-compose up -d --build
 ```
+
+### Step 4: Run the Installer
+
+With the containers running, open `installer.php` in your browser. When prompted for a cache directory, set `DB_DATACACHEPATH` to a writable location (for example `data/cache`) to enable caching.
 
 ---
 

--- a/src/Lotgd/Doctrine/Bootstrap.php
+++ b/src/Lotgd/Doctrine/Bootstrap.php
@@ -42,7 +42,8 @@ class Bootstrap
 
         $paths = [$rootDir . '/src/Lotgd/Entity'];
 
-        $cacheDir = ($settings['DB_DATACACHEPATH'] ?? sys_get_temp_dir()) . '/doctrine';
+        $path = !empty($settings['DB_DATACACHEPATH']) ? $settings['DB_DATACACHEPATH'] : sys_get_temp_dir();
+        $cacheDir = $path . '/doctrine';
 
         // Disable metadata caching only when datacache path is not configured
         $isDevMode = empty($settings['DB_USEDATACACHE']) || empty($settings['DB_DATACACHEPATH']);


### PR DESCRIPTION
## Summary
- Fallback Doctrine cache directory to `sys_get_temp_dir()` when `DB_DATACACHEPATH` is not set
- Document setting `DB_DATACACHEPATH` to a writable path during installation

## Testing
- `php -l src/Lotgd/Doctrine/Bootstrap.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68aae73e24508329a01c48880fdeb881