### PR TITLE
fix: simplify timeout handler for missing session user

### DIFF
--- a/src/Lotgd/Async/Handler/Timeout.php
+++ b/src/Lotgd/Async/Handler/Timeout.php
@@ -24,7 +24,6 @@ class Timeout
         }
 
         if (!isset($session['user'])) {
-            error_log('timeoutStatus: session user not set');
             return jaxon()->newResponse();
         }
 


### PR DESCRIPTION
## Summary
- remove error_log in timeout handler

## Testing
- `composer install`
- `php -l src/Lotgd/Async/Handler/Timeout.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68af4798216c8329985457df00c94fe6