### PR TITLE
Expose database prefix to Doctrine bootstrap

### DIFF
--- a/src/Lotgd/Doctrine/Bootstrap.php
+++ b/src/Lotgd/Doctrine/Bootstrap.php
@@ -26,6 +26,9 @@ class Bootstrap
             throw new \RuntimeException('dbconnect.php not found');
         }
 
+        global $DB_PREFIX;
+        $DB_PREFIX = $settings['DB_PREFIX'] ?? '';
+
         $connection = [
             'driver'       => 'pdo_mysql',
             'host'         => $settings['DB_HOST'] ?? 'localhost',


### PR DESCRIPTION
## Summary
- Assign global `$DB_PREFIX` after reading `dbconnect.php` so Doctrine connections use the configured table prefix

## Testing
- `php -l src/Lotgd/Doctrine/Bootstrap.php`
- `composer install`
- `composer test`
- `php verify_prefix.php` (installer stages run; queries show `tp_` prefix)


------
https://chatgpt.com/codex/tasks/task_e_68ab5569eb108329bd13f363b24edbb9