### PR TITLE
Log Doctrine cache directory for debugging

### DIFF
--- a/src/Lotgd/Doctrine/Bootstrap.php
+++ b/src/Lotgd/Doctrine/Bootstrap.php
@@ -47,6 +47,7 @@ class Bootstrap
 
         $path = !empty($settings['DB_DATACACHEPATH']) ? $settings['DB_DATACACHEPATH'] : sys_get_temp_dir();
         $cacheDir = $path . '/doctrine';
+        error_log('Doctrine cache dir=' . $cacheDir);
 
         // Disable metadata caching only when datacache path is not configured
         $isDevMode = empty($settings['DB_USEDATACACHE']) || empty($settings['DB_DATACACHEPATH']);


### PR DESCRIPTION
## Summary
- Log determined Doctrine cache directory on bootstrap

## Testing
- `php -l src/Lotgd/Doctrine/Bootstrap.php`
- `composer test`
- `php -r "require 'vendor/autoload.php'; require 'src/Lotgd/Doctrine/Bootstrap.php'; Lotgd\\Doctrine\\Bootstrap::getEntityManager();"`
- `php -r "var_export(is_writable('/tmp/doctrine'));"`


------
https://chatgpt.com/codex/tasks/task_e_68ac4a4d2b9483299276e84ab18b2af3