### PR TITLE
Guard mail status logging without user session

### DIFF
--- a/src/Lotgd/Async/Handler/Mail.php
+++ b/src/Lotgd/Async/Handler/Mail.php
@@ -19,18 +19,13 @@ class Mail
     {
         global $session;
 
-        if ($args === false) {
+        if ($args === false || empty($session['user']['acctid'])) {
             return jaxon()->newResponse();
         }
 
         $timeoutSetting = getsetting('LOGINTIMEOUT', 360); // seconds
         $new = maillink();
         $tabtext = maillinktabtext();
-
-        if (!isset($session['user']['acctid'])) {
-            error_log('mailStatus: session user acctid not set');
-            return jaxon()->newResponse();
-        }
 
         // Get the highest message ID for the current user there is
         $sql = 'SELECT MAX(messageid) AS lastid FROM ' . db_prefix('mail')


### PR DESCRIPTION
## Summary
- Prevent asynchronous mail status handler from logging warnings when no user session is available

## Testing
- `php -l src/Lotgd/Async/Handler/Mail.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68af413103ac8329b22fbcdaf98a0f7d