### PR TITLE
Gracefully handle missing translation table

### DIFF
--- a/tests/Translator/TranslationDisabledTest.php
+++ b/tests/Translator/TranslationDisabledTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Translator;
+
+use Lotgd\Translator;
+use Lotgd\Tests\Stubs\DummySettings;
+use Lotgd\Tests\Stubs\Database as StubDatabase;
+use PHPUnit\Framework\TestCase;
+
+final class TranslationDisabledTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['settings'] = new DummySettings(['enabletranslation' => true]);
+        $GLOBALS['session'] = [];
+        $GLOBALS['REQUEST_URI'] = '/';
+        if (!defined('LANGUAGE')) {
+            define('LANGUAGE', 'en');
+        }
+        $GLOBALS['language'] = 'en';
+        if (!defined('DB_CHOSEN')) {
+            define('DB_CHOSEN', true);
+        }
+        Translator::enableTranslation(true);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['settings'], $GLOBALS['session'], $GLOBALS['REQUEST_URI'], $GLOBALS['language']);
+        Translator::enableTranslation(true);
+        StubDatabase::$tableExists = true;
+    }
+
+    public function testFallsBackWhenTranslationsTableMissing(): void
+    {
+        StubDatabase::$tableExists = false;
+        Translator::translate('trigger');
+        $this->assertSame('Hello', Translator::translate('Hello'));
+        $this->assertSame('Hello', Translator::translateInline('Hello'));
+        $this->assertSame('Mail user', Translator::translateMail(['Mail %s', 'user']));
+        $this->assertSame('Hello', Translator::tl('Hello'));
+    }
+}


### PR DESCRIPTION
## Summary
- Skip translation queries when the `translations` table is absent
- Disable translator helpers when translations are disabled
- Add regression test for missing translation table

## Testing
- `composer test`
- `php -l src/Lotgd/Translator.php`
- `php -l tests/Translator/TranslationDisabledTest.php`
- `php -r '$_GET["stage"]="7"; $_SERVER["REQUEST_URI"]="/installer.php?stage=7"; $_SERVER["HTTP_HOST"]="localhost"; include "installer.php";' 2>&1 | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_68b1ad6f88048329815f5be8b89de53c