### PR TITLE
Validate charset and collation compatibility

### DIFF
--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -328,4 +328,29 @@ final class TableDescriptorTest extends TestCase
         TableDescriptor::synctable('dummy', $descriptor);
         $this->assertStringNotContainsString('CHANGE body body text', Database::$lastSql);
     }
+
+    public function testTableCreateFromDescriptorRejectsMismatchedTableCharsetAndCollation(): void
+    {
+        $descriptor = [
+            'charset' => 'utf8mb4',
+            'collation' => 'latin1_swedish_ci',
+            'id' => ['name' => 'id', 'type' => 'int'],
+        ];
+        $this->expectException(\InvalidArgumentException::class);
+        TableDescriptor::tableCreateFromDescriptor('dummy', $descriptor);
+    }
+
+    public function testTableCreateFromDescriptorRejectsMismatchedColumnCharsetAndCollation(): void
+    {
+        $descriptor = [
+            'id' => [
+                'name' => 'id',
+                'type' => 'text',
+                'charset' => 'utf8mb4',
+                'collation' => 'latin1_swedish_ci',
+            ],
+        ];
+        $this->expectException(\InvalidArgumentException::class);
+        TableDescriptor::tableCreateFromDescriptor('dummy', $descriptor);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure table charset and collation pairs are compatible during sync and creation
- validate column-level charset/collation combinations
- add tests for mismatched charset and collation pairs

## Testing
- `php -l src/Lotgd/MySQL/TableDescriptor.php`
- `php -l tests/TableDescriptorTest.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68adfb83178083298f9db21e73e471b4