### PR TITLE
Handle missing settings table

### DIFF
--- a/lib/settings.php
+++ b/lib/settings.php
@@ -1,6 +1,7 @@
 <?php
 
 use Lotgd\Settings;
+use Lotgd\MySQL\Database;
 
 function savesetting($settingname, $value)
 {
@@ -31,8 +32,13 @@ function getsetting($settingname, $default)
 {
     global $settings;
     if (!($settings instanceof Settings)) {
+        if (!Database::tableExists(Database::prefix('settings'))) {
+            return $default;
+        }
+
         $settings = new Settings('settings');
     }
+
     return $settings->getSetting($settingname, $default);
 }
 

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -17,6 +17,7 @@ final class SettingsTest extends TestCase
         \Lotgd\MySQL\Database::$affected_rows = 0;
         \Lotgd\MySQL\Database::$doctrineConnection = null;
         \Lotgd\MySQL\Database::$instance = null;
+        \Lotgd\MySQL\Database::$tableExists = true;
         if (class_exists('Lotgd\\Tests\\Stubs\\DoctrineBootstrap', false)) {
             \Lotgd\Tests\Stubs\DoctrineBootstrap::$conn = null;
         }
@@ -53,6 +54,13 @@ final class SettingsTest extends TestCase
         \Lotgd\MySQL\Database::$settings_table['x'] = '2';
         $settings->loadSettings();
         $this->assertSame('2', $settings->getSetting('x'));
+    }
+
+    public function testLoadSettingsHandlesMissingTable(): void
+    {
+        \Lotgd\MySQL\Database::$tableExists = false;
+        $settings = new Settings('settings');
+        $this->assertSame([], $settings->getArray());
     }
 
     public function testCharsetValueCoercedWhenDifferent(): void

--- a/tests/TranslatorNamespaceTest.php
+++ b/tests/TranslatorNamespaceTest.php
@@ -22,11 +22,16 @@ final class TranslatorNamespaceTest extends TestCase
             'datacachepath' => $this->cacheDir,
             'usedatacache'  => 1,
         ]);
+        \Lotgd\MySQL\Database::$lastCacheName = '';
+        \Lotgd\DataCache::massinvalidate();
         $GLOBALS['session'] = [];
         if (!defined('LANGUAGE')) {
             define('LANGUAGE', 'en');
         }
         $GLOBALS['language'] = 'en';
+        if (!defined('DB_CHOSEN')) {
+            define('DB_CHOSEN', true);
+        }
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
## Summary
- Avoid querying nonexistent settings table in `Settings::loadSettings`
- Return default value in `getsetting` when settings table is absent
- Add tests for missing settings table and isolate translator namespace tests

## Testing
- `composer install`
- `composer test`
- Manual: installer stage 7 shows install type choices without DB errors


------
https://chatgpt.com/codex/tasks/task_e_68b1a0c45ff08329be71556900156381