### PR TITLE
Use cmd_sanitize for restorepage in newday

### DIFF
--- a/newday.php
+++ b/newday.php
@@ -249,15 +249,11 @@ if ($dp < $dkills) {
             translate_inline($sff == 1 ? "fight" : "fights")
         );
     }
-    $rp = $session['user']['restorepage'];
-    $x = max(strrpos($rp, '&'), strrpos($rp, '?'));
-    if ($x > 0) {
-        $rp = substr($rp, 0, $x);
-    }
+    $rp = rtrim(cmd_sanitize($session['user']['restorepage']), '&?');
     if (substr($rp, 0, 10) == "badnav.php") {
         addnav("Continue", "news.php");
     } else {
-        addnav("Continue", cmd_sanitize($rp));
+        addnav("Continue", $rp);
     }
 
     $session['user']['laston'] = date("Y-m-d H:i:s");


### PR DESCRIPTION
## Summary
- use cmd_sanitize and rtrim to strip `c` token while keeping other query parameters for newday continue link

## Testing
- `php -l newday.php`
- `composer install`
- `composer test`
- `php -r 'require "vendor/autoload.php"; require "lib/sanitize.php"; $session["user"]["restorepage"]="foo.php?dwid=16195&c=1"; $rp=rtrim(cmd_sanitize($session["user"]["restorepage"]), "&?"); echo $rp, PHP_EOL;'`


------
https://chatgpt.com/codex/tasks/task_e_68b5e90079588329934307012a797dcc