### PR TITLE
Use appoencode for mail form labels

### DIFF
--- a/pages/mail/case_default.php
+++ b/pages/mail/case_default.php
@@ -193,9 +193,9 @@ function renderMailFooter(array $fromList): void
                 }
                                         </script>";
     rawoutput($script);
-    $checkall = htmlentities(Translator::translateInline('Check All'), ENT_QUOTES | ENT_HTML5, 'UTF-8');
-    $delchecked = htmlentities(Translator::translateInline('Delete Checked'), ENT_QUOTES | ENT_HTML5, 'UTF-8');
-    $checknames = htmlentities(Translator::translateInline('`vCheck by Name'), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    $checkall = appoencode(Translator::translateInline('Check All'));
+    $delchecked = appoencode(Translator::translateInline('Delete Checked'));
+    $checknames = appoencode(Translator::translateInline('`vCheck by Name`0'));
     output_notl("<label for='check_name_select'>" . $checknames . "</label> <select onchange='check_name()' id='check_name_select'>" . $option . "</select><br>", true);
     rawoutput("<input type='button' id='button_check' value=\"$checkall\" class='button' onClick='check_all()'>");
     rawoutput("<input type='submit' class='button' value=\"$delchecked\">");


### PR DESCRIPTION
## Summary
- encode `Check All` and `Delete Checked` using `appoencode`
- append `0` to `Check by Name` to close color spans

## Testing
- `php -l pages/mail/case_default.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b00c8006688329878625f13280eb9c