### PR TITLE
Gate legacy SQL migrations behind LOTGD_BASE_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,17 @@ If you have problems, please visit Dragonprime at the address above.
 
 Legacy installation and upgrade instructions have moved to
 [docs/LegacyREADME.md](docs/LegacyREADME.md).
+
+When upgrading from a legacy release, provide the version you are upgrading
+from through the `LOTGD_BASE_VERSION` environment variable before running the
+installer or Doctrine migrations. This allows migrations to load the
+appropriate legacy SQL.
+
+```bash
+LOTGD_BASE_VERSION="1.1.1 Dragonprime Edition" php vendor/bin/doctrine-migrations migrate
+```
+
+If the variable is omitted, legacy SQL migrations are skipped.
 - [Installation](#installation)
   - [Step 1: Clone the Repository](#step-1-clone-the-repository)
   - [Step 2: Set Up the Docker Environment](#step-2-set-up-the-docker-environment)

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1496,6 +1496,9 @@ class Installer
 
         $from = $session['fromversion'] ?? '-1';
         if ($from !== '-1') {
+            // Expose the source version so migrations can load legacy SQL when upgrading
+            $_ENV['LOTGD_BASE_VERSION'] = $from;
+
             foreach ($map as $ver => $id) {
                 if (version_compare($from, $ver, '<')) {
                     $v = new Version($id);

--- a/migrations/Version20250724000001.php
+++ b/migrations/Version20250724000001.php
@@ -16,6 +16,12 @@ final class Version20250724000001 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
+
+        if ('0.9' !== $base) {
+            return;
+        }
+
         $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
         foreach ($m['0.9'] as $sql) {
             $this->addSql($sql);

--- a/migrations/Version20250724000002.php
+++ b/migrations/Version20250724000002.php
@@ -16,6 +16,12 @@ final class Version20250724000002 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
+
+        if ('0.9.1' !== $base) {
+            return;
+        }
+
         $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
         foreach ($m['0.9.1'] as $sql) {
             $this->addSql($sql);

--- a/migrations/Version20250724000003.php
+++ b/migrations/Version20250724000003.php
@@ -16,6 +16,12 @@ final class Version20250724000003 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
+
+        if ('0.9.7' !== $base) {
+            return;
+        }
+
         $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
         foreach ($m['0.9.7'] as $sql) {
             $this->addSql($sql);

--- a/migrations/Version20250724000004.php
+++ b/migrations/Version20250724000004.php
@@ -16,6 +16,12 @@ final class Version20250724000004 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
+
+        if ('0.9.8-prerelease.1' !== $base) {
+            return;
+        }
+
         $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
         foreach ($m['0.9.8-prerelease.1'] as $sql) {
             $this->addSql($sql);

--- a/migrations/Version20250724000005.php
+++ b/migrations/Version20250724000005.php
@@ -16,6 +16,12 @@ final class Version20250724000005 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
+
+        if ('0.9.8-prerelease.6' !== $base) {
+            return;
+        }
+
         $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
         foreach ($m['0.9.8-prerelease.6'] as $sql) {
             $this->addSql($sql);

--- a/migrations/Version20250724000006.php
+++ b/migrations/Version20250724000006.php
@@ -16,6 +16,12 @@ final class Version20250724000006 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
+
+        if ('0.9.8-prerelease.11' !== $base) {
+            return;
+        }
+
         $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
         foreach ($m['0.9.8-prerelease.11'] as $sql) {
             $this->addSql($sql);

--- a/migrations/Version20250724000007.php
+++ b/migrations/Version20250724000007.php
@@ -16,6 +16,12 @@ final class Version20250724000007 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
+
+        if ('0.9.8-prerelease.12' !== $base) {
+            return;
+        }
+
         $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
         foreach ($m['0.9.8-prerelease.12'] as $sql) {
             $this->addSql($sql);

--- a/migrations/Version20250724000008.php
+++ b/migrations/Version20250724000008.php
@@ -16,6 +16,12 @@ final class Version20250724000008 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
+
+        if ('0.9.8-prerelease.14a' !== $base) {
+            return;
+        }
+
         $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
         foreach ($m['0.9.8-prerelease.14a'] as $sql) {
             $this->addSql($sql);

--- a/migrations/Version20250724000009.php
+++ b/migrations/Version20250724000009.php
@@ -16,6 +16,12 @@ final class Version20250724000009 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
+
+        if ('1.1.0 Dragonprime Edition' !== $base) {
+            return;
+        }
+
         $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
         foreach ($m['1.1.0 Dragonprime Edition'] as $sql) {
             $this->addSql($sql);

--- a/migrations/Version20250724000010.php
+++ b/migrations/Version20250724000010.php
@@ -16,6 +16,12 @@ final class Version20250724000010 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
+
+        if ('1.1.1 Dragonprime Edition' !== $base) {
+            return;
+        }
+
         $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
         foreach ($m['1.1.1 Dragonprime Edition'] as $sql) {
             $this->addSql($sql);

--- a/migrations/Version20250724000011.php
+++ b/migrations/Version20250724000011.php
@@ -16,6 +16,12 @@ final class Version20250724000011 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
+
+        if ('1.1.1.0 Dragonprime Edition +nb' !== $base) {
+            return;
+        }
+
         $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
         foreach ($m['1.1.1.0 Dragonprime Edition +nb'] as $sql) {
             $this->addSql($sql);

--- a/migrations/Version20250724000012.php
+++ b/migrations/Version20250724000012.php
@@ -16,6 +16,12 @@ final class Version20250724000012 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
+
+        if ('1.1.1.1 Dragonprime Edition +nb' !== $base) {
+            return;
+        }
+
         $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
         foreach ($m['1.1.1.1 Dragonprime Edition +nb'] as $sql) {
             $this->addSql($sql);

--- a/migrations/Version20250724000013.php
+++ b/migrations/Version20250724000013.php
@@ -16,6 +16,12 @@ final class Version20250724000013 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
+
+        if ('1.2.6 +nb Edition' !== $base) {
+            return;
+        }
+
         $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
         foreach ($m['1.2.6 +nb Edition'] as $sql) {
             $this->addSql($sql);


### PR DESCRIPTION
## Summary
- Skip legacy SQL migrations unless `LOTGD_BASE_VERSION` is provided
- Allow installer to forward selected base version to migrations
- Document `LOTGD_BASE_VERSION` for legacy upgrades

## Testing
- `php -l install/lib/Installer.php`
- `php -l migrations/Version20250724000001.php`
- `php -l migrations/Version20250724000002.php`
- `php -l migrations/Version20250724000003.php`
- `php -l migrations/Version20250724000004.php`
- `php -l migrations/Version20250724000005.php`
- `php -l migrations/Version20250724000006.php`
- `php -l migrations/Version20250724000007.php`
- `php -l migrations/Version20250724000008.php`
- `php -l migrations/Version20250724000009.php`
- `php -l migrations/Version20250724000010.php`
- `php -l migrations/Version20250724000011.php`
- `php -l migrations/Version20250724000012.php`
- `php -l migrations/Version20250724000013.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b09ee47a0c8329acd54e90425cf698