### PR TITLE
Ensure dbconnect cleanup checks for file existence

### DIFF
--- a/tests/Installer/FreshInstallTest.php
+++ b/tests/Installer/FreshInstallTest.php
@@ -61,7 +61,10 @@ final class FreshInstallTest extends TestCase
         if (self::$serverAvailable) {
             exec(sprintf('mysqladmin --socket=%s -u %s shutdown >/dev/null 2>&1', self::SOCKET, self::DB_USER));
         }
-        @unlink(__DIR__ . '/../../dbconnect.php');
+        $file = __DIR__ . '/../../dbconnect.php';
+        if (is_file($file)) {
+            unlink($file);
+        }
     }
 
     public function testFreshInstall(): void


### PR DESCRIPTION
## Summary
- avoid warnings during FreshInstallTest cleanup by verifying dbconnect.php exists before unlinking

## Testing
- `php -l tests/Installer/FreshInstallTest.php`
- `composer test` *(fails: CronCommonExceptionTest::testExceptionInCommonTriggersEmail)*

------
https://chatgpt.com/codex/tasks/task_e_68af34abdca0832987e2aad7a28c61da