### PR TITLE
Add synctable charset/collation mismatch tests

### DIFF
--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -371,4 +371,29 @@ final class TableDescriptorTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         TableDescriptor::tableCreateFromDescriptor('dummy', $descriptor);
     }
+
+    public function testSynctableRejectsMismatchedTableCharsetAndCollation(): void
+    {
+        $descriptor = [
+            'charset' => 'utf8mb4',
+            'collation' => 'latin1_swedish_ci',
+            'id' => ['name' => 'id', 'type' => 'int'],
+        ];
+        $this->expectException(\InvalidArgumentException::class);
+        TableDescriptor::synctable('dummy', $descriptor);
+    }
+
+    public function testSynctableRejectsMismatchedColumnCharsetAndCollation(): void
+    {
+        $descriptor = [
+            'id' => [
+                'name' => 'id',
+                'type' => 'text',
+                'charset' => 'utf8mb4',
+                'collation' => 'latin1_swedish_ci',
+            ],
+        ];
+        $this->expectException(\InvalidArgumentException::class);
+        TableDescriptor::synctable('dummy', $descriptor);
+    }
 }


### PR DESCRIPTION
## Summary
- test TableDescriptor::synctable rejects mismatched table charset and collation
- test TableDescriptor::synctable rejects mismatched column charset and collation

## Testing
- `php -l tests/TableDescriptorTest.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ae03b457f48329b17c3fec3dd9aa80