### PR TITLE
Use configured charset for mail body truncation

### DIFF
--- a/pages/mail/case_write.php
+++ b/pages/mail/case_write.php
@@ -164,8 +164,8 @@ function mailWrite(): void
                 mb_substr(
                     $body,
                     0,
-                    (int) getsetting('mailsizelimit', 1024, getsetting('charset', 'UTF-8')),
-                    'UTF-8'
+                    (int) getsetting('mailsizelimit', 1024),
+                    getsetting('charset', 'ISO-8859-1')
                 )
             )
         ),


### PR DESCRIPTION
## Summary
- Use game charset for mb_substr when truncating mail body, defaulting to ISO-8859-1

## Testing
- `php -l pages/mail/case_write.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b0487997ec832993501bd59876ff03