### PR TITLE
Add module preference lifecycle tests and fix hook helpers

### DIFF
--- a/tests/Modules/BlockModuleTest.php
+++ b/tests/Modules/BlockModuleTest.php
@@ -17,7 +17,7 @@ use Lotgd\Modules;
 use Lotgd\Tests\Stubs\Database;
 use PHPUnit\Framework\TestCase;
 
-function modulehook(string $name, array $args = [], bool $allowinactive = false, $only = false): array
+function modulehook_block(string $name, array $args = [], bool $allowinactive = false, $only = false): array
 {
     return Modules::hook($name, $args, $allowinactive, $only);
 }
@@ -102,13 +102,13 @@ MODULE
         Modules::block('foo');
         self::assertTrue(Modules::isModuleBlocked('foo'));
 
-        $blocked = modulehook('test', []);
+        $blocked = modulehook_block('test', []);
         self::assertArrayNotHasKey('foo', $blocked);
 
         Modules::unblock('foo');
         self::assertFalse(Modules::isModuleBlocked('foo'));
 
-        $unblocked = modulehook('test', []);
+        $unblocked = modulehook_block('test', []);
         self::assertArrayHasKey('foo', $unblocked);
         self::assertTrue($unblocked['foo']);
     }

--- a/tests/Modules/ModuleHookOptionsTest.php
+++ b/tests/Modules/ModuleHookOptionsTest.php
@@ -29,7 +29,7 @@ use Lotgd\MySQL\Database;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
-function modulehook(string $hookName, array $args = [], bool $allowInactive = false, $only = false): array
+function modulehook_options(string $hookName, array $args = [], bool $allowInactive = false, $only = false): array
 {
     return HookHandler::hook($hookName, $args, $allowInactive, $only);
 }
@@ -60,7 +60,7 @@ final class ModuleHookOptionsTest extends TestCase
     {
         Database::$queryCacheResults['hook-sample'] = $this->hooksAll;
 
-        $result = modulehook('sample', [], false, 'a');
+        $result = modulehook_options('sample', [], false, 'a');
 
         $this->assertSame(['a' => 'A'], $result);
     }
@@ -68,11 +68,11 @@ final class ModuleHookOptionsTest extends TestCase
     public function testInactiveModulesRunWhenAllowed(): void
     {
         Database::$queryCacheResults['hook-sample'] = $this->hooksActive;
-        $activeResult = modulehook('sample', []);
+        $activeResult = modulehook_options('sample', []);
         $this->assertSame(['a' => 'A'], $activeResult);
 
         Database::$queryCacheResults['hook-sample'] = $this->hooksAll;
-        $result = modulehook('sample', [], true);
+        $result = modulehook_options('sample', [], true);
 
         $this->assertSame(['a' => 'A', 'b' => 'B'], $result);
     }
