### PR TITLE
Prevent injection of incomplete modules

### DIFF
--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -64,6 +64,15 @@ class Modules
             }
             require_once $modulefilename;
             $mostrecentmodule = $moduleName;
+
+            $installFname   = $moduleName . '_install';
+            $uninstallFname = $moduleName . '_uninstall';
+            if (! function_exists($installFname) || ! function_exists($uninstallFname)) {
+                Translator::tlschema();
+                self::$injectedModules[$force][$moduleName] = false;
+                return false;
+            }
+
             $info            = '';
             if (! $force) {
                 $fname = $moduleName . '_getmoduleinfo';

--- a/tests/Modules/InjectModuleIncompleteTest.php
+++ b/tests/Modules/InjectModuleIncompleteTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Modules;
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists(__NAMESPACE__ . '\\injectmodule')) {
+    function injectmodule(string $moduleName): bool
+    {
+        return Modules::inject($moduleName);
+    }
+}
+
+final class InjectModuleIncompleteTest extends TestCase
+{
+    private string $moduleDir;
+    private string $moduleFile;
+    private string $origCwd;
+
+    protected function setUp(): void
+    {
+        class_exists(Database::class);
+        \Lotgd\MySQL\Database::$queryCacheResults = [];
+
+        $this->origCwd   = getcwd();
+        $this->moduleDir = sys_get_temp_dir() . '/lotgd_module_' . uniqid();
+        mkdir($this->moduleDir . '/modules', 0777, true);
+
+        $this->moduleFile = $this->moduleDir . '/modules/badModule.php';
+        $code = <<<'PHP'
+<?php
+function badModule_getmoduleinfo(): array { return ['name' => 'Bad Module', 'version' => '1.0']; }
+PHP;
+        file_put_contents($this->moduleFile, $code);
+
+        $filemoddate = date('Y-m-d H:i:s', filemtime($this->moduleFile));
+        \Lotgd\MySQL\Database::$queryCacheResults['inject-badModule'] = [[
+            'active' => 1,
+            'filemoddate' => $filemoddate,
+            'infokeys' => '|name|version|',
+            'version' => '1.0',
+        ]];
+
+        $ref  = new \ReflectionClass(Modules::class);
+        $prop = $ref->getProperty('injectedModules');
+        $prop->setAccessible(true);
+        $prop->setValue(null, [1 => [], 0 => []]);
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->moduleFile)) {
+            unlink($this->moduleFile);
+        }
+        if (is_dir($this->moduleDir . '/modules')) {
+            rmdir($this->moduleDir . '/modules');
+            rmdir($this->moduleDir);
+        }
+        chdir($this->origCwd);
+        \Lotgd\MySQL\Database::$queryCacheResults = [];
+    }
+
+    public function testInjectionFailsAndDoesNotRegister(): void
+    {
+        chdir($this->moduleDir);
+        $result = injectmodule('badModule');
+        chdir($this->origCwd);
+
+        $this->assertFalse($result);
+
+        $ref  = new \ReflectionClass(Modules::class);
+        $prop = $ref->getProperty('injectedModules');
+        $prop->setAccessible(true);
+        $injected = $prop->getValue();
+
+        $this->assertArrayHasKey('badModule', $injected[0]);
+        $this->assertFalse($injected[0]['badModule']);
+    }
+}

--- a/tests/Modules/ModuleRequirementsTest.php
+++ b/tests/Modules/ModuleRequirementsTest.php
@@ -66,11 +66,11 @@ namespace Lotgd\Tests\Modules {
             $prop->setAccessible(true);
             $prop->setValue(null, [1 => [], 0 => []]);
 
-            $this->assertTrue(Modules::checkRequirements(['dep|1.0'], true));
+            $this->assertFalse(Modules::checkRequirements(['dep|1.0'], true));
 
             $current = $prop->getValue();
             $this->assertArrayHasKey('dep', $current[0]);
-            $this->assertTrue($current[0]['dep']);
+            $this->assertFalse($current[0]['dep']);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure `Modules::inject` returns false if a module lacks required install/uninstall handlers
- add regression test covering injection failure of an incomplete module
- update requirements test expectations for failed forced injection

## Testing
- `php -l tests/Modules/InjectModuleIncompleteTest.php`
- `php -l src/Lotgd/Modules.php`
- `php -l tests/Modules/ModuleRequirementsTest.php`
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b81280409c8329837006d1240f663e