### PR TITLE
test: cover default display wrapper args

### DIFF
--- a/tests/Modules/Hooks/ModuleDisplayWrappersTest.php
+++ b/tests/Modules/Hooks/ModuleDisplayWrappersTest.php
@@ -35,5 +35,16 @@ namespace Lotgd\Tests\Modules\Hooks {
                 ['objprefEdit', ['qux', 'quux', 123]],
             ], \Lotgd\Modules\HookHandler::$calls);
         }
+
+        public function testDisplayWrappersDefaultArguments(): void
+        {
+            module_display_events('foo');
+            module_editor_navs('bar', '');
+
+            self::assertSame([
+                ['displayEvents', ['foo', false]],
+                ['editorNavs', ['bar', '']],
+            ], \Lotgd\Modules\HookHandler::$calls);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- test default arguments in module display wrappers

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b836ecef008329a3bca0c9db0adb25