### PR TITLE
docs: clarify migrations configuration and usage

### DIFF
--- a/docs/Doctrine.md
+++ b/docs/Doctrine.md
@@ -28,14 +28,61 @@ $repo = $entityManager->getRepository(Lotgd\Entity\Account::class);
 
 ## Running Migrations
 
-Schema migrations reside in the `migrations/` directory. Execute them with the
-Doctrine migration tool:
+Schema migrations reside in the `migrations/` directory and are configured
+through two files:
 
-```bash
-php vendor/bin/doctrine-migrations migrate --configuration=config/doctrine.php
+* `migrations.php` – defines migration paths and the **connection name**.
+* `migrations-db.php` – provides database credentials keyed by connection name.
+
+In `migrations.php` the `connection` value is only a label. The actual
+credentials belong in `migrations-db.php`:
+
+```php
+<?php
+// migrations.php
+return [
+    'connection' => 'lotgd',
+    'migrations_paths' => [
+        'Lotgd\\Migrations' => __DIR__ . '/../migrations',
+    ],
+];
 ```
 
-The command reads its configuration from `config/doctrine.php`.
+```php
+<?php
+// migrations-db.php
+return [
+    'lotgd' => [
+        'driver' => 'pdo_mysql',
+        'host' => 'localhost',
+        'dbname' => 'lotgd',
+        'user' => 'lotgd_user',
+        'password' => 'secret',
+        'charset' => 'utf8mb4',
+    ],
+];
+```
+
+Run pending migrations:
+
+```bash
+php vendor/bin/doctrine-migrations migrate
+```
+
+The command automatically reads `migrations.php` and `migrations-db.php` from
+the project root. If you store them elsewhere, pass the paths explicitly:
+
+```bash
+php vendor/bin/doctrine-migrations \
+    --configuration=config/migrations.php \
+    --db-configuration=config/migrations-db.php migrate
+```
+
+### Upgrade Notes
+
+Earlier versions used a single `config/doctrine.php`. Replace it with the split
+configuration above and run `php vendor/bin/doctrine-migrations migrate` when
+upgrading.
 
 ## Persisting an Account
 

--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -141,14 +141,24 @@ try {
 
 ## Database Migrations
 
-The project uses [Doctrine Migrations](https://www.doctrine-project.org/projects/migrations.html) to manage schema changes. The migration classes live in the `migrations/` directory defined in `config/doctrine.php`.
+The project uses [Doctrine Migrations](https://www.doctrine-project.org/projects/migrations.html) to manage schema changes. The migration classes live in the `migrations/` directory and are configured through `migrations.php` and `migrations-db.php`.
+
+In `migrations.php` the `connection` value is only a name that matches the credentials array in `migrations-db.php`.
 
 ### Running Migrations
 
 Execute pending migrations with the Doctrine command line tool:
 
 ```bash
-vendor/bin/doctrine-migrations migrations:migrate
+php vendor/bin/doctrine-migrations migrate
+```
+
+The command uses the default `migrations.php` and `migrations-db.php` files in the project root. If your configuration lives elsewhere, provide their paths explicitly:
+
+```bash
+php vendor/bin/doctrine-migrations \
+    --configuration=config/migrations.php \
+    --db-configuration=config/migrations-db.php migrate
 ```
 
 This will apply all new migrations to the configured database. During development you can generate additional migrations using `migrations:diff` or `migrations:generate`.


### PR DESCRIPTION
## Summary
- document separate `migrations.php` and `migrations-db.php` config files
- clarify that `connection` is a name and credentials belong in `migrations-db.php`
- update CLI examples and upgrade notes for Doctrine migrations

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b044d3cde08329ae3a71dedd38bcad