### PR TITLE
Use basename in commentary redirect

### DIFF
--- a/src/Lotgd/Commentary.php
+++ b/src/Lotgd/Commentary.php
@@ -144,7 +144,7 @@ SQL;
         $session['user']['specialinc'] == '';
 
         $returnPath = cmd_sanitize($returnPath);
-        $returnPath = mb_substr($returnPath, strrpos($returnPath, '/') + 1);
+        $returnPath = basename($returnPath);
         if (strpos($returnPath, '?') === false && strpos($returnPath, '&') !== false) {
             $x = strpos($returnPath, '&');
             $returnPath = mb_substr($returnPath, 0, $x - 1) . '?' . mb_substr($returnPath, $x + 1);


### PR DESCRIPTION
## Summary
- Simplify return path handling by using `basename()` in commentary removal redirect

## Testing
- `composer install`
- `php -l src/Lotgd/Commentary.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68af72259eac8329a8d83329d7842c9b