### PR TITLE
Handle missing recommended modules during install

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1031,6 +1031,7 @@ class Installer
     public function stage8(): void
     {
         global $session, $logd_version, $recommended_modules, $noinstallnavs, $stage, $DB_USEDATACACHE;
+        $recommended_modules = is_array($recommended_modules) ? $recommended_modules : [];
         if (array_key_exists('modulesok', $_POST)) {
             $session['moduleoperations'] = $_POST['modules'];
             $session['stagecompleted'] = $stage;

--- a/tests/Installer/Stage8Test.php
+++ b/tests/Installer/Stage8Test.php
@@ -4,12 +4,53 @@ declare(strict_types=1);
 
 namespace Lotgd\Tests\Installer;
 
+use Lotgd\Installer\Installer;
+use Lotgd\Output;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 final class Stage8Test extends TestCase
 {
-    public function testPlaceholder(): void
+    protected function setUp(): void
     {
-        $this->assertTrue(true);
+        global $session, $output, $settings;
+
+        $session   = [];
+        $output    = new Output();
+        $settings  = null;
+        $_POST     = [];
+        $_SERVER['SCRIPT_NAME'] = 'test.php';
+        $GLOBALS['module_status'] = ['uninstalledmodules' => []];
+    }
+
+    public function testStage8RunsWithoutRecommendedModules(): void
+    {
+        global $session, $logd_version, $recommended_modules, $noinstallnavs, $stage, $DB_USEDATACACHE;
+
+        $session['dbinfo']['upgrade'] = false;
+        $logd_version       = '0.0.0';
+        $recommended_modules = null;
+        $noinstallnavs      = [];
+        $stage              = 8;
+        $DB_USEDATACACHE    = false;
+
+        set_error_handler(function ($severity, $message, $file, $line) {
+            if ($severity === E_WARNING) {
+                throw new \ErrorException($message, 0, $severity, $file, $line);
+            }
+
+            return false;
+        });
+
+        $installer = new Installer();
+        $installer->stage8();
+
+        restore_error_handler();
+
+        $this->assertTrue(true); // No warnings were raised
     }
 }
+


### PR DESCRIPTION
## Summary
- Coerce `$recommended_modules` to an empty array before module selection to prevent warnings
- Add regression test for stage 8 with no recommended modules

## Testing
- `php -l install/lib/Installer.php`
- `php -l tests/Installer/Stage8Test.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b84eb8e128832997e5d58e80c88d1e