### PR TITLE
Remove location-based graveyard update in installer

### DIFF
--- a/install/data/installer_sqlstatements.php
+++ b/install/data/installer_sqlstatements.php
@@ -809,7 +809,7 @@ $sql_upgrade_statements = array(
 ),
 "0.9.8-prerelease.12" => array(
 "UPDATE " . db_prefix("creatures") . " SET forest=1",
-"UPDATE " . db_prefix("creatures") . " SET graveyard=1 where location=1",
+//"UPDATE " . db_prefix("creatures") . " SET graveyard=1 where location=1",
 ),
 "0.9.8-prerelease.13" => array(),
 "0.9.8-prerelease.14" => array(),


### PR DESCRIPTION
## Summary
- Comment out legacy SQL line updating `creatures` by nonexistent `location` column

## Testing
- `composer test`
- Installer migrations: `php -r 'define("ALLOW_ANONYMOUS", true); define("OVERRIDE_FORCED_NAV", true); define("IS_INSTALLER", true); require "common.php"; $session=[]; $DB_PREFIX=""; $installer=new \Lotgd\Installer\Installer(); $ref=new ReflectionClass($installer); $method=$ref->getMethod("runMigrations"); $method->setAccessible(true); try { $method->invoke($installer); echo "Migrations completed\n"; } catch (Throwable $e) { echo "Migration error: ".$e->getMessage()."\n"; }'`


------
https://chatgpt.com/codex/tasks/task_e_68ac63ade310832980be7065f0c6133e