### PR TITLE
Specify charset when trimming clan MOTD

### DIFF
--- a/pages/clan/clan_motd.php
+++ b/pages/clan/clan_motd.php
@@ -14,7 +14,7 @@ use Lotgd\Nltoappon;
         Header::pageHeader("Update Clan Description / MoTD");
         Nav::add("Clan Options");
 if ($session['user']['clanrank'] >= CLAN_OFFICER) {
-    $clanmotd = Sanitize::sanitizeMb(mb_substr((string)Http::post('clanmotd'), 0, 4096));
+    $clanmotd = Sanitize::sanitizeMb(mb_substr((string) Http::post('clanmotd'), 0, 4096, getsetting('charset', 'ISO-8859-1')));
     if (
         Http::postIsset('clanmotd') &&
             stripslashes($clanmotd) != $claninfo['clanmotd']


### PR DESCRIPTION
## Summary
- ensure clan MOTD truncation honors site charset

## Testing
- `php -l pages/clan/clan_motd.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b0487cea8c8329a0732cf82e9bb2dd