### PR TITLE
test: cover event_sort wrapper

### DIFF
--- a/tests/Modules/EventSortTest.php
+++ b/tests/Modules/EventSortTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Modules {
+    use PHPUnit\Framework\TestCase;
+
+    /**
+     * @runTestsInSeparateProcesses
+     * @preserveGlobalState disabled
+     */
+    final class EventSortTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            if (!function_exists(__NAMESPACE__ . '\\event_sort')) {
+                $code = file_get_contents(dirname(__DIR__, 2) . '/lib/modules.php');
+                $code = preg_replace('/^<\\?php\\s*declare\\(strict_types=1\\);\\s*/', '', $code);
+                eval('namespace ' . __NAMESPACE__ . '; ' . $code);
+            }
+
+            eval('namespace Lotgd\\Modules; class HookHandler { public static $calls = []; public static $return; public static function eventSort($a, $b): int { self::$calls[] = [$a, $b]; return self::$return; } }');
+            \Lotgd\Modules\HookHandler::$calls = [];
+        }
+
+        public function testEventSortProxiesToHookHandler(): void
+        {
+            \Lotgd\Modules\HookHandler::$return = 123;
+            $result = event_sort(['a'], ['b']);
+
+            self::assertSame(123, $result);
+            self::assertSame([[['a'], ['b']]], \Lotgd\Modules\HookHandler::$calls);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add EventSortTest to verify event_sort passes arguments to HookHandler and returns handler value

## Testing
- `php -l tests/Modules/EventSortTest.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b827ee12b08329a70431dd255fe64f