### PR TITLE
refactor: centralize script name retrieval

### DIFF
--- a/src/Lotgd/Async/Handler/Commentary.php
+++ b/src/Lotgd/Async/Handler/Commentary.php
@@ -6,6 +6,7 @@ namespace Lotgd\Async\Handler;
 
 use Jaxon\Response\Response;
 use Lotgd\Commentary as CoreCommentary;
+use Lotgd\Util\ScriptName;
 use function Jaxon\jaxon;
 
 /**
@@ -43,12 +44,12 @@ class Commentary
     {
         global $session;
         $comments = [];
-        $nobios = ['motd.php' => true];
-        $scriptname = $session['last_comment_scriptname'] ?? $_SERVER['SCRIPT_NAME'];
-        if (!array_key_exists(basename($scriptname), $nobios)) {
-            $nobios[basename($scriptname)] = false;
+        $nobios = ['motd' => true];
+        $scriptname = $session['last_comment_scriptname'] ?? ScriptName::current();
+        if (!array_key_exists($scriptname, $nobios)) {
+            $nobios[$scriptname] = false;
         }
-        $linkbios = !$nobios[basename($scriptname)];
+        $linkbios = !$nobios[$scriptname];
         $sql = 'SELECT ' . db_prefix('commentary') . '.*, '
             . db_prefix('accounts') . '.name, '
             . db_prefix('accounts') . '.acctid, '

--- a/src/Lotgd/Commentary.php
+++ b/src/Lotgd/Commentary.php
@@ -6,6 +6,7 @@ namespace Lotgd;
 
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
+use Lotgd\Util\ScriptName;
 
 class Commentary
 {
@@ -472,9 +473,9 @@ SQL;
         // The guard for null is removed as $section is declared as string and cannot be null.
 
         if ($scriptname_pre === false) {
-            $scriptname = $_SERVER['SCRIPT_NAME'];
+            $scriptname = ScriptName::current();
         } else {
-            $scriptname = $scriptname_pre;
+            $scriptname = pathinfo(basename((string) $scriptname_pre), PATHINFO_FILENAME);
         }
 
         if ($_SERVER['REQUEST_URI'] == '/async/process.php') {
@@ -509,11 +510,11 @@ SQL;
         }
         tlschema('commentary');
 
-        $nobios = ['motd.php' => true];
-        if (!array_key_exists(basename($scriptname), $nobios)) {
-            $nobios[basename($scriptname)] = false;
+        $nobios = ['motd' => true];
+        if (!array_key_exists($scriptname, $nobios)) {
+            $nobios[$scriptname] = false;
         }
-        $linkbios = !$nobios[basename($scriptname)];
+        $linkbios = !$nobios[$scriptname];
 
         if ($message == 'X') {
             $linkbios = true;
@@ -563,10 +564,10 @@ SQL;
         $sect = 'x';
 
         $del = Translator::translateInline('Del');
-        $scriptname = mb_substr($scriptname, strrpos($scriptname, '/') + 1);
+        $scriptnameForReturn = $scriptname . '.php';
         $pos = strpos($real_request_uri, '?');
-        $return = $scriptname . ($pos == false ? '' : mb_substr($real_request_uri, $pos));
-        $one = (strstr($return, '?') == false ? '?' : '&');
+        $return = $scriptnameForReturn . ($pos === false ? '' : mb_substr($real_request_uri, $pos));
+        $one = (strstr($return, '?') === false ? '?' : '&');
 
         $editrights = ($session['user']['superuser'] & SU_EDIT_COMMENTS ? 1 : 0);
         for (; $i >= 0; $i--) {

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -14,6 +14,7 @@ use Lotgd\Translator;
 use Lotgd\Forms;
 use Lotgd\Sanitize;
 use Lotgd\Modules\Installer;
+use Lotgd\Util\ScriptName;
 
 class Modules
 {
@@ -378,7 +379,7 @@ class Modules
         }
 
         if (!is_array($args)) {
-            $where = $mostrecentmodule ?: ($_SERVER['SCRIPT_NAME'] ?? '');
+            $where = $mostrecentmodule ?: ScriptName::current();
             debug("Args parameter to modulehook $hookName from $where is not an array.");
         }
 

--- a/src/Lotgd/Pvp.php
+++ b/src/Lotgd/Pvp.php
@@ -12,6 +12,7 @@ use Lotgd\Translator;
 use Lotgd\MySQL\Database;
 use Lotgd\DateTime;
 use Lotgd\Mail;
+use Lotgd\Util\ScriptName;
 
 class Pvp
 {
@@ -268,7 +269,7 @@ class Pvp
             $location = $session['user']['location'];
         }
         if ($link === false) {
-            $link = basename($_SERVER['SCRIPT_NAME']);
+            $link = ScriptName::current() . '.php';
         }
         if ($extra === false) {
             $extra = '?act=attack';


### PR DESCRIPTION
## Summary
- Replace `$_SERVER['SCRIPT_NAME']` lookups with `ScriptName::current()` in commentary, PvP, and module helpers
- Normalize script name handling to work without extensions

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68af6d4ce45c83298af1af576201a09f