### PR TITLE
Add legacy upgrade tooling and streamline migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,16 +208,15 @@ If you have problems, please visit Dragonprime at the address above.
 Legacy installation and upgrade instructions have moved to
 [docs/LegacyREADME.md](docs/LegacyREADME.md).
 
-When upgrading from a legacy release, provide the version you are upgrading
-from through the `LOTGD_BASE_VERSION` environment variable before running the
-installer or Doctrine migrations. This allows migrations to load the
-appropriate legacy SQL.
+When upgrading from a legacy release, pass the version you are upgrading from
+to the Doctrine command line tool. This applies all legacy SQL for newer
+versions before running migrations.
 
 ```bash
-LOTGD_BASE_VERSION="1.1.1 Dragonprime Edition" php vendor/bin/doctrine-migrations migrate
+php bin/doctrine --from-version="1.1.1 Dragonprime Edition" migrate
 ```
 
-If the variable is omitted, legacy SQL migrations are skipped.
+If `--from-version` is omitted, legacy SQL processing is skipped.
 - [Installation](#installation)
   - [Step 1: Clone the Repository](#step-1-clone-the-repository)
   - [Step 2: Set Up the Docker Environment](#step-2-set-up-the-docker-environment)

--- a/bin/doctrine
+++ b/bin/doctrine
@@ -1,0 +1,39 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$argv = $_SERVER['argv'];
+array_shift($argv); // remove script name
+
+$fromVersion = null;
+$filtered = [];
+while ($argv) {
+    $arg = array_shift($argv);
+    if (str_starts_with($arg, '--from-version=')) {
+        $fromVersion = substr($arg, 15);
+        continue;
+    }
+    if ($arg === '--from-version') {
+        $fromVersion = array_shift($argv) ?: '';
+        continue;
+    }
+    $filtered[] = $arg;
+}
+
+if ($fromVersion !== null && $fromVersion !== '') {
+    $cmd = __DIR__ . '/legacy-upgrade --from-version ' . escapeshellarg($fromVersion);
+    passthru($cmd, $code);
+    if ($code !== 0) {
+        exit($code);
+    }
+}
+
+$vendor = __DIR__ . '/../vendor/bin/doctrine-migrations';
+$command = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($vendor);
+if ($filtered) {
+    $command .= ' ' . implode(' ', array_map('escapeshellarg', $filtered));
+}
+
+passthru($command, $exitCode);
+exit($exitCode);

--- a/bin/legacy-upgrade
+++ b/bin/legacy-upgrade
@@ -1,0 +1,30 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../autoload.php';
+
+use Lotgd\Legacy\LegacySql;
+
+$options = getopt('', ['from-version:']);
+if (! isset($options['from-version'])) {
+    fwrite(STDERR, "Usage: bin/legacy-upgrade --from-version=<version>\n");
+    exit(1);
+}
+
+$from = $options['from-version'];
+
+$statements = require __DIR__ . '/../install/data/legacy_sql.php';
+$toRun     = LegacySql::filterStatements($statements, $from);
+
+if ($toRun === []) {
+    fwrite(STDOUT, "No legacy SQL needed for version {$from}\n");
+    exit(0);
+}
+
+foreach ($toRun as $sql) {
+    db_query($sql);
+}
+
+echo "Legacy upgrade from {$from} completed.\n";

--- a/migrations/Version20250724000001.php
+++ b/migrations/Version20250724000001.php
@@ -16,16 +16,7 @@ final class Version20250724000001 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
-
-        if ('0.9' !== $base) {
-            return;
-        }
-
-        $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
-        foreach ($m['0.9'] as $sql) {
-            $this->addSql($sql);
-        }
+        // Legacy SQL handled via bin/legacy-upgrade.
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250724000002.php
+++ b/migrations/Version20250724000002.php
@@ -16,16 +16,7 @@ final class Version20250724000002 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
-
-        if ('0.9.1' !== $base) {
-            return;
-        }
-
-        $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
-        foreach ($m['0.9.1'] as $sql) {
-            $this->addSql($sql);
-        }
+        // Legacy SQL handled via bin/legacy-upgrade.
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250724000003.php
+++ b/migrations/Version20250724000003.php
@@ -16,16 +16,7 @@ final class Version20250724000003 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
-
-        if ('0.9.7' !== $base) {
-            return;
-        }
-
-        $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
-        foreach ($m['0.9.7'] as $sql) {
-            $this->addSql($sql);
-        }
+        // Legacy SQL handled via bin/legacy-upgrade.
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250724000004.php
+++ b/migrations/Version20250724000004.php
@@ -16,16 +16,7 @@ final class Version20250724000004 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
-
-        if ('0.9.8-prerelease.1' !== $base) {
-            return;
-        }
-
-        $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
-        foreach ($m['0.9.8-prerelease.1'] as $sql) {
-            $this->addSql($sql);
-        }
+        // Legacy SQL handled via bin/legacy-upgrade.
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250724000005.php
+++ b/migrations/Version20250724000005.php
@@ -16,16 +16,7 @@ final class Version20250724000005 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
-
-        if ('0.9.8-prerelease.6' !== $base) {
-            return;
-        }
-
-        $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
-        foreach ($m['0.9.8-prerelease.6'] as $sql) {
-            $this->addSql($sql);
-        }
+        // Legacy SQL handled via bin/legacy-upgrade.
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250724000006.php
+++ b/migrations/Version20250724000006.php
@@ -16,16 +16,7 @@ final class Version20250724000006 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
-
-        if ('0.9.8-prerelease.11' !== $base) {
-            return;
-        }
-
-        $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
-        foreach ($m['0.9.8-prerelease.11'] as $sql) {
-            $this->addSql($sql);
-        }
+        // Legacy SQL handled via bin/legacy-upgrade.
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250724000007.php
+++ b/migrations/Version20250724000007.php
@@ -16,16 +16,7 @@ final class Version20250724000007 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
-
-        if ('0.9.8-prerelease.12' !== $base) {
-            return;
-        }
-
-        $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
-        foreach ($m['0.9.8-prerelease.12'] as $sql) {
-            $this->addSql($sql);
-        }
+        // Legacy SQL handled via bin/legacy-upgrade.
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250724000008.php
+++ b/migrations/Version20250724000008.php
@@ -16,16 +16,7 @@ final class Version20250724000008 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
-
-        if ('0.9.8-prerelease.14a' !== $base) {
-            return;
-        }
-
-        $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
-        foreach ($m['0.9.8-prerelease.14a'] as $sql) {
-            $this->addSql($sql);
-        }
+        // Legacy SQL handled via bin/legacy-upgrade.
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250724000009.php
+++ b/migrations/Version20250724000009.php
@@ -16,16 +16,7 @@ final class Version20250724000009 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
-
-        if ('1.1.0 Dragonprime Edition' !== $base) {
-            return;
-        }
-
-        $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
-        foreach ($m['1.1.0 Dragonprime Edition'] as $sql) {
-            $this->addSql($sql);
-        }
+        // Legacy SQL handled via bin/legacy-upgrade.
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250724000010.php
+++ b/migrations/Version20250724000010.php
@@ -16,16 +16,7 @@ final class Version20250724000010 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
-
-        if ('1.1.1 Dragonprime Edition' !== $base) {
-            return;
-        }
-
-        $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
-        foreach ($m['1.1.1 Dragonprime Edition'] as $sql) {
-            $this->addSql($sql);
-        }
+        // Legacy SQL handled via bin/legacy-upgrade.
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250724000011.php
+++ b/migrations/Version20250724000011.php
@@ -16,16 +16,7 @@ final class Version20250724000011 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
-
-        if ('1.1.1.0 Dragonprime Edition +nb' !== $base) {
-            return;
-        }
-
-        $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
-        foreach ($m['1.1.1.0 Dragonprime Edition +nb'] as $sql) {
-            $this->addSql($sql);
-        }
+        // Legacy SQL handled via bin/legacy-upgrade.
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250724000012.php
+++ b/migrations/Version20250724000012.php
@@ -16,16 +16,7 @@ final class Version20250724000012 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
-
-        if ('1.1.1.1 Dragonprime Edition +nb' !== $base) {
-            return;
-        }
-
-        $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
-        foreach ($m['1.1.1.1 Dragonprime Edition +nb'] as $sql) {
-            $this->addSql($sql);
-        }
+        // Legacy SQL handled via bin/legacy-upgrade.
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250724000013.php
+++ b/migrations/Version20250724000013.php
@@ -16,16 +16,7 @@ final class Version20250724000013 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $base = $_ENV['LOTGD_BASE_VERSION'] ?? null;
-
-        if ('1.2.6 +nb Edition' !== $base) {
-            return;
-        }
-
-        $m = require dirname(__DIR__) . '/install/data/legacy_sql.php';
-        foreach ($m['1.2.6 +nb Edition'] as $sql) {
-            $this->addSql($sql);
-        }
+        // Legacy SQL handled via bin/legacy-upgrade.
     }
 
     public function down(Schema $schema): void

--- a/src/Lotgd/Legacy/LegacySql.php
+++ b/src/Lotgd/Legacy/LegacySql.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Legacy;
+
+final class LegacySql
+{
+    /**
+     * Filter legacy SQL statements for versions newer than the provided one.
+     *
+     * @param array<string,array<int,string>> $statements
+     * @return string[]
+     */
+    public static function filterStatements(array $statements, string $from): array
+    {
+        uksort($statements, 'version_compare');
+
+        $result = [];
+        foreach ($statements as $version => $sqls) {
+            if (version_compare((string) $version, $from, '>')) {
+                $result = array_merge($result, $sqls);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/LegacySqlTest.php
+++ b/tests/LegacySqlTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Legacy\LegacySql;
+use PHPUnit\Framework\TestCase;
+
+final class LegacySqlTest extends TestCase
+{
+    public function testFilterStatementsRunsNewerVersions(): void
+    {
+        $statements = [
+            '0.9' => ['a'],
+            '1.0' => ['b'],
+            '1.1' => ['c'],
+        ];
+
+        self::assertSame(['b', 'c'], LegacySql::filterStatements($statements, '0.9'));
+        self::assertSame(['c'], LegacySql::filterStatements($statements, '1.0'));
+        self::assertSame([], LegacySql::filterStatements($statements, '1.1'));
+    }
+
+    public function testFilterStatementsHandlesMissingVersion(): void
+    {
+        $statements = [
+            '1.0.0' => ['a'],
+            '1.0.1' => ['b'],
+        ];
+
+        self::assertSame(['a', 'b'], LegacySql::filterStatements($statements, '0.9'));
+    }
+}


### PR DESCRIPTION
## Summary
- add `bin/legacy-upgrade` script to run legacy SQL based on `--from-version`
- provide `bin/doctrine` wrapper that runs legacy SQL only when `--from-version` is supplied
- remove legacy SQL loading from migration classes and update README
- ensure legacy SQL runs sequentially for all versions after `--from-version`

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a416f58c8329b55e100af97c1022