### PR TITLE
Allow function defaults with arguments

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -613,7 +613,7 @@ class TableDescriptor
                 if ($input['default'] === null) {
                     $return .= " DEFAULT NULL";
                 } elseif (is_string($input['default'])) {
-                    if (preg_match('/^[A-Z_]+(?:\(\))?$/i', $input['default'])) {
+                    if (preg_match('/^[A-Z_]+(?:\([^)]*\))?$/i', $input['default'])) {
                         $return .= " DEFAULT {$input['default']}";
                     } else {
                         $escapedDefault = Database::escape($input['default']);

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -84,6 +84,18 @@ final class TableDescriptorTest extends TestCase
         $this->assertStringContainsString('DEFAULT CURRENT_TIMESTAMP', $sql);
     }
 
+    public function testDescriptorCreateSqlUnquotedExpressionWithArgumentsDefault(): void
+    {
+        $descriptor = [
+            'name' => 'created',
+            'type' => 'datetime',
+            'default' => 'CURRENT_TIMESTAMP(6)',
+        ];
+
+        $sql = TableDescriptor::descriptorCreateSql($descriptor);
+        $this->assertStringContainsString('DEFAULT CURRENT_TIMESTAMP(6)', $sql);
+    }
+
     public function testCollationIsCaptured(): void
     {
         Database::$full_columns_rows = [


### PR DESCRIPTION
## Summary
- broaden default expression detection to handle functions with arguments
- ensure CURRENT_TIMESTAMP(6) default stays unquoted

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ae14c8863c8329a9ca424b5fe18b27