### PR TITLE
Guard PayPal setup when DB not selected

### DIFF
--- a/src/Lotgd/Page/Footer.php
+++ b/src/Lotgd/Page/Footer.php
@@ -122,13 +122,15 @@ class Footer
 
         $palreplace = (strpos($footer, '{paypal}') || strpos($header, '{paypal}')) ? '{paypal}' : '{stats}';
 
-        list($header, $footer) = PageParts::buildPaypalDonationMarkup(
-            $palreplace,
-            $header,
-            $footer,
-            $settings ?? null,
-            $logd_version
-        );
+        if (defined('DB_CHOSEN')) {
+            list($header, $footer) = PageParts::buildPaypalDonationMarkup(
+                $palreplace,
+                $header,
+                $footer,
+                $settings ?? null,
+                $logd_version
+            );
+        }
 
         list($header, $footer) = PageParts::generateNavigationOutput($header, $footer, $builtnavs);
         if (TwigTemplate::isActive()) {

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -548,7 +548,9 @@ class PageParts
         global $session;
 
         $paypalstr = '<table align="center"><tr><td>';
-        $currency = isset($settings) ? $settings->getSetting('paypalcurrency', 'USD') : 'USD';
+        $currency = (isset($settings) && defined('DB_CHOSEN'))
+            ? $settings->getSetting('paypalcurrency', 'USD')
+            : 'USD';
 
         $laston = $session['user']['laston'] ?? '1970-01-01 00:00:00';
 


### PR DESCRIPTION
## Summary
- Skip PayPal markup when database is not configured
- Safely retrieve currency setting only after DB is chosen

## Testing
- `php -l src/Lotgd/Page/Footer.php`
- `php -l src/Lotgd/PageParts.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b19ae358408329889d700565874f4a