### PR TITLE
Avoid storing charset for tables with binary collation

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -373,7 +373,9 @@ class TableDescriptor
         $row = Database::fetchAssoc($status);
         if ($row && !empty($row['Collation'])) {
             $descriptor['collation'] = $row['Collation'];
-            $descriptor['charset'] = explode('_', $row['Collation'], 2)[0];
+            if (strpos($row['Collation'], '_') !== false) {
+                $descriptor['charset'] = explode('_', $row['Collation'], 2)[0];
+            }
         }
         $sql = "SHOW KEYS FROM $tablename";
         $result = Database::query($sql);

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -108,6 +108,24 @@ final class TableDescriptorTest extends TestCase
         $this->assertStringNotContainsString('CHARACTER SET', $sql);
     }
 
+    public function testTableStatusCollationWithoutUnderscoreDoesNotSetCharset(): void
+    {
+        Database::$full_columns_rows = [
+            [
+                'Field' => 'body',
+                'Type' => 'text',
+                'Null' => 'NO',
+                'Default' => null,
+                'Extra' => '',
+                'Collation' => 'utf8mb4_unicode_ci',
+            ],
+        ];
+        Database::$table_status_rows = [['Collation' => 'binary']];
+        $descriptor = TableDescriptor::tableCreateDescriptor('dummy');
+        $this->assertSame('binary', $descriptor['collation']);
+        $this->assertArrayNotHasKey('charset', $descriptor);
+    }
+
     public function testTableCreateFromDescriptorFallsBackToDefaultCharset(): void
     {
         $descriptor = [


### PR DESCRIPTION
## Summary
- Only record `charset` when table collation includes a charset prefix
- Add test ensuring `tableCreateDescriptor` omits charset for `SHOW TABLE STATUS` collation `binary`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68adfea7b4c88329b64e7fd5986552d9