### PR TITLE
Add test for module user preference deletion cache clearing

### DIFF
--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -726,8 +726,13 @@ class Modules
      */
     public static function deleteUserPrefs(int $user): void
     {
+        global $module_prefs;
+
         $sql = 'DELETE FROM ' . Database::prefix('module_userprefs') . " WHERE userid='$user'";
         Database::query($sql);
+
+        unset($module_prefs[$user]);
+        massinvalidate("module_userprefs-$user");
     }
 
     /**

--- a/tests/Modules/ModuleDeleteUserPrefsTest.php
+++ b/tests/Modules/ModuleDeleteUserPrefsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (!function_exists('module_delete_userprefs')) {
+        function module_delete_userprefs(int $user): void
+        {
+            \Lotgd\Modules\HookHandler::deleteUserPrefs($user);
+        }
+    }
+}
+
+namespace Lotgd\Tests\Modules {
+
+use Lotgd\Tests\Stubs\Database;
+use Lotgd\Tests\Stubs\DoctrineConnection;
+use PHPUnit\Framework\TestCase;
+
+final class ModuleDeleteUserPrefsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        class_exists(Database::class);
+
+        $conn = new DoctrineConnection();
+        Database::$doctrineConnection = $conn;
+        \Lotgd\Doctrine\Bootstrap::$conn = $conn;
+
+        global $session, $module_prefs, $massinvalidates;
+        $session = ['user' => ['acctid' => 1, 'loggedin' => true]];
+        $module_prefs = [];
+        $massinvalidates = [];
+    }
+
+    protected function tearDown(): void
+    {
+        Database::$doctrineConnection = null;
+        \Lotgd\Doctrine\Bootstrap::$conn = null;
+    }
+
+    public function testDeleteUserPrefsClearsGlobalCache(): void
+    {
+        global $module_prefs, $massinvalidates;
+
+        $userId = 1;
+        $module_prefs = [
+            $userId => [
+                'modA' => ['prefA' => 'value'],
+                'modB' => ['prefB' => 'value'],
+            ],
+            2 => [
+                'modC' => ['prefC' => 'value'],
+            ],
+        ];
+
+        module_delete_userprefs($userId);
+
+        self::assertArrayNotHasKey($userId, $module_prefs);
+        self::assertArrayHasKey(2, $module_prefs);
+        self::assertContains("module_userprefs-$userId", $massinvalidates);
+    }
+}
+
+}


### PR DESCRIPTION
## Summary
- ensure module user preference deletion clears in-memory cache and invalidates datacache
- test `module_delete_userprefs` to confirm cache removal

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b75f129b0c8329884728bed65d7653