### PR TITLE
Fix DATETIME_DATEMIN resolution in TableDescriptor

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -6,6 +6,7 @@ namespace Lotgd\MySQL;
 
 use RuntimeException;
 
+use const DATETIME_DATEMIN;
 
 /**
  * Helper for creating, reading and synchronising table descriptors.


### PR DESCRIPTION
## Summary
- import DATETIME_DATEMIN constant into TableDescriptor namespace so global constant resolves

## Testing
- `php -l src/Lotgd/MySQL/TableDescriptor.php`
- `composer test`
- `php vendor/bin/doctrine-migrations migrations:migrate --no-interaction` *(fails: It was not possible to locate any configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b09031e4308329814c074e66af6dfe