### PR TITLE
Add Doctrine table prefix event subscriber

### DIFF
--- a/src/Lotgd/Doctrine/Bootstrap.php
+++ b/src/Lotgd/Doctrine/Bootstrap.php
@@ -6,9 +6,11 @@ namespace Lotgd\Doctrine;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\ORMSetup;
+use Doctrine\Common\EventManager;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Lotgd\MySQL\Database;
+use Lotgd\Doctrine\TablePrefixSubscriber;
 
 class Bootstrap
 {
@@ -67,6 +69,9 @@ class Bootstrap
             $cache
         );
 
-        return EntityManager::create($connection, $config);
+        $eventManager = new EventManager();
+        $eventManager->addEventSubscriber(new TablePrefixSubscriber($DB_PREFIX));
+
+        return EntityManager::create($connection, $config, $eventManager);
     }
 }

--- a/src/Lotgd/Doctrine/TablePrefixSubscriber.php
+++ b/src/Lotgd/Doctrine/TablePrefixSubscriber.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Doctrine;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+
+/**
+ * Adds a table prefix to Doctrine metadata.
+ */
+class TablePrefixSubscriber implements EventSubscriber
+{
+    private string $prefix;
+
+    public function __construct(string $prefix)
+    {
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getSubscribedEvents(): array
+    {
+        return ['loadClassMetadata'];
+    }
+
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs): void
+    {
+        if ($this->prefix === '') {
+            return;
+        }
+
+        $classMetadata = $eventArgs->getClassMetadata();
+
+        $classMetadata->table['name'] = $this->prefix . $classMetadata->table['name'];
+
+        foreach ($classMetadata->associationMappings as $fieldName => $mapping) {
+            if (isset($mapping['joinTable']['name'])) {
+                $classMetadata->associationMappings[$fieldName]['joinTable']['name'] =
+                    $this->prefix . $mapping['joinTable']['name'];
+            }
+        }
+    }
+}

--- a/tests/EntityPrefixTest.php
+++ b/tests/EntityPrefixTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\EventManager;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\ORM\Tools\Setup;
+use Lotgd\Doctrine\TablePrefixSubscriber;
+use Lotgd\Entity\Account;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lotgd\Doctrine\TablePrefixSubscriber
+ */
+final class EntityPrefixTest extends TestCase
+{
+    private EntityManager $em;
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('PDO SQLite extension not installed');
+        }
+
+        if (!class_exists('Doctrine\\Common\\Annotations\\AnnotationReader')) {
+            $this->markTestSkipped('Doctrine annotations not installed');
+        }
+
+        global $DB_PREFIX;
+        $DB_PREFIX = 'pre_';
+
+        $config = Setup::createAnnotationMetadataConfiguration([
+            __DIR__ . '/../src/Lotgd/Entity'
+        ], true, null, new ArrayCache(), false);
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber(new TablePrefixSubscriber($DB_PREFIX));
+
+        $this->em = EntityManager::create(['driver' => 'pdo_sqlite', 'memory' => true], $config, $evm);
+        $tool = new SchemaTool($this->em);
+        $tool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testAccountPersistAndRetrieveWithPrefix(): void
+    {
+        $meta = $this->em->getClassMetadata(Account::class);
+        $this->assertSame('pre_accounts', $meta->getTableName());
+
+        $account = new Account();
+        $account->setLogin('tester')
+            ->setEmailaddress('tester@example.com')
+            ->setPassword('secret')
+            ->setName('Tester')
+            ->setLevel(1)
+            ->setGems(0);
+        $account->setLaston(new \DateTime());
+        $this->em->persist($account);
+        $this->em->flush();
+        $id = $account->getAcctid();
+        $this->em->clear();
+
+        $found = $this->em->find(Account::class, $id);
+        $this->assertNotNull($found);
+        $this->assertSame('tester@example.com', $found->getEmailaddress());
+    }
+}


### PR DESCRIPTION
## Summary
- Prefix Doctrine entity tables and many-to-many join tables via `TablePrefixSubscriber`
- Register table prefix subscriber through Doctrine `EventManager`
- Test entity persistence when a table prefix is configured

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b1885d0a248329a3849723a67f91bc