### PR TITLE
Add tests for display wrapper functions

### DIFF
--- a/tests/Modules/ModuleDisplayWrappersTest.php
+++ b/tests/Modules/ModuleDisplayWrappersTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Modules {
+    use PHPUnit\Framework\TestCase;
+
+    /**
+     * @runTestsInSeparateProcesses
+     * @preserveGlobalState disabled
+     */
+    final class ModuleDisplayWrappersTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            if (!function_exists(__NAMESPACE__ . '\\module_display_events')) {
+                $code = file_get_contents(dirname(__DIR__, 2) . '/lib/modules.php');
+                $code = preg_replace('/^<\\?php\\s*declare\\(strict_types=1\\);\\s*/', '', $code);
+                eval('namespace ' . __NAMESPACE__ . '; ' . $code);
+            }
+            eval('namespace Lotgd\\Modules; class HookHandler { public static $calls; public static function displayEvents(string $eventtype, $forcescript = false): void { self::$calls[] = [__FUNCTION__, func_get_args()]; } public static function editorNavs(string $like, string $linkprefix): void { self::$calls[] = [__FUNCTION__, func_get_args()]; } public static function objprefEdit(string $type, string $module, $id): void { self::$calls[] = [__FUNCTION__, func_get_args()]; } }');
+            \Lotgd\Modules\HookHandler::$calls = [];
+        }
+
+        public function testDisplayWrappers(): void
+        {
+            module_display_events('foo', true);
+            module_editor_navs('bar', 'baz');
+            module_objpref_edit('qux', 'quux', 123);
+
+            self::assertSame([
+                ['displayEvents', ['foo', true]],
+                ['editorNavs', ['bar', 'baz']],
+                ['objprefEdit', ['qux', 'quux', 123]],
+            ], \Lotgd\Modules\HookHandler::$calls);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- cover module display wrappers with tests

## Testing
- `php -l tests/Modules/ModuleDisplayWrappersTest.php`
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b808c4ad048329a925eb809dc0e1b1