### PR TITLE
Guard HTTP error handling in CLI

### DIFF
--- a/src/Lotgd/ErrorHandler.php
+++ b/src/Lotgd/ErrorHandler.php
@@ -26,9 +26,7 @@ class ErrorHandler
      */
     public static function renderError(string $message, string $file, int $line, string $backtrace): void
     {
-        if ('cli' === PHP_SAPI) {
-            error_log(sprintf('HTTP 500: "%s" in %s at %s', $message, $file, $line));
-        } elseif (!headers_sent()) {
+        if ('cli' !== PHP_SAPI && !headers_sent()) {
             http_response_code(500);
         }
         echo "<!DOCTYPE html>\n";


### PR DESCRIPTION
## Summary
- Avoid logging fatal errors to CLI by removing error_log in ErrorHandler::renderError
- Keep HTTP 500 response for web requests by guarding with PHP_SAPI check

## Testing
- `php -l src/Lotgd/ErrorHandler.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68af47b318c0832985a041df48f311f9