### PR TITLE
Validate game directory before changing

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -22,7 +22,7 @@ if (!($settings instanceof Settings)) {
 
 BootstrapErrorHandler::register();
 
-$result = @chdir($GAME_DIR);
+$result = ($GAME_DIR !== '' && is_dir($GAME_DIR)) ? chdir($GAME_DIR) : false;
 if (!defined('CRON_TEST')) {
     require_once 'common.php';
 }


### PR DESCRIPTION
## Summary
- safely change to game directory only when it exists

## Testing
- `php -l cron.php`
- `composer test` *(fails: Cron common.php failure; mysqli_connect(): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af34b00354832995b22f9daa8a13d1