### PR TITLE
refactor: use basename for return paths

### DIFF
--- a/bio.php
+++ b/bio.php
@@ -171,13 +171,13 @@ if ($target = Database::fetchAssoc($result)) {
     tlschema();
 
     if ($ret == "") {
-        $return = substr($return, strrpos($return, "/") + 1);
+        $return = basename($return);
         tlschema("nav");
         Nav::add("Return");
         Nav::add("Return to the warrior list", $return);
         tlschema();
     } else {
-        $return = substr($return, strrpos($return, "/") + 1);
+        $return = basename($return);
         tlschema("nav");
         Nav::add("Return");
         if ($return == "list.php") {
@@ -194,13 +194,13 @@ if ($target = Database::fetchAssoc($result)) {
     Header::pageHeader("Character has been deleted");
     $output->output("This character is already deleted.");
     if ($ret == "") {
-        $return = substr($return, strrpos($return, "/") + 1);
+        $return = basename($return);
         tlschema("nav");
         Nav::add("Return");
         Nav::add("Return to the warrior list", $return);
         tlschema();
     } else {
-        $return = substr($return, strrpos($return, "/") + 1);
+        $return = basename($return);
         tlschema("nav");
         Nav::add("Return");
         if ($return == "list.php") {

--- a/donators.php
+++ b/donators.php
@@ -20,7 +20,7 @@ SuperuserNav::render();
 
 $ret = httpget('ret');
 $return = cmd_sanitize($ret);
-$return = substr($return, strrpos($return, "/") + 1);
+$return = basename($return);
 tlschema("nav");
 addnav("Return whence you came", $return);
 tlschema();

--- a/moderate.php
+++ b/moderate.php
@@ -92,7 +92,7 @@ if ($op == "commentdelete") {
     db_query($sql);
     $return = httpget('return');
     $return = cmd_sanitize($return);
-    $return = substr($return, strrpos($return, "/") + 1);
+    $return = basename($return);
     if (strpos($return, "?") === false && strpos($return, "&") !== false) {
         $x = strpos($return, "&");
         $return = substr($return, 0, $x - 1) . "?" . substr($return, $x + 1);

--- a/superuser.php
+++ b/superuser.php
@@ -30,7 +30,7 @@ if ($op == "keepalive") {
     db_query($sql);
     $return = httpget('return');
     $return = cmd_sanitize($return);
-    $return = substr($return, strrpos($return, "/") + 1);
+    $return = basename($return);
     redirect($return);
 }
 


### PR DESCRIPTION
## Summary
- replace manual path parsing with `basename` in various entry points

## Testing
- `php -l bio.php && php -l donators.php && php -l moderate.php && php -l superuser.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68af6c404cdc83299dccb5949074e438