### PR TITLE
Handle column charset mismatches in TableDescriptor sync

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -59,6 +59,7 @@ class TableDescriptor
             unset($existing['charset'], $existing['collation']);
             reset($descriptor);
             $changes = array();
+            $columnsNeedConversion = false;
             foreach ($descriptor as $key => $val) {
                 if ($key == "RequireMyISAM") {
                     continue;
@@ -92,9 +93,15 @@ class TableDescriptor
                 }
                 if (isset($existing[$key])) {
                     if (!isset($val['collation'])) {
+                        if (isset($existing[$key]['collation']) && $existing[$key]['collation'] !== $tableCollation) {
+                            $columnsNeedConversion = true;
+                        }
                         unset($existing[$key]['collation']);
                     }
                     if (!isset($val['charset'])) {
+                        if (isset($existing[$key]['charset']) && $existing[$key]['charset'] !== $tableCharset) {
+                            $columnsNeedConversion = true;
+                        }
                         unset($existing[$key]['charset']);
                     }
                 }
@@ -132,7 +139,7 @@ class TableDescriptor
                 }//end if
                 unset($existing[$key]);
             }//end foreach
-            if ($existingCollation !== null && $existingCollation !== $tableCollation) {
+            if (($existingCollation !== null && $existingCollation !== $tableCollation) || $columnsNeedConversion) {
                 $changes[] = "CONVERT TO CHARACTER SET $tableCharset COLLATE $tableCollation";
             }
             //drop no longer needed columns

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -165,4 +165,31 @@ final class TableDescriptorTest extends TestCase
         TableDescriptor::synctable('dummy', $descriptor);
         $this->assertStringNotContainsString('CHANGE', Database::$lastSql);
     }
+
+    public function testSynctableDetectsColumnCollationMismatch(): void
+    {
+        Database::$full_columns_rows = [
+            [
+                'Field' => 'body',
+                'Type' => 'text',
+                'Null' => 'NO',
+                'Default' => null,
+                'Extra' => '',
+                'Collation' => 'latin1_swedish_ci',
+            ],
+        ];
+        Database::$keys_rows = [];
+        Database::$table_status_rows = [['Collation' => 'utf8mb4_unicode_ci']];
+        Database::$lastSql = '';
+        $descriptor = [
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'body' => ['name' => 'body', 'type' => 'text'],
+        ];
+        TableDescriptor::synctable('dummy', $descriptor);
+        $this->assertStringContainsString(
+            'CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci',
+            Database::$lastSql
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- detect columns whose charset/collation differ from table defaults and trigger table conversion
- add test covering mismatched column collation triggering conversion

## Testing
- `composer install`
- `php -l src/Lotgd/MySQL/TableDescriptor.php tests/TableDescriptorTest.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ade140274483299815ed2c429b3d1d