### PR TITLE
test: clean up dbconnect file in Stage4Test

### DIFF
--- a/tests/Installer/Stage4Test.php
+++ b/tests/Installer/Stage4Test.php
@@ -25,6 +25,9 @@ final class Stage4Test extends TestCase
         Database::$instance = null;
         Database::$doctrineConnection = null;
 
+        // Remove any existing dbconnect.php to ensure a clean state
+        @unlink(dirname(__DIR__, 2) . '/dbconnect.php');
+
         // Swap config directory with an empty one
         $this->configDir = dirname(__DIR__, 2) . '/config';
         $this->configBackup = $this->configDir . '_backup';
@@ -44,6 +47,9 @@ final class Stage4Test extends TestCase
         if (is_dir($this->configBackup)) {
             rename($this->configBackup, $this->configDir);
         }
+
+        // Clean up dbconnect.php created during the test run
+        @unlink(dirname(__DIR__, 2) . '/dbconnect.php');
 
         parent::tearDown();
     }


### PR DESCRIPTION
## Summary
- remove any existing dbconnect.php before Stage4Test
- ensure dbconnect.php removed after Stage4Test

## Testing
- `php -l tests/Installer/Stage4Test.php`
- `composer install`
- `composer test` *(fails: Cron common.php failure and datacache write errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af3aa9292883299d7ff99d7b69827a