### PR TITLE
Add PHPDoc for InstallerLogger log method

### DIFF
--- a/install/lib/InstallerLogger.php
+++ b/install/lib/InstallerLogger.php
@@ -28,6 +28,13 @@ class InstallerLogger
         return rtrim($fallback, '/') . '/install.log';
     }
 
+    /**
+     * Append a message to the installer log file.
+     *
+     * @param string $message Message to write to the log.
+     *
+     * @return bool True on success, false otherwise.
+     */
     public static function log(string $message): bool
     {
         $logFile = self::getLogFilePath();


### PR DESCRIPTION
## Summary
- document installer log function

## Testing
- `php -l install/lib/InstallerLogger.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9e7399788329bf9d3621594e5057