### PR TITLE
Ensure installer preserves DB prefix

### DIFF
--- a/install/data/legacy_sql.php
+++ b/install/data/legacy_sql.php
@@ -3,8 +3,14 @@
 declare(strict_types=1);
 
 require_once dirname(__DIR__, 2) . '/src/Lotgd/Config/constants.php';
+
+$config = require dirname(__DIR__, 2) . '/dbconnect.php';
+global $DB_PREFIX;
+$DB_PREFIX = $config['DB_PREFIX'] ?? '';
+
 require_once dirname(__DIR__, 2) . '/lib/dbmysqli.php';
-require_once dirname(__DIR__, 2) . '/src/Lotgd/MySQL/Database.php';
+\Lotgd\MySQL\Database::setPrefix($DB_PREFIX);
+error_log('Legacy SQL DB_PREFIX=' . $DB_PREFIX);
 
 $settings = new class
 {
@@ -13,12 +19,6 @@ $settings = new class
         return $default;
     }
 };
-
-$config = require dirname(__DIR__, 2) . '/dbconnect.php';
-global $DB_PREFIX;
-$DB_PREFIX = $config['DB_PREFIX'] ?? '';
-\Lotgd\MySQL\Database::setPrefix($DB_PREFIX);
-error_log('Legacy SQL DB_PREFIX=' . $DB_PREFIX);
 
 include __DIR__ . '/installer_sqlstatements.php';
 


### PR DESCRIPTION
## Summary
- remove direct inclusion of `Database` and rely on autoloading
- set the table prefix after loading legacy DB wrapper so installer uses configured prefix

## Testing
- `composer install`
- `php -l install/data/legacy_sql.php`
- `composer test` *(fails: session user acctid not set, Unable to write datacache for error_notify)*
- `php -r 'ini_set("error_log","/dev/stdout"); require "autoload.php"; require "install/data/legacy_sql.php"; echo db_prefix("creatures", null), PHP_EOL;'`


------
https://chatgpt.com/codex/tasks/task_e_68ac570a38348329a71a3290d8b22be4