### PR TITLE
Initialize REQUEST_URI in home.php when absent

### DIFF
--- a/home.php
+++ b/home.php
@@ -14,6 +14,15 @@ use Lotgd\Cookies;
 // mail ready
 
 define("ALLOW_ANONYMOUS", true);
+
+if (! isset($_SERVER['REQUEST_URI'])) {
+    $_SERVER['REQUEST_URI'] = '/home.php';
+}
+
+if (! isset($REQUEST_URI)) {
+    $REQUEST_URI = $_SERVER['REQUEST_URI'];
+}
+
 require_once("common.php");
 
 use Lotgd\Page\Header;


### PR DESCRIPTION
## Summary
- Prevent fatal error when `REQUEST_URI` is missing by setting a default in `home.php`

## Testing
- `php -l home.php`
- `composer install`
- `composer test`
- `php -r "unset($_SERVER['REQUEST_URI']); require 'home.php';"`


------
https://chatgpt.com/codex/tasks/task_e_68b194ff7cac8329920d95b5160c61a4