### PR TITLE
Avoid array offset on RequireMyISAM descriptors

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -459,17 +459,13 @@ class TableDescriptor
         $columnMap = [];
         $i = 0;
         foreach ($descriptor as $key => $val) {
-            $val['type'] = self::descriptorSanitizeType($val['type']);
-            if ($key === "RequireMyISAM" && $val == 1) {
-                // Let's hope that we don't run into badly formatted strings
-                // but you know what, if we do, tough
-                if (Database::getServerVersion() < "4.0.14") {
-                    $type = "MyISAM";
+            if ($key === 'RequireMyISAM') {
+                if ($val == 1 && Database::getServerVersion() < '4.0.14') {
+                    $type = 'MyISAM';
                 }
                 continue;
-            } elseif ($key === "RequireMyISAM") {
-                continue;
             }
+            $val['type'] = self::descriptorSanitizeType($val['type']);
             if (!isset($val['name'])) {
                 if (
                     ($val['type'] == "key" ||


### PR DESCRIPTION
## Summary
- guard `RequireMyISAM` descriptor before accessing `type` in `TableDescriptor::tableCreateFromDescriptor`

## Testing
- `composer test`
- `php vendor/bin/doctrine-migrations --configuration=config/migrations.php --db-configuration=config/migrations-db.php migrate --no-interaction` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b07391f7b48329826827021915abcc