### PR TITLE
Throw exception for charset missing default collation

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -561,7 +561,7 @@ class TableDescriptor
         if ($row && isset($row['Collation'])) {
             return $row['Collation'];
         }
-        return $candidate;
+        throw new \InvalidArgumentException("Charset '$charset' lacks a default collation.");
     }
 
     /**

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -545,4 +545,15 @@ final class TableDescriptorTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         TableDescriptor::synctable('dummy', $descriptor);
     }
+
+    public function testUnknownCharsetWithoutDefaultCollationThrows(): void
+    {
+        Database::$collation_rows = [[], []];
+        $descriptor = [
+            'charset' => 'mystery_charset',
+            'id' => ['name' => 'id', 'type' => 'int'],
+        ];
+        $this->expectException(\InvalidArgumentException::class);
+        TableDescriptor::tableCreateFromDescriptor('dummy', $descriptor);
+    }
 }


### PR DESCRIPTION
## Summary
- throw exception when charset lacks a default collation
- test unknown charset handling in TableDescriptor

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ae178e5df8832990c695e24f2ebf5f