### PR TITLE
fix missing closing brace in ModulePrefsTest

### DIFF
--- a/tests/Modules/ModulePrefsTest.php
+++ b/tests/Modules/ModulePrefsTest.php
@@ -207,6 +207,8 @@ MODULE
             'flag' => 'on',
             'count' => 2.0,
         ], $prefs);
+    }
+
     public function testClassFalseUser(): void
     {
         $this->runLifecycle([Modules::class, 'setModulePref'], [Modules::class, 'getModulePref'], [Modules::class, 'incrementModulePref'], [Modules::class, 'clearModulePref'], 'modA', false, 'off');


### PR DESCRIPTION
## Summary
- add missing closing brace to terminate `testGetAllModulePrefs`

## Testing
- `php -l tests/Modules/ModulePrefsTest.php`
- `phpunit tests/Modules/ModulePrefsTest.php` *(fails: Class `Lotgd\Tests\Stubs\DoctrineConnection` not found)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b75cbc8fc08329977f21bd447b8712