### PR TITLE
Guard HTTP 500 header

### DIFF
--- a/src/Lotgd/ErrorHandler.php
+++ b/src/Lotgd/ErrorHandler.php
@@ -26,7 +26,11 @@ class ErrorHandler
      */
     public static function renderError(string $message, string $file, int $line, string $backtrace): void
     {
-        http_response_code(500);
+        if ('cli' === PHP_SAPI) {
+            error_log(sprintf('HTTP 500: "%s" in %s at %s', $message, $file, $line));
+        } elseif (!headers_sent()) {
+            http_response_code(500);
+        }
         echo "<!DOCTYPE html>\n";
         echo "<html lang='en'><head>\n";
         echo "<meta charset='UTF-8'>\n";


### PR DESCRIPTION
## Summary
- avoid HTTP header warnings when rendering errors after headers sent
- log HTTP 500 failures on CLI instead of emitting header warnings

## Testing
- `composer install`
- `php -l src/Lotgd/ErrorHandler.php`
- `composer test` *(fails: mysqli_connect(): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af38599fdc8329a1bec3d9776ab934