### PR TITLE
Ensure installer includes default favicon

### DIFF
--- a/src/Lotgd/Page/Footer.php
+++ b/src/Lotgd/Page/Footer.php
@@ -45,6 +45,14 @@ class Footer
 
         Buffs::restoreBuffFields();
 
+        $defaultFaviconLink =
+            "<link rel=\"shortcut icon\" HREF=\"/images/favicon/favicon.ico\" TYPE=\"image/x-icon\"/>" .
+            "<link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/images/favicon/apple-touch-icon.png\">" .
+            "<link rel=\"icon\" type=\"image/png\" sizes=\"32x32\" href=\"/images/favicon/favicon-32x32.png\">" .
+            "<link rel=\"icon\" type=\"image/png\" sizes=\"16x16\" href=\"/images/favicon/favicon-16x16.png\">" .
+            "<link rel=\"manifest\" href=\"/images/favicon/site.webmanifest\">";
+        $pre_headscript = $defaultFaviconLink;
+
         if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
             $sql     = 'SELECT motddate FROM ' . Database::prefix('motd') . ' ORDER BY motditem DESC LIMIT 1';
             $result  = Database::query($sql);
@@ -63,23 +71,15 @@ class Footer
             } else {
                 $session['needtoviewmotd'] = false;
             }
-            $favicon = [
-                'favicon-link' =>
-                "<link rel=\"shortcut icon\" HREF=\"/images/favicon/favicon.ico\" TYPE=\"image/x-icon\"/>" .
-                "<link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/images/favicon/apple-touch-icon.png\">" .
-                "<link rel=\"icon\" type=\"image/png\" sizes=\"32x32\" href=\"/images/favicon/favicon-32x32.png\">" .
-                "<link rel=\"icon\" type=\"image/png\" sizes=\"16x16\" href=\"/images/favicon/favicon-16x16.png\">" .
-                "<link rel=\"manifest\" href=\"/images/favicon/site.webmanifest\">",
-            ];
-                        $favicon        = modulehook('pageparts-favicon', $favicon);
-                        $pre_headscript = PageParts::canonicalLink() . $favicon['favicon-link'];
+            $favicon = ['favicon-link' => $defaultFaviconLink];
+            $favicon        = modulehook('pageparts-favicon', $favicon);
+            $pre_headscript = PageParts::canonicalLink() . $favicon['favicon-link'];
             if (isset($settings) && $settings->getSetting('ajax', 1) == 1 && isset($session['user']['prefs']['ajax']) && $session['user']['prefs']['ajax']) {
                 if (file_exists('async/setup.php')) {
                     require 'async/setup.php';
                 }
             }
         } else {
-            $pre_headscript = '';
             $headscript     = '';
         }
 

--- a/tests/Installer/Stage0Test.php
+++ b/tests/Installer/Stage0Test.php
@@ -8,8 +8,24 @@ use PHPUnit\Framework\TestCase;
 
 final class Stage0Test extends TestCase
 {
-    public function testPlaceholder(): void
+    public function testInstallerOutputsDefaultFavicon(): void
     {
-        $this->assertTrue(true);
+        $root = dirname(__DIR__, 2);
+        $config = $root . '/dbconnect.php';
+        $backup = $config . '.bak';
+
+        if (file_exists($config)) {
+            rename($config, $backup);
+        }
+
+        $cmd    = sprintf('cd %s && php installer.php', escapeshellarg($root));
+        $output = shell_exec($cmd);
+
+        if (file_exists($backup)) {
+            rename($backup, $config);
+        }
+
+        $this->assertIsString($output);
+        $this->assertStringContainsString('/images/favicon/favicon.ico', $output);
     }
 }


### PR DESCRIPTION
## Summary
- Include default favicon links in page header prior to installer checks.
- Apply favicon module hook and canonical link only for non-installer pages.
- Add installer test ensuring favicon markup is present.

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ac6bbf827483298109e157f3dc2897