### PR TITLE
Sanitize log viewer file parameter

### DIFF
--- a/logviewer.php
+++ b/logviewer.php
@@ -17,7 +17,8 @@ addnav('Navigation');
 SuperuserNav::render();
 
 $logDir = __DIR__ . '/logs';
-$requested = basename(httpget('file'));
+$param = httpget('file');
+$requested = $param !== false ? basename($param) : '';
 $files = [];
 if (is_dir($logDir)) {
     $files = array_values(array_filter(scandir($logDir), static function ($file) use ($logDir) {


### PR DESCRIPTION
## Summary
- ensure logviewer validates file parameter before basename

## Testing
- `php -l logviewer.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68af6085de60832986af4e99cf8c08ee