### PR TITLE
Use TableDescriptor for utf8mb4 migration and update docs

### DIFF
--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -73,6 +73,8 @@ SQL errors throw exceptions with detailed messages from `DbMysqli`. In debug mod
 
 Modules may ship schema descriptions for their tables. `TableDescriptor::schematize()` converts descriptor arrays into CREATE or ALTER statements during `install.php`.
 
+Modules that define their own tables **must** call `TableDescriptor::synctable()` during install and upgrade routines. This keeps schemas in sync and guarantees the `utf8mb4` charset and `utf8mb4_unicode_ci` collation are applied.
+
 #### Detecting default values
 
 `TableDescriptor::tableCreateDescriptor()` reads column metadata using

--- a/migrations/Version20250724000016.php
+++ b/migrations/Version20250724000016.php
@@ -6,44 +6,18 @@ namespace Lotgd\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
-use Lotgd\MySQL\Database;
-
-use function array_column;
-use function array_unshift;
-use function array_unique;
-use function implode;
-use function sprintf;
 
 final class Version20250724000016 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Convert core tables to utf8mb4_unicode_ci';
+        return 'Legacy migration – conversions handled in Version20250724000018';
     }
 
     public function up(Schema $schema): void
     {
-        $schemaManager = $this->connection->createSchemaManager();
-        $dbName        = $this->connection->getDatabase();
-
-        $tables = $schemaManager->listTableNames();
-        array_unshift($tables, Database::prefix('mail'));
-        $tables = array_unique($tables);
-
-        foreach ($tables as $table) {
-            $columns = $this->connection->fetchAllAssociative(
-                'SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME != ?',
-                [$dbName, $table, 'utf8mb4_unicode_ci']
-            );
-
-            if (empty($columns)) {
-                continue;
-            }
-
-            $columnNames = array_column($columns, 'COLUMN_NAME');
-            $this->write(sprintf('Converting %s columns: %s', $table, implode(', ', $columnNames)));
-            $this->addSql(sprintf('ALTER TABLE %s CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci', $table));
-        }
+        // Table conversions are managed by Version20250724000018
+        // through TableDescriptor::synctable().
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250724000018.php
+++ b/migrations/Version20250724000018.php
@@ -7,6 +7,9 @@ namespace Lotgd\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 use Lotgd\MySQL\Database;
+use Lotgd\MySQL\TableDescriptor;
+
+use function dirname;
 
 final class Version20250724000018 extends AbstractMigration
 {
@@ -17,6 +20,12 @@ final class Version20250724000018 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        require_once dirname(__DIR__) . '/src/Lotgd/Config/constants.php';
+
+        Database::setDoctrineConnection($this->connection);
+        require_once dirname(__DIR__) . '/install/data/tables.php';
+        require_once dirname(__DIR__) . '/lib/tabledescriptor.php';
+
         $tables = [
             'accounts',
             'accounts_output',
@@ -60,60 +69,20 @@ final class Version20250724000018 extends AbstractMigration
             'titles',
         ];
 
+        $descriptors = get_all_tables();
         foreach ($tables as $table) {
-            $name = Database::prefix($table);
-            $this->addSql("ALTER TABLE $name CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;");
+            if (! isset($descriptors[$table])) {
+                continue;
+            }
+
+            $name       = Database::prefix($table);
+            $descriptor = $descriptors[$table];
+            TableDescriptor::synctable($name, $descriptor);
         }
     }
 
     public function down(Schema $schema): void
     {
-        $tables = [
-            'accounts',
-            'accounts_output',
-            'companions',
-            'debug',
-            'deathmessages',
-            'paylog',
-            'armor',
-            'bans',
-            'clans',
-            'commentary',
-            'creatures',
-            'debuglog',
-            'debuglog_archive',
-            'faillog',
-            'gamelog',
-            'logdnetbans',
-            'logdnet',
-            'mail',
-            'masters',
-            'moderatedcomments',
-            'module_event_hooks',
-            'module_hooks',
-            'module_objprefs',
-            'module_settings',
-            'module_userprefs',
-            'modules',
-            'motd',
-            'mounts',
-            'nastywords',
-            'news',
-            'petitions',
-            'pollresults',
-            'referers',
-            'settings',
-            'settings_extended',
-            'taunts',
-            'untranslated',
-            'translations',
-            'weapons',
-            'titles',
-        ];
-
-        foreach ($tables as $table) {
-            $name = Database::prefix($table);
-            $this->addSql("ALTER TABLE $name CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci;");
-        }
+        // Irreversible migration.
     }
 }


### PR DESCRIPTION
## Summary
- Retire blanket table conversion migration
- Switch core table migration to `TableDescriptor::synctable`
- Document that modules must sync schemas with `TableDescriptor::synctable` on install/upgrade

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b16721b7b88329b08652f85cf64200