### PR TITLE
Derive default MySQL collations from charset

### DIFF
--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -111,10 +111,12 @@ synctable('mytable', $desc);
 Both `charset` and `collation` keys can appear at the top level to affect the
 entire table or within individual column definitions to override the defaults.
 If you omit `charset` but provide `collation`, the engine will infer the
-character set from the collation name automatically. Because
-`utf8mb4_unicode_ci` sorts and compares virtually all scripts and emoji
-correctly, choosing a different collation is rarely sensible. If you change it,
-be certain you understand why.
+character set from the collation name automatically. If only `charset` is
+provided, `synctable()` assumes `<charset>_unicode_ci` when supported or falls
+back to the server's default collation for that charset. Unsupported
+combinations must be specified explicitly. Because `utf8mb4_unicode_ci` sorts
+and compares virtually all scripts and emoji correctly, choosing a different
+collation is rarely sensible. If you change it, be certain you understand why.
 
 Ensure that the application's output encoding matches the database encoding to
 avoid memory errors when strings are converted between PHP and MySQL.

--- a/tests/Stubs/Database.php
+++ b/tests/Stubs/Database.php
@@ -19,6 +19,7 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
         public static array $keys_rows = [];
         public static array $full_columns_rows = [];
         public static array $table_status_rows = [];
+        public static array $collation_rows = [];
         public static ?object $doctrineConnection = null;
         public static ?object $instance = null;
         public static array $queryCacheResults = [];
@@ -96,6 +97,15 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
 
             if (strpos($sql, 'SHOW KEYS FROM') === 0) {
                 $last_query_result = self::$keys_rows;
+                return $last_query_result;
+            }
+
+            if (strpos($sql, 'SHOW COLLATION') === 0) {
+                if (self::$collation_rows) {
+                    $last_query_result = array_shift(self::$collation_rows);
+                } else {
+                    $last_query_result = [];
+                }
                 return $last_query_result;
             }
 

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -17,6 +17,7 @@ final class TableDescriptorTest extends TestCase
         Database::$keys_rows = [];
         Database::$full_columns_rows = [];
         Database::$table_status_rows = [['Collation' => 'utf8mb4_unicode_ci']];
+        Database::$collation_rows = [];
     }
 
     public function testDefaultZeroIsDetected(): void
@@ -207,6 +208,32 @@ final class TableDescriptorTest extends TestCase
         TableDescriptor::synctable('dummy', $descriptor);
         $this->assertStringContainsString(
             'CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci',
+            Database::$lastSql
+        );
+    }
+
+    public function testSynctableDerivesCollationFromCharset(): void
+    {
+        Database::$full_columns_rows = [
+            [
+                'Field' => 'body',
+                'Type' => 'text',
+                'Null' => 'NO',
+                'Default' => null,
+                'Extra' => '',
+                'Collation' => 'utf8mb4_unicode_ci',
+            ],
+        ];
+        Database::$keys_rows = [];
+        Database::$table_status_rows = [['Collation' => 'utf8mb4_unicode_ci']];
+        Database::$collation_rows = [[], [['Collation' => 'latin1_swedish_ci']]];
+        $descriptor = [
+            'charset' => 'latin1',
+            'body' => ['name' => 'body', 'type' => 'text'],
+        ];
+        TableDescriptor::synctable('dummy', $descriptor);
+        $this->assertStringContainsString(
+            'CONVERT TO CHARACTER SET latin1 COLLATE latin1_swedish_ci',
             Database::$lastSql
         );
     }


### PR DESCRIPTION
## Summary
- Derive table collations from charsets when not explicitly provided in `synctable()` and table creation.
- Document automatic collation selection and requirement for explicit unsupported combinations.
- Add regression test verifying latin1 defaults to `latin1_swedish_ci` during conversion.

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ade4fa65f48329bdadaac8e1fa8488