### PR TITLE
Remove unused RuntimeException import in InstallerLogger

### DIFF
--- a/install/lib/InstallerLogger.php
+++ b/install/lib/InstallerLogger.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lotgd\Installer;
 
-use RuntimeException;
-
 class InstallerLogger
 {
     /**


### PR DESCRIPTION
## Summary
- remove unused RuntimeException import in InstallerLogger

## Testing
- `php -l install/lib/InstallerLogger.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9bd4aa288329b51f7757a8f88366