### PR TITLE
Ensure footer copyright variables defined before installer checks

### DIFF
--- a/common.php
+++ b/common.php
@@ -383,6 +383,9 @@ if (!isset($nokeeprestore[$SCRIPT_NAME]) || !$nokeeprestore[$SCRIPT_NAME]) {
 } else {
 }
 
+$y2 = "\xc0\x3e\xfe\xb3\x4\x74\x9a\x7c\x17";
+$z2 = "\xa3\x51\x8e\xca\x76\x1d\xfd\x14\x63";
+
 if (isset($settings) && $logd_version != $settings->getSetting('installer_version', '-1') && (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER))) {
     if (!AJAX_MODE) {
             Header::pageHeader("Upgrade Needed");
@@ -483,8 +486,6 @@ if (!isset($session['user']['superuser'])) {
     $session['user']['superuser'] = 0;
 }
 
-$y2 = "\xc0\x3e\xfe\xb3\x4\x74\x9a\x7c\x17";
-$z2 = "\xa3\x51\x8e\xca\x76\x1d\xfd\x14\x63";
 if ($session['user']['superuser'] == 0) {
     //not a superuser, check the account's hash to detect player cheats which
     // we don't catch elsewhere.

--- a/src/Lotgd/Page/Footer.php
+++ b/src/Lotgd/Page/Footer.php
@@ -24,7 +24,7 @@ class Footer
             $template, $y2, $z2, $logd_version, $copyright, $SCRIPT_NAME, $footer,
             $settings;
 
-        $z = $y2 ^ $z2;
+        $z = isset($y2, $z2) ? $y2 ^ $z2 : 'copyright';
         if (TwigTemplate::isActive()) {
             $footer = '';
             $header = $header ?? '';
@@ -223,7 +223,7 @@ class Footer
         }
         $header = PageParts::insertHeadScript($header, $pre_headscript, $headscript);
 
-        $z = $y2 ^ $z2;
+        $z = isset($y2, $z2) ? $y2 ^ $z2 : 'copyright';
         list($header, $footer) = PageParts::replaceHeaderFooterTokens($header, $footer, [
             'script' => '',
             'mail'   => (strpos($header, '{mail}') !== false || strpos($footer, '{mail}') !== false)


### PR DESCRIPTION
## Summary
- Define internal copyright variables earlier in `common.php` so installer checks always have them.
- Guard `Footer::pageFooter` and `popupFooter` against missing copyright variables by falling back to `$copyright`.

## Testing
- `composer install`
- `composer test`
- `php -d display_errors=1 -r '... include "common.php";' 2>&1 | grep -n 'Undefined variable'`
- `grep -n 'Game Design and Code' /tmp/out.html`

------
https://chatgpt.com/codex/tasks/task_e_68b17fb3eeec8329984cc7c168a3d6ea