### PR TITLE
Use mb_substr for mail body truncation

### DIFF
--- a/pages/mail/case_send.php
+++ b/pages/mail/case_send.php
@@ -118,7 +118,7 @@ function escapeAndTruncateBody(string $body): string
 {
     $limit = (int) getsetting('mailsizelimit', 1024);
 
-    return addslashes(substr(stripslashes($body), 0, $limit));
+    return addslashes(mb_substr(stripslashes($body), 0, $limit, 'UTF-8'));
 }
 
 mailSend();

--- a/pages/mail/case_write.php
+++ b/pages/mail/case_write.php
@@ -155,13 +155,18 @@ function mailWrite(): void
         "<table style='border:0;cellspacing:10'><tr><td><input type='button' onClick=\"increase(textarea1,1);\" value='+' accesskey='+'></td><td><input type='button' onClick=\"increase(textarea1,-1);\" value='-' accesskey='-'></td><td><input type='button' onClick=\"cincrease(textarea1,-1);\" value='<-'></td><td><input type='button' onClick=\"cincrease(textarea1,1);\" value='->' accesskey='-'></td></tr></table>"
     );
 
-    // substr is necessary if you have chars that take up more than 1 byte.
+    // mb_substr is necessary if you have chars that take up more than 1 byte.
     $textBody = htmlentities(
         str_replace(
             '`n',
             "\n",
             Sanitize::sanitizeMb(
-                substr($body, 0, (int) getsetting('mailsizelimit', 1024, getsetting('charset', 'ISO-8859-1')))
+                mb_substr(
+                    $body,
+                    0,
+                    (int) getsetting('mailsizelimit', 1024, getsetting('charset', 'ISO-8859-1')),
+                    'UTF-8'
+                )
             )
         ),
         ENT_COMPAT,


### PR DESCRIPTION
## Summary
- Use `mb_substr` when truncating mail bodies in send and write cases to respect multibyte characters

## Testing
- `php -l pages/mail/case_send.php`
- `php -l pages/mail/case_write.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b005d06ac4832989a0dc56e8397897