### PR TITLE
Use ScriptName for nobios check

### DIFF
--- a/src/Lotgd/Moderate.php
+++ b/src/Lotgd/Moderate.php
@@ -188,12 +188,14 @@ class Moderate
         }
         tlschema('commentary');
 
+        $scriptname = ScriptName::current() . '.php';
+
         // Some pages should not link to character bios from commentary lines
         $nobios = ['motd.php' => true];
-        if (!array_key_exists(basename($_SERVER['SCRIPT_NAME']), $nobios)) {
-            $nobios[basename($_SERVER['SCRIPT_NAME'])] = false;
+        if (!array_key_exists($scriptname, $nobios)) {
+            $nobios[$scriptname] = false;
         }
-        $linkbios = !$nobios[basename($_SERVER['SCRIPT_NAME'])];
+        $linkbios = !$nobios[$scriptname];
         if ($message == 'X') {
             $linkbios = true;
         }


### PR DESCRIPTION
## Summary
- retrieve current script with `ScriptName::current()` and reuse for nobios lookup

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68af704c24c08329ac313860b1c30264