### PR TITLE
Use DATETIME_DATEMIN for bans

### DIFF
--- a/pages/user/user_removeban.php
+++ b/pages/user/user_removeban.php
@@ -28,7 +28,7 @@ if ($subop == "xml") {
     $output->rawOutput("</xml>");
     exit();
 }
-    Database::query("DELETE FROM " . Database::prefix("bans") . " WHERE banexpire < \"" . date("Y-m-d") . "\" AND banexpire>'0000-00-00'");
+Database::query("DELETE FROM " . Database::prefix("bans") . " WHERE banexpire < \"" . date("Y-m-d") . "\" AND banexpire>'" . DATETIME_DATEMIN . "'");
 $duration =  httpget("duration");
 if (httpget('notbefore')) {
     $operator = ">=";
@@ -37,17 +37,17 @@ if (httpget('notbefore')) {
 }
 
 if ($duration == "") {
-    $since = " WHERE banexpire $operator '" . date("Y-m-d H:i:s", strtotime("+2 weeks")) . "' AND banexpire > '0000-00-00 00:00:00'";
+    $since = " WHERE banexpire $operator '" . date("Y-m-d H:i:s", strtotime("+2 weeks")) . "' AND banexpire > '" . DATETIME_DATEMIN . "'";
         $output->output("`bShowing bans that will expire within 2 weeks.`b`n`n");
 } else {
     if ($duration == "forever") {
-        $since = " WHERE banexpire='0000-00-00 00:00:00'";
+        $since = " WHERE banexpire='" . DATETIME_DATEMIN . "'";
         $output->output("`bShowing all permanent bans`b`n`n");
     } elseif ($duration == "all") {
         $since = "";
         $output->output("`bShowing all bans`b`n`n");
     } else {
-        $since = " WHERE banexpire $operator '" . date("Y-m-d H:i:s", strtotime("+" . $duration)) . "' AND banexpire > '0000-00-00 00:00:00'";
+        $since = " WHERE banexpire $operator '" . date("Y-m-d H:i:s", strtotime("+" . $duration)) . "' AND banexpire > '" . DATETIME_DATEMIN . "'";
         $output->output("`bShowing bans that will expire within %s.`b`n`n", $duration);
     }
 }
@@ -148,7 +148,7 @@ while ($row = Database::fetchAssoc($result)) {
     ) {
         $expire = Translator::translateInline("Tomorrow");
     }
-    if ($row['banexpire'] == "0000-00-00 00:00:00") {
+    if ($row['banexpire'] == DATETIME_DATEMIN) {
         $expire = Translator::translateInline("Never");
     }
     $output->outputNotl("%s", $expire);

--- a/pages/user/user_saveban.php
+++ b/pages/user/user_saveban.php
@@ -24,7 +24,7 @@ if ($type == "ip") {
 }
 $duration = (int)httppost("duration");
 if ($duration == 0) {
-    $duration = "0000-00-00";
+    $duration = DATETIME_DATEMIN;
 } else {
     $duration = date("Y-m-d", strtotime("+$duration days"));
 }

--- a/pages/user/user_searchban.php
+++ b/pages/user/user_searchban.php
@@ -131,7 +131,7 @@ while ($row = Database::fetchAssoc($result)) {
     ) {
         $expire = Translator::translateInline("Tomorrow");
     }
-    if ($row['banexpire'] == "0000-00-00 00:00:00") {
+    if ($row['banexpire'] == DATETIME_DATEMIN) {
         $expire = Translator::translateInline("Never");
     }
     $output->outputNotl("%s", $expire);

--- a/tests/UserBanTest.php
+++ b/tests/UserBanTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (!function_exists('httpget')) {
+        function httpget(string $name): string
+        {
+            return $_GET[$name] ?? '';
+        }
+    }
+    if (!function_exists('httppost')) {
+        function httppost(string $name): string
+        {
+            return $_POST[$name] ?? '';
+        }
+    }
+    if (!function_exists('URLEncode')) {
+        function URLEncode(string $str): string
+        {
+            return urlencode($str);
+        }
+    }
+    if (!function_exists('relativedate')) {
+        function relativedate(string $date): string
+        {
+            return $date;
+        }
+    }
+    if (!function_exists('sprintf_translate')) {
+        function sprintf_translate(string $format, ...$args): string
+        {
+            return vsprintf($format, $args);
+        }
+    }
+    if (!function_exists('debuglog')) {
+        function debuglog(string $message): void
+        {
+        }
+    }
+}
+
+namespace Lotgd {
+    if (!class_exists(__NAMESPACE__ . '\\Nav')) {
+        class Nav
+        {
+            public static function add(mixed ...$args): void
+            {
+            }
+        }
+    }
+
+    if (!class_exists(__NAMESPACE__ . '\\Translator')) {
+        class Translator
+        {
+            public static function translateInline(string $text): string
+            {
+                return $text;
+            }
+        }
+    }
+}
+
+namespace Lotgd\Tests {
+    use Lotgd\MySQL\Database;
+    use PHPUnit\Framework\TestCase;
+
+    final class UserSaveBanTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            $mockDb = new class {
+                public array $queries = [];
+                public function query(string $sql): array
+                {
+                    $this->queries[] = $sql;
+                    return [];
+                }
+            };
+            \Lotgd\MySQL\Database::$instance = $mockDb;
+            global $_POST, $_SERVER;
+            $GLOBALS['session'] = ['user' => ['name' => 'Admin']];
+            $_POST   = [
+                'type'     => 'ip',
+                'ip'       => '8.8.8.8',
+                'duration' => '0',
+                'reason'   => 'Test',
+            ];
+            $_SERVER['REMOTE_ADDR'] = '1.2.3.4';
+            $GLOBALS['output'] = new class {
+                public function output(string $format, ...$args): void {}
+                public function outputNotl(string $format, ...$args): void {}
+            };
+        }
+
+        public function testPermanentBanUsesDatetimeDatemin(): void
+        {
+            $include = function (): void {
+                global $session, $_POST, $_SERVER, $output;
+                require __DIR__ . '/../pages/user/user_saveban.php';
+            };
+            \Closure::bind($include, null, null)();
+            $queries = Database::getInstance()->queries;
+            $this->assertStringContainsString('"' . DATETIME_DATEMIN . '"', $queries[0] ?? '');
+        }
+    }
+
+    final class UserRemoveBanTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            $mockDb = new class {
+                public array $queries = [];
+                public function query(string $sql): array
+                {
+                    $this->queries[] = $sql;
+                    return [];
+                }
+            };
+            \Lotgd\MySQL\Database::$instance = $mockDb;
+            global $_GET, $_POST;
+            $_GET = [];
+            $_POST = [];
+            $GLOBALS['output'] = new class {
+                public function rawOutput(string $text): void {}
+                public function output(string $format, ...$args): void {}
+                public function outputNotl(string $format, ...$args): void {}
+            };
+        }
+
+        public function testQueriesUseDatetimeDatemin(): void
+        {
+            $include = function (): void {
+                global $_GET, $_POST, $output;
+                require __DIR__ . '/../pages/user/user_removeban.php';
+            };
+            \Closure::bind($include, null, null)();
+            $queries = Database::getInstance()->queries;
+            $this->assertNotEmpty($queries);
+            $this->assertStringContainsString(DATETIME_DATEMIN, $queries[0] ?? '');
+            $this->assertStringContainsString(DATETIME_DATEMIN, $queries[1] ?? '');
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace zero dates with DATETIME_DATEMIN in user ban pages
- ensure ban queries and comparisons use DATETIME_DATEMIN
- add tests covering permanent ban save and listing logic

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b0043edb508329b97bed72625aeba4