### PR TITLE
Guard myDefine against redeclaration

### DIFF
--- a/src/Lotgd/Config/constants.php
+++ b/src/Lotgd/Config/constants.php
@@ -4,12 +4,17 @@
 // translator ready
 // mail ready
 
-$defines = array();
-function myDefine($name, $value)
-{
-    global $defines;
-    define($name, $value);
-    $defines[$name] = $value;
+if (!isset($defines)) {
+    $defines = array();
+}
+
+if (!function_exists('myDefine')) {
+    function myDefine($name, $value)
+    {
+        global $defines;
+        define($name, $value);
+        $defines[$name] = $value;
+    }
 }
 
 //Superuser constants


### PR DESCRIPTION
## Summary
- Protect the `myDefine` helper in `constants.php` with a `function_exists` guard and avoid reinitializing `$defines`

## Testing
- `php -l src/Lotgd/Config/constants.php`
- `composer test`
- `php vendor/bin/doctrine-migrations migrate --no-interaction --configuration=config/migrations.php --db-configuration=config/migrations-db.php` *(fails: General error near "SHOW" using SQLite)*

------
https://chatgpt.com/codex/tasks/task_e_68b09a6e54808329915787c18b3c1e97