### PR TITLE
Handle null navigation links safely

### DIFF
--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -529,10 +529,23 @@ class Nav
         return $builtnavs;
     }
 
-    public static function privateAddNav($text, $link = false, $priv = false, $pop = false, $popsize = '500x300')
+    /**
+     * Add a navigation link or header.
+     *
+     * @param string|array          $text    Link label or header text
+     * @param string|false|null     $link    Target URL; false for header, '' or null for help text
+     * @param bool                  $priv    Passed to appoencode()
+     * @param bool                  $pop     Open in popup window
+     * @param string                $popsize Popup size when $pop is true
+     *
+     * @return string|false HTML for the navigation item or false when blocked
+     */
+    public static function privateAddNav($text, string|false|null $link = false, $priv = false, $pop = false, $popsize = '500x300')
     {
         global $nav, $session, $REQUEST_URI, $notranslate, $settings;
-        if ($link != false) {
+
+        if ($link !== false) {
+            $link = (string) $link;
             if (self::isBlocked($link)) {
                 return false;
             }

--- a/tests/NavNullLinkTest.php
+++ b/tests/NavNullLinkTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Nav;
+use Lotgd\Output;
+use Lotgd\Template;
+use PHPUnit\Framework\TestCase;
+
+final class NavNullLinkTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $session, $nav, $template, $output;
+        $session = ['user' => ['prefs' => []], 'allowednavs' => [], 'loggedin' => false];
+        $nav = '';
+        $output = new Output();
+        $template = [
+            'navitem' => '<a href="{link}"{accesskey}{popup}>{text}</a>',
+            'navhelp' => '<span class="navhelp">{text}</span>',
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        global $session, $nav, $template, $output;
+        unset($session, $nav, $template, $output);
+    }
+
+    public function testNullLinkBehavesLikeEmptyString(): void
+    {
+        $expected = Nav::privateAddNav('Help', '');
+        $actual = Nav::privateAddNav('Help', null);
+
+        $this->assertSame($expected, $actual);
+    }
+}


### PR DESCRIPTION
## Summary
- Allow `privateAddNav` to receive null links and cast them safely
- Cover null-link navigation items with a dedicated unit test

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b854e5c88c83299805bc69f53640f4