### PR TITLE
Handle missing POST name in installer

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -262,7 +262,8 @@ class Installer
             if ($showform) {
                 $this->output->rawOutput("<form action='installer.php?stage=$stage' method='POST'>");
                 $this->output->output("Enter a name for your superuser account:");
-                $this->output->rawOutput("<input name='name' value=\"" . htmlentities(Http::post("name"), ENT_COMPAT, $this->getSetting("charset", "ISO-8859-1")) . "\">");
+                $postedName = Http::post('name');
+                $this->output->rawOutput("<input name='name' value=\"" . htmlentities((string) $postedName, ENT_COMPAT, $this->getSetting('charset', 'ISO-8859-1')) . "\">");
                 $this->output->output("`nEnter a password: ");
                 $this->output->rawOutput("<input name='pass1' type='password'>");
                 $this->output->output("`nConfirm your password: ");


### PR DESCRIPTION
## Summary
- Safely handle missing `name` when rendering stage 10 form in installer

## Testing
- `php -l install/lib/Installer.php`
- `composer test` *(fails: Unable to write datacache for error_notify)*

------
https://chatgpt.com/codex/tasks/task_e_68ac75ae5ce0832991cd3ef535f014e2