### PR TITLE
Guard against null Settings in error handler

### DIFF
--- a/src/Lotgd/ErrorHandler.php
+++ b/src/Lotgd/ErrorHandler.php
@@ -120,16 +120,21 @@ class ErrorHandler
     public static function errorNotify(int $errno, string $errstr, string $errfile, int $errline, string $backtrace): void
     {
         global $session, $settings;
-        if ((!isset($settings) || !($settings instanceof Settings)) && !function_exists('getsetting')) {
+        if (!$settings instanceof Settings && !function_exists('getsetting')) {
             $settings = new Settings('settings');
         }
 
-        $sendto = explode(';', isset($settings) && $settings instanceof Settings
-            ? $settings->getSetting('notify_address', '')
-            : (function_exists('getsetting') ? getsetting('notify_address', '') : ''));
-        $howoften = isset($settings) && $settings instanceof Settings
-            ? $settings->getSetting('notify_every', 30)
-            : (function_exists('getsetting') ? getsetting('notify_every', 30) : 30);
+        $addressList = '';
+        if ($settings instanceof Settings) {
+            $addressList = (string) $settings->getSetting('notify_address', '');
+        } elseif (function_exists('getsetting')) {
+            $addressList = (string) getsetting('notify_address', '');
+        }
+        $sendto = array_filter(array_map('trim', explode(';', $addressList)));
+
+        $howoften = $settings instanceof Settings
+            ? (int) $settings->getSetting('notify_every', 30)
+            : (function_exists('getsetting') ? (int) getsetting('notify_every', 30) : 30);
         $data = DataCache::datacache('error_notify', 86400);
         if (!is_array($data)) {
             $data = ['firstrun' => false, 'errors' => []];
@@ -168,7 +173,7 @@ class ErrorHandler
                 $body = $html_text;
                 foreach ($sendto as $email) {
                     debug("Notifying $email of this error.");
-                    $admin = isset($settings) && $settings instanceof Settings
+                    $admin = $settings instanceof Settings
                         ? $settings->getSetting('gameadminemail', 'postmaster@localhost')
                         : (function_exists('getsetting')
                             ? getsetting('gameadminemail', 'postmaster@localhost')
@@ -200,13 +205,16 @@ class ErrorHandler
         $trace = Backtrace::show($exception->getTrace());
         self::renderError($exception->getMessage(), $exception->getFile(), $exception->getLine(), $trace);
 
-        if ((!isset($settings) || !($settings instanceof Settings)) && !function_exists('getsetting')) {
+        if (!$settings instanceof Settings && !function_exists('getsetting')) {
             $settings = new Settings('settings');
         }
 
-        $notify = isset($settings) && $settings instanceof Settings
-            ? (bool) $settings->getSetting('notify_on_error', 0)
-            : (bool) (function_exists('getsetting') ? getsetting('notify_on_error', 0) : 0);
+        $notify = false;
+        if ($settings instanceof Settings) {
+            $notify = (bool) $settings->getSetting('notify_on_error', 0);
+        } elseif (function_exists('getsetting')) {
+            $notify = (bool) getsetting('notify_on_error', 0);
+        }
 
         if ($notify) {
             self::errorNotify(E_ERROR, $exception->getMessage(), $exception->getFile(), $exception->getLine(), $trace);


### PR DESCRIPTION
## Summary
- Ensure `Settings` object is validated before use in `errorNotify` and `handleException`
- Default to safe values and skip empty recipients when settings are missing

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68aed545dc2083299fc024a15587f95d