### PR TITLE
Expose DB prefix in Doctrine config

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -1,15 +1,17 @@
 <?php
 
-$config = require dirname(__DIR__) . '/dbconnect.php';
+$db = require dirname(__DIR__) . '/dbconnect.php';
 
 return [
     'driver' => 'pdo_mysql',
-    'host' => $config['DB_HOST'] ?? 'localhost',
-    'dbname' => $config['DB_NAME'] ?? '',
-    'user' => $config['DB_USER'] ?? '',
-    'password' => $config['DB_PASS'] ?? '',
+    'host' => $db['DB_HOST'] ?? 'localhost',
+    'dbname' => $db['DB_NAME'] ?? '',
+    'user' => $db['DB_USER'] ?? '',
+    'password' => $db['DB_PASS'] ?? '',
     'charset' => 'utf8mb4',
+    'db_prefix' => $db['DB_PREFIX'] ?? '',
     'migrations_paths' => [
-        'Lotgd\Migrations' => dirname(__DIR__) . '/migrations',
+        'Lotgd\\Migrations' => dirname(__DIR__) . '/migrations',
     ],
 ];
+

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1456,7 +1456,10 @@ class Installer
     private function runMigrations(): void
     {
         global $session;
+
         $config = require dirname(__DIR__, 2) . '/config/doctrine.php';
+        global $DB_PREFIX;
+        $DB_PREFIX = $config['db_prefix'] ?? '';
 
         $em = Bootstrap::getEntityManager();
 


### PR DESCRIPTION
## Summary
- Include `db_prefix` in Doctrine configuration
- Installer migrations read DB prefix from doctrine settings

## Testing
- `php -l config/doctrine.php`
- `php -l install/lib/Installer.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ac4e86b5f08329a79cfedd4faeefbc