### PR TITLE
test: add default wrapper calls

### DIFF
--- a/tests/Modules/ModuleUtilityWrappersTest.php
+++ b/tests/Modules/ModuleUtilityWrappersTest.php
@@ -32,12 +32,20 @@ namespace Lotgd\Tests\Modules {
             \Lotgd\Modules::$getRaceNameReturn = 'orc';
 
             $status = get_module_install_status(false);
-            $race   = get_racename();
-
             self::assertSame(['ok'], $status);
-            self::assertSame('orc', $race);
             self::assertSame([false], \Lotgd\Modules\Installer::$getInstallStatusArgs);
+
+            $status = get_module_install_status();
+            self::assertSame(['ok'], $status);
+            self::assertSame([true], \Lotgd\Modules\Installer::$getInstallStatusArgs);
+
+            $race = get_racename();
+            self::assertSame('orc', $race);
             self::assertSame([true], \Lotgd\Modules::$getRaceNameArgs);
+
+            $race = get_racename('');
+            self::assertSame('orc', $race);
+            self::assertSame([''], \Lotgd\Modules::$getRaceNameArgs);
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend ModuleUtilityWrappersTest to cover default `get_module_install_status()` and `get_racename('')` wrappers

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b80d4e4d0c8329a25035db6fd8e7a5