### PR TITLE
refactor: nest database config under connection

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -3,13 +3,15 @@
 $db = require dirname(__DIR__) . '/dbconnect.php';
 
 return [
-    'driver' => 'pdo_mysql',
-    'host' => $db['DB_HOST'] ?? 'localhost',
-    'dbname' => $db['DB_NAME'] ?? '',
-    'user' => $db['DB_USER'] ?? '',
-    'password' => $db['DB_PASS'] ?? '',
-    'charset' => 'utf8mb4',
-    'db_prefix' => $db['DB_PREFIX'] ?? '',
+    'connection' => [
+        'driver' => 'pdo_mysql',
+        'host' => $db['DB_HOST'] ?? 'localhost',
+        'dbname' => $db['DB_NAME'] ?? '',
+        'user' => $db['DB_USER'] ?? '',
+        'password' => $db['DB_PASS'] ?? '',
+        'charset' => 'utf8mb4',
+        'db_prefix' => $db['DB_PREFIX'] ?? '',
+    ],
     'migrations_paths' => [
         'Lotgd\\Migrations' => dirname(__DIR__) . '/migrations',
     ],

--- a/migrations.php
+++ b/migrations.php
@@ -1,0 +1,4 @@
+<?php
+
+return require __DIR__ . '/config/doctrine.php';
+


### PR DESCRIPTION
## Summary
- nest database parameters under a `connection` key in `config/doctrine.php`
- add root-level `migrations.php` returning the doctrine config

## Testing
- `php -l config/doctrine.php`
- `php -l migrations.php`
- `composer install`
- `composer test`
- `php vendor/bin/doctrine-migrations migrations:list` *(fails: Argument #1 ($connectionName) must be of type ?string, array given)*

------
https://chatgpt.com/codex/tasks/task_e_68b03c67f4ec83299cd5f7b1ab4a3ba2