### PR TITLE
Load db prefix before migrations

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1455,11 +1455,13 @@ class Installer
      */
     private function runMigrations(): void
     {
-        global $session;
+        global $session, $DB_PREFIX;
+
+        $db        = require dirname(__DIR__, 2) . '/dbconnect.php';
+        $DB_PREFIX = $db['DB_PREFIX'] ?? '';
+        InstallerLogger::log('DB_PREFIX set to ' . $DB_PREFIX);
 
         $config = require dirname(__DIR__, 2) . '/config/doctrine.php';
-        global $DB_PREFIX;
-        $DB_PREFIX = $config['db_prefix'] ?? '';
 
         $em = Bootstrap::getEntityManager();
 


### PR DESCRIPTION
## Summary
- Ensure installer sets `$DB_PREFIX` from `dbconnect.php` before running migrations
- Add debug logging of the database prefix in migration step

## Testing
- `composer install`
- `php -l install/lib/Installer.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ac571adf948329ad5c12f65664fc6f