### PR TITLE
Prevent duplicate charset writes

### DIFF
--- a/src/Lotgd/Settings.php
+++ b/src/Lotgd/Settings.php
@@ -114,6 +114,11 @@ class Settings
         if (!isset($this->settings[$settingname])) {
             $this->loadSettings();
             if (!isset($this->settings[$settingname])) {
+                if ($settingname === 'charset') {
+                    $this->saveSetting('charset', 'UTF-8');
+
+                    return 'UTF-8';
+                }
                 if (file_exists('config/' . $this->tablename . '.php')) {
                     require 'config/' . $this->tablename . '.php';
                 }

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -68,7 +68,17 @@ final class SettingsTest extends TestCase
     {
         \Lotgd\MySQL\Database::$settings_table = [];
         $settings = new Settings('settings');
+
+        \Lotgd\MySQL\Database::$affected_rows = 0;
+        \Lotgd\MySQL\Database::$lastSql = '';
         $this->assertSame('UTF-8', $settings->getSetting('charset', 'ISO-8859-1'));
+        $this->assertStringContainsString('INSERT INTO settings', \Lotgd\MySQL\Database::$lastSql);
+        $this->assertSame(1, \Lotgd\MySQL\Database::$affected_rows);
+
+        \Lotgd\MySQL\Database::$affected_rows = 0;
+        \Lotgd\MySQL\Database::$lastSql = '';
         $this->assertSame('UTF-8', $settings->getSetting('charset'));
+        $this->assertSame('', \Lotgd\MySQL\Database::$lastSql);
+        $this->assertSame(0, \Lotgd\MySQL\Database::$affected_rows);
     }
 }


### PR DESCRIPTION
## Summary
- avoid double `charset` writes by inserting `UTF-8` when missing
- test that charset initialization only writes once

## Testing
- `php -l src/Lotgd/Settings.php`
- `php -l tests/SettingsTest.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b029090264832980cfd3397a055f33