### PR TITLE
Handle ALTER TABLE failures in synctable

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -322,7 +322,13 @@ class TableDescriptor
                 //we have changes to do!  Woohoo!
                 $sql = "ALTER TABLE $tablename \n" . join(",\n", $changes);
                 debug(nl2br($sql));
-                Database::query($sql);
+                $result = Database::query($sql);
+                if ($result === false) {
+                    throw new \RuntimeException(Database::error());
+
+                    return null;
+                }
+
                 return count($changes);
             }
         // end if

--- a/tests/Stubs/Database.php
+++ b/tests/Stubs/Database.php
@@ -25,6 +25,7 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
         public static ?object $instance = null;
         public static array $queryCacheResults = [];
         public static string $last_error = '';
+        public static bool $alterFail = false;
 
         public static function connect(string $host, string $user, string $pass): bool
         {
@@ -144,6 +145,12 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
             $mysqli = self::getInstance();
 
             if (strpos($sql, 'ALTER TABLE') === 0) {
+                if (self::$alterFail) {
+                    self::$last_error = 'Alter table failed';
+                    $last_query_result = false;
+                    return false;
+                }
+
                 $last_query_result = true;
                 return true;
             }

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -107,6 +107,37 @@ final class TableDescriptorTest extends TestCase
         Database::$tableExists = true;
     }
 
+    public function testSynctableThrowsExceptionOnAlterFailure(): void
+    {
+        Database::$full_columns_rows = [
+            [
+                'Field' => 'id',
+                'Type' => 'int',
+                'Null' => 'NO',
+                'Default' => null,
+                'Extra' => '',
+                'Collation' => null,
+            ],
+        ];
+        Database::$alterFail = true;
+
+        $descriptor = [
+            'id' => ['name' => 'id', 'type' => 'int'],
+            'name' => ['name' => 'name', 'type' => 'int'],
+        ];
+
+        $result = null;
+
+        try {
+            $result = TableDescriptor::synctable('dummy', $descriptor);
+            $this->fail('Expected exception was not thrown');
+        } catch (\RuntimeException $e) {
+            $this->assertNull($result);
+        }
+
+        Database::$alterFail = false;
+    }
+
     public function testCollationIsCaptured(): void
     {
         Database::$full_columns_rows = [


### PR DESCRIPTION
## Summary
- Throw a runtime exception and return null when ALTER TABLE fails in TableDescriptor::synctable
- Allow database stub to simulate ALTER TABLE failures
- Add test to ensure synctable propagates errors

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68aeaa6522a48329b4afff942f874320