@@ -81,7 +81,7 @@ final class ModuleHookOptionsTest extends TestCase
     {
         Database::$queryCacheResults['hook-empty'] = [];
 
-        $result = modulehook('empty', []);
+        $result = modulehook_options('empty', []);
 
         $this->assertIsArray($result);
         $this->assertSame([], $result);

--- a/tests/Modules/ModulePrefsTest.php
+++ b/tests/Modules/ModulePrefsTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (!function_exists('set_module_pref')) {
+        function set_module_pref(string $name, mixed $value, ?string $module = null, ?int $user = null): void
+        {
+            \Lotgd\Modules\HookHandler::setModulePref($name, $value, $module, $user);
+        }
+    }
+    if (!function_exists('get_module_pref')) {
+        function get_module_pref(string $name, ?string $module = null, ?int $user = null)
+        {
+            return \Lotgd\Modules\HookHandler::getModulePref($name, $module, $user);
+        }
+    }
+    if (!function_exists('increment_module_pref')) {
+        function increment_module_pref(string $name, int|float $value = 1, ?string $module = null, ?int $user = null): void
+        {
+            \Lotgd\Modules\HookHandler::incrementModulePref($name, $value, $module, $user);
+        }
+    }
+    if (!function_exists('clear_module_pref')) {
+        function clear_module_pref(string $name, ?string $module = null, ?int $user = null): void
+        {
+            \Lotgd\Modules\HookHandler::clearModulePref($name, $module, $user);
+        }
+    }
+}
+
+namespace Lotgd\Tests\Modules {
+
+use Lotgd\Modules;
+use Lotgd\Tests\Stubs\Database;
+use Lotgd\Tests\Stubs\DoctrineConnection;
+use Lotgd\Tests\Stubs\DoctrineResult;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class ModulePrefsTest extends TestCase
+{
+    private string $moduleFile;
+
+    protected function setUp(): void
+    {
+        class_exists(Database::class);
+        Database::$queryCacheResults = [];
+        Database::$lastSql           = '';
+        $conn                        = new class extends DoctrineConnection {
+            public function executeQuery(string $sql): DoctrineResult
+            {
+                $this->queries[] = $sql;
+                return new DoctrineResult([]);
+            }
+        };
+        Database::$doctrineConnection        = $conn;
+        \Lotgd\Doctrine\Bootstrap::$conn = $conn;
+
+        global $session, $module_prefs, $mostrecentmodule;
+        $session         = ['user' => ['acctid' => 1, 'loggedin' => true]];
+        $module_prefs    = [];
+        $mostrecentmodule = '';
+
+        $ref  = new ReflectionClass(Modules::class);
+        $prop = $ref->getProperty('injectedModules');
+        $prop->setAccessible(true);
+        $prop->setValue(null, [1 => [], 0 => []]);
+        $prop = $ref->getProperty('modulehookQueries');
+        $prop->setAccessible(true);
+        $prop->setValue(null, []);
+
+        $this->moduleFile = dirname(__DIR__, 2) . '/modules/modA.php';
+        file_put_contents($this->moduleFile, <<<'MODULE'
+<?php
+
+declare(strict_types=1);
+
+function modA_getmoduleinfo(): array
+{
+    return [
+        'name' => 'modA',
+        'version' => '1.0',
+        'author' => 'Test',
+        'category' => 'Test',
+        'download' => '',
+        'description' => '',
+        'requires' => [],
+        'prefs' => [
+            'flag'  => 'Flag,bool|off',
+            'count' => 'Count,int|0',
+        ],
+    ];
+}
+
+function modA_install(): bool
+{
+    return true;
+}
+
+function modA_uninstall(): bool
+{
+    return true;
+}
+MODULE
+        );
+
+        $filemoddate = date('Y-m-d H:i:s', filemtime($this->moduleFile));
+        Database::$queryCacheResults['inject-modA'] = [
+            [
+                'active'     => 1,
+                'filemoddate' => $filemoddate,
+                'infokeys'   => '|name|version|author|category|description|download|requires|prefs|',
+                'version'    => '1.0',
+            ],
+        ];
+
+    }
+
+    protected function tearDown(): void
+    {
+        unlink($this->moduleFile);
+        unset(Database::$queryCacheResults['inject-modA']);
+        Database::$doctrineConnection = null;
+        \Lotgd\Doctrine\Bootstrap::$conn = null;
+    }
+
+    /**
+     * @param callable    $set
+     * @param callable    $get
+     * @param callable    $inc
+     * @param callable    $clear
+     * @param string|null $module
+     * @param int|null    $user
+     * @param mixed       $expected
+     */
+    private function runLifecycle(callable $set, callable $get, callable $inc, callable $clear, ?string $module, ?int $user, $expected): void
+    {
+        $set('flag', 'on', $module, $user);
+        $set('count', 0, $module, $user);
+        self::assertSame('on', $get('flag', $module, $user));
+
+        $inc('count', 1, $module, $user);
+        $inc('count', 1, $module, $user);
+        $inc('count', 1, $module, $user);
+        self::assertSame(3.0, $get('count', $module, $user));
+
+        $clear('flag', $module, $user);
+        self::assertSame($expected, $get('flag', $module, $user));
+    }
+
+    public function testWrapperExplicitUserAndModule(): void
+    {
+        $this->runLifecycle('set_module_pref', 'get_module_pref', 'increment_module_pref', 'clear_module_pref', 'modA', 1, 'off');
+    }
+
+    public function testWrapperFallbackUser(): void
+    {
+        $this->runLifecycle('set_module_pref', 'get_module_pref', 'increment_module_pref', 'clear_module_pref', 'modA', null, 'off');
+    }
+
+    public function testWrapperEmptyModule(): void
+    {
+        $this->runLifecycle('set_module_pref', 'get_module_pref', 'increment_module_pref', 'clear_module_pref', '', 1, null);
+    }
+
+    public function testClassExplicitUserAndModule(): void
+    {
+        $this->runLifecycle([Modules::class, 'setModulePref'], [Modules::class, 'getModulePref'], [Modules::class, 'incrementModulePref'], [Modules::class, 'clearModulePref'], 'modA', 1, 'off');
+    }
+
+    public function testClassFallbackUser(): void
+    {
+        $this->runLifecycle([Modules::class, 'setModulePref'], [Modules::class, 'getModulePref'], [Modules::class, 'incrementModulePref'], [Modules::class, 'clearModulePref'], 'modA', null, 'off');
+    }
+
+    public function testClassEmptyModule(): void
+    {
+        $this->runLifecycle([Modules::class, 'setModulePref'], [Modules::class, 'getModulePref'], [Modules::class, 'incrementModulePref'], [Modules::class, 'clearModulePref'], '', 1, null);
+    }
+}
+}
+
+
+


### PR DESCRIPTION
## Summary
- cover module preference lifecycle via wrapper functions and Modules class
- resolve test hook redeclaration by using unique helper names

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b7442ab95c83299a69f814e75fcfb5