### PR TITLE
Gracefully handle unwritable installer log directory

### DIFF
--- a/install/lib/InstallerLogger.php
+++ b/install/lib/InstallerLogger.php
@@ -13,23 +13,48 @@ class InstallerLogger
      */
     public static function getLogFilePath(): string
     {
-        return __DIR__ . '/../errors/install.log';
+        $defaultDir = __DIR__ . '/../errors';
+
+        // Use the default install directory when it is writable
+        if ((is_dir($defaultDir) && is_writable($defaultDir))
+            || (!is_dir($defaultDir) && is_writable(dirname($defaultDir)))) {
+            return $defaultDir . '/install.log';
+        }
+
+        // Fall back to a configurable data directory or the system temp dir
+        $fallback = getenv('LOTGD_DATA_DIR');
+        if (!$fallback) {
+            $fallback = sys_get_temp_dir() . '/lotgd_install';
+        }
+
+        return rtrim($fallback, '/') . '/install.log';
     }
 
     public static function log(string $message): bool
     {
-        $logDir = dirname(self::getLogFilePath());
+        $logFile = self::getLogFilePath();
+        $logDir  = dirname($logFile);
+
         if (!is_dir($logDir)) {
-            if (!mkdir($logDir, 0755, true) && !is_dir($logDir)) {
+            $parent = dirname($logDir);
+            if (!is_writable($parent)) {
                 return false;
             }
+
+            if (!@mkdir($logDir, 0755, true) && !is_dir($logDir)) {
+                return false;
+            }
+        }
+
+        if (!is_writable($logDir)) {
+            return false;
         }
 
         $date  = date('Y-m-d H:i:s');
         $entry = sprintf("[%s] %s\n", $date, $message);
 
         try {
-            $written = file_put_contents(self::getLogFilePath(), $entry, FILE_APPEND | LOCK_EX);
+            $written = @file_put_contents($logFile, $entry, FILE_APPEND | LOCK_EX);
         } catch (\Throwable $th) {
             return false;
         }
@@ -39,7 +64,7 @@ class InstallerLogger
         }
 
         if (function_exists('output')) {
-            output("`n`^See %s for a detailed error log.`n", self::getLogFilePath());
+            output("`n`^See %s for a detailed error log.`n", $logFile);
         }
 
         return true;

--- a/tests/InstallerLoggerTest.php
+++ b/tests/InstallerLoggerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Installer {
+    function is_writable(string $path): bool
+    {
+        return false;
+    }
+}
+
+namespace Lotgd\Tests {
+
+use Lotgd\Installer\InstallerLogger;
+use PHPUnit\Framework\TestCase;
+
+final class InstallerLoggerTest extends TestCase
+{
+    public function testLogReturnsFalseWithoutWarningsWhenDirectoryIsNotWritable(): void
+    {
+        $warnings = [];
+        set_error_handler(function (int $severity, string $message) use (&$warnings) {
+            $warnings[] = $message;
+            return true;
+        });
+
+        $result = InstallerLogger::log('test message');
+
+        restore_error_handler();
+
+        $this->assertFalse($result);
+        $this->assertSame([], $warnings);
+    }
+}
+
+}


### PR DESCRIPTION
## Summary
- Avoid PHP warnings in `InstallerLogger::log` by checking directory writability and suppressing failing operations
- Add fallback log path (custom data dir or system temp) when default install dir is not writable
- Cover unwritable directory behavior with tests

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ac911a23fc8329a2d381d43575350a