### PR TITLE
Set database prefix before initialization

### DIFF
--- a/common.php
+++ b/common.php
@@ -185,6 +185,7 @@ if (file_exists("dbconnect.php")) {
     $DB_PASS = $config['DB_PASS'] ?? '';
     $DB_NAME = $config['DB_NAME'] ?? '';
     $DB_PREFIX = $config['DB_PREFIX'] ?? '';
+    \Lotgd\MySQL\Database::setPrefix($DB_PREFIX);
     $DB_USEDATACACHE = $config['DB_USEDATACACHE'] ?? 0;
     $DB_DATACACHEPATH = $config['DB_DATACACHEPATH'] ?? '';
 } else {


### PR DESCRIPTION
## Summary
- Set the global database prefix immediately after loading `dbconnect.php` to configure the Database class before any queries

## Testing
- `php -l common.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b17be9eee083299d9b5eb99b6a810f