### PR TITLE
Add log viewer utility for superusers

### DIFF
--- a/logviewer.php
+++ b/logviewer.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Lotgd\SuAccess;
+use Lotgd\Nav\SuperuserNav;
+
+require_once 'common.php';
+require_once 'lib/http.php';
+
+SuAccess::check(SU_EDIT_CONFIG);
+
+tlschema('logviewer');
+
+page_header('Log Viewer');
+addnav('Navigation');
+SuperuserNav::render();
+
+$logDir = __DIR__ . '/logs';
+$requested = basename(httpget('file'));
+$files = [];
+if (is_dir($logDir)) {
+    $files = array_values(array_filter(scandir($logDir), static function ($file) use ($logDir) {
+        return is_file($logDir . '/' . $file) && substr($file, -4) === '.log';
+    }));
+}
+
+addnav('Logs');
+foreach ($files as $file) {
+    addnav($file, "logviewer.php?file=" . rawurlencode($file));
+}
+
+if ($requested && in_array($requested, $files, true)) {
+    $content = file_get_contents($logDir . '/' . $requested);
+    rawoutput('<pre>');
+    rawoutput(htmlentities($content));
+    rawoutput('</pre>');
+} else {
+    output('Select a log file from the navigation to view its contents.');
+}
+
+page_footer();

--- a/src/Lotgd/Nav/SuperuserNav.php
+++ b/src/Lotgd/Nav/SuperuserNav.php
@@ -23,6 +23,7 @@ class SuperuserNav
                 $args = modulehook('grottonav');
                 if (!array_key_exists('handled', $args) || !$args['handled']) {
                     addnav('G?Return to the Grotto', 'superuser.php');
+                    addnav('L?View Log Files', 'logviewer.php');
                 }
             }
         }


### PR DESCRIPTION
## Summary
- introduce `logviewer.php` to browse server log files with superuser privileges
- add Grotto navigation link for the log viewer

## Testing
- `php -l logviewer.php`
- `php -l src/Lotgd/Nav/SuperuserNav.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68af309c23d08329ae8a68d0652b888a