### PR TITLE
Add tests for module utility wrappers

### DIFF
--- a/tests/Modules/ModuleUtilityWrappersTest.php
+++ b/tests/Modules/ModuleUtilityWrappersTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Modules {
+    use PHPUnit\Framework\TestCase;
+
+    /**
+     * @runTestsInSeparateProcesses
+     * @preserveGlobalState disabled
+     */
+    final class ModuleUtilityWrappersTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            if (!function_exists(__NAMESPACE__ . '\\get_module_install_status')) {
+                $code = file_get_contents(dirname(__DIR__, 2) . '/lib/modules.php');
+                $code = preg_replace('/^<\\?php\\s*declare\\(strict_types=1\\);\\s*/', '', $code);
+                eval('namespace ' . __NAMESPACE__ . '; ' . $code);
+            }
+
+            eval('namespace Lotgd\\Modules; class Installer { public static $getInstallStatusArgs; public static $getInstallStatusReturn; public static function getInstallStatus(bool $with_db = true): array { self::$getInstallStatusArgs = [$with_db]; return self::$getInstallStatusReturn; } }');
+            \Lotgd\Modules\Installer::$getInstallStatusArgs = [];
+
+            eval('namespace Lotgd; class Modules { public static $getRaceNameArgs; public static $getRaceNameReturn; public static function getRaceName($thisuser = true): string { self::$getRaceNameArgs = [$thisuser]; return self::$getRaceNameReturn; } }');
+            \Lotgd\Modules::$getRaceNameArgs = [];
+        }
+
+        public function testUtilityWrappers(): void
+        {
+            \Lotgd\Modules\Installer::$getInstallStatusReturn = ['ok'];
+            \Lotgd\Modules::$getRaceNameReturn = 'orc';
+
+            $status = get_module_install_status(false);
+            $race   = get_racename();
+
+            self::assertSame(['ok'], $status);
+            self::assertSame('orc', $race);
+            self::assertSame([false], \Lotgd\Modules\Installer::$getInstallStatusArgs);
+            self::assertSame([true], \Lotgd\Modules::$getRaceNameArgs);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- test module helper wrappers for install status and race name

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b80a265f9083299d4e9edb37f403c8