### PR TITLE
Use DROP INDEX for clans migration

### DIFF
--- a/migrations/Version20250724000015.php
+++ b/migrations/Version20250724000015.php
@@ -17,7 +17,7 @@ final class Version20250724000015 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE ' . Database::prefix('clans') . ' DROP INDEX IF EXISTS clanname');
+        $this->addSql('DROP INDEX IF EXISTS clanname ON ' . Database::prefix('clans'));
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
## Summary
- drop `clanname` index using `DROP INDEX IF EXISTS` syntax in migration

## Testing
- `php -l migrations/Version20250724000015.php`
- `composer install`
- `composer test` *(fails: mailStatus session user acctid not set, test run hung)*

------
https://chatgpt.com/codex/tasks/task_e_68ac69e0c60083298ddb0f8ec36aee63