### PR TITLE
Apply incremental table sync in initial migration

### DIFF
--- a/migrations/Version20250724000000.php
+++ b/migrations/Version20250724000000.php
@@ -26,8 +26,13 @@ final class Version20250724000000 extends AbstractMigration
 
         $tables = get_all_tables();
         foreach ($tables as $name => $descriptor) {
-            $sql = TableDescriptor::tableCreateFromDescriptor(Database::prefix($name), $descriptor);
-            $this->addSql($sql);
+            $full = Database::prefix($name);
+            if (Database::tableExists($full)) {
+                TableDescriptor::synctable($full, $descriptor);
+            } else {
+                $sql = TableDescriptor::tableCreateFromDescriptor($full, $descriptor);
+                $this->addSql($sql);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Update initial migration to apply incremental table changes when tables already exist

## Testing
- `php -l migrations/Version20250724000000.php`
- `composer install`
- `composer test`
- `vendor/bin/doctrine-migrations --no-interaction --configuration=config/migrations.php --db-configuration=/tmp/migrations-db.php migrate` *(fails: Specified key was too long; max key length is 1000 bytes)*

------
https://chatgpt.com/codex/tasks/task_e_68b08423740c8329b58b6fef98db4200