### PR TITLE
Lazily instantiate settings helper

### DIFF
--- a/lib/settings.php
+++ b/lib/settings.php
@@ -31,7 +31,7 @@ function getsetting($settingname, $default)
 {
     global $settings;
     if (!($settings instanceof Settings)) {
-        return '';
+        $settings = new Settings('settings');
     }
     return $settings->getSetting($settingname, $default);
 }


### PR DESCRIPTION
## Summary
- Instantiate the Settings handler on demand in `getsetting`

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68aec33e73088329b6929ef2e1288a5f