### PR TITLE
Use configured charset in multibyte substring operations

### DIFF
--- a/pages/clan/clan_motd.php
+++ b/pages/clan/clan_motd.php
@@ -32,7 +32,7 @@ if ($session['user']['clanrank'] >= CLAN_OFFICER) {
             stripslashes($clandesc) != $claninfo['clandesc'] &&
             $claninfo['descauthor'] != 4294967295
     ) {
-        $sql = "UPDATE " . Database::prefix("clans") . " SET clandesc='" . addslashes(mb_substr(stripslashes($clandesc), 0, 4096, 'UTF-8')) . "',descauthor={$session['user']['acctid']} WHERE clanid={$claninfo['clanid']}";
+        $sql = "UPDATE " . Database::prefix("clans") . " SET clandesc='" . addslashes(mb_substr(stripslashes($clandesc), 0, 4096, getsetting('charset', 'ISO-8859-1'))) . "',descauthor={$session['user']['acctid']} WHERE clanid={$claninfo['clanid']}";
         Database::query($sql);
         DataCache::invalidatedatacache("clandata-{$claninfo['clanid']}");
         $output->output("Updating description`n");

--- a/pages/mail/case_send.php
+++ b/pages/mail/case_send.php
@@ -118,7 +118,7 @@ function escapeAndTruncateBody(string $body): string
 {
     $limit = (int) getsetting('mailsizelimit', 1024);
 
-    return addslashes(mb_substr(stripslashes($body), 0, $limit, 'UTF-8'));
+    return addslashes(mb_substr(stripslashes($body), 0, $limit, getsetting('charset', 'ISO-8859-1')));
 }
 
 mailSend();

--- a/src/Lotgd/Sanitize.php
+++ b/src/Lotgd/Sanitize.php
@@ -275,8 +275,8 @@ class Sanitize
         if ($str == '') {
             return '';
         }
-        while (!mb_check_encoding($str, getsetting('charset', 'ISO-8859-1')) && mb_strlen($str, 'UTF-8') > 0) {
-            $str = mb_substr($str, 0, mb_strlen($str, 'UTF-8') - 1, 'UTF-8');
+        while (!mb_check_encoding($str, getsetting('charset', 'ISO-8859-1')) && mb_strlen($str, getsetting('charset', 'ISO-8859-1')) > 0) {
+            $str = mb_substr($str, 0, mb_strlen($str, getsetting('charset', 'ISO-8859-1')) - 1, getsetting('charset', 'ISO-8859-1'));
         }
         return $str;
     }


### PR DESCRIPTION
## Summary
- Use `getsetting('charset', 'ISO-8859-1')` in multibyte substring operations instead of hardcoded `UTF-8`
- Apply configured charset in sanitization utilities for consistent encoding handling

## Testing
- `php -l pages/clan/clan_motd.php`
- `php -l pages/mail/case_send.php`
- `php -l src/Lotgd/Sanitize.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b02f9575e08329972e7d7daaacca4c