### PR TITLE
chore: validate cache directory before creation

### DIFF
--- a/src/Lotgd/DataCache.php
+++ b/src/Lotgd/DataCache.php
@@ -72,6 +72,9 @@ class DataCache
             }
 
             $dir = dirname($fullname);
+            if (is_file($dir)) {
+                return false;
+            }
             if (!is_dir($dir) && !@mkdir($dir, 0777, true)) {
                 return false;
             }


### PR DESCRIPTION
## Summary
- guard against invalid cache paths before invoking mkdir

## Testing
- `php -l src/Lotgd/DataCache.php`
- `composer install`
- `composer test` *(fails: Cron common.php failure and datacache path errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af3aaa645083298503f48cd4a96937