### PR TITLE
Add PHPMailer stub properties used by Mail::send

### DIFF
--- a/tests/Stubs/PHPMailer.php
+++ b/tests/Stubs/PHPMailer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lotgd\Tests\Stubs;
 
+#[\AllowDynamicProperties]
 class PHPMailer
 {
     public array $to = [];
@@ -12,6 +13,17 @@ class PHPMailer
     public $Body = '';
     public $AltBody = '';
     public $Subject = '';
+    public $Host = '';
+    public $Username = '';
+    public $Password = '';
+    public $SMTPAuth = false;
+    public $SMTPSecure = '';
+    public $Port = 0;
+    public $From = '';
+    public $FromName = '';
+    public $WordWrap = 0;
+    public $CharSet = '';
+    public $ErrorInfo = '';
 
     public function __construct(bool $exc = false)
     {


### PR DESCRIPTION
## Summary
- add explicit properties for PHPMailer stub fields accessed in Mail::send
- allow dynamic properties on PHPMailer test stub

## Testing
- `php -l tests/Stubs/PHPMailer.php`
- `composer install`
- `composer test` *(fails: mysqli_connect(): No such file or directory; stream_get_contents() bad file descriptor)*

------
https://chatgpt.com/codex/tasks/task_e_68af384dda3083298c8ba5400965ccc5