### PR TITLE
Use global debug function in TableDescriptor

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -6,6 +6,8 @@ namespace Lotgd\MySQL;
 
 use RuntimeException;
 
+use function debug;
+
 /**
  * Helper for creating, reading and synchronising table descriptors.
  *


### PR DESCRIPTION
## Summary
- Import global `debug` function in `TableDescriptor`
- Ensure debug calls reference global function

## Testing
- `php -l src/Lotgd/MySQL/TableDescriptor.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b088163df8832984643df6561f1cd9