### PR TITLE
test: add module preference tests

### DIFF
--- a/tests/Modules/BlockModuleTest.php
+++ b/tests/Modules/BlockModuleTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd {
+    if (!function_exists(__NAMESPACE__ . '\\getmicrotime')) {
+        function getmicrotime(): float
+        {
+            return microtime(true);
+        }
+    }
+}
+
+namespace Lotgd\Tests\Modules {
+
+use Lotgd\Modules;
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists(__NAMESPACE__ . '\\modulehook')) {
+    function modulehook(string $name, array $args = [], bool $allowinactive = false, $only = false): array
+    {
+        return Modules::hook($name, $args, $allowinactive, $only);
+    }
+}
+
+final class BlockModuleTest extends TestCase
+{
+    private string $moduleFile;
+
+    protected function setUp(): void
+    {
+        $this->moduleFile = dirname(__DIR__, 2) . '/modules/foo.php';
+
+        file_put_contents($this->moduleFile, <<<'MODULE'
+<?php
+
+declare(strict_types=1);
+
+function foo_getmoduleinfo(): array
+{
+    return [
+        'name' => 'Foo',
+        'version' => '1.0',
+        'author' => 'Test',
+        'category' => 'Test',
+        'download' => '',
+        'description' => '',
+        'requires' => [],
+    ];
+}
+
+function foo_install(): bool
+{
+    return true;
+}
+
+function foo_uninstall(): bool
+{
+    return true;
+}
+
+function foo_dohook(string $hookname, array $args): array
+{
+    if ($hookname === 'test') {
+        $args['foo'] = true;
+    }
+
+    return $args;
+}
+MODULE
+);
+
+        $filemoddate = date('Y-m-d H:i:s', filemtime($this->moduleFile));
+
+        Database::$queryCacheResults['inject-foo'] = [
+            [
+                'active' => 1,
+                'filemoddate' => $filemoddate,
+                'infokeys' => '|name|version|author|category|description|download|requires|',
+                'version' => '1.0',
+            ],
+        ];
+
+        Database::$queryCacheResults['hook-test'] = [
+            [
+                'modulename' => 'foo',
+                'location' => 'test',
+                'hook_callback' => 'foo_dohook',
+                'whenactive' => '',
+            ],
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        unlink($this->moduleFile);
+        unset(Database::$queryCacheResults['inject-foo'], Database::$queryCacheResults['hook-test']);
+        Modules::unblock('foo');
+    }
+
+    public function testBlockAndUnblockModule(): void
+    {
+        Modules::block('foo');
+        self::assertTrue(Modules::isModuleBlocked('foo'));
+
+        $blocked = modulehook('test', []);
+        self::assertArrayNotHasKey('foo', $blocked);
+
+        Modules::unblock('foo');
+        self::assertFalse(Modules::isModuleBlocked('foo'));
+
+        $unblocked = modulehook('test', []);
+        self::assertArrayHasKey('foo', $unblocked);
+        self::assertTrue($unblocked['foo']);
+    }
+}
+}

--- a/tests/Modules/ModuleHookOptionsTest.php
+++ b/tests/Modules/ModuleHookOptionsTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    function a_sample(string $hookName, array $args): array
+    {
+        $args['a'] = 'A';
+        return $args;
+    }
+
+    function b_sample(string $hookName, array $args): array
+    {
+        $args['b'] = 'B';
+        return $args;
+    }
+
+    function getmicrotime(): float
+    {
+        return microtime(true);
+    }
+}
+
+namespace Lotgd\Tests\Modules {
+
+use Lotgd\Modules;
+use Lotgd\Modules\HookHandler;
+use Lotgd\MySQL\Database;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+if (!function_exists(__NAMESPACE__ . '\\modulehook')) {
+    function modulehook(string $hookName, array $args = [], bool $allowInactive = false, $only = false): array
+    {
+        return HookHandler::hook($hookName, $args, $allowInactive, $only);
+    }
+}
+
+final class ModuleHookOptionsTest extends TestCase
+{
+    private array $hooksAll;
+    private array $hooksActive;
+
+    protected function setUp(): void
+    {
+        global $session;
+        $session = ['user' => ['superuser' => 0]];
+
+        $this->hooksAll = [
+            ['modulename' => 'a', 'location' => 'sample', 'hook_callback' => 'a_sample', 'whenactive' => ''],
+            ['modulename' => 'b', 'location' => 'sample', 'hook_callback' => 'b_sample', 'whenactive' => ''],
+        ];
+        $this->hooksActive = [$this->hooksAll[0]];
+
+        $ref  = new ReflectionClass(Modules::class);
+        $prop = $ref->getProperty('injectedModules');
+        $prop->setAccessible(true);
+        $prop->setValue(null, [1 => ['a' => true, 'b' => true], 0 => ['a' => true]]);
+    }
+
+    public function testOnlySpecificModuleIsMerged(): void
+    {
+        Database::$queryCacheResults['hook-sample'] = $this->hooksAll;
+
+        $result = modulehook('sample', [], false, 'a');
+
+        $this->assertSame(['a' => 'A'], $result);
+    }
+
+    public function testInactiveModulesRunWhenAllowed(): void
+    {
+        Database::$queryCacheResults['hook-sample'] = $this->hooksActive;
+        $activeResult = modulehook('sample', []);
+        $this->assertSame(['a' => 'A'], $activeResult);
+
+        Database::$queryCacheResults['hook-sample'] = $this->hooksAll;
+        $result = modulehook('sample', [], true);
+
+        $this->assertSame(['a' => 'A', 'b' => 'B'], $result);
+    }
+
+    public function testReturnsArrayWhenNoModules(): void
+    {
+        Database::$queryCacheResults['hook-empty'] = [];
+
+        $result = modulehook('empty', []);
+
+        $this->assertIsArray($result);
+        $this->assertSame([], $result);
+    }
+}
+
+}

