### PR TITLE
test: ensure errors don't notify when disabled

### DIFF
--- a/tests/ErrorHandlerErrorDisabledTest.php
+++ b/tests/ErrorHandlerErrorDisabledTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+final class ErrorHandlerErrorDisabledTest extends TestCase
+{
+    public function testErrorNotificationIsDisabled(): void
+    {
+        $script = __DIR__ . '/error_handler_error_disabled.php';
+        $cmd    = sprintf('php %s', escapeshellarg($script));
+        $output = shell_exec($cmd);
+
+        $this->assertIsString($output);
+        $this->assertStringContainsString('mail_sent_count=0', $output);
+    }
+}

--- a/tests/error_handler_error_disabled.php
+++ b/tests/error_handler_error_disabled.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Lotgd\ErrorHandler;
+use Lotgd\Tests\Stubs\DummySettings;
+use Lotgd\Tests\Stubs\PHPMailer;
+
+require __DIR__ . '/bootstrap.php';
+
+global $settings, $mail_sent_count, $last_subject, $output;
+
+$mail_sent_count = 0;
+$last_subject = '';
+$settings = new DummySettings([
+    'notify_address' => 'admin@example.com',
+    'gameadminemail' => 'admin@example.com',
+    'usedatacache' => 0,
+]);
+
+new PHPMailer();
+
+$output = new class {
+    public function appoencode($data, $priv)
+    {
+        return $data;
+    }
+};
+
+$_SERVER['HTTP_HOST'] = 'example.com';
+
+ob_start();
+register_shutdown_function(function (): void {
+    ob_end_clean();
+    echo 'mail_sent_count=' . ($GLOBALS['mail_sent_count'] ?? 0);
+});
+
+ErrorHandler::handleError(E_ERROR, 'Test error', 'file.php', 42);


### PR DESCRIPTION
## Summary
- add `ErrorHandlerErrorDisabledTest` to confirm errors aren't notified when `notify_on_error` is missing

## Testing
- `php -l tests/error_handler_error_disabled.php`
- `php -l tests/ErrorHandlerErrorDisabledTest.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b84eb324388329bfee004466dd4f4a