### PR TITLE
Log database prefixes during installation

### DIFF
--- a/install/data/legacy_sql.php
+++ b/install/data/legacy_sql.php
@@ -17,6 +17,7 @@ $settings = new class
 $config = require dirname(__DIR__, 2) . '/dbconnect.php';
 global $DB_PREFIX;
 $DB_PREFIX = $config['DB_PREFIX'] ?? '';
+error_log('Legacy SQL DB_PREFIX=' . $DB_PREFIX);
 
 include __DIR__ . '/installer_sqlstatements.php';
 

--- a/src/Lotgd/Doctrine/Bootstrap.php
+++ b/src/Lotgd/Doctrine/Bootstrap.php
@@ -28,6 +28,7 @@ class Bootstrap
 
         global $DB_PREFIX;
         $DB_PREFIX = $settings['DB_PREFIX'] ?? '';
+        error_log('Bootstrap DB_PREFIX=' . $DB_PREFIX);
 
         $connection = [
             'driver'       => 'pdo_mysql',

--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -354,6 +354,7 @@ class Database
         } else {
             $prefix = $force;
         }
+        error_log('db_prefix(' . $tablename . ') -> ' . $prefix);
         return $prefix . $tablename;
     }
 }


### PR DESCRIPTION
## Summary
- Log configured DB prefix in Doctrine bootstrap
- Record DB prefix when loading legacy SQL installer data
- Trace table prefix computations in Database::prefix

## Testing
- `composer install --no-interaction --no-progress`
- `php -l src/Lotgd/Doctrine/Bootstrap.php`
- `php -l install/data/legacy_sql.php`
- `php -l src/Lotgd/MySQL/Database.php`
- `composer test`
- `php -d log_errors=On -d error_log=/tmp/php_errors.log installer.php`
- `php -d log_errors=On -d error_log=/tmp/php_errors.log -r "require 'install/data/legacy_sql.php';"`
- `php -d log_errors=On -d error_log=/tmp/php_errors.log -r "require 'vendor/autoload.php'; try { \Lotgd\Doctrine\Bootstrap::getEntityManager(); } catch (\Throwable $e) {}"`

------
https://chatgpt.com/codex/tasks/task_e_68ac4a33f08c83298279f406323fc2f3