### PR TITLE
Isolate InstallerLoggerTest process

### DIFF
--- a/tests/InstallerLoggerTest.php
+++ b/tests/InstallerLoggerTest.php
@@ -14,6 +14,10 @@ namespace Lotgd\Tests {
 use Lotgd\Installer\InstallerLogger;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @runInSeparateProcess
+ * @preserveGlobalState disabled
+ */
 final class InstallerLoggerTest extends TestCase
 {
     public function testLogReturnsFalseWithoutWarningsWhenDirectoryIsNotWritable(): void


### PR DESCRIPTION
## Summary
- run InstallerLoggerTest in separate process so its is_writable mock doesn't leak to other tests

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68aca1b0764c83299322177202847e0d