### PR TITLE
Sanitize module name in get_module_info wrapper

### DIFF
--- a/lib/modules.php
+++ b/lib/modules.php
@@ -163,6 +163,7 @@ function load_module_prefs(string $module, ?int $user = null): void
 
 function get_module_info(string $shortname, bool $with_db = true): array
 {
+    $shortname = modulename_sanitize($shortname);
     return Modules::getModuleInfo($shortname, $with_db);
 }
 

--- a/tests/Modules/GetModuleInfoTest.php
+++ b/tests/Modules/GetModuleInfoTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (!function_exists('modulename_sanitize')) {
+        function modulename_sanitize($in)
+        {
+            return \Lotgd\Sanitize::modulenameSanitize($in);
+        }
+    }
+}
+
+namespace Lotgd\Tests\Modules {
+    use PHPUnit\Framework\TestCase;
+
+    /**
+     * @runTestsInSeparateProcesses
+     * @preserveGlobalState disabled
+     */
+    final class GetModuleInfoTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            if (!function_exists(__NAMESPACE__ . '\\get_module_info')) {
+                $code = file_get_contents(dirname(__DIR__, 2) . '/lib/modules.php');
+                $code = preg_replace('/^<\\?php\\s*declare\\(strict_types=1\\);\\s*/', '', $code);
+                eval('namespace ' . __NAMESPACE__ . '; ' . $code);
+            }
+
+            eval('namespace Lotgd; class Modules { public static $getModuleInfoArgs; public static $getModuleInfoReturn; public static function getModuleInfo(string $shortname, bool $with_db = true): array { self::$getModuleInfoArgs = [$shortname, $with_db]; return self::$getModuleInfoReturn; } }');
+            \Lotgd\Modules::$getModuleInfoArgs = [];
+        }
+
+        public function testGetModuleInfoWrapperSanitizesName(): void
+        {
+            \Lotgd\Modules::$getModuleInfoReturn = ['stub' => 'data'];
+
+            $result = get_module_info('../foo');
+
+            self::assertSame(['stub' => 'data'], $result);
+            self::assertSame(['foo', true], \Lotgd\Modules::$getModuleInfoArgs);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize module names passed to get_module_info
- test get_module_info to ensure sanitized name and stub array result

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b827eb026483299041654c13a935a3