### PR TITLE
Refactor script name handling with utility function

### DIFF
--- a/common.php
+++ b/common.php
@@ -18,6 +18,7 @@ use Lotgd\Nav;
 use Lotgd\LocalConfig;
 use Lotgd\PageParts;
 use Lotgd\Page\Header;
+use Lotgd\Util\ScriptName;
 use Lotgd\Page\Footer;
 use Lotgd\Redirect;
 use Lotgd\Template;
@@ -346,7 +347,7 @@ if (!AJAX_MODE) {
     ForcedNavigation::doForcedNav(ALLOW_ANONYMOUS, OVERRIDE_FORCED_NAV);
 }
 
-$script = substr($SCRIPT_NAME, 0, strrpos($SCRIPT_NAME, "."));
+$script = ScriptName::current();
 if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
     mass_module_prepare(array(
                 'template-header','template-footer','template-statstart','template-stathead','template-statrow','template-statbuff','template-statend',

--- a/src/Lotgd/Nav/SuperuserNav.php
+++ b/src/Lotgd/Nav/SuperuserNav.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Lotgd\Nav;
 
+use Lotgd\Util\ScriptName;
+
 /**
  * Navigation helpers for superuser areas.
  */
@@ -18,7 +20,7 @@ class SuperuserNav
         tlschema('nav');
         addnav('Navigation');
         if ($session['user']['superuser'] & ~ SU_DOESNT_GIVE_GROTTO) {
-            $script = substr($SCRIPT_NAME, 0, strpos($SCRIPT_NAME, '.'));
+            $script = ScriptName::current();
             if ($script != 'superuser') {
                 $args = modulehook('grottonav');
                 if (!array_key_exists('handled', $args) || !$args['handled']) {

--- a/src/Lotgd/Page/Footer.php
+++ b/src/Lotgd/Page/Footer.php
@@ -14,6 +14,7 @@ use Lotgd\Buffs;
 use Lotgd\Nav;
 use Lotgd\Accounts;
 use Lotgd\MySQL\Database;
+use Lotgd\Util\ScriptName;
 
 class Footer
 {
@@ -31,7 +32,7 @@ class Footer
             $footer = $template['footer'];
         }
 
-        $script = !empty($SCRIPT_NAME) ? substr($SCRIPT_NAME, 0, strpos($SCRIPT_NAME, '.')) : '';
+        $script = ScriptName::current();
         list($header, $footer) = PageParts::applyFooterHooks($header, $footer, $script);
 
         $builtnavs = Nav::buildNavs();

--- a/src/Lotgd/Page/Header.php
+++ b/src/Lotgd/Page/Header.php
@@ -11,6 +11,7 @@ use Lotgd\TwigTemplate;
 use Lotgd\Sanitize;
 use Lotgd\HolidayText;
 use Lotgd\Buffs;
+use Lotgd\Util\ScriptName;
 
 class Header
 {
@@ -28,7 +29,7 @@ class Header
         Translator::translatorSetup();
         Template::prepareTemplate();
         if (isset($SCRIPT_NAME)) {
-            $script = substr($SCRIPT_NAME, 0, strrpos($SCRIPT_NAME, '.'));
+            $script = ScriptName::current();
             if ($script) {
                 if (!array_key_exists($script, PageParts::$runHeaders)) {
                     PageParts::$runHeaders[$script] = false;

--- a/src/Lotgd/Util/ScriptName.php
+++ b/src/Lotgd/Util/ScriptName.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Util;
+
+/**
+ * Utility to determine the current script name without its extension.
+ */
+class ScriptName
+{
+    /**
+     * Get the current script name without its file extension.
+     */
+    public static function current(): string
+    {
+        $script = $_SERVER['SCRIPT_NAME'] ?? '';
+        $script = rtrim($script, '/');
+        return pathinfo(basename($script), PATHINFO_FILENAME);
+    }
+}

--- a/tests/Util/ScriptNameTest.php
+++ b/tests/Util/ScriptNameTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Util;
+
+use Lotgd\Util\ScriptName;
+use PHPUnit\Framework\TestCase;
+
+class ScriptNameTest extends TestCase
+{
+    public function testScriptWithoutExtension(): void
+    {
+        $_SERVER['SCRIPT_NAME'] = '/village';
+        $this->assertSame('village', ScriptName::current());
+    }
+
+    public function testDirectoryStyleRequest(): void
+    {
+        $_SERVER['SCRIPT_NAME'] = '/village/';
+        $this->assertSame('village', ScriptName::current());
+    }
+}


### PR DESCRIPTION
## Summary
- add `Lotgd\Util\ScriptName::current()` helper for normalized script names
- refactor header/footer/common/superuser nav to use new helper
- test script name parsing for extensionless and directory-style routes

## Testing
- `composer test`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68af6184a7808329a8773d94b1de3cd0