### PR TITLE
Guard error handler when settings unavailable

### DIFF
--- a/src/Lotgd/ErrorHandler.php
+++ b/src/Lotgd/ErrorHandler.php
@@ -194,7 +194,11 @@ class ErrorHandler
         $trace = Backtrace::show($exception->getTrace());
         self::renderError($exception->getMessage(), $exception->getFile(), $exception->getLine(), $trace);
 
-        if ($settings->getSetting('notify_on_error', 0)) {
+        $notify = isset($settings) && $settings instanceof Settings
+            ? (bool) $settings->getSetting('notify_on_error', 0)
+            : (bool) getsetting('notify_on_error', 0);
+
+        if ($notify) {
             self::errorNotify(E_ERROR, $exception->getMessage(), $exception->getFile(), $exception->getLine(), $trace);
         }
     }

--- a/tests/ErrorHandlerEarlyExceptionTest.php
+++ b/tests/ErrorHandlerEarlyExceptionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests {
+    use Lotgd\ErrorHandler;
+    use Lotgd\Tests\Stubs\PHPMailer;
+    use PHPUnit\Framework\TestCase;
+
+    final class ErrorHandlerEarlyExceptionTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            global $settings, $mail_sent_count, $output;
+
+            $mail_sent_count = 0;
+
+            // Provide settings object that is not an instance of Lotgd\Settings
+            $settings = new class {
+                public function getSetting(string $name, $default = null)
+                {
+                    $map = [
+                        'notify_on_error' => 1,
+                        'notify_address' => 'admin@example.com',
+                        'gameadminemail' => 'admin@example.com',
+                        'notify_every' => 30,
+                        'usedatacache' => 0,
+                    ];
+
+                    return $map[$name] ?? $default;
+                }
+            };
+
+            // Ensure the PHPMailer stub is loaded so Mail::send uses it
+            new PHPMailer();
+
+            // Provide minimal output handler for debug()
+            $output = new class {
+                public function appoencode($data, $priv)
+                {
+                    return $data;
+                }
+            };
+        }
+
+        public function testExceptionBeforeSettingsSendsNotification(): void
+        {
+            try {
+                strlen([]);
+            } catch (\TypeError $e) {
+                ob_start();
+                @ErrorHandler::handleException($e);
+                ob_end_clean();
+            }
+
+            $this->assertSame(1, $GLOBALS['mail_sent_count']);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Avoid fatal errors in `ErrorHandler::handleException` by verifying the `$settings` object and falling back to `getsetting()`
- Add PHPUnit test ensuring exceptions before settings initialization still trigger notifications

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68aebce27a8883298454e925d423a62b