### PR TITLE
Avoid saving settings when underlying table is missing

### DIFF
--- a/src/Lotgd/Settings.php
+++ b/src/Lotgd/Settings.php
@@ -40,6 +40,10 @@ class Settings
      */
     public function saveSetting(string|int $settingname, mixed $value): bool
     {
+        if (!Database::tableExists($this->tablename)) {
+            return false;
+        }
+
         $this->loadSettings();
         if (!isset($this->settings[$settingname]) && $value) {
             $settingValue = is_string($value) ? '"' . addslashes($value) . '"' : $value;
@@ -126,7 +130,9 @@ class Settings
             $this->loadSettings();
             if (!isset($this->settings[$settingname])) {
                 if ($settingname === 'charset') {
-                    $this->saveSetting('charset', 'UTF-8');
+                    if (Database::tableExists($this->tablename)) {
+                        $this->saveSetting('charset', 'UTF-8');
+                    }
 
                     return 'UTF-8';
                 }
@@ -138,7 +144,9 @@ class Settings
                 } else {
                     $value = $default;
                 }
-                $this->saveSetting($settingname, $value);
+                if (Database::tableExists($this->tablename)) {
+                    $this->saveSetting($settingname, $value);
+                }
             } else {
                 $value = $this->settings[$settingname];
             }
@@ -147,7 +155,9 @@ class Settings
         }
 
         if ($settingname === 'charset' && $value !== 'UTF-8') {
-            $this->saveSetting('charset', 'UTF-8');
+            if (Database::tableExists($this->tablename)) {
+                $this->saveSetting('charset', 'UTF-8');
+            }
 
             return 'UTF-8';
         }


### PR DESCRIPTION
## Summary
- Guard saveSetting with a table-existence check to avoid unintended queries during install
- Persist default settings only when the settings table exists

## Testing
- `php -l src/Lotgd/Settings.php`
- `composer install`
- `composer test`
- `php -r 'define("IS_INSTALLER", true); define("DB_NODB", true); $_SERVER["REQUEST_URI"]="installer.php?stage=7"; $REQUEST_URI="installer.php?stage=7"; require "vendor/autoload.php"; $session=["stagecompleted"=>6,"dbinfo"=>[]]; $logd_version="1.0"; $recommended_modules=[]; $noinstallnavs=false; $stage=7; $DB_USEDATACACHE=0; $settings=new Lotgd\Settings(); $output=new Lotgd\Output(); $installer=new Lotgd\Installer\Installer(); $installer->stage7(); echo $output->getOutput();' | head -n 40`

------
https://chatgpt.com/codex/tasks/task_e_68b1a76d8e2083299477914cf97a9848