### PR TITLE
Ensure module requirements fail on version mismatch

### DIFF
--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -221,7 +221,8 @@ class Modules
      */
     public static function isInstalled(string $moduleName, string|false $version = false): bool
     {
-        return (bool) (self::getStatus($moduleName, $version) & (MODULE_INSTALLED | MODULE_VERSION_OK));
+        $status = self::getStatus($moduleName, $version);
+        return (bool) (($status & MODULE_INSTALLED) && ($status & MODULE_VERSION_OK));
     }
 
     /**

--- a/tests/Modules/ModuleRequirementsTest.php
+++ b/tests/Modules/ModuleRequirementsTest.php
@@ -50,6 +50,21 @@ namespace Lotgd\Tests\Modules {
             $this->assertFalse(Modules::checkRequirements(['dep|1.0']));
         }
 
+        public function testInstalledDependencyVersionMismatchFails(): void
+        {
+            $filemoddate = date('Y-m-d H:i:s', filemtime($this->moduleFile));
+            Database::$queryCacheResults['inject-dep'] = [
+                [
+                    'active'      => 1,
+                    'filemoddate' => $filemoddate,
+                    'infokeys'    => '|',
+                    'version'     => '1.0',
+                ],
+            ];
+
+            $this->assertFalse(Modules::checkRequirements(['dep|2.0']));
+        }
+
         public function testForceInjectCallsInject(): void
         {
             $filemoddate = date('Y-m-d H:i:s', filemtime($this->moduleFile));


### PR DESCRIPTION
## Summary
- add test verifying Modules::checkRequirements fails for lower dependency versions
- fix Modules::isInstalled to require both installation and version match

## Testing
- `composer install`
- `php -l tests/Modules/ModuleRequirementsTest.php`
- `php -l src/Lotgd/Modules.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b8127df6cc8329a65f6b5d85e3e314