### PR TITLE
Register error handler for cron and add early exception test

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/autoload.php';
 use Lotgd\Newday;
 use Lotgd\Settings;
 use Lotgd\Mail;
+use Lotgd\ErrorHandler;
 
 define('CRON_NEWDAY', 1);
 define('CRON_DBCLEANUP', 2);
@@ -17,6 +18,9 @@ require __DIR__ . '/settings.php';
 if (!($settings instanceof Settings)) {
     $settings = new Settings('settings');
 }
+
+ErrorHandler::register();
+
 $result = @chdir($GAME_DIR);
 if (!defined('CRON_TEST')) {
     require_once 'common.php';

--- a/tests/CronCommonExceptionTest.php
+++ b/tests/CronCommonExceptionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+final class CronCommonExceptionTest extends TestCase
+{
+    public function testExceptionInCommonTriggersEmail(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'cron');
+        shell_exec('php ' . escapeshellarg(__DIR__ . '/cron_common_exception.php') . ' ' . escapeshellarg($file));
+        $this->assertSame('1', trim((string) file_get_contents($file)));
+    }
+}
+

--- a/tests/cron_common_exception.php
+++ b/tests/cron_common_exception.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Cron;
+
+require __DIR__ . '/../autoload.php';
+require_once __DIR__ . '/Stubs/Functions.php';
+
+use Lotgd\Tests\Stubs\DummySettings;
+use Lotgd\Tests\Stubs\PHPMailer;
+
+$testFile = $argv[1] ?? null;
+
+global $settings, $GAME_DIR, $argv, $mail_sent_count, $output;
+
+$settings = new DummySettings([
+    'notify_on_error' => 1,
+    'notify_address'  => 'admin@example.com',
+    'gameadminemail'  => 'admin@example.com',
+]);
+
+$GAME_DIR = '/PATH/TO/GAME';
+$argv = [];
+
+if (!is_dir($GAME_DIR)) {
+    mkdir($GAME_DIR, 0777, true);
+}
+copy(__DIR__ . '/fixtures/cron_exception/common.php', $GAME_DIR . '/common.php');
+
+$mail_sent_count = 0;
+new PHPMailer();
+
+$output = new class {
+    public function appoencode($data, $priv)
+    {
+        return $data;
+    }
+};
+
+register_shutdown_function(function () use ($testFile): void {
+    if ($testFile) {
+        file_put_contents($testFile, (string) ($GLOBALS['mail_sent_count'] ?? ''));
+    }
+});
+
+require __DIR__ . '/../cron.php';
+

--- a/tests/fixtures/cron_exception/common.php
+++ b/tests/fixtures/cron_exception/common.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+throw new \RuntimeException('Cron common.php failure');
+


### PR DESCRIPTION
## Summary
- register global error handler in `cron.php` before including `common.php`
- add test harness simulating an exception in `common.php` to verify email notification

## Testing
- `composer install`
- `composer test` *(fails: Tests: 236, Assertions: 373, Errors: 1, Failures: 2)*
- `vendor/bin/phpunit tests/CronCommonExceptionTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68aedd5adc94832989c7cbe207f56457