### PR TITLE
Centralize database prefix handling

### DIFF
--- a/install/data/legacy_sql.php
+++ b/install/data/legacy_sql.php
@@ -17,6 +17,7 @@ $settings = new class
 $config = require dirname(__DIR__, 2) . '/dbconnect.php';
 global $DB_PREFIX;
 $DB_PREFIX = $config['DB_PREFIX'] ?? '';
+\Lotgd\MySQL\Database::setPrefix($DB_PREFIX);
 error_log('Legacy SQL DB_PREFIX=' . $DB_PREFIX);
 
 include __DIR__ . '/installer_sqlstatements.php';

--- a/src/Lotgd/Doctrine/Bootstrap.php
+++ b/src/Lotgd/Doctrine/Bootstrap.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\ORMSetup;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Lotgd\MySQL\Database;
 
 class Bootstrap
 {
@@ -28,6 +29,7 @@ class Bootstrap
 
         global $DB_PREFIX;
         $DB_PREFIX = $settings['DB_PREFIX'] ?? '';
+        Database::setPrefix($DB_PREFIX);
         error_log('Bootstrap DB_PREFIX=' . $DB_PREFIX);
 
         $connection = [

--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -37,6 +37,19 @@ class Database
     ];
 
     /**
+     * Default table prefix for prefixed database tables.
+     */
+    private static string $prefix = '';
+
+    /**
+     * Set the default table prefix.
+     */
+    public static function setPrefix(string $prefix): void
+    {
+        self::$prefix = $prefix;
+    }
+
+    /**
      * Get a statistic from the database info store.
      */
     public static function getInfo(string $key, mixed $default = null): mixed
@@ -341,20 +354,20 @@ class Database
      */
     public static function prefix(string $tablename, ?string $force = null): string
     {
-        global $DB_PREFIX;
         if ($force === null) {
             $special_prefixes = [];
             if (file_exists('prefixes.php')) {
                 require_once 'prefixes.php';
             }
-            $prefix = $DB_PREFIX;
+            $prefix = self::$prefix;
             if (isset($special_prefixes[$tablename])) {
                 $prefix = $special_prefixes[$tablename];
             }
         } else {
             $prefix = $force;
         }
-        error_log('db_prefix(' . $tablename . ') -> ' . $prefix);
-        return $prefix . $tablename;
+        $table = $prefix . $tablename;
+        error_log('db_prefix(' . $tablename . ') -> ' . $table);
+        return $table;
     }
 }


### PR DESCRIPTION
## Summary
- Add static prefix property and setter to Database and default `prefix()` to it
- Store DB prefix via `Database::setPrefix()` in Bootstrap and installer

## Testing
- `php -l src/Lotgd/MySQL/Database.php`
- `php -l src/Lotgd/Doctrine/Bootstrap.php`
- `php -l install/data/legacy_sql.php`
- `composer install`
- `php -r 'require "install/data/legacy_sql.php"; \Lotgd\MySQL\Database::prefix("creatures");'`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ac533871fc8329a3aff756090d5540