### PR TITLE
Avoid empty charset in table descriptor generation

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -283,9 +283,6 @@ class TableDescriptor
                 $item['collation'] = $row['Collation'];
                 if (strpos($row['Collation'], '_') !== false) {
                     $item['charset'] = explode('_', $row['Collation'], 2)[0];
-                } else {
-                    // Collation name does not follow expected pattern; do not set charset
-                    $item['charset'] = null;
                 }
             }
             $descriptor[$item['name']] = $item;
@@ -377,7 +374,7 @@ class TableDescriptor
             . $input['type']
             . (isset($input['null']) && $input['null'] ? "" : " NOT NULL")
             . (isset($input['default']) ? " default '{$input['default']}'" : "")
-            . (isset($input['charset']) ? " CHARACTER SET {$input['charset']}" : "")
+            . (!empty($input['charset']) ? " CHARACTER SET {$input['charset']}" : "")
             . (isset($input['collation']) ? " COLLATE {$input['collation']}" : "")
             . " " . $input['extra'];
         }

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -76,6 +76,24 @@ final class TableDescriptorTest extends TestCase
         $this->assertSame('latin1_swedish_ci', $descriptor['collation']);
     }
 
+    public function testCollationWithoutUnderscoreDoesNotSetCharset(): void
+    {
+        Database::$full_columns_rows = [
+            [
+                'Field' => 'body',
+                'Type' => 'text',
+                'Null' => 'NO',
+                'Default' => null,
+                'Extra' => '',
+                'Collation' => 'utf8mb4',
+            ],
+        ];
+        $descriptor = TableDescriptor::tableCreateDescriptor('dummy');
+        $this->assertArrayNotHasKey('charset', $descriptor['body']);
+        $sql = TableDescriptor::descriptorCreateSql($descriptor['body']);
+        $this->assertStringNotContainsString('CHARACTER SET', $sql);
+    }
+
     public function testSynctableAltersTableCollation(): void
     {
         Database::$full_columns_rows = [


### PR DESCRIPTION
## Summary
- Omit charset from column descriptors when collation lacks an underscore
- Skip empty charset values when building SQL
- Add regression test for collations without underscores

## Testing
- `php -l src/Lotgd/MySQL/TableDescriptor.php`
- `php -l tests/TableDescriptorTest.php`
- `composer install`
- `composer test` *(fails: Cannot redeclare class Lotgd\Commentary)*


------
https://chatgpt.com/codex/tasks/task_e_68ade3b4706c832992b5c979aa0f3f38