### PR TITLE
Handle collations without underscores in table creation

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -218,7 +218,11 @@ class TableDescriptor
         $tableCharset = $descriptor['charset'] ?? null;
         $tableCollation = $descriptor['collation'] ?? null;
         if (!$tableCharset && $tableCollation) {
-            $tableCharset = explode('_', $tableCollation, 2)[0];
+            if (strpos($tableCollation, '_') !== false) {
+                $tableCharset = explode('_', $tableCollation, 2)[0];
+            } else {
+                $tableCharset = 'utf8mb4';
+            }
         }
         if ($tableCharset && !$tableCollation) {
             $tableCollation = self::defaultCollation($tableCharset);

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -95,6 +95,17 @@ final class TableDescriptorTest extends TestCase
         $this->assertStringNotContainsString('CHARACTER SET', $sql);
     }
 
+    public function testTableCreateFromDescriptorFallsBackToDefaultCharset(): void
+    {
+        $descriptor = [
+            'collation' => 'utf16',
+            'id' => ['name' => 'id', 'type' => 'int'],
+        ];
+        $sql = TableDescriptor::tableCreateFromDescriptor('dummy', $descriptor);
+        $this->assertStringContainsString('DEFAULT CHARSET=utf8mb4', $sql);
+        $this->assertStringContainsString('COLLATE=utf16', $sql);
+    }
+
     public function testSynctableAltersTableCollation(): void
     {
         Database::$full_columns_rows = [


### PR DESCRIPTION
## Summary
- handle collations without underscores when deriving charset
- add regression test for table creation with underscore-less collations

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68adf703e26c8329a82bd4637e319aaa