### PR TITLE
Load DB prefix for legacy SQL installer

### DIFF
--- a/install/data/legacy_sql.php
+++ b/install/data/legacy_sql.php
@@ -20,6 +20,10 @@ if (!class_exists('Lotgd\\Settings')) {
 
 $settings = new \Lotgd\Settings();
 
+$config = require dirname(__DIR__, 2) . '/dbconnect.php';
+global $DB_PREFIX;
+$DB_PREFIX = $config['DB_PREFIX'] ?? '';
+
 include __DIR__ . '/installer_sqlstatements.php';
 
 return $sql_upgrade_statements;


### PR DESCRIPTION
## Summary
- Load DB configuration and expose `DB_PREFIX` before building legacy SQL statements

## Testing
- `php -l install/data/legacy_sql.php`
- `composer test`
- `php -r 'require "src/Lotgd/Config/constants.php"; require "src/Lotgd/MySQL/Database.php"; $config=require "dbconnect.php"; $GLOBALS["DB_PREFIX"]=$config["DB_PREFIX"]; function db_prefix($tablename, $force=null){return \Lotgd\MySQL\Database::prefix($tablename, $force); } include "install/data/installer_sqlstatements.php"; foreach($sql_upgrade_statements["0.9"] as $stmt){ if (str_contains($stmt, "test_creatures")) { echo $stmt; break; }}'`


------
https://chatgpt.com/codex/tasks/task_e_68ac339cdb788329a5d009112462bdeb