### PR TITLE
Guard restorepage redirect in login flow

### DIFF
--- a/login.php
+++ b/login.php
@@ -121,8 +121,10 @@ if ($name != "") {
                         . "' WHERE acctid=" . $session['user']['acctid']
                     );
                     $session['allowednavs'] = [];
-                    \Lotgd\Nav::add('', $session['user']['restorepage']);
-                    header("Location: {$session['user']['restorepage']}");
+                    if (!empty($session['user']['restorepage'])) {
+                        \Lotgd\Nav::add('', $session['user']['restorepage']);
+                        header("Location: {$session['user']['restorepage']}");
+                    }
                     Accounts::saveUser();
                     echo $str;
                     exit();


### PR DESCRIPTION
## Summary
- Prevent blank redirect by checking `restorepage` before redirecting in `login.php`

## Testing
- `php -l login.php`
- `composer install`
- `composer test`
- `php -r '$session=["user"=>["loggedin"=>true,"restorepage"=>""]];$session["allowednavs"]=[];if($session["user"]["loggedin"]){if(!empty($session["user"]["restorepage"])){echo"redirect";}else{echo"no redirect";}}'`


------
https://chatgpt.com/codex/tasks/task_e_68b854e57c2c8329891b0285cd4b4e61