### PR TITLE
Guard translation and MOTD before DB setup

### DIFF
--- a/src/Lotgd/Page/Footer.php
+++ b/src/Lotgd/Page/Footer.php
@@ -140,7 +140,11 @@ class Footer
             PageParts::$twigVars['bodyad']   = '';
         }
 
-        $motd_link = PageParts::motdLink();
+        if (defined('DB_CHOSEN') && DB_CHOSEN) {
+            $motd_link = PageParts::motdLink();
+        } else {
+            $motd_link = '';
+        }
         $motd_link = modulehook('motd-link', ['link' => $motd_link]);
         $motd_link = $motd_link['link'];
 

--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -347,6 +347,10 @@ class Translator
      */
     public static function translateLoadNamespace(string $namespace, string|false $language = false)
     {
+        if (!defined('DB_CHOSEN') || !DB_CHOSEN) {
+            return [];
+        }
+
         global $language, $session;
         if (defined("LANGUAGE")) {
             if ($language === false) {


### PR DESCRIPTION
## Summary
- Avoid MOTD link generation when no database is configured
- Short-circuit translation namespace loading when database isn't chosen

## Testing
- `composer install`
- `php -S 127.0.0.1:8000` then `curl http://127.0.0.1:8000/installer.php?stage=4` *(fails: No such file or directory in DbMysqli.php)*
- `composer test` *(fails: Script phpunit --configuration phpunit.xml handling the test event returned with error code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b19d6e92908329b038ad60f33e4893