### PR TITLE
Use UTF-8 charset by default and migrate existing settings

### DIFF
--- a/install/data/installer_sqlstatements.php
+++ b/install/data/installer_sqlstatements.php
@@ -857,7 +857,7 @@ $sql_upgrade_statements = array(
 "1.1.0 Dragonprime Edition" => array(
 "UPDATE " . db_prefix("accounts") . " SET clanrank = clanrank * 10",
 "INSERT IGNORE INTO " . db_prefix("settings") . " VALUES ('newdaycron', '0')",
-"INSERT IGNORE INTO " . db_prefix("settings") . " VALUES ('charset', 'ISO-8859-1')",
+"INSERT IGNORE INTO " . db_prefix("settings") . " VALUES ('charset', 'UTF-8')",
 "INSERT IGNORE INTO " . db_prefix("settings") . " VALUES ('allowspecialswitch', '1')",
 ),
 "1.1.1 Dragonprime Edition" => array(

--- a/migrations/Version20250724000017.php
+++ b/migrations/Version20250724000017.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Lotgd\MySQL\Database;
+
+final class Version20250724000017 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update charset setting to UTF-8';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = Database::prefix('settings');
+        $this->addSql("UPDATE $table SET value = 'UTF-8' WHERE setting = 'charset'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = Database::prefix('settings');
+        $this->addSql("UPDATE $table SET value = 'ISO-8859-1' WHERE setting = 'charset'");
+    }
+}


### PR DESCRIPTION
## Summary
- default `settings` install sets charset to UTF-8
- migrate existing settings rows to UTF-8

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b00df6c6e88329ba20f098a51f7a44