### PR TITLE
Use UTF-8 as default charset fallback

### DIFF
--- a/common.php
+++ b/common.php
@@ -321,7 +321,7 @@ if (isset($settings) && $logd_version == $settings->getSetting("installer_versio
     define("IS_INSTALLER", false);
 }
 
-$charset = isset($settings) ? $settings->getSetting('charset', 'ISO-8859-1') : 'utf8';
+$charset = isset($settings) ? $settings->getSetting('charset', 'ISO-8859-1') : 'UTF-8';
 
 header("Content-Type: text/html; charset=" . $charset);
 


### PR DESCRIPTION
## Summary
- default to UTF-8 charset when generating headers

## Testing
- `php -l common.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b029057dd483299c2fabb38cbffbb8