### PR TITLE
Coerce charset setting to UTF-8

### DIFF
--- a/src/Lotgd/Settings.php
+++ b/src/Lotgd/Settings.php
@@ -113,22 +113,30 @@ class Settings
         }
         if (!isset($this->settings[$settingname])) {
             $this->loadSettings();
-        } else {
-            return $this->settings[$settingname];
-        }
-        if (!isset($this->settings[$settingname])) {
-            if (file_exists("config/" . $this->tablename . ".php")) {
-                require "config/" . $this->tablename . ".php";
-            }
-            if ($default === false) {
-                $setDefault = $defaults[$settingname] ?? '';
+            if (!isset($this->settings[$settingname])) {
+                if (file_exists('config/' . $this->tablename . '.php')) {
+                    require 'config/' . $this->tablename . '.php';
+                }
+                if ($default === false) {
+                    $value = $defaults[$settingname] ?? '';
+                } else {
+                    $value = $default;
+                }
+                $this->saveSetting($settingname, $value);
             } else {
-                $setDefault = $default;
+                $value = $this->settings[$settingname];
             }
-            $this->saveSetting($settingname, $setDefault);
-            return $setDefault;
+        } else {
+            $value = $this->settings[$settingname];
         }
-        return $this->settings[$settingname];
+
+        if ($settingname === 'charset' && $value !== 'UTF-8') {
+            $this->saveSetting('charset', 'UTF-8');
+
+            return 'UTF-8';
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -54,4 +54,21 @@ final class SettingsTest extends TestCase
         $settings->loadSettings();
         $this->assertSame('2', $settings->getSetting('x'));
     }
+
+    public function testCharsetValueCoercedWhenDifferent(): void
+    {
+        \Lotgd\MySQL\Database::$settings_table = ['charset' => 'ISO-8859-1'];
+        $settings = new Settings('settings');
+        $this->assertSame('UTF-8', $settings->getSetting('charset'));
+        $this->assertArrayHasKey('charset', \Lotgd\MySQL\Database::$settings_table);
+        $this->assertSame('UTF-8', \Lotgd\MySQL\Database::$settings_table['charset']);
+    }
+
+    public function testCharsetValueCoercedWhenMissing(): void
+    {
+        \Lotgd\MySQL\Database::$settings_table = [];
+        $settings = new Settings('settings');
+        $this->assertSame('UTF-8', $settings->getSetting('charset', 'ISO-8859-1'));
+        $this->assertSame('UTF-8', $settings->getSetting('charset'));
+    }
 }


### PR DESCRIPTION
## Summary
- Force settings lookup for `charset` to return and persist `UTF-8`
- Test charset coercion for existing and missing values

## Testing
- `composer install`
- `php -l src/Lotgd/Settings.php`
- `php -l tests/SettingsTest.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b00df0da80832983ae5581eaa45555