### PR TITLE
Quote lowercase defaults in SQL generation

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -667,7 +667,7 @@ class TableDescriptor
                 if ($input['default'] === null) {
                     $return .= " DEFAULT NULL";
                 } elseif (is_string($input['default'])) {
-                    if (preg_match('/^[A-Z_]+(?:\([^)]*\))?$/i', $input['default'])) {
+                    if (preg_match('/^[A-Z_]+(?:\([^)]*\))?$/', $input['default'])) {
                         $return .= " DEFAULT {$input['default']}";
                     } else {
                         $escapedDefault = Database::escape($input['default']);

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -96,6 +96,18 @@ final class TableDescriptorTest extends TestCase
         $this->assertStringContainsString('DEFAULT CURRENT_TIMESTAMP(6)', $sql);
     }
 
+    public function testDescriptorCreateSqlQuotedLowercaseDefault(): void
+    {
+        $descriptor = [
+            'name' => 'weapon',
+            'type' => 'varchar(255)',
+            'default' => 'Fists',
+        ];
+
+        $sql = TableDescriptor::descriptorCreateSql($descriptor);
+        $this->assertStringContainsString("DEFAULT 'Fists'", $sql);
+    }
+
     public function testSynctableReturnsOneWhenTableCreated(): void
     {
         Database::$tableExists = false;


### PR DESCRIPTION
## Summary
- Treat only fully-uppercase defaults as SQL expressions when building column definitions
- Add coverage for lowercase default values being quoted

## Testing
- `composer install`
- `php -l src/Lotgd/MySQL/TableDescriptor.php`
- `php -l tests/TableDescriptorTest.php`
- `composer test` *(fails: Test was run in child process and ended unexpectedly)*
- `./vendor/bin/phpunit tests/TableDescriptorTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68aedf42d90c83299255f4b413c74be6