### PR TITLE
feat(mysql): handle charset and collation

### DIFF
--- a/install/data/tables.php
+++ b/install/data/tables.php
@@ -962,6 +962,8 @@ function get_all_tables()
             )
         ),
     'mail' => array(
+        'charset' => 'utf8mb4',
+        'collation' => 'utf8mb4_unicode_ci',
         'messageid' => array(
             'name' => 'messageid',
             'type' => 'int(11) unsigned',

--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -251,7 +251,12 @@ class TableDescriptor
             }
             if (!empty($row['Collation'])) {
                 $item['collation'] = $row['Collation'];
-                $item['charset'] = explode('_', $row['Collation'], 2)[0];
+                if (strpos($row['Collation'], '_') !== false) {
+                    $item['charset'] = explode('_', $row['Collation'], 2)[0];
+                } else {
+                    // Collation name does not follow expected pattern; do not set charset
+                    $item['charset'] = null;
+                }
             }
             $descriptor[$item['name']] = $item;
         }

--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -260,7 +260,8 @@ class TableDescriptor
             }
             $descriptor[$item['name']] = $item;
         }
-        $status = Database::query("SHOW TABLE STATUS LIKE '$tablename'");
+        $tablename_escaped = addslashes($tablename);
+        $status = Database::query("SHOW TABLE STATUS LIKE '$tablename_escaped'");
         $row = Database::fetchAssoc($status);
         if ($row && !empty($row['Collation'])) {
             $descriptor['collation'] = $row['Collation'];

--- a/tests/Stubs/Database.php
+++ b/tests/Stubs/Database.php
@@ -17,6 +17,8 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
         public static string $lastCacheName = '';
         public static array $describe_rows = [];
         public static array $keys_rows = [];
+        public static array $full_columns_rows = [];
+        public static array $table_status_rows = [];
         public static ?object $doctrineConnection = null;
         public static ?object $instance = null;
         public static array $queryCacheResults = [];
@@ -77,8 +79,18 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
                 return true;
             }
 
+            if (strpos($sql, 'SHOW FULL COLUMNS FROM') === 0) {
+                $last_query_result = self::$full_columns_rows;
+                return $last_query_result;
+            }
+
             if (strpos($sql, 'DESCRIBE ') === 0) {
                 $last_query_result = self::$describe_rows;
+                return $last_query_result;
+            }
+
+            if (strpos($sql, 'SHOW TABLE STATUS LIKE') === 0) {
+                $last_query_result = self::$table_status_rows;
                 return $last_query_result;
             }
 
@@ -93,6 +105,11 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
             }
 
             $mysqli = self::getInstance();
+
+            if (strpos($sql, 'ALTER TABLE') === 0) {
+                $last_query_result = true;
+                return true;
+            }
 
             if (preg_match("/SELECT prefs,emailaddress FROM accounts WHERE acctid='?(\d+)'?/", $sql, $m)) {
                 $acctid = (int) $m[1];


### PR DESCRIPTION
## Summary
- track table and column charset/collation and include them in generated SQL
- default tables to utf8mb4_unicode_ci when none specified
- note mail table descriptor's collation

## Testing
- `composer test`
- `php /tmp/test_sync.php`

------
https://chatgpt.com/codex/tasks/task_e_68ad6653df54832980fc8965c1e6ac67