### PR TITLE
Handle cache directory conflicts

### DIFF
--- a/src/Lotgd/DataCache.php
+++ b/src/Lotgd/DataCache.php
@@ -72,8 +72,12 @@ class DataCache
             }
 
             $dir = dirname($fullname);
+            if (is_file($dir)) {
+                return false;
+            }
             if (!is_dir($dir)) {
-                if (is_file($dir) || (!@mkdir($dir, 0777, true) && !is_dir($dir))) {
+                @mkdir($dir, 0777, true);
+                if (!is_dir($dir)) {
                     return false;
                 }
             }


### PR DESCRIPTION
## Summary
- Avoid creating data cache directories when path is a file
- Ensure cache directory is created and verified before writing

## Testing
- `php -l src/Lotgd/DataCache.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68af411666f88329b189d3d99da312a0