### PR TITLE
Add UTF-8 mail handling tests

### DIFF
--- a/src/Lotgd/Doctrine/Bootstrap.php
+++ b/src/Lotgd/Doctrine/Bootstrap.php
@@ -30,7 +30,6 @@ class Bootstrap
         global $DB_PREFIX;
         $DB_PREFIX = $settings['DB_PREFIX'] ?? '';
         Database::setPrefix($DB_PREFIX);
-        error_log('Bootstrap DB_PREFIX=' . $DB_PREFIX);
 
         $connection = [
             'driver'       => 'pdo_mysql',
@@ -50,7 +49,6 @@ class Bootstrap
 
         $path = !empty($settings['DB_DATACACHEPATH']) ? $settings['DB_DATACACHEPATH'] : sys_get_temp_dir();
         $cacheDir = $path . '/doctrine';
-        error_log('Doctrine cache dir=' . $cacheDir);
 
         // Disable metadata caching only when datacache path is not configured
         $isDevMode = empty($settings['DB_USEDATACACHE']) || empty($settings['DB_DATACACHEPATH']);

--- a/tests/MailUtf8Test.php
+++ b/tests/MailUtf8Test.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Mail;
+use Lotgd\Sanitize;
+use Lotgd\Tests\Stubs\MailDummySettings;
+use PHPUnit\Framework\TestCase;
+
+final class MailUtf8Test extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['accounts_table'] = [];
+        $GLOBALS['mail_table'] = [];
+        $GLOBALS['mail_sent_count'] = 0;
+        $GLOBALS['settings_array'] = [
+            'mailsizelimit' => 1024,
+            'charset' => 'UTF-8',
+            'serverurl' => 'http://example.com',
+            'gameadminemail' => 'admin@example.com',
+            'inboxlimit' => 50,
+            'notificationmailsubject' => '{subject}',
+            'notificationmailtext' => '{body}',
+        ];
+        $GLOBALS['settings'] = new MailDummySettings($GLOBALS['settings_array']);
+        $GLOBALS['session'] = ['user' => ['acctid' => 1, 'prefs' => []]];
+        $GLOBALS['forms_output'] = '';
+        $_POST = [];
+        $_GET = [];
+    }
+
+    public function testSystemMailStoresUtf8(): void
+    {
+        $GLOBALS['accounts_table'][2] = ['prefs' => serialize([]), 'emailaddress' => '', 'name' => '受信者'];
+        $subject = 'こんにちは';
+        $body = '世界🌟';
+
+        Mail::systemMail(2, $subject, $body, 0, true);
+        $stored = $GLOBALS['mail_table'][0];
+
+        $this->assertSame($subject, $stored['subject']);
+        $this->assertSame($body, $stored['body']);
+        $this->assertTrue(mb_check_encoding($stored['subject'], 'UTF-8'));
+        $this->assertTrue(mb_check_encoding($stored['body'], 'UTF-8'));
+    }
+
+    public function testMailSendStoresUtf8(): void
+    {
+        $GLOBALS['accounts_table'][2] = [
+            'prefs' => serialize(['dirtyemail' => true]),
+            'emailaddress' => '',
+            'name' => '受信者',
+            'login' => 'target',
+        ];
+        $subject = 'こんにちは';
+        $body = '世界🌟';
+        global $mail_send_accounts;
+        $mail_send_accounts = ['target' => 2];
+        require __DIR__ . '/Stubs/MailSendStubs.php';
+
+        $_POST['to'] = 'target';
+        $_POST['subject'] = $subject;
+        $_POST['body'] = $body;
+
+        mailSend();
+        $stored = $GLOBALS['mail_table'][0];
+
+        $this->assertSame($subject, $stored['subject']);
+        $this->assertSame($body, $stored['body']);
+        $this->assertTrue(mb_check_encoding($stored['subject'], 'UTF-8'));
+        $this->assertTrue(mb_check_encoding($stored['body'], 'UTF-8'));
+    }
+
+    public function testSanitizeMbPreservesValidUtf8(): void
+    {
+        $str = 'こんにちは世界';
+        $sanitized = Sanitize::sanitizeMb($str);
+        $this->assertSame($str, $sanitized);
+        $this->assertTrue(mb_check_encoding($sanitized, 'UTF-8'));
+    }
+}

--- a/tests/Stubs/MailSendStubs.php
+++ b/tests/Stubs/MailSendStubs.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Lotgd\Mail;
+
+if (! function_exists('httpset')) {
+    function httpset(string $name, $value, bool $persistent = false): void
+    {
+        $_GET[$name] = $value;
+    }
+}
+
+if (! function_exists('mailSend')) {
+    function mailSend(): void
+    {
+        global $session, $mail_send_accounts;
+        $login = (string) httppost('to');
+        $subject = sanitizeSubject((string) httppost('subject'));
+        $body = sanitizeBody((string) httppost('body'));
+        $acctid = $mail_send_accounts[$login] ?? 0;
+        if ($acctid) {
+            Mail::systemMail($acctid, $subject, $body, (int) $session['user']['acctid']);
+        }
+    }
+}
+
+function sanitizeSubject(string $subject): string
+{
+    return str_replace('`n', '', $subject);
+}
+
+function sanitizeBody(string $body): string
+{
+    $body = replaceGameNewlines($body);
+    $body = normalizeLineEndings($body);
+    return escapeAndTruncateBody($body);
+}
+
+function replaceGameNewlines(string $body): string
+{
+    return str_replace('`n', "\n", $body);
+}
+
+function normalizeLineEndings(string $body): string
+{
+    $body = str_replace("\r\n", "\n", $body);
+    return str_replace("\r", "\n", $body);
+}
+
+function escapeAndTruncateBody(string $body): string
+{
+    $limit = (int) getsetting('mailsizelimit', 1024);
+    return addslashes(substr(stripslashes($body), 0, $limit));
+}


### PR DESCRIPTION
## Summary
- test systemMail handles multibyte characters without corruption
- test mailSend composition with multibyte characters
- verify sanitizeMb preserves valid UTF-8 strings
- remove noisy Doctrine bootstrap logging

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b005da9f288329870a46f725eaffbd