### PR TITLE
Improve error notification subject and context

### DIFF
--- a/tests/ErrorHandlerNotifyNoAddressTest.php
+++ b/tests/ErrorHandlerNotifyNoAddressTest.php
@@ -13,9 +13,11 @@ final class ErrorHandlerNotifyNoAddressTest extends TestCase
 {
     protected function setUp(): void
     {
-        global $settings, $mail_sent_count, $output;
+        global $settings, $mail_sent_count, $output, $last_subject;
 
         $mail_sent_count = 0;
+        $last_subject = '';
+        unset($_SERVER['HTTP_HOST']);
         $settings = new DummySettings([
             'notify_on_error' => 1,
             'gameadminemail' => 'admin@example.com',
@@ -39,5 +41,6 @@ final class ErrorHandlerNotifyNoAddressTest extends TestCase
         ErrorHandler::errorNotify(E_ERROR, 'Test error', 'file.php', 42, '<trace>');
 
         $this->assertSame(1, $GLOBALS['mail_sent_count']);
+        $this->assertSame('LotGD Error on CLI execution – hostname unavailable', $GLOBALS['last_subject']);
     }
 }

--- a/tests/ErrorHandlerNotifyTest.php
+++ b/tests/ErrorHandlerNotifyTest.php
@@ -13,9 +13,10 @@ final class ErrorHandlerNotifyTest extends TestCase
 {
     protected function setUp(): void
     {
-        global $settings, $mail_sent_count, $output;
+        global $settings, $mail_sent_count, $output, $last_subject;
 
         $mail_sent_count = 0;
+        $last_subject = '';
         $settings = new DummySettings([
             'notify_on_error' => 1,
             'notify_address' => 'admin@example.com',
@@ -37,8 +38,10 @@ final class ErrorHandlerNotifyTest extends TestCase
 
     public function testErrorNotificationIsSent(): void
     {
+        $_SERVER['HTTP_HOST'] = 'example.com';
         ErrorHandler::errorNotify(E_ERROR, 'Test error', 'file.php', 42, '<trace>');
 
         $this->assertSame(1, $GLOBALS['mail_sent_count']);
+        $this->assertSame('LotGD Error on example.com', $GLOBALS['last_subject']);
     }
 }

--- a/tests/Stubs/PHPMailer.php
+++ b/tests/Stubs/PHPMailer.php
@@ -63,6 +63,7 @@ class PHPMailer
     public function Send()
     {
         $GLOBALS['mail_sent_count'] = ($GLOBALS['mail_sent_count'] ?? 0) + 1;
+        $GLOBALS['last_subject'] = $this->Subject;
     }
 }
 


### PR DESCRIPTION
## Summary
- Map PHP error levels to human-friendly labels
- Include host and error type in notification subject and body
- Test email subject and hostname fallback

## Testing
- `php -l src/Lotgd/ErrorHandler.php`
- `php -l tests/Stubs/PHPMailer.php`
- `php -l tests/ErrorHandlerNotifyTest.php`
- `php -l tests/ErrorHandlerNotifyNoAddressTest.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b48a93809c832997f0118c31266b58