### PR TITLE
test: ensure synctable ignores missing collation

### DIFF
--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -143,4 +143,26 @@ final class TableDescriptorTest extends TestCase
         TableDescriptor::synctable('dummy', $descriptor);
         $this->assertStringNotContainsString('CHANGE', Database::$lastSql);
     }
+
+    public function testSynctableNoChangeWithoutCollationInDescriptor(): void
+    {
+        Database::$full_columns_rows = [
+            [
+                'Field' => 'body',
+                'Type' => 'text',
+                'Null' => 'NO',
+                'Default' => null,
+                'Extra' => '',
+                'Collation' => 'utf8mb4_unicode_ci',
+            ],
+        ];
+        Database::$keys_rows = [];
+        Database::$table_status_rows = [['Collation' => 'utf8mb4_unicode_ci']];
+        Database::$lastSql = '';
+        $descriptor = [
+            'body' => ['name' => 'body', 'type' => 'text'],
+        ];
+        TableDescriptor::synctable('dummy', $descriptor);
+        $this->assertStringNotContainsString('CHANGE', Database::$lastSql);
+    }
 }


### PR DESCRIPTION
## Summary
- add regression test for synctable when descriptor lacks charset/collation

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68addbf52110832994d919df7cc00f81