### PR TITLE
Document censor helpers with strict types

### DIFF
--- a/lib/censor.php
+++ b/lib/censor.php
@@ -1,22 +1,44 @@
 <?php
 
+declare(strict_types=1);
+
 // translator ready
 // addnews ready
 // mail ready
 
 use Lotgd\Censor;
 
-function soap($input, $debug = false, $skiphook = false)
+/**
+ * Filter a text string for banned words.
+ *
+ * @param string $input    Input string
+ * @param bool   $debug    Output debug information
+ * @param bool   $skiphook Skip module hook
+ *
+ * @return string Filtered string
+ */
+function soap(string $input, bool $debug = false, bool $skiphook = false): string
 {
     return Censor::soap($input, $debug, $skiphook);
 }
 
-function good_word_list()
+/**
+ * Retrieve exception words that bypass the filter.
+ *
+ * @return array<string> List of allowed words
+ */
+function good_word_list(): array
 {
     return Censor::goodWordList();
 }
 
-function nasty_word_list()
+/**
+ * List of banned words used by the filter.
+ *
+ * @return array<string> Compiled regexes
+ */
+function nasty_word_list(): array
 {
     return Censor::nastyWordList();
 }
+


### PR DESCRIPTION
## Summary
- add strict types and PHPDoc to censor helper functions
- type-hint soap, good_word_list, and nasty_word_list wrappers

## Testing
- `php -l lib/censor.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b346651a448329b50d253104d9367b