### PR TITLE
Add module requirement injection tests

### DIFF
--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -242,14 +242,18 @@ class Modules
         }
 
         foreach ($reqs as $key => $val) {
-            $info = explode('|', $val);
-            if (! self::isInstalled($key, $info[0])) {
+            if (is_int($key)) {
+                [$key, $ver] = array_pad(explode('|', $val), 2, '');
+            } else {
+                [$ver] = explode('|', $val);
+            }
+            if (! self::isInstalled($key, $ver)) {
                 return false;
             }
             $status = self::getStatus($key);
             if (
                 ! (
-                $status & MODULE_INJECTED
+                    $status & MODULE_INJECTED
                 ) && $forceinject
             ) {
                 $result = $result && self::inject($key);

--- a/tests/Modules/ModuleRequirementsTest.php
+++ b/tests/Modules/ModuleRequirementsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (! function_exists('modulename_sanitize')) {
+        function modulename_sanitize($in)
+        {
+            return \Lotgd\Sanitize::modulenameSanitize($in);
+        }
+    }
+    if (! function_exists('module_compare_versions')) {
+        function module_compare_versions($a, $b): int
+        {
+            return strcmp($a, $b);
+        }
+    }
+}
+
+namespace Lotgd\Tests\Modules {
+    use Lotgd\Modules;
+    use Lotgd\Tests\Stubs\Database;
+    use PHPUnit\Framework\TestCase;
+    use ReflectionProperty;
+
+    final class ModuleRequirementsTest extends TestCase
+    {
+        private string $moduleFile;
+
+        protected function setUp(): void
+        {
+            class_exists(Database::class);
+            $this->moduleFile = __DIR__ . '/../../modules/dep.php';
+            file_put_contents($this->moduleFile, "<?php\nfunction dep_getmoduleinfo() { return []; }\n");
+        }
+
+        protected function tearDown(): void
+        {
+            if (file_exists($this->moduleFile)) {
+                unlink($this->moduleFile);
+            }
+            Database::$queryCacheResults = [];
+            $prop = new ReflectionProperty(Modules::class, 'injectedModules');
+            $prop->setAccessible(true);
+            $prop->setValue(null, [1 => [], 0 => []]);
+        }
+
+        public function testUninstalledDependencyFails(): void
+        {
+            $this->assertFalse(Modules::checkRequirements(['dep|1.0']));
+        }
+
+        public function testForceInjectCallsInject(): void
+        {
+            $filemoddate = date('Y-m-d H:i:s', filemtime($this->moduleFile));
+            Database::$queryCacheResults['inject-dep'] = [
+                [
+                    'active'      => 1,
+                    'filemoddate' => $filemoddate,
+                    'infokeys'    => '|',
+                    'version'     => '1.0',
+                ],
+            ];
+
+            $prop = new ReflectionProperty(Modules::class, 'injectedModules');
+            $prop->setAccessible(true);
+            $prop->setValue(null, [1 => [], 0 => []]);
+
+            $this->assertTrue(Modules::checkRequirements(['dep|1.0'], true));
+
+            $current = $prop->getValue();
+            $this->assertArrayHasKey('dep', $current[0]);
+            $this->assertTrue($current[0]['dep']);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add tests for Modules::checkRequirements handling dependencies
- handle numeric requirement entries in Modules::checkRequirements

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b74f465b3c8329860328c4e4b41aac