### PR TITLE
Fix restore page URL parsing in newday

### DIFF
--- a/newday.php
+++ b/newday.php
@@ -250,7 +250,7 @@ if ($dp < $dkills) {
         );
     }
     $rp = $session['user']['restorepage'];
-    $x = max(strrpos("&", $rp), strrpos("?", $rp));
+    $x = max(strrpos($rp, '&'), strrpos($rp, '?'));
     if ($x > 0) {
         $rp = substr($rp, 0, $x);
     }


### PR DESCRIPTION
## Summary
- Correct restore-page max() call to inspect `$rp` string for `&` or `?`

## Testing
- `php -l newday.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b002463ac88329a70dbbf7aee2883d