### PR TITLE
Log migration errors during installer

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1508,7 +1508,12 @@ class Installer
         $plan = $dependencyFactory->getMigrationPlanCalculator()->getPlanUntilVersion($latestVersion);
         $factory = $dependencyFactory->getConsoleInputMigratorConfigurationFactory();
         $migratorConfig = $factory->getMigratorConfiguration(new ArrayInput([]));
-        $dependencyFactory->getMigrator()->migrate($plan, $migratorConfig);
+        try {
+            $dependencyFactory->getMigrator()->migrate($plan, $migratorConfig);
+        } catch (\Throwable $e) {
+            InstallerLogger::log('Migration error: ' . $e->getMessage());
+            throw $e;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- log migration failures to install/errors/install.log and rethrow

## Testing
- `php -l install/lib/Installer.php`
- `composer install`
- `composer test`
- `php installer.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac69e2e2848329849de224553c5d72