### PR TITLE
fix: guard legacy settings alias

### DIFF
--- a/install/data/legacy_sql.php
+++ b/install/data/legacy_sql.php
@@ -6,14 +6,17 @@ require_once dirname(__DIR__, 2) . '/src/Lotgd/Config/constants.php';
 require_once dirname(__DIR__, 2) . '/lib/dbmysqli.php';
 require_once dirname(__DIR__, 2) . '/src/Lotgd/MySQL/Database.php';
 
-class LegacySettings
-{
-    public function getSetting(string|int $name, mixed $default = false): mixed
+if (!class_exists('Lotgd\\Settings')) {
+    class LegacySettings
     {
-        return $default;
+        public function getSetting(string|int $name, mixed $default = false): mixed
+        {
+            return $default;
+        }
     }
+
+    class_alias('LegacySettings', 'Lotgd\\Settings');
 }
-class_alias('LegacySettings', 'Lotgd\Settings');
 
 $settings = new \Lotgd\Settings();
 


### PR DESCRIPTION
## Summary
- prevent duplicate class alias during migrations

## Testing
- `php -l install/data/legacy_sql.php`
- `composer install`
- `composer test`
- `php run_migrations.php` *(fails: SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5e68090c8329a9cb7cf58e221d3f