### PR TITLE
Set Doctrine connection in migrations

### DIFF
--- a/migrations/Version20250724000000.php
+++ b/migrations/Version20250724000000.php
@@ -20,6 +20,7 @@ final class Version20250724000000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        Database::setDoctrineConnection($this->connection);
         require_once dirname(__DIR__) . '/install/data/tables.php';
         require_once dirname(__DIR__) . '/lib/tabledescriptor.php';
 
@@ -32,6 +33,7 @@ final class Version20250724000000 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        Database::setDoctrineConnection($this->connection);
         require_once dirname(__DIR__) . '/install/data/tables.php';
         $tables = array_keys(get_all_tables());
         foreach ($tables as $name) {

--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -82,6 +82,14 @@ class Database
     }
 
     /**
+     * Assign the Doctrine DBAL connection.
+     */
+    public static function setDoctrineConnection(Connection $conn): void
+    {
+        self::$doctrine = $conn;
+    }
+
+    /**
      * Set the client character set.
      */
     public static function setCharset(string $charset): bool


### PR DESCRIPTION
## Summary
- add a setter for the Doctrine connection in `Database`
- initialize Doctrine connection in initial migration before using `Database`

## Testing
- `composer test`
- `php vendor/bin/doctrine-migrations migrate --configuration=migrations.php --db-configuration=migrations-db.php --no-interaction` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b06b5a2eb8832989fa402c0f9967a0