### PR TITLE
Add module status tests

### DIFF
--- a/tests/Modules/ModuleStatusTest.php
+++ b/tests/Modules/ModuleStatusTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (! function_exists('modulename_sanitize')) {
+        function modulename_sanitize($in)
+        {
+            return \Lotgd\Sanitize::modulenameSanitize($in);
+        }
+    }
+}
+
+namespace Lotgd\Tests\Modules {
+    use Lotgd\Modules;
+    use Lotgd\Tests\Stubs\Database;
+    use PHPUnit\Framework\TestCase;
+    use ReflectionProperty;
+
+    final class ModuleStatusTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            class_exists(Database::class);
+        }
+
+        protected function tearDown(): void
+        {
+            Database::$queryCacheResults = [];
+            $prop = new ReflectionProperty(Modules::class, 'injectedModules');
+            $prop->setAccessible(true);
+            $prop->setValue(null, [1 => [], 0 => []]);
+        }
+
+        public function testMissingFileReturnsFileNotPresent(): void
+        {
+            $status = Modules::getStatus('missingmodule');
+            $this->assertSame(MODULE_FILE_NOT_PRESENT, $status);
+        }
+
+        public function testInstalledInactiveReturnsInstalledOnly(): void
+        {
+            $name = 'inactivemodule';
+            $file = __DIR__ . "/../../modules/{$name}.php";
+            file_put_contents($file, "<?php\n");
+            Database::$queryCacheResults["inject-$name"] = [
+                ['active' => 0, 'filemoddate' => '', 'infokeys' => '|', 'version' => '1.0'],
+            ];
+            $status = Modules::getStatus($name);
+            $mask   = MODULE_INSTALLED | MODULE_ACTIVE | MODULE_INJECTED;
+            $this->assertSame(MODULE_INSTALLED, $status & $mask);
+            unlink($file);
+        }
+
+        public function testActiveAndInjectedReturnsInstalledActiveInjected(): void
+        {
+            $name = 'activemodule';
+            $file = __DIR__ . "/../../modules/{$name}.php";
+            file_put_contents($file, "<?php\n");
+            Database::$queryCacheResults["inject-$name"] = [
+                ['active' => 1, 'filemoddate' => '', 'infokeys' => '|', 'version' => '1.0'],
+            ];
+            $prop    = new ReflectionProperty(Modules::class, 'injectedModules');
+            $prop->setAccessible(true);
+            $current = $prop->getValue();
+            $current[0][$name] = true;
+            $prop->setValue(null, $current);
+            $status = Modules::getStatus($name);
+            $mask   = MODULE_INSTALLED | MODULE_ACTIVE | MODULE_INJECTED;
+            $this->assertSame(MODULE_INSTALLED | MODULE_ACTIVE | MODULE_INJECTED, $status & $mask);
+            unlink($file);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for module status scenarios

## Testing
- `php -l tests/Modules/ModuleStatusTest.php`
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b733eea3248329bc4af8c60aa4f740