### PR TITLE
Normalize timestamps in charrestore module

### DIFF
--- a/modules/charrestore.php
+++ b/modules/charrestore.php
@@ -485,7 +485,7 @@ function charrestore_run(): void
                 } elseif (! isset($known_columns[$key])) {
                     output("`2Dropping the column `^%s`n", $key);
                 } else {
-                    if ($val === "0000-00-00 00:00:00") {
+                    if ($val < DATETIME_DATEMIN) {
                         $val = DATETIME_DATEMIN; // fix old time stamps
                     }
                     array_push($keys, $key);


### PR DESCRIPTION
## Summary
- use `DATETIME_DATEMIN` constant to replace invalid timestamps when restoring accounts

## Testing
- `composer install`
- `php -l modules/charrestore.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b0042e4b58832984adde1905235238