### PR TITLE
Remove charset configuration

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -33,6 +33,9 @@ switch ($type_setting) {
                 $old = $settings_extended->getArray();
                 $current = $settings_extended->getArray();
                 foreach ($post as $key => $val) {
+                    if ('charset' === $key) {
+                        continue;
+                    }
                     if (!isset($current[$key]) || (stripslashes($val) != $current[$key])) {
                         if (!isset($old[$key])) {
                             $old[$key] = "";
@@ -118,6 +121,9 @@ switch ($type_setting) {
                 $old = $settings->getArray();
                 $current = $settings->getArray();
                 foreach ($post as $key => $val) {
+                    if ('charset' === $key) {
+                        continue;
+                    }
                     if (!isset($current[$key]) || (stripslashes($val) != $current[$key])) {
                         if (!isset($old[$key])) {
                             $old[$key] = "";
@@ -311,6 +317,7 @@ switch ($type_setting) {
                 $useful_vals = array(
                     "datacachepath" => $DB_DATACACHEPATH,
                     "usedatacache" => $DB_USEDATACACHE,
+                    "charset" => getsetting('charset', 'UTF-8'),
                     "defaultsuperuser" => getsetting('defaultsuperuser', 0), // this needs to be there as the showform loads from the database; so a value has to be present if it's not set, and this is a technical field
                     "dayduration" => round(($details['dayduration'] / 60 / 60), 0) . " hours",
                     "gziphandler" => $gz_handler_on,

--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -119,7 +119,9 @@ and compares virtually all scripts and emoji correctly, choosing a different
 collation is rarely sensible. If you change it, be certain you understand why.
 
 Ensure that the application's output encoding matches the database encoding to
-avoid memory errors when strings are converted between PHP and MySQL.
+avoid memory errors when strings are converted between PHP and MySQL. The engine
+always outputs UTF-8, so configure your database with UTF-8 compatible encodings
+such as `utf8mb4`.
 
 `synctable()` and `TableDescriptor::tableCreateFromDescriptor()` validate the
 provided charset and collation. They throw an `InvalidArgumentException` for

--- a/src/Lotgd/Config/configuration.php
+++ b/src/Lotgd/Config/configuration.php
@@ -300,7 +300,8 @@ $setup = array(
     "permacollect" => "Permanently collect untranslated texts (overrides the next settings!),bool",
     "collecttexts" => "Are we currently collecting untranslated texts?,viewonly",
     "tl_maxallowed" => "Collect untranslated texts if you have fewer player than this logged in. (0 never collects),int",
-    "charset" => "Which charset should be used for htmlentities?",
+    "charset" => "Which charset should be used for htmlentities?,viewonly",
+    "UTF-8 is enforced as the character encoding and cannot be changed.,note",
 
     "Error Notification,title",
     "Note: you MUST have data caching turned on if you want to use this feature.  Also the first error within any 24 hour period will not generate a notice; I'm sorry: that's really just how it is for technical reasons.,note",


### PR DESCRIPTION
## Summary
- show charset setting in admin config as view-only
- note that UTF-8 encoding is enforced

## Testing
- `php -l configuration.php`
- `php -l src/Lotgd/Config/configuration.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b0111127548329bcddc75f9976149a