### PR TITLE
Move Doctrine migrations config files to config directory

### DIFF
--- a/config/migrations-db.php
+++ b/config/migrations-db.php
@@ -1,6 +1,6 @@
 <?php
 
-$db = require __DIR__ . '/dbconnect.php';
+$db = require dirname(__DIR__) . '/dbconnect.php';
 
 return [
     'driver' => $db['DB_DRIVER'] ?? 'pdo_mysql',

--- a/config/migrations.php
+++ b/config/migrations.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'migrations_paths' => [
+        'Lotgd\\Migrations' => dirname(__DIR__) . '/migrations',
+    ],
+];
+

--- a/docs/Doctrine.md
+++ b/docs/Doctrine.md
@@ -29,31 +29,32 @@ $repo = $entityManager->getRepository(Lotgd\Entity\Account::class);
 ## Running Migrations
 
 Schema migrations reside in the `migrations/` directory and are configured
-through two files:
+through two files stored in `config/`:
 
-* `migrations.php` – defines migration paths. When using a single connection no
-  additional options are required. For multiple connections you may specify a
-  `connection` key to select which database configuration to use.
-* `migrations-db.php` – provides the database credentials. With one connection
-  it returns the parameters directly. To support multiple connections return an
-  array keyed by connection name.
+* `config/migrations.php` – defines migration paths. When using a single
+  connection no additional options are required. For multiple connections you
+  may specify a `connection` key to select which database configuration to use.
+* `config/migrations-db.php` – provides the database credentials. With one
+  connection it returns the parameters directly. To support multiple connections
+  return an array keyed by connection name.
 
-In a single connection setup `migrations.php` only lists `migrations_paths` and
-`migrations-db.php` contains the connection details:
+In a single connection setup `config/migrations.php` only lists
+`migrations_paths` and `config/migrations-db.php` contains the connection
+details:
 
 ```php
 <?php
-// migrations.php
+// config/migrations.php
 return [
     'migrations_paths' => [
-        'Lotgd\\Migrations' => __DIR__ . '/../migrations',
+        'Lotgd\\Migrations' => dirname(__DIR__) . '/migrations',
     ],
 ];
 ```
 
 ```php
 <?php
-// migrations-db.php
+// config/migrations-db.php
 return [
     'driver' => 'pdo_mysql',
     'host' => 'localhost',
@@ -65,8 +66,8 @@ return [
 ```
 
 If you need more than one connection, add a `connection` key in
-`migrations.php` and return an array of credentials keyed by name from
-`migrations-db.php`.
+`config/migrations.php` and return an array of credentials keyed by name from
+`config/migrations-db.php`.
 
 Run pending migrations:
 
@@ -75,8 +76,9 @@ Run pending migrations:
 php vendor/bin/doctrine-migrations migrate
 ```
 
-The command automatically reads `migrations.php` and `migrations-db.php` from
-the project root. If you store them elsewhere, pass the paths explicitly:
+The command automatically reads `config/migrations.php` and
+`config/migrations-db.php`. If you store them elsewhere, pass the paths
+explicitly:
 
 ```bash
 php vendor/bin/doctrine-migrations \

--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -142,9 +142,9 @@ try {
 
 ## Database Migrations
 
-The project uses [Doctrine Migrations](https://www.doctrine-project.org/projects/migrations.html) to manage schema changes. The migration classes live in the `migrations/` directory and are configured through `migrations.php` and `migrations-db.php`.
+The project uses [Doctrine Migrations](https://www.doctrine-project.org/projects/migrations.html) to manage schema changes. The migration classes live in the `migrations/` directory and are configured through `config/migrations.php` and `config/migrations-db.php`.
 
-`migrations.php` defines the migration paths. With a single database connection it contains only `migrations_paths` and all connection parameters reside in `migrations-db.php`. If multiple connections are required, add a `connection` key in `migrations.php` and return an array of credentials keyed by name from `migrations-db.php`.
+`config/migrations.php` defines the migration paths. With a single database connection it contains only `migrations_paths` and all connection parameters reside in `config/migrations-db.php`. If multiple connections are required, add a `connection` key in `config/migrations.php` and return an array of credentials keyed by name from `config/migrations-db.php`.
 
 ### Running Migrations
 
@@ -154,7 +154,7 @@ Execute pending migrations with the Doctrine command line tool:
 php vendor/bin/doctrine-migrations migrate
 ```
 
-The command uses the default `migrations.php` and `migrations-db.php` files in the project root. If your configuration lives elsewhere, provide their paths explicitly:
+The command uses the default `config/migrations.php` and `config/migrations-db.php` files. If your configuration lives elsewhere, provide their paths explicitly:
 
 ```bash
 php vendor/bin/doctrine-migrations \

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1464,7 +1464,7 @@ class Installer
         $DB_PREFIX = $db['DB_PREFIX'] ?? '';
         InstallerLogger::log('DB_PREFIX set to ' . $DB_PREFIX);
 
-        $config = require dirname(__DIR__, 2) . '/migrations.php';
+        $config = require dirname(__DIR__, 2) . '/config/migrations.php';
 
         $em = Bootstrap::getEntityManager();
 

--- a/migrations.php
+++ b/migrations.php
@@ -1,8 +1,0 @@
-<?php
-
-return [
-    'migrations_paths' => [
-        'Lotgd\\Migrations' => __DIR__ . '/migrations',
-    ],
-];
-


### PR DESCRIPTION
## Summary
- relocate Doctrine migrations configuration files into `config/`
- update installer and docs to reference `config/migrations.php` and `config/migrations-db.php`

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b06d540a34832981661c23ff3c9e62