### PR TITLE
Use ScriptName for safe self-referential URLs

### DIFF
--- a/src/Lotgd/Battle.php
+++ b/src/Lotgd/Battle.php
@@ -10,6 +10,7 @@ use Lotgd\Buffs;
 use Lotgd\FightBar;
 use Lotgd\BellRand;
 use Lotgd\Substitute;
+use Lotgd\Util\ScriptName;
 
 class Battle
 {
@@ -350,7 +351,7 @@ class Battle
         global $session, $newenemies, $companions;
         tlschema('fightnav');
         if ($script === false) {
-            $script = substr($_SERVER['PHP_SELF'], strrpos($_SERVER['PHP_SELF'], '/') + 1) . '?';
+            $script = ScriptName::current() . '.php?';
         } else {
             if (!strpos($script, '?')) {
                 $script .= '?';

--- a/src/Lotgd/Events.php
+++ b/src/Lotgd/Events.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\Http;
+use Lotgd\Util\ScriptName;
 
 class Events
 {
@@ -27,7 +28,7 @@ class Events
     public static function handleEvent(string $location, ?string $baseLink = null, ?string $needHeader = null): bool
     {
         if ($baseLink === null) {
-                $baseLink = substr($_SERVER['PHP_SELF'], strrpos($_SERVER['PHP_SELF'], "/") + 1) . "?";
+                $baseLink = ScriptName::current() . '.php?';
         } else {
                 //debug("Base link was specified as $baseLink");
                 //debug(debug_backtrace());

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -1189,7 +1189,7 @@ class Modules
     public static function moduleEvents(string $eventtype, int $basechance, ?string $baseLink = null): int
     {
         if ($baseLink === null) {
-            $baseLink = substr($_SERVER['PHP_SELF'], strrpos($_SERVER['PHP_SELF'], '/') + 1) . '?';
+            $baseLink = ScriptName::current() . '.php?';
         }
 
         if (e_rand(1, 100) <= $basechance) {
@@ -1227,7 +1227,7 @@ class Modules
         global $navsection, $mostrecentmodule;
 
         if ($baseLink === null) {
-            $baseLink = substr($_SERVER['PHP_SELF'], strrpos($_SERVER['PHP_SELF'], '/') + 1) . '?';
+            $baseLink = ScriptName::current() . '.php?';
         }
 
         if (!isset($mostrecentmodule)) {
@@ -1259,14 +1259,14 @@ class Modules
      */
     public static function displayEvents(string $eventtype, $forcescript = false): void
     {
-        global $PHP_SELF, $session;
+        global $session;
 
         if (!($session['user']['superuser'] & SU_DEVELOPER)) {
             return;
         }
 
         if ($forcescript === false) {
-            $script = substr($_SERVER['PHP_SELF'], strrpos($_SERVER['PHP_SELF'], '/') + 1);
+            $script = ScriptName::current() . '.php';
         } else {
             $script = $forcescript;
         }


### PR DESCRIPTION
## Summary
- Use ScriptName::current() for building self links in battle navigation and event handlers
- Drop direct reliance on $_SERVER['PHP_SELF'] in module event functions and displays

## Testing
- `php -l src/Lotgd/Battle.php && php -l src/Lotgd/Events.php && php -l src/Lotgd/Modules.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68af7220ba608329b1689f80c50710c7