### PR TITLE
Ensure clanname index removal checks schema

### DIFF
--- a/migrations/Version20250724000015.php
+++ b/migrations/Version20250724000015.php
@@ -17,7 +17,12 @@ final class Version20250724000015 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('DROP INDEX IF EXISTS clanname ON ' . Database::prefix('clans'));
+        $schemaManager = $this->connection->createSchemaManager();
+        $table         = Database::prefix('clans');
+
+        if (array_key_exists('clanname', $schemaManager->listTableIndexes($table))) {
+            $this->addSql('DROP INDEX clanname ON ' . $table);
+        }
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
## Summary
- Drop `clanname` index only if it exists during migration

## Testing
- `php -l migrations/Version20250724000015.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ac6c5d65ac8329be07896e857e2d25