### PR TITLE
Namespace Doctrine cache by database prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Regular upkeep tasks:
 - Run `composer test` to execute the unit tests.
 - Schedule `cron.php` via cron for automated jobs.
 - Configure SMTP settings in `config/configuration.php`.
+- If you change `DB_PREFIX`, clear the cache directory to avoid reusing metadata from the previous prefix.
 
 ## Further Reading
 

--- a/src/Lotgd/Doctrine/Bootstrap.php
+++ b/src/Lotgd/Doctrine/Bootstrap.php
@@ -55,11 +55,12 @@ class Bootstrap
         // Disable metadata caching only when datacache path is not configured
         $isDevMode = empty($settings['DB_USEDATACACHE']) || empty($settings['DB_DATACACHEPATH']);
 
+        // Include the table prefix in the cache namespace so metadata isn't reused across different prefixes.
         if (class_exists(FilesystemAdapter::class)) {
-            $cache = new FilesystemAdapter('', 0, $cacheDir);
+            $cache = new FilesystemAdapter($DB_PREFIX, 0, $cacheDir);
         } else {
             // Fallback to an in-memory cache when Symfony cache is missing.
-            $cache = new ArrayAdapter();
+            $cache = (new ArrayAdapter())->withSubNamespace($DB_PREFIX);
         }
 
         $config = ORMSetup::createAnnotationMetadataConfiguration(


### PR DESCRIPTION
## Summary
- scope Doctrine metadata cache by the database prefix to avoid cross-prefix reuse
- note in README that changing DB_PREFIX requires clearing cache

## Testing
- `composer install`
- `php -l src/Lotgd/Doctrine/Bootstrap.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b18cd3aee883299bf623cef88b038a