### PR TITLE
test: verify cron exception is logged

### DIFF
--- a/tests/CronCommonExceptionTest.php
+++ b/tests/CronCommonExceptionTest.php
@@ -8,11 +8,21 @@ use PHPUnit\Framework\TestCase;
 
 final class CronCommonExceptionTest extends TestCase
 {
-    public function testExceptionInCommonTriggersEmail(): void
+    public function testExceptionInCommonIsLogged(): void
     {
-        $file = tempnam(sys_get_temp_dir(), 'cron');
-        shell_exec('php ' . escapeshellarg(__DIR__ . '/cron_common_exception.php') . ' ' . escapeshellarg($file));
-        $this->assertSame('1', trim((string) file_get_contents($file)));
+        $logFile = __DIR__ . '/../logs/bootstrap.log';
+
+        if (file_exists($logFile)) {
+            unlink($logFile);
+        }
+
+        shell_exec('php ' . escapeshellarg(__DIR__ . '/cron_common_exception.php'));
+
+        $this->assertFileExists($logFile);
+        $log = (string) file_get_contents($logFile);
+        $this->assertStringContainsString('Cron common.php failure', $log);
+
+        unlink($logFile);
     }
 }
 

--- a/tests/cron_common_exception.php
+++ b/tests/cron_common_exception.php
@@ -14,8 +14,6 @@ if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') !== __FILE__) {
 use Lotgd\Tests\Stubs\DummySettings;
 use Lotgd\Tests\Stubs\PHPMailer;
 
-$testFile = $argv[1] ?? null;
-
 global $settings, $GAME_DIR, $argv, $mail_sent_count, $output;
 
 $cacheDir = sys_get_temp_dir();
@@ -58,11 +56,7 @@ $output = new class {
     }
 };
 
-register_shutdown_function(function () use ($testFile, $GAME_DIR, $settingsFile, $originalSettings): void {
-    if ($testFile) {
-        file_put_contents($testFile, (string) ($GLOBALS['mail_sent_count'] ?? ''));
-    }
-
+register_shutdown_function(function () use ($GAME_DIR, $settingsFile, $originalSettings): void {
     file_put_contents($settingsFile, $originalSettings);
 
     $file = $GAME_DIR . '/common.php';


### PR DESCRIPTION
## Summary
- Check cron exception is written to logs instead of counting emails
- Remove temp file logic in cron_common_exception test helper

## Testing
- `php -l tests/CronCommonExceptionTest.php`
- `php -l tests/cron_common_exception.php`
- `composer test` *(fails: mysqli_connect(): No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68af34b41a6c8329a7f1d59ce9988fca