### PR TITLE
Remove unreachable return in TableDescriptor

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -325,8 +325,6 @@ class TableDescriptor
                 $result = Database::query($sql);
                 if ($result === false) {
                     throw new \RuntimeException(Database::error());
-
-                    return null;
                 }
 
                 return count($changes);


### PR DESCRIPTION
## Summary
- remove unreachable return following thrown RuntimeException in table migration routine

## Testing
- `php -l src/Lotgd/MySQL/TableDescriptor.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68aeac6d7fec832985454ec64a80602f