### PR TITLE
Add test for module_delete_userprefs without stored prefs

### DIFF
--- a/tests/Modules/ModuleDeleteUserPrefsTest.php
+++ b/tests/Modules/ModuleDeleteUserPrefsTest.php
@@ -60,6 +60,17 @@ final class ModuleDeleteUserPrefsTest extends TestCase
         self::assertArrayHasKey(2, $module_prefs);
         self::assertContains("module_userprefs-$userId", $massinvalidates);
     }
+
+    public function testDeletingWithEmptyPrefsDoesNothing(): void
+    {
+        global $module_prefs;
+
+        $userId = 1;
+
+        module_delete_userprefs($userId);
+
+        self::assertSame([], $module_prefs);
+    }
 }
 
 }


### PR DESCRIPTION
## Summary
- add regression test ensuring `module_delete_userprefs` is harmless when no module prefs exist

## Testing
- `php -l tests/Modules/ModuleDeleteUserPrefsTest.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b8122319848329ac84a8f2015c794d