### PR TITLE
Ensure cache directory exists before writing

### DIFF
--- a/src/Lotgd/DataCache.php
+++ b/src/Lotgd/DataCache.php
@@ -71,6 +71,11 @@ class DataCache
                 return false;
             }
 
+            $dir = dirname($fullname);
+            if (!is_dir($dir) && !@mkdir($dir, 0777, true)) {
+                return false;
+            }
+
             $fp = @fopen($fullname, 'w');
             if ($fp === false) {
                 return false;

--- a/tests/DataCacheTest.php
+++ b/tests/DataCacheTest.php
@@ -70,7 +70,7 @@ final class DataCacheTest extends TestCase
 
     public function testUpdateCacheFailureOnBadPath(): void
     {
-        $invalidPath = '/nonexistent/' . uniqid();
+        $invalidPath = '/dev/null/' . uniqid();
         $GLOBALS['settings']->saveSetting('datacachepath', $invalidPath);
 
         $this->assertFalse(DataCache::updatedatacache('failpath', ['x' => 1]));


### PR DESCRIPTION
## Summary
- Ensure `updatedatacache` creates cache directory before writing files
- Adjust data cache test to use an uncreatable path

## Testing
- `php -l src/Lotgd/DataCache.php`
- `php -l tests/DataCacheTest.php`
- `composer test` *(fails: `Lotgd\Tests\Installer\RollbackTest::testInterruptedMigrationResumes`)*

------
https://chatgpt.com/codex/tasks/task_e_68af385b726c8329bdf6778800af3da8