### PR TITLE
test: cover negative and fractional increments

### DIFF
--- a/tests/Modules/ModulePrefsTest.php
+++ b/tests/Modules/ModulePrefsTest.php
@@ -209,6 +209,16 @@ MODULE
         ], $prefs);
     } // end testGetAllModulePrefs
 
+    public function testIncrementModulePrefWithNegativeAndFractionalValues(): void
+    {
+        foreach ([-1.0, 1.5] as $increment) {
+            set_module_pref('count', 0, 'modA', 1);
+            increment_module_pref('count', $increment, 'modA', 1);
+
+            self::assertSame($increment, get_module_pref('count', 'modA', 1), "increment {$increment}");
+        }
+    }
+
     public function testClassFalseUser(): void
     {
         $this->runLifecycle([Modules::class, 'setModulePref'], [Modules::class, 'getModulePref'], [Modules::class, 'incrementModulePref'], [Modules::class, 'clearModulePref'], 'modA', false, 'off');

--- a/tests/Modules/ModuleSettingsTest.php
+++ b/tests/Modules/ModuleSettingsTest.php
@@ -102,6 +102,19 @@ final class ModuleSettingsTest extends TestCase
             'counter' => 2.0,
         ], $settings);
     }
+
+    public function testIncrementModuleSettingWithNegativeAndFractionalValues(): void
+    {
+        global $mostrecentmodule;
+        $mostrecentmodule = 'mymodule';
+
+        foreach ([-1.0, 1.5] as $increment) {
+            set_module_setting('counter', '0');
+            increment_module_setting('counter', $increment);
+
+            $this->assertSame($increment, get_module_setting('counter'), "increment {$increment}");
+        }
+    }
 }
 
 }


### PR DESCRIPTION
## Summary
- add subtests for negative and fractional increments in module settings
- add subtests for negative and fractional increments in module prefs

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b8127a66188329a47ab2bac6158e31