### PR TITLE
feat: add bootstrap error handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ config/composer.local.json
 config/async.settings.php
 .phpunit.result.cache
 dbconnect.php
+
+logs/*.log

--- a/common.php
+++ b/common.php
@@ -1,8 +1,9 @@
 <?php
 
-use Lotgd\SuAccess;
-
 require_once __DIR__ . '/autoload.php';
+
+use Lotgd\BootstrapErrorHandler;
+use Lotgd\SuAccess;
 use Lotgd\AddNews;
 use Lotgd\Buffs;
 use Lotgd\Mounts;
@@ -23,6 +24,9 @@ use Lotgd\Template;
 use Lotgd\MySQL\Database;
 use Lotgd\DateTime;
 use Lotgd\Cookies;
+use Lotgd\ErrorHandler;
+
+BootstrapErrorHandler::register();
 // translator ready
 // addnews ready
 // mail ready
@@ -67,8 +71,6 @@ require_once("lib/output.php");
 $output = new Output();
 LocalConfig::apply();
 require_once("src/Lotgd/Config/constants.php");
-use Lotgd\ErrorHandler;
-ErrorHandler::register();
 
 // Legacy, because modules may rely on that, but those files are already migrated to namespace structure
 require_once("lib/dbwrapper.php");
@@ -103,7 +105,7 @@ require_once("lib/datacache.php");
 require_once("lib/buffs.php");
 require_once("lib/fightnav.php");
 
-
+ErrorHandler::register();
 
 //start the gzip compression
 if (isset($gz_handler_on) && $gz_handler_on) {

--- a/src/Lotgd/BootstrapErrorHandler.php
+++ b/src/Lotgd/BootstrapErrorHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Lotgd;
+
+/**
+ * Simple bootstrap error handler that logs to logs/bootstrap.log.
+ */
+class BootstrapErrorHandler
+{
+    private const LOG_FILE = __DIR__ . '/../../logs/bootstrap.log';
+
+    /**
+     * Register temporary error and exception handlers.
+     */
+    public static function register(): void
+    {
+        $dir = dirname(self::LOG_FILE);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+
+        set_error_handler(static function (int $severity, string $message, string $file = '', int $line = 0): bool {
+            $entry = sprintf('[%s] %s in %s on line %d', date('c'), $message, $file, $line);
+            error_log($entry);
+            file_put_contents(self::LOG_FILE, $entry . PHP_EOL, FILE_APPEND);
+
+            return false;
+        });
+
+        set_exception_handler(static function (\Throwable $throwable): void {
+            $entry = sprintf(
+                '[%s] Uncaught %s: %s in %s on line %d%s%s',
+                date('c'),
+                get_class($throwable),
+                $throwable->getMessage(),
+                $throwable->getFile(),
+                $throwable->getLine(),
+                PHP_EOL,
+                $throwable->getTraceAsString()
+            );
+            error_log($entry);
+            file_put_contents(self::LOG_FILE, $entry . PHP_EOL, FILE_APPEND);
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- add BootstrapErrorHandler to log startup issues
- call bootstrap error handler in common.php and defer full ErrorHandler
- ignore runtime logs

## Testing
- `php -l src/Lotgd/BootstrapErrorHandler.php`
- `php -l common.php`
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68af2ad398348329bc0034709f663ccb