### PR TITLE
test: add fatal shutdown handler test

### DIFF
--- a/tests/ErrorHandlerFatalShutdownTest.php
+++ b/tests/ErrorHandlerFatalShutdownTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\ErrorHandler;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runInSeparateProcess
+ */
+final class ErrorHandlerFatalShutdownTest extends TestCase
+{
+    public function testFatalShutdownOutputsError(): void
+    {
+        eval(<<<'PHP'
+namespace Lotgd;
+function error_get_last(): ?array
+{
+    static $called = false;
+    if ($called) {
+        return null;
+    }
+    $called = true;
+    return [
+        'type' => E_ERROR,
+        'message' => 'Fatal example',
+        'file' => 'fatal.php',
+        'line' => 13,
+    ];
+}
+PHP);
+
+        ob_start();
+        ErrorHandler::fatalShutdown();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Fatal example', $output);
+        $this->assertStringContainsString('fatal.php', $output);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add regression test for fatal error handler shutdown

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b81226b1988329b5b26ad295759bf5