### PR TITLE
test: add module event hook wrapper tests

### DIFF
--- a/tests/Modules/ModuleEventHookTest.php
+++ b/tests/Modules/ModuleEventHookTest.php
@@ -3,6 +3,9 @@
 declare(strict_types=1);
 
 namespace Lotgd\Tests\Modules\Fixtures {
+    /**
+     * Simple mock used to capture calls to the HookHandler facade.
+     */
     class HookHandlerMock
     {
         public static array $added = [];
@@ -23,18 +26,14 @@ namespace Lotgd\Tests\Modules\Fixtures {
 namespace {
     use Lotgd\Tests\Modules\Fixtures\HookHandlerMock;
 
-    if (!function_exists('module_addeventhook')) {
-        function module_addeventhook(string $type, string $chance): void
-        {
-            HookHandlerMock::addEventHook($type, $chance);
-        }
+    function module_addeventhook(string $type, string $chance): void
+    {
+        HookHandlerMock::addEventHook($type, $chance);
     }
 
-    if (!function_exists('module_dropeventhook')) {
-        function module_dropeventhook(string $type): void
-        {
-            HookHandlerMock::dropEventHook($type);
-        }
+    function module_dropeventhook(string $type): void
+    {
+        HookHandlerMock::dropEventHook($type);
     }
 }
 
@@ -42,6 +41,8 @@ namespace Lotgd\Tests\Modules {
 
 use Lotgd\Tests\Modules\Fixtures\HookHandlerMock;
 use PHPUnit\Framework\TestCase;
+use function module_addeventhook;
+use function module_dropeventhook;
 
 final class ModuleEventHookTest extends TestCase
 {

--- a/tests/Modules/ModuleEventHookTest.php
+++ b/tests/Modules/ModuleEventHookTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Modules\Fixtures {
+    class HookHandlerMock
+    {
+        public static array $added = [];
+        public static array $dropped = [];
+
+        public static function addEventHook(string $type, string $chance): void
+        {
+            self::$added[] = ['type' => $type, 'chance' => $chance];
+        }
+
+        public static function dropEventHook(string $type): void
+        {
+            self::$dropped[] = ['type' => $type];
+        }
+    }
+}
+
+namespace {
+    use Lotgd\Tests\Modules\Fixtures\HookHandlerMock;
+
+    if (!function_exists('module_addeventhook')) {
+        function module_addeventhook(string $type, string $chance): void
+        {
+            HookHandlerMock::addEventHook($type, $chance);
+        }
+    }
+
+    if (!function_exists('module_dropeventhook')) {
+        function module_dropeventhook(string $type): void
+        {
+            HookHandlerMock::dropEventHook($type);
+        }
+    }
+}
+
+namespace Lotgd\Tests\Modules {
+
+use Lotgd\Tests\Modules\Fixtures\HookHandlerMock;
+use PHPUnit\Framework\TestCase;
+
+final class ModuleEventHookTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        HookHandlerMock::$added = [];
+        HookHandlerMock::$dropped = [];
+    }
+
+    public function testAddEventHookPassesTypeAndChance(): void
+    {
+        module_addeventhook('forest', '25%');
+        self::assertSame([
+            ['type' => 'forest', 'chance' => '25%'],
+        ], HookHandlerMock::$added);
+    }
+
+    public function testDropEventHookPassesType(): void
+    {
+        module_dropeventhook('forest');
+        self::assertSame([
+            ['type' => 'forest'],
+        ], HookHandlerMock::$dropped);
+    }
+
+    public function testEmptyEventType(): void
+    {
+        module_addeventhook('', '10%');
+        module_dropeventhook('');
+
+        self::assertSame([
+            ['type' => '', 'chance' => '10%'],
+        ], HookHandlerMock::$added);
+        self::assertSame([
+            ['type' => ''],
+        ], HookHandlerMock::$dropped);
+    }
+}
+}


### PR DESCRIPTION
## Summary
- add `ModuleEventHookTest` to verify wrapper functions delegate to HookHandler
- ensure type and chance parameters pass through, including empty event types

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b75f13f9dc83298537de3109a54c30