### PR TITLE
Handle missing session data in charStats

### DIFF
--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -216,9 +216,24 @@ class PageParts
 
         self::wipeCharStats();
 
-        $u =& $session['user'];
+        $u = $session['user'] ?? [];
+        if (!is_array($u)) {
+            $u = [];
+        }
 
-        if (isset($session['loggedin']) && $session['loggedin']) {
+        $loggedIn = isset($session['loggedin']) && $session['loggedin'];
+        foreach (['race', 'name'] as $key) {
+            if (!isset($u[$key])) {
+                $loggedIn = false;
+            }
+        }
+
+        if (!$loggedIn) {
+            $u['race'] = $u['race'] ?? RACE_UNKNOWN;
+            $u['name'] = $u['name'] ?? '';
+        }
+
+        if ($loggedIn) {
             $u['hitpoints'] = round((int)$u['hitpoints'], 0);
             $u['experience'] = round((float)$u['experience'], 0);
             $u['maxhitpoints'] = round((int)$u['maxhitpoints'], 0);
@@ -228,6 +243,9 @@ class PageParts
                 $spirits[(int)$u['spirits']] = Translator::translateInline("DEAD", "stats");
             }
             //calculate_buff_fields();
+            if (!isset($session['bufflist']) || !is_array($session['bufflist'])) {
+                $session['bufflist'] = [];
+            }
             reset($session['bufflist']);
             /*not so easy anymore
               $atk=$u['attack'];

--- a/tests/CharStatsEmptySessionTest.php
+++ b/tests/CharStatsEmptySessionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\DataCache;
+use Lotgd\Output;
+use Lotgd\PageParts;
+use Lotgd\Tests\Stubs\Database;
+use Lotgd\Tests\Stubs\DummySettings;
+use PHPUnit\Framework\TestCase;
+
+final class CharStatsEmptySessionTest extends TestCase
+{
+    public function testCharStatsHandlesEmptySession(): void
+    {
+        global $session, $settings, $output, $modulehook_returns;
+        $modulehook_returns = [
+            'onlinecharlist' => ['handled' => true, 'count' => 0, 'list' => ''],
+        ];
+        class_exists(Database::class);
+        class_exists(DataCache::class);
+        $session = [];
+        $output = new Output();
+        $settings = new DummySettings([
+            'usedatacache' => 0,
+            'LOGINTIMEOUT' => 900,
+            'homeonline_mode' => 0,
+            'homeonline_minutes' => 15,
+            'enabletranslation' => false,
+        ]);
+        Database::$lastSql = '';
+        Database::$instance = new class {
+            public array $queries = [];
+            public function query(string $sql)
+            {
+                $this->queries[] = $sql;
+                return [];
+            }
+        };
+
+        $outputString = PageParts::charStats();
+        $this->assertIsString($outputString);
+        $this->assertArrayNotHasKey('user', $session);
+    }
+}


### PR DESCRIPTION
## Summary
- Guard `PageParts::charStats` against missing session data and provide safe defaults for race and name
- Added regression test to ensure empty sessions do not trigger errors
- Avoid mutating the global session when user data is absent

## Testing
- `composer install`
- `php -l src/Lotgd/PageParts.php`
- `php -l tests/CharStatsEmptySessionTest.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b1972884c0832986265dc20a89e0bc