### PR TITLE
Remove orphaned module event hooks on force uninstall

### DIFF
--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -1010,13 +1010,15 @@ class Modules
     }
 
     /**
-     * Remove all hooks for the current module.
+     * Remove all hooks and event hooks for the current module.
      */
     public static function wipeHooks(): void
     {
         global $mostrecentmodule;
 
         $sql = 'DELETE FROM ' . Database::prefix('module_hooks') . " WHERE modulename='$mostrecentmodule'";
+        Database::query($sql);
+        $sql = 'DELETE FROM ' . Database::prefix('module_event_hooks') . " WHERE modulename='$mostrecentmodule'";
         Database::query($sql);
         invalidatedatacache('hook-' . $mostrecentmodule);
         invalidatedatacache('module_prepare');

--- a/tests/ModulesWipeHooksTest.php
+++ b/tests/ModulesWipeHooksTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Modules;
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
+
+final class ModulesWipeHooksTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        class_exists(Database::class);
+        \Lotgd\MySQL\Database::$lastSql = '';
+        global $mostrecentmodule;
+        $mostrecentmodule = 'mymodule';
+    }
+
+    public function testWipeHooksRemovesEventHooks(): void
+    {
+        Modules::wipeHooks();
+        $this->assertStringContainsString('module_event_hooks', \Lotgd\MySQL\Database::$lastSql);
+        $this->assertStringContainsString("modulename='mymodule'", \Lotgd\MySQL\Database::$lastSql);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Clear module_event_hooks entries when wiping module hooks
- Add test verifying event hook cleanup during module removal

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e3173fac8329b8bc812d457aec74