### PR TITLE
Load constants for initial migration

### DIFF
--- a/migrations/Version20250724000000.php
+++ b/migrations/Version20250724000000.php
@@ -20,6 +20,8 @@ final class Version20250724000000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        require_once dirname(__DIR__) . '/src/Lotgd/Config/constants.php';
+
         Database::setDoctrineConnection($this->connection);
         require_once dirname(__DIR__) . '/install/data/tables.php';
         require_once dirname(__DIR__) . '/lib/tabledescriptor.php';
@@ -38,6 +40,8 @@ final class Version20250724000000 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        require_once dirname(__DIR__) . '/src/Lotgd/Config/constants.php';
+
         Database::setDoctrineConnection($this->connection);
         require_once dirname(__DIR__) . '/install/data/tables.php';
         $tables = array_keys(get_all_tables());


### PR DESCRIPTION
## Summary
- ensure constants are loaded before using TableDescriptor or Database in migration 20250724000000

## Testing
- `composer install`
- `php -l migrations/Version20250724000000.php`
- `composer test`
- `vendor/bin/doctrine-migrations migrate --configuration=config/migrations.php --db-configuration=config/migrations-db.php --no-interaction` *(fails: Specified key was too long; confirms constants are resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68b091714b2c83299e7c16fd659a7a81