### PR TITLE
Handle missing common file in cron

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -27,7 +27,16 @@ if (!defined('CRON_TEST')) {
     try {
         require_once 'common.php';
     } catch (\Throwable $e) {
-        error_log($e->getMessage());
+        $message = sprintf(
+            '[%s] Cron common.php failure: %s in %s on line %d%s',
+            date('c'),
+            $e->getMessage(),
+            $e->getFile(),
+            $e->getLine(),
+            PHP_EOL
+        );
+        error_log($message, 3, __DIR__ . '/logs/bootstrap.log');
+
         $email = $settings->getSetting('gameadminemail', '');
         if ($email !== '') {
             $body = sprintf(


### PR DESCRIPTION
## Summary
- log and notify on failure to include `common.php` in cron

## Testing
- `composer install`
- `php -l cron.php`
- `composer test` *(fails: Script phpunit --configuration phpunit.xml handling the test event returned with error code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68af47a3ad9c8329a027bee68fbdec4c