### PR TITLE
Ensure DataCache validates directory creation

### DIFF
--- a/src/Lotgd/DataCache.php
+++ b/src/Lotgd/DataCache.php
@@ -72,11 +72,10 @@ class DataCache
             }
 
             $dir = dirname($fullname);
-            if (is_file($dir)) {
-                return false;
-            }
-            if (!is_dir($dir) && !@mkdir($dir, 0777, true)) {
-                return false;
+            if (!is_dir($dir)) {
+                if (is_file($dir) || (!@mkdir($dir, 0777, true) && !is_dir($dir))) {
+                    return false;
+                }
             }
 
             $fp = @fopen($fullname, 'w');


### PR DESCRIPTION
## Summary
- verify parent directories exist when writing cache to avoid parent-file collisions

## Testing
- `composer install`
- `composer test` *(fails: Cron common.php failure and 4 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68af3e8cc5fc8329a794758bd1b2a721