### PR TITLE
Ensure settings object exists for admin notifications

### DIFF
--- a/lib/settings.php
+++ b/lib/settings.php
@@ -35,3 +35,13 @@ function getsetting($settingname, $default)
     }
     return $settings->getSetting($settingname, $default);
 }
+
+function get_admin_email($default = 'postmaster@localhost')
+{
+    global $settings;
+    if (!($settings instanceof Settings)) {
+        $settings = new Settings('settings');
+    }
+
+    return (string) $settings->getSetting('gameadminemail', $default);
+}

--- a/tests/CronMisconfiguredGameDirTest.php
+++ b/tests/CronMisconfiguredGameDirTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+final class CronMisconfiguredGameDirTest extends TestCase
+{
+    public function testMisconfiguredGameDirTriggersEmail(): void
+    {
+        $count = require __DIR__ . '/cron_misconfigured_game_dir.php';
+        $this->assertSame(1, $count);
+    }
+}

--- a/tests/cron_misconfigured_game_dir.php
+++ b/tests/cron_misconfigured_game_dir.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Cron;
+
+use Lotgd\Tests\Stubs\DummySettings;
+use Lotgd\Tests\Stubs\PHPMailer;
+
+global $settings, $GAME_DIR, $argv, $mail_sent_count;
+
+$settings = new DummySettings([
+    'gameadminemail' => 'admin@example.com',
+    'serverurl' => 'http://example.com',
+]);
+
+$GAME_DIR = '';
+$argv = [];
+
+$mail_sent_count = 0;
+new PHPMailer();
+
+define('CRON_TEST', true);
+
+require __DIR__ . '/../cron.php';
+$sent = $mail_sent_count;
+unset($settings, $GAME_DIR, $argv, $mail_sent_count);
+
+return $sent;


### PR DESCRIPTION
## Summary
- Instantiate settings on demand when fetching admin email
- Use settings object for early cron failures and send via Mail
- Add regression test verifying cron emails on missing game directory

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68aed65e89d083298d7c4e5f50acee96