### PR TITLE
Fix default DB prefix handling

### DIFF
--- a/lib/dbmysqli.php
+++ b/lib/dbmysqli.php
@@ -65,7 +65,7 @@ function db_table_exists($tablename)
 {
     return Database::tableExists($tablename);
 }
-function db_prefix($tablename, $force = false)
+function db_prefix($tablename, $force = null)
 {
     return Database::prefix($tablename, $force);
 }

--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -352,9 +352,9 @@ class Database
     /**
      * Get a table name with the configured prefix.
      */
-    public static function prefix(string $tablename, ?string $force = null): string
+    public static function prefix(string $tablename, string|false|null $force = null): string
     {
-        if ($force === null) {
+        if ($force === null || $force === false) {
             $special_prefixes = [];
             if (file_exists('prefixes.php')) {
                 require_once 'prefixes.php';


### PR DESCRIPTION
## Summary
- Avoid forcing false prefix in `db_prefix` wrapper
- Allow `Database::prefix` to treat `false` as `null`

## Testing
- `php -l lib/dbmysqli.php`
- `php -l src/Lotgd/MySQL/Database.php`
- `composer install`
- `composer test`
- `php -r "require 'vendor/autoload.php'; require 'lib/dbmysqli.php'; \\Lotgd\\MySQL\\Database::setPrefix('test_'); db_prefix('creatures');"`


------
https://chatgpt.com/codex/tasks/task_e_68ac5c8e149c83298db79186ca7b3fd7