### PR TITLE
Set up datacache for cron exception test

### DIFF
--- a/tests/cron_common_exception.php
+++ b/tests/cron_common_exception.php
@@ -7,6 +7,10 @@ namespace Lotgd\Tests\Cron;
 require __DIR__ . '/../autoload.php';
 require_once __DIR__ . '/Stubs/Functions.php';
 
+if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') !== __FILE__) {
+    return;
+}
+
 use Lotgd\Tests\Stubs\DummySettings;
 use Lotgd\Tests\Stubs\PHPMailer;
 
@@ -14,10 +18,13 @@ $testFile = $argv[1] ?? null;
 
 global $settings, $GAME_DIR, $argv, $mail_sent_count, $output;
 
+$cacheDir = sys_get_temp_dir();
 $settings = new DummySettings([
     'notify_on_error' => 1,
     'notify_address'  => 'admin@example.com',
     'gameadminemail'  => 'admin@example.com',
+    'usedatacache'    => 1,
+    'datacachepath'   => $cacheDir,
 ]);
 
 $GAME_DIR = sys_get_temp_dir() . '/cron-test-' . uniqid();
@@ -27,6 +34,10 @@ if (!is_dir($GAME_DIR)) {
     mkdir($GAME_DIR, 0777, true);
 }
 copy(__DIR__ . '/fixtures/cron_exception/common.php', $GAME_DIR . '/common.php');
+
+if (!is_dir($cacheDir)) {
+    mkdir($cacheDir, 0777, true);
+}
 
 $settingsFile     = __DIR__ . '/../settings.php';
 $originalSettings = file_get_contents($settingsFile);


### PR DESCRIPTION
## Summary
- enable DataCache in cron exception helper script
- ensure a writable temporary cache directory before running cron
- prevent the helper script from running when included during test discovery

## Testing
- `php -l tests/cron_common_exception.php`
- `composer test`
- `./vendor/bin/phpunit tests/CronCommonExceptionTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68aee2b77cc08329b412f7176b7a6f2a