### PR TITLE
Fix installer SQL update statements

### DIFF
--- a/install/data/installer_sqlstatements.php
+++ b/install/data/installer_sqlstatements.php
@@ -808,8 +808,8 @@ $sql_upgrade_statements = array(
 "UPDATE " . db_prefix("accounts") . " SET specialty='' WHERE specialty='0'",
 ),
 "0.9.8-prerelease.12" => array(
-"1|UPDATE " . db_prefix("creatures") . " SET forest=1",
-"1|UPDATE " . db_prefix("creatures") . " SET graveyard=1 where location=1",
+"UPDATE " . db_prefix("creatures") . " SET forest=1",
+"UPDATE " . db_prefix("creatures") . " SET graveyard=1 where location=1",
 ),
 "0.9.8-prerelease.13" => array(),
 "0.9.8-prerelease.14" => array(),


### PR DESCRIPTION
## Summary
- remove stray `1|` prefixes from two installer update statements

## Testing
- `composer install`
- `php -l install/data/installer_sqlstatements.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ac6133ed808329a519977afe255e0c