### PR TITLE
Rename module hook callback column

### DIFF
--- a/docs/LegacyREADME.md
+++ b/docs/LegacyREADME.md
@@ -13,6 +13,10 @@ If you are upgrading from **0.9.7** or earlier, move the deprecated
 After the upgrade completes, read the [Post Installation](#post-installation)
 section to verify your configuration.
 
+## Upgrade Notes
+
+- The `module_hooks` table now uses a `hook_callback` column instead of the reserved word `function`. Run the corresponding migration and update any custom modules referencing this column.
+
 
 ## INSTALLATION:
 

--- a/install/data/tables.php
+++ b/install/data/tables.php
@@ -1129,8 +1129,8 @@ function get_all_tables()
         'location' => array(
             'name' => 'location', 'type' => 'varchar(50)'
             ),
-        'function' => array(
-            'name' => '`function`', 'type' => 'varchar(50)'
+        'hook_callback' => array(
+            'name' => 'hook_callback', 'type' => 'varchar(50)'
             ),
         'whenactive' => array(
             'name' => 'whenactive', 'type' => 'text'
@@ -1142,7 +1142,7 @@ function get_all_tables()
             'name' => 'PRIMARY',
             'type' => 'primary key',
             'unique' => '1',
-            'columns' => 'modulename,location,`function`'
+            'columns' => 'modulename,location,hook_callback'
             ),
         'key-location' => array(
             'name' => 'location', 'type' => 'key', 'columns' => 'location'

--- a/migrations/Version20250724000019.php
+++ b/migrations/Version20250724000019.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Lotgd\MySQL\Database;
+
+final class Version20250724000019 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Rename module_hooks.function to hook_callback';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = Database::prefix('module_hooks');
+        $this->addSql("ALTER TABLE $table DROP PRIMARY KEY");
+        $this->addSql("ALTER TABLE $table CHANGE COLUMN `function` hook_callback VARCHAR(50) NOT NULL");
+        $this->addSql("ALTER TABLE $table ADD PRIMARY KEY (modulename, location, hook_callback)");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = Database::prefix('module_hooks');
+        $this->addSql("ALTER TABLE $table DROP PRIMARY KEY");
+        $this->addSql("ALTER TABLE $table CHANGE COLUMN hook_callback `function` VARCHAR(50) NOT NULL");
+        $this->addSql("ALTER TABLE $table ADD PRIMARY KEY (modulename, location, `function`)");
+    }
+}


### PR DESCRIPTION
## Summary
- rename `module_hooks.function` to `hook_callback`
- adjust module hook queries to use `hook_callback`
- add migration and upgrade note for column rename

## Testing
- `php -l install/data/tables.php`
- `php -l src/Lotgd/Modules.php`
- `php -l migrations/Version20250724000019.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b1c4948dd08329921c3255a39b3a24