### PR TITLE
chore(tests): organize module tests into subdirectories

### DIFF
--- a/tests/Modules/Events/EventSortTest.php
+++ b/tests/Modules/Events/EventSortTest.php
@@ -2,19 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Events {
     use PHPUnit\Framework\TestCase;
 
     /**
      * @runTestsInSeparateProcesses
      * @preserveGlobalState disabled
+     * @group events
      */
     final class EventSortTest extends TestCase
     {
         protected function setUp(): void
         {
             if (!function_exists(__NAMESPACE__ . '\\event_sort')) {
-                $code = file_get_contents(dirname(__DIR__, 2) . '/lib/modules.php');
+                $code = file_get_contents(dirname(__DIR__, 3) . '/lib/modules.php');
                 $code = preg_replace('/^<\\?php\\s*declare\\(strict_types=1\\);\\s*/', '', $code);
                 eval('namespace ' . __NAMESPACE__ . '; ' . $code);
             }

--- a/tests/Modules/Events/ModuleEventHookTest.php
+++ b/tests/Modules/Events/ModuleEventHookTest.php
@@ -37,13 +37,16 @@ namespace {
     }
 }
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Events {
 
 use Lotgd\Tests\Modules\Fixtures\HookHandlerMock;
 use PHPUnit\Framework\TestCase;
 use function module_addeventhook;
 use function module_dropeventhook;
 
+/**
+ * @group events
+ */
 final class ModuleEventHookTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Modules/Events/ModuleEventWrappersTest.php
+++ b/tests/Modules/Events/ModuleEventWrappersTest.php
@@ -2,19 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Events {
     use PHPUnit\Framework\TestCase;
 
     /**
      * @runTestsInSeparateProcesses
      * @preserveGlobalState disabled
+     * @group events
      */
     final class ModuleEventWrappersTest extends TestCase
     {
         protected function setUp(): void
         {
             if (!function_exists(__NAMESPACE__ . '\\module_sem_acquire')) {
-                $code = file_get_contents(dirname(__DIR__, 2) . '/lib/modules.php');
+                $code = file_get_contents(dirname(__DIR__, 3) . '/lib/modules.php');
                 $code = preg_replace('/^<\\?php\\s*declare\\(strict_types=1\\);\\s*/', '', $code);
                 eval('namespace ' . __NAMESPACE__ . '; ' . $code);
             }

--- a/tests/Modules/Hooks/BlockModuleTest.php
+++ b/tests/Modules/Hooks/BlockModuleTest.php
@@ -11,7 +11,7 @@ namespace Lotgd {
     }
 }
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Hooks {
 
 use Lotgd\Modules;
 use Lotgd\Tests\Stubs\Database;
@@ -22,13 +22,16 @@ function modulehook_block(string $name, array $args = [], bool $allowinactive = 
     return Modules::hook($name, $args, $allowinactive, $only);
 }
 
+/**
+ * @group hooks
+ */
 final class BlockModuleTest extends TestCase
 {
     private string $moduleFile;
 
     protected function setUp(): void
     {
-        $this->moduleFile = dirname(__DIR__, 2) . '/modules/foo.php';
+        $this->moduleFile = dirname(__DIR__, 3) . '/modules/foo.php';
 
         file_put_contents($this->moduleFile, <<<'MODULE'
 <?php

--- a/tests/Modules/Hooks/MassModulePrepareTest.php
+++ b/tests/Modules/Hooks/MassModulePrepareTest.php
@@ -2,19 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Lotgd\Tests\Modules;
+namespace Lotgd\Tests\Modules\Hooks;
 
 use PHPUnit\Framework\TestCase;
 
 /**
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
+ * @group hooks
  */
 final class MassModulePrepareTest extends TestCase
 {
     public function testMassModulePrepareDelegatesHooks(): void
     {
-        require __DIR__ . '/../Stubs/MassModulePrepareFunctions.php';
+        require __DIR__ . '/../../Stubs/MassModulePrepareFunctions.php';
         \Lotgd\Modules\HookHandler::$received = [];
         \Lotgd\Modules\HookHandler::$calls    = 0;
 
@@ -28,7 +29,7 @@ final class MassModulePrepareTest extends TestCase
 
     public function testMassModulePrepareWithEmptyHooksReturnsTrue(): void
     {
-        require __DIR__ . '/../Stubs/MassModulePrepareFunctions.php';
+        require __DIR__ . '/../../Stubs/MassModulePrepareFunctions.php';
         \Lotgd\Modules\HookHandler::$received = [];
         \Lotgd\Modules\HookHandler::$calls    = 0;
 

--- a/tests/Modules/Hooks/ModuleDisplayWrappersTest.php
+++ b/tests/Modules/Hooks/ModuleDisplayWrappersTest.php
@@ -2,19 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Hooks {
     use PHPUnit\Framework\TestCase;
 
     /**
      * @runTestsInSeparateProcesses
      * @preserveGlobalState disabled
+     * @group hooks
      */
     final class ModuleDisplayWrappersTest extends TestCase
     {
         protected function setUp(): void
         {
             if (!function_exists(__NAMESPACE__ . '\\module_display_events')) {
-                $code = file_get_contents(dirname(__DIR__, 2) . '/lib/modules.php');
+                $code = file_get_contents(dirname(__DIR__, 3) . '/lib/modules.php');
                 $code = preg_replace('/^<\\?php\\s*declare\\(strict_types=1\\);\\s*/', '', $code);
                 eval('namespace ' . __NAMESPACE__ . '; ' . $code);
             }

--- a/tests/Modules/Hooks/ModuleHookOptionsTest.php
+++ b/tests/Modules/Hooks/ModuleHookOptionsTest.php
@@ -21,7 +21,7 @@ namespace {
     }
 }
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Hooks {
 
 use Lotgd\Modules;
 use Lotgd\Modules\HookHandler;
@@ -34,6 +34,9 @@ function modulehook_options(string $hookName, array $args = [], bool $allowInact
     return HookHandler::hook($hookName, $args, $allowInactive, $only);
 }
 
+/**
+ * @group hooks
+ */
 final class ModuleHookOptionsTest extends TestCase
 {
     private array $hooksAll;

--- a/tests/Modules/Hooks/ModuleHookRegistrationTest.php
+++ b/tests/Modules/Hooks/ModuleHookRegistrationTest.php
@@ -66,7 +66,7 @@ namespace Lotgd\Tests\Modules\Hooks {
     }
 }
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Hooks {
 
 use Lotgd\Tests\Stubs\HookHandler;
 use PHPUnit\Framework\TestCase;
@@ -74,6 +74,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
+ * @group hooks
  */
 final class ModuleHookRegistrationTest extends TestCase
 {

--- a/tests/Modules/Hooks/ModuleHookValidationTest.php
+++ b/tests/Modules/Hooks/ModuleHookValidationTest.php
@@ -16,7 +16,7 @@ namespace {
     }
 }
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Hooks {
 
 use Lotgd\Modules;
 use Lotgd\MySQL\Database;
@@ -37,6 +37,9 @@ function modulehook_validation(string $hookName, $args = [], bool $allowInactive
     return Modules::hook($hookName, $args, $allowInactive, $only);
 }
 
+/**
+ * @group hooks
+ */
 final class ModuleHookValidationTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Modules/Hooks/ModuleUtilityWrappersTest.php
+++ b/tests/Modules/Hooks/ModuleUtilityWrappersTest.php
@@ -2,19 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Hooks {
     use PHPUnit\Framework\TestCase;
 
     /**
      * @runTestsInSeparateProcesses
      * @preserveGlobalState disabled
+     * @group hooks
      */
     final class ModuleUtilityWrappersTest extends TestCase
     {
         protected function setUp(): void
         {
             if (!function_exists(__NAMESPACE__ . '\\get_module_install_status')) {
-                $code = file_get_contents(dirname(__DIR__, 2) . '/lib/modules.php');
+                $code = file_get_contents(dirname(__DIR__, 3) . '/lib/modules.php');
                 $code = preg_replace('/^<\\?php\\s*declare\\(strict_types=1\\);\\s*/', '', $code);
                 eval('namespace ' . __NAMESPACE__ . '; ' . $code);
             }

--- a/tests/Modules/Hooks/ModuleWipeHooksTest.php
+++ b/tests/Modules/Hooks/ModuleWipeHooksTest.php
@@ -26,7 +26,7 @@ namespace Lotgd\Tests\Modules\Hooks {
     }
 }
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Hooks {
 
 use Lotgd\Tests\Modules\ModuleWipeHooks\Stubs\HookHandler;
 use PHPUnit\Framework\TestCase;
@@ -34,6 +34,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
+ * @group hooks
  */
 final class ModuleWipeHooksTest extends TestCase
 {

--- a/tests/Modules/Injection/InjectModuleFailureTest.php
+++ b/tests/Modules/Injection/InjectModuleFailureTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Lotgd\Tests;
+namespace Lotgd\Tests\Modules\Injection;
 
 use Lotgd\Modules;
 use Lotgd\Tests\Stubs\Database;
@@ -13,6 +13,9 @@ function injectmodule(string $moduleName): bool
     return Modules::inject($moduleName);
 }
 
+/**
+ * @group injection
+ */
 final class InjectModuleFailureTest extends TestCase
 {
     private string $moduleFile;
@@ -21,7 +24,7 @@ final class InjectModuleFailureTest extends TestCase
     {
         class_exists(Database::class);
         \Lotgd\MySQL\Database::$queryCacheResults = [];
-        $this->moduleFile = __DIR__ . '/../../modules/inactive.php';
+        $this->moduleFile = __DIR__ . '/../../../modules/inactive.php';
         file_put_contents($this->moduleFile, "<?php\n");
     }
 

--- a/tests/Modules/Installer/GetModuleInfoTest.php
+++ b/tests/Modules/Installer/GetModuleInfoTest.php
@@ -11,19 +11,20 @@ namespace {
     }
 }
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Installer {
     use PHPUnit\Framework\TestCase;
 
     /**
      * @runTestsInSeparateProcesses
      * @preserveGlobalState disabled
+     * @group installer
      */
     final class GetModuleInfoTest extends TestCase
     {
         protected function setUp(): void
         {
             if (!function_exists(__NAMESPACE__ . '\\get_module_info')) {
-                $code = file_get_contents(dirname(__DIR__, 2) . '/lib/modules.php');
+                $code = file_get_contents(dirname(__DIR__, 3) . '/lib/modules.php');
                 $code = preg_replace('/^<\\?php\\s*declare\\(strict_types=1\\);\\s*/', '', $code);
                 eval('namespace ' . __NAMESPACE__ . '; ' . $code);
             }

--- a/tests/Modules/Installer/ModuleActiveInstalledTest.php
+++ b/tests/Modules/Installer/ModuleActiveInstalledTest.php
@@ -2,19 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Installer {
     use PHPUnit\Framework\TestCase;
 
     /**
      * @runTestsInSeparateProcesses
      * @preserveGlobalState disabled
+     * @group installer
      */
     final class ModuleActiveInstalledTest extends TestCase
     {
         protected function setUp(): void
         {
             if (!function_exists(__NAMESPACE__ . '\\is_module_active')) {
-                $code = file_get_contents(dirname(__DIR__, 2) . '/lib/modules.php');
+                $code = file_get_contents(dirname(__DIR__, 3) . '/lib/modules.php');
                 $code = preg_replace('/^<\\?php\\s*declare\\(strict_types=1\\);\\s*/', '', $code);
                 eval('namespace ' . __NAMESPACE__ . '; ' . $code);
             }

--- a/tests/Modules/Installer/ModuleCheckRequirementsWrapperTest.php
+++ b/tests/Modules/Installer/ModuleCheckRequirementsWrapperTest.php
@@ -2,19 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Installer {
     use PHPUnit\Framework\TestCase;
 
     /**
      * @runTestsInSeparateProcesses
      * @preserveGlobalState disabled
+     * @group installer
      */
     final class ModuleCheckRequirementsWrapperTest extends TestCase
     {
         protected function setUp(): void
         {
             if (! function_exists(__NAMESPACE__ . '\\module_check_requirements')) {
-                $code = file_get_contents(dirname(__DIR__, 2) . '/lib/modules.php');
+                $code = file_get_contents(dirname(__DIR__, 3) . '/lib/modules.php');
                 $code = preg_replace('/^<\\?php\\s*declare\\(strict_types=1\\);\\s*/', '', $code);
                 eval('namespace ' . __NAMESPACE__ . '; ' . $code);
             }

--- a/tests/Modules/Installer/ModuleCompareVersionsTest.php
+++ b/tests/Modules/Installer/ModuleCompareVersionsTest.php
@@ -2,11 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Lotgd\Tests\Modules;
+namespace Lotgd\Tests\Modules\Installer;
 
 use Lotgd\Modules;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group installer
+ */
 final class ModuleCompareVersionsTest extends TestCase
 {
     public function testReturnsNegativeWhenFirstVersionLower(): void

--- a/tests/Modules/Installer/ModuleInstallerWrappersTest.php
+++ b/tests/Modules/Installer/ModuleInstallerWrappersTest.php
@@ -2,16 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Installer {
     use PHPUnit\Framework\TestCase;
 
-    $code = file_get_contents(dirname(__DIR__, 2) . '/lib/modules.php');
+    $code = file_get_contents(dirname(__DIR__, 3) . '/lib/modules.php');
     $code = preg_replace('/^<\?php\s*declare\(strict_types=1\);\s*/', '', $code);
     eval('namespace ' . __NAMESPACE__ . '; ' . $code);
 
     /**
      * @runTestsInSeparateProcesses
      * @preserveGlobalState disabled
+     * @group installer
      */
     final class ModuleInstallerWrappersTest extends TestCase
     {

--- a/tests/Modules/Installer/ModuleRequirementsTest.php
+++ b/tests/Modules/Installer/ModuleRequirementsTest.php
@@ -17,12 +17,15 @@ namespace {
     }
 }
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Installer {
     use Lotgd\Modules;
     use Lotgd\Tests\Stubs\Database;
     use PHPUnit\Framework\TestCase;
     use ReflectionProperty;
 
+    /**
+     * @group installer
+     */
     final class ModuleRequirementsTest extends TestCase
     {
         private string $moduleFile;
@@ -30,7 +33,7 @@ namespace Lotgd\Tests\Modules {
         protected function setUp(): void
         {
             class_exists(Database::class);
-            $this->moduleFile = __DIR__ . '/../../modules/dep.php';
+            $this->moduleFile = __DIR__ . '/../../../modules/dep.php';
             file_put_contents($this->moduleFile, "<?php\nfunction dep_getmoduleinfo() { return []; }\n");
         }
 

--- a/tests/Modules/Installer/ModuleStatusTest.php
+++ b/tests/Modules/Installer/ModuleStatusTest.php
@@ -15,12 +15,15 @@ namespace {
     }
 }
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Installer {
     use Lotgd\Modules;
     use Lotgd\Tests\Stubs\Database;
     use PHPUnit\Framework\TestCase;
     use ReflectionProperty;
 
+    /**
+     * @group installer
+     */
     final class ModuleStatusTest extends TestCase
     {
         protected function setUp(): void
@@ -45,7 +48,7 @@ namespace Lotgd\Tests\Modules {
         public function testInstalledInactiveReturnsInstalledOnly(): void
         {
             $name = 'inactivemodule';
-            $file = __DIR__ . "/../../modules/{$name}.php";
+            $file = __DIR__ . "/../../../modules/{$name}.php";
             file_put_contents($file, "<?php\n");
             Database::$queryCacheResults["inject-$name"] = [
                 ['active' => 0, 'filemoddate' => '', 'infokeys' => '|', 'version' => '1.0'],
@@ -59,7 +62,7 @@ namespace Lotgd\Tests\Modules {
         public function testActiveAndInjectedReturnsInstalledActiveInjected(): void
         {
             $name = 'activemodule';
-            $file = __DIR__ . "/../../modules/{$name}.php";
+            $file = __DIR__ . "/../../../modules/{$name}.php";
             file_put_contents($file, "<?php\n");
             Database::$queryCacheResults["inject-$name"] = [
                 ['active' => 1, 'filemoddate' => '', 'infokeys' => '|', 'version' => '1.0'],
@@ -78,7 +81,7 @@ namespace Lotgd\Tests\Modules {
         public function testVersionTooLowReturnsOutOfDate(): void
         {
             $name = 'outofdatemodule';
-            $file = __DIR__ . "/../../modules/{$name}.php";
+            $file = __DIR__ . "/../../../modules/{$name}.php";
             file_put_contents($file, "<?php\n");
             Database::$queryCacheResults["inject-$name"] = [
                 ['active' => 1, 'filemoddate' => '', 'infokeys' => '|', 'version' => '1.0'],

--- a/tests/Modules/Prefs/ModuleDeleteUserPrefsTest.php
+++ b/tests/Modules/Prefs/ModuleDeleteUserPrefsTest.php
@@ -11,12 +11,15 @@ namespace {
     }
 }
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Prefs {
 
 use Lotgd\Tests\Stubs\Database;
 use Lotgd\Tests\Stubs\DoctrineConnection;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group prefs
+ */
 final class ModuleDeleteUserPrefsTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Modules/Prefs/ModuleObjPrefsTest.php
+++ b/tests/Modules/Prefs/ModuleObjPrefsTest.php
@@ -29,13 +29,16 @@ namespace {
     }
 }
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Prefs {
 
 use Lotgd\Tests\Stubs\Database;
 use Lotgd\Tests\Stubs\DoctrineConnection;
 use Lotgd\Tests\Stubs\DoctrineResult;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group prefs
+ */
 final class ModuleObjPrefsTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Modules/Prefs/ModulePrefsTest.php
+++ b/tests/Modules/Prefs/ModulePrefsTest.php
@@ -35,7 +35,7 @@ namespace {
     }
 }
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Prefs {
 
 use Lotgd\Modules;
 use Lotgd\Tests\Stubs\Database;
@@ -44,6 +44,9 @@ use Lotgd\Tests\Stubs\DoctrineResult;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
+/**
+ * @group prefs
+ */
 final class ModulePrefsTest extends TestCase
 {
     private string $moduleFile;
@@ -76,7 +79,7 @@ final class ModulePrefsTest extends TestCase
         $prop->setAccessible(true);
         $prop->setValue(null, []);
 
-        $this->moduleFile = dirname(__DIR__, 2) . '/modules/modA.php';
+        $this->moduleFile = dirname(__DIR__, 3) . '/modules/modA.php';
         file_put_contents($this->moduleFile, <<<'MODULE'
 <?php
 

--- a/tests/Modules/Settings/ModuleLoadSettingsPrefsTest.php
+++ b/tests/Modules/Settings/ModuleLoadSettingsPrefsTest.php
@@ -17,13 +17,16 @@ namespace {
     }
 }
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Settings {
 
 use Lotgd\Tests\Stubs\Database;
 use Lotgd\Tests\Stubs\DoctrineConnection;
 use Lotgd\Tests\Stubs\DoctrineResult;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group settings
+ */
 final class ModuleLoadSettingsPrefsTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Modules/Settings/ModuleSettingsTest.php
+++ b/tests/Modules/Settings/ModuleSettingsTest.php
@@ -35,11 +35,14 @@ namespace {
     }
 }
 
-namespace Lotgd\Tests\Modules {
+namespace Lotgd\Tests\Modules\Settings {
 
 use Lotgd\Tests\Stubs\Database;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group settings
+ */
 final class ModuleSettingsTest extends TestCase
 {
     protected function setUp(): void


### PR DESCRIPTION
## Summary
- group module tests into Hooks, Events, Injection, Prefs, Settings, and Installer subdirectories
- add `@group` annotations for targeted PHPUnit runs
- adjust namespaces and relative paths after moving files

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b830bf7f44832980d667047d964a16