### PR TITLE
Guard datacache writes in error notifier

### DIFF
--- a/src/Lotgd/ErrorHandler.php
+++ b/src/Lotgd/ErrorHandler.php
@@ -148,7 +148,8 @@ class ErrorHandler
         $data = DataCache::datacache('error_notify', 86400);
         if (!is_array($data)) {
             $data = ['firstrun' => false, 'errors' => []];
-            if (!DataCache::updatedatacache('error_notify', $data)) {
+            if ($settings->getSetting('usedatacache', 0)
+                && !DataCache::updatedatacache('error_notify', $data)) {
                 error_log('Unable to write datacache for error_notify');
             }
         } else {
@@ -194,7 +195,8 @@ class ErrorHandler
                 debug('Not notifying users for this error, it\'s only been ' . round((strtotime('now') - $data['errors'][$msg]) / 60, 2) . ' minutes.');
             }
         }
-        if (!DataCache::updatedatacache('error_notify', $data)) {
+        if ($settings->getSetting('usedatacache', 0)
+            && !DataCache::updatedatacache('error_notify', $data)) {
             error_log('Unable to write datacache for error_notify');
         }
         debug($data);


### PR DESCRIPTION
## Summary
- Avoid datacache writes when data cache is disabled
- Log datacache failures only when caching is enabled

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68af47ba054883299619b4088d8b6ddf