--- a/tests/Modules/ModulePrefsTest.php
+++ b/tests/Modules/ModulePrefsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (!function_exists('get_module_pref')) {
+        function get_module_pref(string $name, ?string $module = null, ?int $user = null)
+        {
+            if ($user === false) {
+                $user = null;
+            }
+            return \Lotgd\Modules\HookHandler::getModulePref($name, $module, $user);
+        }
+    }
+    if (!function_exists('set_module_pref')) {
+        function set_module_pref(string $name, mixed $value, ?string $module = null, ?int $user = null): void
+        {
+            if ($user === false) {
+                $user = null;
+            }
+            \Lotgd\Modules\HookHandler::setModulePref($name, $value, $module, $user);
+        }
+    }
+    if (!function_exists('increment_module_pref')) {
+        function increment_module_pref(string $name, int|float $value = 1, ?string $module = null, ?int $user = null): void
+        {
+            if ($user === false) {
+                $user = null;
+            }
+            \Lotgd\Modules\HookHandler::incrementModulePref($name, $value, $module, $user);
+        }
+    }
+    if (!function_exists('clear_module_pref')) {
+        function clear_module_pref(string $name, ?string $module = null, ?int $user = null): void
+        {
+            \Lotgd\Modules\HookHandler::clearModulePref($name, $module, $user);
+        }
+    }
+    if (!function_exists('modulename_sanitize')) {
+        function modulename_sanitize($in)
+        {
+            return \Lotgd\Sanitize::modulenameSanitize($in);
+        }
+    }
+}
+
+namespace Lotgd\Tests\Modules {
+
+use PHPUnit\Framework\TestCase;
+
+final class ModulePrefsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $session, $module_prefs, $mostrecentmodule, $mysqli;
+        $session = ['user' => ['acctid' => 1, 'loggedin' => true]];
+        $module_prefs = [1 => ['modA' => [], '' => []]];
+        $mostrecentmodule = '';
+        $mysqli = null;
+    }
+
+    public function testExplicitModuleAndUser(): void
+    {
+        set_module_pref('flag', 'on', 'modA', 1);
+        $this->assertSame('on', get_module_pref('flag', 'modA', 1));
+
+        set_module_pref('count', 0, 'modA', 1);
+        increment_module_pref('count', 1, 'modA', 1);
+        increment_module_pref('count', 1, 'modA', 1);
+        increment_module_pref('count', 1, 'modA', 1);
+        $this->assertSame(3.0, get_module_pref('count', 'modA', 1));
+
+        clear_module_pref('flag', 'modA', 1);
+        $this->assertNull(get_module_pref('flag', 'modA', 1));
+    }
+
+    public function testFallbackUserAndModule(): void
+    {
+        global $mostrecentmodule;
+        $mostrecentmodule = 'modA';
+
+        set_module_pref('flag', 'on', '', null);
+        $this->assertSame('on', get_module_pref('flag', '', null));
+
+        set_module_pref('count', 0, '', null);
+        increment_module_pref('count', 1, '', null);
+        increment_module_pref('count', 1, '', null);
+        increment_module_pref('count', 1, '', null);
+        $this->assertSame(3.0, get_module_pref('count', '', null));
+
+        clear_module_pref('flag', '', null);
+        $this->assertNull(get_module_pref('flag', '', null));
+    }
+}
+
+}


### PR DESCRIPTION
## Summary
- add tests covering set/get/increment/clear module pref helpers
- verify fallback behavior for default user and module identifiers

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b733f3b64c8329a488629a95ad8723