### PR TITLE
test: verify module out-of-date status

### DIFF
--- a/tests/Modules/ModuleStatusTest.php
+++ b/tests/Modules/ModuleStatusTest.php
@@ -9,6 +9,10 @@ namespace {
             return \Lotgd\Sanitize::modulenameSanitize($in);
         }
     }
+
+    if (! defined('MODULE_OUT_OF_DATE')) {
+        define('MODULE_OUT_OF_DATE', MODULE_VERSION_TOO_LOW);
+    }
 }
 
 namespace Lotgd\Tests\Modules {
@@ -68,6 +72,19 @@ namespace Lotgd\Tests\Modules {
             $status = Modules::getStatus($name);
             $mask   = MODULE_INSTALLED | MODULE_ACTIVE | MODULE_INJECTED;
             $this->assertSame(MODULE_INSTALLED | MODULE_ACTIVE | MODULE_INJECTED, $status & $mask);
+            unlink($file);
+        }
+
+        public function testVersionTooLowReturnsOutOfDate(): void
+        {
+            $name = 'outofdatemodule';
+            $file = __DIR__ . "/../../modules/{$name}.php";
+            file_put_contents($file, "<?php\n");
+            Database::$queryCacheResults["inject-$name"] = [
+                ['active' => 1, 'filemoddate' => '', 'infokeys' => '|', 'version' => '1.0'],
+            ];
+            $status = Modules::getStatus($name, '2.0');
+            $this->assertSame(MODULE_OUT_OF_DATE, $status & MODULE_OUT_OF_DATE);
             unlink($file);
         }
     }


### PR DESCRIPTION
## Summary
- ensure getStatus flags modules as out of date when version is behind

## Testing
- `php -l tests/Modules/ModuleStatusTest.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b82a13a4dc832999260cfa3391da1e