### PR TITLE
Ensure primary key indexes truncate oversized columns

### DIFF
--- a/src/Lotgd/MySQL/TableDescriptor.php
+++ b/src/Lotgd/MySQL/TableDescriptor.php
@@ -240,7 +240,7 @@ class TableDescriptor
                 if ($colCharset && !$colCollation) {
                     $colCollation = self::defaultCollation($colCharset);
                 }
-                if ($val['type'] === 'key' || $val['type'] === 'unique key') {
+                if (in_array($val['type'], ['key', 'unique key', 'primary key'], true)) {
                     [$val['columns']] = self::adjustIndexColumns($val['columns'], $columnMap, $tableCharset, $engine);
                 }
                 $newsql = self::descriptorCreateSql($val);
@@ -555,7 +555,7 @@ class TableDescriptor
             if ($colCharset && !$colCollation) {
                 $colCollation = self::defaultCollation($colCharset);
             }
-            if ($val['type'] === 'key' || $val['type'] === 'unique key') {
+            if (in_array($val['type'], ['key', 'unique key', 'primary key'], true)) {
                 [$val['columns']] = self::adjustIndexColumns($val['columns'], $columnMap, $tableCharset, $type);
             } else {
                 $columnMap[$val['name']] = $val;

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -830,6 +830,16 @@ final class TableDescriptorTest extends TestCase
         $this->assertStringContainsString('KEY name_idx (name(191))', $sql);
     }
 
+    public function testPrimaryKeyColumnsAreAutoTruncated(): void
+    {
+        $descriptor = [
+            'id' => ['name' => 'id', 'type' => 'varchar(255)'],
+            'key-PRIMARY' => ['type' => 'primary key', 'name' => 'PRIMARY', 'columns' => 'id'],
+        ];
+        $sql = TableDescriptor::tableCreateFromDescriptor('dummy', $descriptor);
+        $this->assertStringContainsString('PRIMARY KEY (id(191))', $sql);
+    }
+
     public function testMultiColumnIndexTruncationIsDistributed(): void
     {
         $descriptor = [


### PR DESCRIPTION
## Summary
- Allow `synctable()` and `tableCreateFromDescriptor()` to truncate columns in primary key indexes
- Test primary key index truncation

## Testing
- `composer install`
- `composer dump-autoload`
- `php vendor/bin/doctrine-migrations migrations:migrate --no-interaction --configuration=config/migrations.php --db-configuration=config/migrations-db.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b0962079208329a2a6813c94f671da