### PR TITLE
refactor: remove legacy settings alias

### DIFF
--- a/install/data/legacy_sql.php
+++ b/install/data/legacy_sql.php
@@ -6,19 +6,13 @@ require_once dirname(__DIR__, 2) . '/src/Lotgd/Config/constants.php';
 require_once dirname(__DIR__, 2) . '/lib/dbmysqli.php';
 require_once dirname(__DIR__, 2) . '/src/Lotgd/MySQL/Database.php';
 
-if (!class_exists('Lotgd\\Settings')) {
-    class LegacySettings
+$settings = new class
+{
+    public function getSetting(string|int $name, mixed $default = false): mixed
     {
-        public function getSetting(string|int $name, mixed $default = false): mixed
-        {
-            return $default;
-        }
+        return $default;
     }
-
-    class_alias('LegacySettings', 'Lotgd\\Settings');
-}
-
-$settings = new \Lotgd\Settings();
+};
 
 $config = require dirname(__DIR__, 2) . '/dbconnect.php';
 global $DB_PREFIX;


### PR DESCRIPTION
## Summary
- replace legacy settings alias with local stub in installer SQL loader
- keep database prefix initialization and installer include

## Testing
- `php -l install/data/legacy_sql.php`
- `composer install`
- `composer test`
- `php create_tables.php` (verifies table creation with prefix)

------
https://chatgpt.com/codex/tasks/task_e_68ac436bd0f483298a374a3afe7100ca