### PR TITLE
Clear modulehook overrides in PagePartsOnlineListTest

### DIFF
--- a/tests/PagePartsOnlineListTest.php
+++ b/tests/PagePartsOnlineListTest.php
@@ -15,7 +15,8 @@ final class PagePartsOnlineListTest extends TestCase
 {
     protected function setUp(): void
     {
-        global $session, $settings, $output;
+        global $session, $settings, $output, $modulehook_returns;
+        $modulehook_returns = [];
         class_exists(Database::class);
         $session = ['loggedin' => false];
         $output = new Output();
@@ -39,8 +40,9 @@ final class PagePartsOnlineListTest extends TestCase
 
     protected function tearDown(): void
     {
-        global $session, $settings, $output;
+        global $session, $settings, $output, $modulehook_returns;
         unset($session, $settings, $output);
+        $modulehook_returns = [];
     }
 
     public function testMode0CurrentOnline(): void


### PR DESCRIPTION
## Summary
- Ensure PagePartsOnlineListTest setUp/tearDown reset module hook overrides so charStats always runs its SQL

## Testing
- `php -l tests/PagePartsOnlineListTest.php`
- `composer install`
- `composer test` *(fails: Cron common.php failure; TemplateTest and PagePartsOnlineListTest assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68af3e8755088329ba9c5cfd5ff31080