### PR TITLE
Handle SQL expression defaults in table descriptors

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -613,8 +613,12 @@ class TableDescriptor
                 if ($input['default'] === null) {
                     $return .= " DEFAULT NULL";
                 } elseif (is_string($input['default'])) {
-                    $escapedDefault = Database::escape($input['default']);
-                    $return .= " DEFAULT '{$escapedDefault}'";
+                    if (preg_match('/^[A-Z_]+(?:\(\))?$/i', $input['default'])) {
+                        $return .= " DEFAULT {$input['default']}";
+                    } else {
+                        $escapedDefault = Database::escape($input['default']);
+                        $return .= " DEFAULT '{$escapedDefault}'";
+                    }
                 } else {
                     $return .= " DEFAULT {$input['default']}";
                 }

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -72,6 +72,18 @@ final class TableDescriptorTest extends TestCase
         $this->assertStringContainsString('DEFAULT NULL', $sql);
     }
 
+    public function testDescriptorCreateSqlUnquotedExpressionDefault(): void
+    {
+        $descriptor = [
+            'name' => 'created',
+            'type' => 'datetime',
+            'default' => 'CURRENT_TIMESTAMP',
+        ];
+
+        $sql = TableDescriptor::descriptorCreateSql($descriptor);
+        $this->assertStringContainsString('DEFAULT CURRENT_TIMESTAMP', $sql);
+    }
+
     public function testCollationIsCaptured(): void
     {
         Database::$full_columns_rows = [


### PR DESCRIPTION
## Summary
- allow SQL expressions like CURRENT_TIMESTAMP to be emitted without quotes in descriptor defaults
- cover expression defaults with a new test

## Testing
- `php -l src/Lotgd/MySQL/TableDescriptor.php`
- `php -l tests/TableDescriptorTest.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0ec1cb448329ba069fe3e51dc390