### PR TITLE
test: verify notice label in error notifications

### DIFF
--- a/tests/ErrorHandlerNoticeLabelTest.php
+++ b/tests/ErrorHandlerNoticeLabelTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\ErrorHandler;
+use Lotgd\Tests\Stubs\DummySettings;
+use Lotgd\Tests\Stubs\PHPMailer;
+use PHPUnit\Framework\TestCase;
+
+final class ErrorHandlerNoticeLabelTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $settings, $mail_sent_count, $output, $last_subject;
+
+        $mail_sent_count = 0;
+        $last_subject = '';
+        $settings = new DummySettings([
+            'notify_on_error' => 1,
+            'notify_address' => 'admin@example.com',
+            'gameadminemail' => 'admin@example.com',
+            'usedatacache' => 0,
+        ]);
+
+        // Ensure the PHPMailer stub is loaded so Mail::send uses it
+        new PHPMailer();
+
+        // Provide minimal output handler for debug()
+        $output = new class {
+            public function appoencode($data, $priv)
+            {
+                return $data;
+            }
+        };
+    }
+
+    public function testErrorNotificationHasNoticeLabel(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'example.com';
+        ErrorHandler::errorNotify(E_NOTICE, 'Test', 'file.php', 1, '<trace>');
+
+        $this->assertSame(1, $GLOBALS['mail_sent_count']);
+        $this->assertSame('LotGD Notice on example.com', $GLOBALS['last_subject']);
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage ensuring E_NOTICE notifications use the "Notice" subject label

## Testing
- `php -l tests/ErrorHandlerNoticeLabelTest.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b5881f620c8329a11e586b462d737d