### PR TITLE
Quote reserved columns in index definitions

### DIFF
--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -850,4 +850,14 @@ final class TableDescriptorTest extends TestCase
         $sql = TableDescriptor::tableCreateFromDescriptor('dummy', $descriptor);
         $this->assertStringContainsString('KEY foobar_idx (foo(95),bar(95))', $sql);
     }
+
+    public function testPrimaryKeyReservedWordIsQuoted(): void
+    {
+        $descriptor = [
+            'function' => ['name' => 'function', 'type' => 'int'],
+            'key-PRIMARY' => ['type' => 'primary key', 'name' => 'PRIMARY', 'columns' => 'function'],
+        ];
+        $sql = TableDescriptor::tableCreateFromDescriptor('dummy', $descriptor);
+        $this->assertStringContainsString('PRIMARY KEY (`function`)', $sql);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure reserved or quoted index columns are wrapped in backticks
- test primary key generation for reserved word column

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b1b8596a188329910acc986c04929e