### PR TITLE
Validate datacache base path before directory creation

### DIFF
--- a/src/Lotgd/DataCache.php
+++ b/src/Lotgd/DataCache.php
@@ -63,23 +63,27 @@ class DataCache
             return false;
         }
         if ($settings->getSetting('usedatacache', 0)) {
+            $base = $settings->getSetting('datacachepath', '/tmp');
+            if (file_exists($base) && !is_dir($base)) {
+                return false;
+            }
+            $parent = dirname($base);
+            if (!is_dir($parent)) {
+                return false;
+            }
+            if (!is_dir($base)) {
+                if (!@mkdir($base, 0777, true) && !is_dir($base)) {
+                    return false;
+                }
+            }
+
+            self::$path = $base;
             $fullname = self::makecachetempname($name);
             self::$cache[$name] = $data;
 
             $encoded = json_encode($data);
             if ($encoded === false) {
                 return false;
-            }
-
-            $dir = dirname($fullname);
-            if (is_file($dir)) {
-                return false;
-            }
-            if (!is_dir($dir)) {
-                @mkdir($dir, 0777, true);
-                if (!is_dir($dir)) {
-                    return false;
-                }
             }
 
             $fp = @fopen($fullname, 'w');

--- a/tests/DataCacheTest.php
+++ b/tests/DataCacheTest.php
@@ -77,6 +77,17 @@ final class DataCacheTest extends TestCase
         $this->assertFileDoesNotExist(DataCache::makecachetempname('failpath'));
     }
 
+    public function testUpdateCacheFailureWhenBasePathIsFile(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'cachefile');
+        $GLOBALS['settings']->saveSetting('datacachepath', $file);
+
+        $this->assertFalse(DataCache::updatedatacache('filebase', ['x' => 1]));
+        $this->assertFileDoesNotExist(DataCache::makecachetempname('filebase'));
+
+        unlink($file);
+    }
+
     public function testLongCacheKeyIsHashed(): void
     {
         $longKey = str_repeat('a', 250);


### PR DESCRIPTION
## Summary
- Guard datacache updates against invalid base paths
- Test datacache failure when base path points to a file

## Testing
- `composer install`
- `php -l src/Lotgd/DataCache.php`
- `php -l tests/DataCacheTest.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68af47ad0a8c8329a86fbc57c93633f1