### PR TITLE
docs: clarify Doctrine migration config for single connection

### DIFF
--- a/docs/Doctrine.md
+++ b/docs/Doctrine.md
@@ -31,17 +31,20 @@ $repo = $entityManager->getRepository(Lotgd\Entity\Account::class);
 Schema migrations reside in the `migrations/` directory and are configured
 through two files:
 
-* `migrations.php` – defines migration paths and the **connection name**.
-* `migrations-db.php` – provides database credentials keyed by connection name.
+* `migrations.php` – defines migration paths. When using a single connection no
+  additional options are required. For multiple connections you may specify a
+  `connection` key to select which database configuration to use.
+* `migrations-db.php` – provides the database credentials. With one connection
+  it returns the parameters directly. To support multiple connections return an
+  array keyed by connection name.
 
-In `migrations.php` the `connection` value is only a label. The actual
-credentials belong in `migrations-db.php`:
+In a single connection setup `migrations.php` only lists `migrations_paths` and
+`migrations-db.php` contains the connection details:
 
 ```php
 <?php
 // migrations.php
 return [
-    'connection' => 'lotgd',
     'migrations_paths' => [
         'Lotgd\\Migrations' => __DIR__ . '/../migrations',
     ],
@@ -52,16 +55,18 @@ return [
 <?php
 // migrations-db.php
 return [
-    'lotgd' => [
-        'driver' => 'pdo_mysql',
-        'host' => 'localhost',
-        'dbname' => 'lotgd',
-        'user' => 'lotgd_user',
-        'password' => 'secret',
-        'charset' => 'utf8mb4',
-    ],
+    'driver' => 'pdo_mysql',
+    'host' => 'localhost',
+    'dbname' => 'lotgd',
+    'user' => 'lotgd_user',
+    'password' => 'secret',
+    'charset' => 'utf8mb4',
 ];
 ```
+
+If you need more than one connection, add a `connection` key in
+`migrations.php` and return an array of credentials keyed by name from
+`migrations-db.php`.
 
 Run pending migrations:
 

--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -144,7 +144,7 @@ try {
 
 The project uses [Doctrine Migrations](https://www.doctrine-project.org/projects/migrations.html) to manage schema changes. The migration classes live in the `migrations/` directory and are configured through `migrations.php` and `migrations-db.php`.
 
-In `migrations.php` the `connection` value is only a name that matches the credentials array in `migrations-db.php`.
+`migrations.php` defines the migration paths. With a single database connection it contains only `migrations_paths` and all connection parameters reside in `migrations-db.php`. If multiple connections are required, add a `connection` key in `migrations.php` and return an array of credentials keyed by name from `migrations-db.php`.
 
 ### Running Migrations
 


### PR DESCRIPTION
## Summary
- clarify that `migrations.php` only defines `migrations_paths` for single-connection setups
- document how to supply connection details in `migrations-db.php` and mention optional multi-connection usage

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b0608532808329822b3bd64108dd69