### PR TITLE
Use mb_substr for clan description

### DIFF
--- a/pages/clan/clan_motd.php
+++ b/pages/clan/clan_motd.php
@@ -32,7 +32,7 @@ if ($session['user']['clanrank'] >= CLAN_OFFICER) {
             stripslashes($clandesc) != $claninfo['clandesc'] &&
             $claninfo['descauthor'] != 4294967295
     ) {
-        $sql = "UPDATE " . Database::prefix("clans") . " SET clandesc='" . addslashes(substr(stripslashes($clandesc), 0, 4096)) . "',descauthor={$session['user']['acctid']} WHERE clanid={$claninfo['clanid']}";
+        $sql = "UPDATE " . Database::prefix("clans") . " SET clandesc='" . addslashes(mb_substr(stripslashes($clandesc), 0, 4096, 'UTF-8')) . "',descauthor={$session['user']['acctid']} WHERE clanid={$claninfo['clanid']}";
         Database::query($sql);
         DataCache::invalidatedatacache("clandata-{$claninfo['clanid']}");
         $output->output("Updating description`n");


### PR DESCRIPTION
## Summary
- use `mb_substr` to safely limit clan description length with UTF-8 characters

## Testing
- `php -l pages/clan/clan_motd.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b005d96b888329ab37b9996401d663