### PR TITLE
Return count after creating table in synctable

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -33,7 +33,7 @@ class TableDescriptor
      * @param array  $descriptor Schema description to match against.
      * @param bool   $nodrop     If true, columns not in the descriptor are left intact.
      *
-     * @return int|null Number of schema changes applied or null when none are required.
+     * @return int|null Number of schema changes applied. Creating a missing table counts as 1. Returns null when no changes are required or creation failed.
      */
     public static function synctable(string $tablename, array $descriptor, bool $nodrop = false): ?int
     {
@@ -47,9 +47,13 @@ class TableDescriptor
             if (!Database::query($sql)) {
                 output("`\$Error:`^ %s`n", Database::error());
                 rawoutput("<pre>" . htmlentities($sql, ENT_COMPAT, getsetting("charset", "ISO-8859-1")) . "</pre>");
-            } else {
-                output("`^Table `#%s`^ created.`n", $tablename);
+
+                return null;
             }
+
+            output("`^Table `#%s`^ created.`n", $tablename);
+
+            return 1;
         } else {
             //the table exists, so we need to compare it against the descriptor.
             $existing = self::tableCreateDescriptor($tablename);

--- a/tests/Stubs/Database.php
+++ b/tests/Stubs/Database.php
@@ -20,6 +20,7 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
         public static array $full_columns_rows = [];
         public static array $table_status_rows = [];
         public static array $collation_rows = [];
+        public static bool $tableExists = true;
         public static ?object $doctrineConnection = null;
         public static ?object $instance = null;
         public static array $queryCacheResults = [];
@@ -328,7 +329,7 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
 
         public static function tableExists(string $table): bool
         {
-            return true;
+            return self::$tableExists;
         }
 
         public static function queryCached(string $sql, string $name, int $duration = 900): array

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -96,6 +96,17 @@ final class TableDescriptorTest extends TestCase
         $this->assertStringContainsString('DEFAULT CURRENT_TIMESTAMP(6)', $sql);
     }
 
+    public function testSynctableReturnsOneWhenTableCreated(): void
+    {
+        Database::$tableExists = false;
+        $descriptor = [
+            'id' => ['name' => 'id', 'type' => 'int'],
+        ];
+
+        $this->assertSame(1, TableDescriptor::synctable('dummy', $descriptor));
+        Database::$tableExists = true;
+    }
+
     public function testCollationIsCaptured(): void
     {
         Database::$full_columns_rows = [


### PR DESCRIPTION
## Summary
- return 1 when `TableDescriptor::synctable` creates a missing table
- allow Database test stub to simulate missing tables
- add regression test for table creation return value

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ae161204ac8329a1259fd9b0e02199