### PR TITLE
Remove duplicate sanitize include

### DIFF
--- a/common.php
+++ b/common.php
@@ -82,7 +82,6 @@ require_once("lib/nav.php");
 require_once("lib/http.php");
 require_once("lib/e_rand.php");
 require_once("lib/pageparts.php");
-require_once("lib/sanitize.php");
 require_once("lib/tempstat.php");
 require_once("lib/su_access.php");
 require_once("lib/datetime.php");


### PR DESCRIPTION
## Summary
- remove extra `sanitize.php` include from `common.php`

## Testing
- `php -l common.php`
- `composer install`
- `composer test` *(fails: Cron common.php failure and mysqli_connect no such file)*

------
https://chatgpt.com/codex/tasks/task_e_68af366b3a748329bdc334e6954fbbad