### PR TITLE
Add tests for retrieving module configuration

### DIFF
--- a/tests/Modules/ModulePrefsTest.php
+++ b/tests/Modules/ModulePrefsTest.php
@@ -27,6 +27,12 @@ namespace {
             \Lotgd\Modules\HookHandler::clearModulePref($name, $module, $user);
         }
     }
+    if (!function_exists('get_all_module_prefs')) {
+        function get_all_module_prefs(?string $module = null, ?int $user = null): array
+        {
+            return \Lotgd\Modules\HookHandler::getAllModulePrefs($module, $user);
+        }
+    }
 }
 
 namespace Lotgd\Tests\Modules {
@@ -177,6 +183,21 @@ MODULE
     public function testClassEmptyModule(): void
     {
         $this->runLifecycle([Modules::class, 'setModulePref'], [Modules::class, 'getModulePref'], [Modules::class, 'incrementModulePref'], [Modules::class, 'clearModulePref'], '', 1, null);
+    }
+
+    public function testGetAllModulePrefs(): void
+    {
+        set_module_pref('flag', 'on', 'modA', 1);
+        set_module_pref('count', 0, 'modA', 1);
+        increment_module_pref('count', 1, 'modA', 1);
+        increment_module_pref('count', 1, 'modA', 1);
+
+        $prefs = get_all_module_prefs('modA', 1);
+
+        self::assertSame([
+            'flag' => 'on',
+            'count' => 2.0,
+        ], $prefs);
     }
 }
 }

--- a/tests/Modules/ModuleSettingsTest.php
+++ b/tests/Modules/ModuleSettingsTest.php
@@ -27,6 +27,12 @@ namespace {
             \Lotgd\Modules\HookHandler::clearModuleSettings($module);
         }
     }
+    if (!function_exists('get_all_module_settings')) {
+        function get_all_module_settings(?string $module = null): array
+        {
+            return \Lotgd\Modules\HookHandler::getAllModuleSettings($module);
+        }
+    }
 }
 
 namespace Lotgd\Tests\Modules {
@@ -77,6 +83,24 @@ final class ModuleSettingsTest extends TestCase
         clear_module_settings('');
         $this->assertNull(get_module_setting('key', ''));
         $this->assertNull(get_module_setting('counter', ''));
+    }
+
+    public function testGetAllModuleSettings(): void
+    {
+        global $mostrecentmodule;
+        $mostrecentmodule = 'mymodule';
+
+        set_module_setting('key', 'value');
+        set_module_setting('counter', '0');
+        increment_module_setting('counter');
+        increment_module_setting('counter');
+
+        $settings = get_all_module_settings('mymodule');
+
+        $this->assertSame([
+            'key' => 'value',
+            'counter' => 2.0,
+        ], $settings);
     }
 }
 


### PR DESCRIPTION
## Summary
- add wrapper and subtest to verify `get_all_module_settings`
- add wrapper and subtest to verify `get_all_module_prefs`

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b74f4960388329821f98e298f5ee5d