### PR TITLE
Handle non-string name search in list.php

### DIFF
--- a/list.php
+++ b/list.php
@@ -47,17 +47,29 @@ $totalplayers = $row['c'];
 
 $op = Http::get('op');
 $page = Http::get('page');
-$search = "";
-$limit = "";
+$search = '';
+$limit = '';
 
 if ($op == "search") {
-    $search = "%";
-    $n = Database::escape(Http::post('name'));
-    for ($x = 0; $x < strlen($n); $x++) {
-        $search .= substr($n, $x, 1) . "%";
+    $rawName = Http::post('name');
+    $n = '';
+
+    if (is_string($rawName)) {
+        $n = Database::escape($rawName);
     }
-    $search = " AND name LIKE '" . addslashes($search) . "' ";
-} else {
+
+    if ($n !== '') {
+        $search = "%";
+        for ($x = 0; $x < strlen($n); $x++) {
+            $search .= substr($n, $x, 1) . "%";
+        }
+        $search = " AND name LIKE '" . addslashes($search) . "' ";
+    } else {
+        $op = "";
+    }
+}
+
+if ($op !== "search") {
     $pageoffset = (int)$page;
     if ($pageoffset > 0) {
         $pageoffset--;


### PR DESCRIPTION
## Summary
- Ensure search input is a string before escaping in `list.php`
- Bypass search when no valid name is provided

## Testing
- `php -l list.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68aedd54ae6883298a7602feb46a605a