### PR TITLE
Prefer Doctrine connection for server version lookup

### DIFF
--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -294,7 +294,15 @@ class Database
      */
     public static function getServerVersion(): string
     {
-        return self::getInstance()->getServerVersion();
+        if (self::$doctrine) {
+            return self::$doctrine->getServerVersion();
+        }
+
+        if (self::$instance) {
+            return self::$instance->getServerVersion();
+        }
+
+        throw new \RuntimeException('No database connection available to determine server version.');
     }
 
     /**


### PR DESCRIPTION
## Summary
- Prefer Doctrine DBAL connection in `Database::getServerVersion`
- Throw a runtime exception if no database connection is available

## Testing
- `php -l src/Lotgd/MySQL/Database.php`
- `composer install`
- `composer test`
- `php vendor/bin/doctrine-migrations migrations:status --db-configuration=config/migrations-db.php --configuration=config/migrations.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0769064e083299eb730ecad453fa0