### PR TITLE
Use admin email when notify address missing

### DIFF
--- a/src/Lotgd/ErrorHandler.php
+++ b/src/Lotgd/ErrorHandler.php
@@ -131,6 +131,9 @@ class ErrorHandler
 
         $addressList = $hasSettings ? (string) $settings->getSetting('notify_address', '') : '';
         $sendto = array_filter(array_map('trim', explode(';', $addressList)));
+        if (empty($sendto)) {
+            $sendto = [$settings->getSetting('gameadminemail', 'postmaster@localhost')];
+        }
 
         $howoften = $hasSettings ? (int) $settings->getSetting('notify_every', 30) : 30;
         $data = DataCache::datacache('error_notify', 86400);

--- a/tests/ErrorHandlerNotifyNoAddressTest.php
+++ b/tests/ErrorHandlerNotifyNoAddressTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\ErrorHandler;
+use Lotgd\Tests\Stubs\DummySettings;
+use Lotgd\Tests\Stubs\PHPMailer;
+use PHPUnit\Framework\TestCase;
+
+final class ErrorHandlerNotifyNoAddressTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $settings, $mail_sent_count, $output;
+
+        $mail_sent_count = 0;
+        $settings = new DummySettings([
+            'notify_on_error' => 1,
+            'gameadminemail' => 'admin@example.com',
+            'usedatacache' => 0,
+        ]);
+
+        // Ensure the PHPMailer stub is loaded so Mail::send uses it
+        new PHPMailer();
+
+        // Provide minimal output handler for debug()
+        $output = new class {
+            public function appoencode($data, $priv)
+            {
+                return $data;
+            }
+        };
+    }
+
+    public function testErrorNotificationUsesDefaultAddress(): void
+    {
+        ErrorHandler::errorNotify(E_ERROR, 'Test error', 'file.php', 42, '<trace>');
+
+        $this->assertSame(1, $GLOBALS['mail_sent_count']);
+    }
+}


### PR DESCRIPTION
## Summary
- default error notification recipients to the admin email when notify_address is empty
- test error notification fallback when notify_address is absent

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68aedb1e96ac83298c98357e9002316a