### PR TITLE
Use mb_substr for system mail truncation

### DIFF
--- a/src/Lotgd/Mail.php
+++ b/src/Lotgd/Mail.php
@@ -66,7 +66,17 @@ class Mail
         }
 
         $settings = self::getSettings();
-        $body = addslashes(substr(stripslashes($body), 0, (int) $settings->getSetting('mailsizelimit', 1024)));
+        $limit = (int) $settings->getSetting('mailsizelimit', 1024);
+        $charset = $settings->getSetting('charset', 'UTF-8');
+        $body = stripslashes($body);
+
+        if (extension_loaded('mbstring')) {
+            $body = mb_substr($body, 0, $limit, $charset);
+        } else {
+            $body = substr($body, 0, $limit);
+        }
+
+        $body = addslashes($body);
         $sql = 'INSERT INTO ' . Database::prefix('mail') . " (msgfrom,msgto,subject,body,sent) VALUES ('" . (int)$from . "','" . (int)$to . "','$subject','$body','" . date('Y-m-d H:i:s') . "')";
         Database::query($sql);
         DataCache::invalidatedatacache("mail-$to");


### PR DESCRIPTION
## Summary
- switch system mail truncation to multibyte-safe `mb_substr`
- fallback to `substr` when `mbstring` is unavailable

## Testing
- `php -l src/Lotgd/Mail.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b005cd59ec8329abde8497a5caa6a2