### PR TITLE
Ensure exact table status lookup for underscore names

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -496,8 +496,8 @@ class TableDescriptor
         }
         // 2. Obtain table level charset/collation and then
         // 3. Generate key/index entries.
-        $tablename_escaped = addslashes($tablename);
-        $status = Database::query("SHOW TABLE STATUS LIKE '$tablename_escaped'");
+        $tablenameEsc = Database::escape($tablename);
+        $status = Database::query("SHOW TABLE STATUS WHERE Name = '$tablenameEsc'");
         $row = Database::fetchAssoc($status);
         if ($row && !empty($row['Collation'])) {
             $descriptor['collation'] = $row['Collation'];

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -138,6 +138,26 @@ final class TableDescriptorTest extends TestCase
         $this->assertArrayNotHasKey('charset', $descriptor);
     }
 
+    public function testTableNameWithUnderscoreMatchesExactly(): void
+    {
+        Database::$full_columns_rows = [
+            [
+                'Field' => 'id',
+                'Type' => 'int',
+                'Null' => 'NO',
+                'Default' => null,
+                'Extra' => '',
+                'Collation' => null,
+            ],
+        ];
+        Database::$table_status_rows = [
+            ['Name' => 'dummyXtable', 'Collation' => 'latin1_swedish_ci'],
+            ['Name' => 'dummy_table', 'Collation' => 'utf8mb4_unicode_ci'],
+        ];
+        $descriptor = TableDescriptor::tableCreateDescriptor('dummy_table');
+        $this->assertSame('utf8mb4_unicode_ci', $descriptor['collation']);
+    }
+
     public function testTableCreateFromDescriptorRejectsUnknownCollation(): void
     {
         Database::$collation_rows = [[]];


### PR DESCRIPTION
## Summary
- Query table status by exact name to avoid wildcard matches
- Emulate exact and LIKE behaviour in database test stub
- Add test ensuring tables with underscores are matched precisely

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ae0f83b15483298612779fe66bab23