### PR TITLE
Add tests for module event wrappers

### DIFF
--- a/tests/Modules/ModuleEventWrappersTest.php
+++ b/tests/Modules/ModuleEventWrappersTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Modules {
+    use PHPUnit\Framework\TestCase;
+
+    /**
+     * @runTestsInSeparateProcesses
+     * @preserveGlobalState disabled
+     */
+    final class ModuleEventWrappersTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            if (!function_exists(__NAMESPACE__ . '\\module_sem_acquire')) {
+                $code = file_get_contents(dirname(__DIR__, 2) . '/lib/modules.php');
+                $code = preg_replace('/^<\\?php\\s*declare\\(strict_types=1\\);\\s*/', '', $code);
+                eval('namespace ' . __NAMESPACE__ . '; ' . $code);
+            }
+            eval('namespace Lotgd\\Modules; class HookHandler { public static $calls; public static $collectEventsReturn; public static $moduleEventsReturn; public static function semAcquire(): void { self::$calls[] = [__FUNCTION__, func_get_args()]; } public static function semRelease(): void { self::$calls[] = [__FUNCTION__, func_get_args()]; } public static function collectEvents(string $type, bool $allowinactive = false): array { self::$calls[] = [__FUNCTION__, func_get_args()]; return self::$collectEventsReturn; } public static function moduleEvents(string $eventtype, int $basechance, ?string $baseLink = null): int { self::$calls[] = [__FUNCTION__, func_get_args()]; return self::$moduleEventsReturn; } public static function doEvent(string $type, string $module, bool $allowinactive = false, ?string $baseLink = null): void { self::$calls[] = [__FUNCTION__, func_get_args()]; } }');
+            \Lotgd\Modules\HookHandler::$calls = [];
+        }
+
+        public function testEventWrappers(): void
+        {
+            \Lotgd\Modules\HookHandler::$collectEventsReturn = ['alpha'];
+            \Lotgd\Modules\HookHandler::$moduleEventsReturn = 7;
+
+            module_sem_acquire();
+            module_sem_release();
+            $collect = module_collect_events('foo', true);
+            $events = module_events('bar', 3, 'baz');
+            module_do_event('qux', 'corge', false, 'grault');
+
+            self::assertSame(['alpha'], $collect);
+            self::assertSame(7, $events);
+            self::assertSame([
+                ['semAcquire', []],
+                ['semRelease', []],
+                ['collectEvents', ['foo', true]],
+                ['moduleEvents', ['bar', 3, 'baz']],
+                ['doEvent', ['qux', 'corge', false, 'grault']],
+            ], \Lotgd\Modules\HookHandler::$calls);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ModuleEventWrappersTest to verify wrapper calls to HookHandler

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b8020e23488329963876b44b28a14e