### PR TITLE
refactor: replace modulehook wrapper with HookHandler

### DIFF
--- a/src/Lotgd/Battle.php
+++ b/src/Lotgd/Battle.php
@@ -11,6 +11,7 @@ use Lotgd\FightBar;
 use Lotgd\BellRand;
 use Lotgd\Substitute;
 use Lotgd\Util\ScriptName;
+use Lotgd\Modules\HookHandler;
 
 class Battle
 {
@@ -343,7 +344,7 @@ class Battle
             'schema' => 'skill',
             ]);
         }
-        modulehook('apply-specialties');
+        HookHandler::hook('apply-specialties');
     }
 
     public static function fightnav(bool $allowSpecial = true, bool $allowFlee = true, $script = false): void
@@ -387,13 +388,13 @@ class Battle
 
         if ($allowSpecial) {
             addnav('Special Abilities');
-            modulehook('fightnav-specialties', ['script' => $script]);
+            HookHandler::hook('fightnav-specialties', ['script' => $script]);
 
             if ($session['user']['superuser'] & SU_DEVELOPER) {
                 addnav('`&Super user`0', '');
                 addnav('!?`&&#149; __GOD MODE', $script . 'op=fight&skill=godmode', true);
             }
-            modulehook('fightnav', ['script' => $script]);
+            HookHandler::hook('fightnav', ['script' => $script]);
         }
 
         if (count($newenemies) > 1) {
@@ -573,7 +574,7 @@ class Battle
             $options = array();
         }
         $fightoptions = $options + $basicoptions;
-        $fightoptions = modulehook("fightoptions", $fightoptions);
+        $fightoptions = HookHandler::hook("fightoptions", $fightoptions);
 
         // We'll also reset the companions here...
         self::prepareCompanions();

--- a/src/Lotgd/Buffs.php
+++ b/src/Lotgd/Buffs.php
@@ -6,6 +6,7 @@ namespace Lotgd;
 
 use Lotgd\Substitute;
 use Lotgd\Translator;
+use Lotgd\Modules\HookHandler;
 
 class Buffs
 {
@@ -164,7 +165,7 @@ class Buffs
         if (isset($session['bufflist'][$name])) {
             self::restoreBuffFields();
         }
-        $buff = modulehook('modify-buff', ['name' => $name, 'buff' => $buff]);
+        $buff = HookHandler::hook('modify-buff', ['name' => $name, 'buff' => $buff]);
         $session['bufflist'][$name] = $buff['buff'];
         self::calculateBuffFields();
     }
@@ -222,7 +223,7 @@ class Buffs
             $companions = @unserialize($session['user']['companions']);
         }
         $companionsallowed = getsetting('companionsallowed', 1);
-        $args = modulehook('companionsallowed', ['maxallowed' => $companionsallowed]);
+        $args = HookHandler::hook('companionsallowed', ['maxallowed' => $companionsallowed]);
         $companionsallowed = $args['maxallowed'];
         $current = 0;
         if (!$ignorelimit) {

--- a/src/Lotgd/Censor.php
+++ b/src/Lotgd/Censor.php
@@ -6,6 +6,7 @@ namespace Lotgd;
 
 use Lotgd\MySQL\Database;
 use Lotgd\Sanitize;
+use Lotgd\Modules\HookHandler;
 
 class Censor
 {
@@ -79,7 +80,7 @@ class Censor
                 return $input;
             }
             if ($changed_content && !$skiphook) {
-                modulehook('censor', ['input' => $input]);
+                HookHandler::hook('censor', ['input' => $input]);
             }
             return $final_output;
         }

--- a/src/Lotgd/Commentary.php
+++ b/src/Lotgd/Commentary.php
@@ -7,6 +7,7 @@ namespace Lotgd;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Util\ScriptName;
+use Lotgd\Modules\HookHandler;
 
 class Commentary
 {
@@ -40,7 +41,7 @@ class Commentary
             self::$comsecs['beta'] = Translator::translateInline('Pavilion');
         }
         tlschema();
-        self::$comsecs = modulehook('moderate', self::$comsecs);
+        self::$comsecs = HookHandler::hook('moderate', self::$comsecs);
         rawoutput(tlbutton_clear());
         return self::$comsecs;
     }
@@ -207,7 +208,7 @@ SQL;
         [$commentary, $talkline] = self::applyHooks($section, $commentary, $talkline, $schema);
 
         // Determine if comment is a /game command and if the user is a GM
-        $args = modulehook('gmcommentarea', ['section' => $section, 'allow_gm' => false, 'commentary' => $commentary]);
+        $args = HookHandler::hook('gmcommentarea', ['section' => $section, 'allow_gm' => false, 'commentary' => $commentary]);
         $isGameComment = strncmp($commentary, '/game', 5) === 0;
         $isGm = (($session['user']['superuser'] & SU_IS_GAMEMASTER) === SU_IS_GAMEMASTER) || $args['allow_gm'] === true;
 
@@ -262,7 +263,7 @@ SQL;
     private static function applyHooks(string $section, string $commentary, string $talkline, $schema): array
     {
         $args = ['section' => $section, 'commentline' => $commentary, 'commenttalk' => $talkline];
-        $args = modulehook('commentary', $args);
+        $args = HookHandler::hook('commentary', $args);
         $commentary = $args['commentline'];
         $talkline = $args['commenttalk'];
 
@@ -445,7 +446,7 @@ SQL;
      */
     public static function commentDisplay(string $intro, string $section, string $message = 'Interject your own commentary?', int $limit = 10, string $talkline = 'says', $schema = false): void
     {
-        $args = modulehook('blockcommentarea', ['section' => $section]);
+        $args = HookHandler::hook('blockcommentarea', ['section' => $section]);
         if (isset($args['block']) && ($args['block'] == 'yes')) {
             return;
         }
@@ -500,7 +501,7 @@ SQL;
 
         rawoutput("<a name='$section'></a>");
 
-        $args = modulehook('blockcommentarea', ['section' => $section]);
+        $args = HookHandler::hook('blockcommentarea', ['section' => $section]);
         if (isset($args['block']) && ($args['block'] == 'yes')) {
             return null;
         }
@@ -591,20 +592,20 @@ SQL;
         foreach ($outputcomments as $sec => $v) {
             if ($sec != 'x') {
                 if ($needclose) {
-                    modulehook('}collapse');
+                    HookHandler::hook('}collapse');
                 }
                 output_notl("`n<hr><a href='moderate.php?area=%s'>`b`^%s`0`b</a>`n", $sec, isset($sections[$sec]) ? $sections[$sec] : "($sec)", true);
                 addnav('', "moderate.php?area=$sec");
-                modulehook('collapse{', ['name' => 'com-' . $sec]);
+                HookHandler::hook('collapse{', ['name' => 'com-' . $sec]);
                 $needclose = 1;
             } else {
-                modulehook('collapse{', ['name' => 'com-' . $section]);
+                HookHandler::hook('collapse{', ['name' => 'com-' . $section]);
                 $needclose = 1;
             }
             reset($v);
             foreach ($v as $key => $val) {
                 $args = ['commentline' => $val];
-                $args = modulehook('viewcommentary', $args);
+                $args = HookHandler::hook('viewcommentary', $args);
                 $val = $args['commentline'];
                 output_notl($val, true);
             }
@@ -698,7 +699,7 @@ SQL;
         }
         tlschema();
         if ($needclose) {
-            modulehook('}collapse');
+            HookHandler::hook('}collapse');
         }
         rawoutput('</div>');
         return null;
@@ -875,7 +876,7 @@ SQL;
     {
         global $session;
 
-        $args = modulehook("insertcomment", array("section" => $section));
+        $args = HookHandler::hook("insertcomment", array("section" => $section));
         if (
             array_key_exists("mute", $args) && $args['mute'] &&
                         !($session['user']['superuser'] & SU_EDIT_COMMENTS)

--- a/src/Lotgd/Forest.php
+++ b/src/Lotgd/Forest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\Nav\VillageNav;
+use Lotgd\Modules\HookHandler;
 
 class Forest
 {
@@ -37,7 +38,7 @@ class Forest
         addnav('Other');
         if ($session['user']['level'] >= getsetting('maxlevel', 15) && $session['user']['seendragon'] == 0) {
             $isforest = 0;
-            $vloc = modulehook('validforestloc', []);
+            $vloc = HookHandler::hook('validforestloc', []);
             foreach ($vloc as $i => $l) {
                 if ($session['user']['location'] == $i) {
                     $isforest = 1;
@@ -54,9 +55,9 @@ class Forest
             output('The thick foliage of the forest restricts your view to only a few yards in most places.');
             output('The paths would be imperceptible except for your trained eye.');
             output('You move as silently as a soft breeze across the thick moss covering the ground, wary to avoid stepping on a twig or any of the numerous pieces of bleached bone that populate the forest floor, lest you betray your presence to one of the vile beasts that wander the forest.`n');
-            modulehook('forest-desc');
+            HookHandler::hook('forest-desc');
         }
-        modulehook('forest', []);
+        HookHandler::hook('forest', []);
         module_display_events('forest', 'forest.php');
         tlschema();
     }

--- a/src/Lotgd/Forest/Outcomes.php
+++ b/src/Lotgd/Forest/Outcomes.php
@@ -15,6 +15,7 @@ use Lotgd\PageParts;
 use Lotgd\Translator;
 use Lotgd\Settings;
 use Lotgd\Nav;
+use Lotgd\Modules\HookHandler;
 
 class Outcomes
 {
@@ -68,7 +69,7 @@ class Outcomes
             debuglog('received gold for slaying a monster.', false, false, 'forestwin', $gold);
         }
         $gemChance = $settings->getSetting('forestgemchance', 25);
-        $args = modulehook('alter-gemchance', ['chance' => $gemChance]);
+        $args = HookHandler::hook('alter-gemchance', ['chance' => $gemChance]);
         $gemchances = (int)$args['chance'];
         $maxLevel = $settings->getSetting('maxlevel', 15);
         if ($session['user']['level'] < $maxLevel && e_rand(1, $gemchances) == 1) {
@@ -215,11 +216,11 @@ class Outcomes
             $badguy['creaturegold'] = (int) round((int) $badguy['creaturegold'] * $bonus, 0);
             $badguy['creatureexp'] = (int) round((int) $badguy['creatureexp'] * $bonus, 0);
         }
-        $badguy = modulehook('creatureencounter', $badguy);
+        $badguy = HookHandler::hook('creatureencounter', $badguy);
         debug("DEBUG: $dk modification points total.");
         debug("DEBUG: +$atkflux allocated to attack.");
         debug("DEBUG: +$defflux allocated to defense.");
         debug("DEBUG: +" . ($hpflux / 5) . "*5 to hitpoints.");
-        return modulehook('buffbadguy', $badguy);
+        return HookHandler::hook('buffbadguy', $badguy);
     }
 }

--- a/src/Lotgd/Forms.php
+++ b/src/Lotgd/Forms.php
@@ -6,6 +6,7 @@ namespace Lotgd;
 
 use Lotgd\Translator;
 use Lotgd\DumpItem;
+use Lotgd\Modules\HookHandler;
 
 class Forms
 {
@@ -183,7 +184,7 @@ JS;
         $showform_id++;
         $formSections = [];
         $returnvalues = [];
-        $extensions = modulehook('showformextensions', []);
+        $extensions = HookHandler::hook('showformextensions', []);
 
         rawoutput("<table width='100%' cellpadding='0' cellspacing='0'><tr><td>");
         rawoutput("<div id='showFormSection$showform_id'></div>");
@@ -347,7 +348,7 @@ JS;
                 $vname = getsetting('villagename', LOCATION_FIELDS);
                 $vloc[$vname] = 'village';
                 $vloc['all'] = 1;
-                $vloc = modulehook('validlocation', $vloc);
+                $vloc = HookHandler::hook('validlocation', $vloc);
                 unset($vloc['all']);
                 reset($vloc);
                 rawoutput("<select id='$entityId' name='$keyout'>");

--- a/src/Lotgd/HolidayText.php
+++ b/src/Lotgd/HolidayText.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use Lotgd\Modules\HookHandler;
+
 /**
  * Text helper to replace certain messages with seasonal variants.
  */
@@ -31,7 +33,7 @@ class HolidayText
             if (isset($currenthook) && $currenthook === 'holiday') {
                 return $text;
             }
-            $args = modulehook('holiday', $args);
+            $args = HookHandler::hook('holiday', $args);
         }
         $text = $args['text'];
         return $text;

--- a/src/Lotgd/Moderate.php
+++ b/src/Lotgd/Moderate.php
@@ -14,6 +14,7 @@ use Lotgd\HolidayText;
 use Lotgd\Commentary;
 use Lotgd\Translator;
 use Lotgd\Util\ScriptName;
+use Lotgd\Modules\HookHandler;
 
 class Moderate
 {
@@ -162,7 +163,7 @@ class Moderate
         // Decide whether to limit to a specific section or view all
         if ($viewall === false) {
             rawoutput("<a name='$section'></a>");
-            $args = modulehook('blockcommentarea', ['section' => $section]);
+            $args = HookHandler::hook('blockcommentarea', ['section' => $section]);
             if (isset($args['block']) && ($args['block'] == 'yes')) {
                 return;
             }
@@ -424,27 +425,27 @@ class Moderate
         foreach ($outputcomments as $sec => $v) {
             if ($sec != 'x') {
                 if ($needclose) {
-                    modulehook('}collapse');
+                    HookHandler::hook('}collapse');
                 }
                 output_notl("`n<hr><a href='moderate.php?area=%s'>`b`^%s`0`b</a>`n", $sec, isset($sections[$sec]) ? $sections[$sec] : "($sec)", true);
                 addnav('', "moderate.php?area=$sec");
-                modulehook('collapse{', ['name' => 'com-' . $sec]);
+                HookHandler::hook('collapse{', ['name' => 'com-' . $sec]);
                 $needclose = 1;
             } else {
-                modulehook('collapse{', ['name' => 'com-' . $section]);
+                HookHandler::hook('collapse{', ['name' => 'com-' . $section]);
                 $needclose = 1;
             }
             reset($v);
             foreach ($v as $key => $val) {
                 $args = ['commentline' => $val];
-                $args = modulehook('viewcommentary', $args);
+                $args = HookHandler::hook('viewcommentary', $args);
                 $val = $args['commentline'];
                 output_notl($val, true);
             }
         }
 
         if ($moderating && $needclose) {
-            modulehook('}collapse');
+            HookHandler::hook('}collapse');
             $needclose = 0;
         }
 
@@ -459,7 +460,7 @@ class Moderate
         }
 
         if ($session['user']['loggedin']) {
-            $args = modulehook('insertcomment', ['section' => $section]);
+            $args = HookHandler::hook('insertcomment', ['section' => $section]);
             if (array_key_exists('mute', $args) && $args['mute'] && !($session['user']['superuser'] & SU_EDIT_COMMENTS)) {
                 output_notl('%s', $args['mutemsg']);
             } elseif ($counttoday < ($limit / 2) || ($session['user']['superuser'] & ~SU_DOESNT_GIVE_GROTTO) || !getsetting('postinglimit', 1)) {
@@ -481,7 +482,7 @@ class Moderate
         self::showNavLinks($section, $limit, $cid, $rowcount, $jump, $com, $REQUEST_URI, $newadded);
         tlschema();
         if ($needclose) {
-            modulehook('}collapse');
+            HookHandler::hook('}collapse');
         }
     }
 }

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -15,6 +15,7 @@ use Lotgd\Forms;
 use Lotgd\Sanitize;
 use Lotgd\Modules\Installer;
 use Lotgd\Util\ScriptName;
+use Lotgd\Modules\HookHandler;
 
 class Modules
 {
@@ -1201,7 +1202,7 @@ class Modules
             }
         }
 
-        return modulehook('collect-events', $events);
+        return HookHandler::hook('collect-events', $events);
     }
 
     /**
@@ -1263,7 +1264,7 @@ class Modules
             $fname = $module . '_runevent';
             $fname($type, $baseLink);
             Translator::tlschema();
-            modulehook("runevent_$module", ['type' => $type, 'baselink' => $baseLink, 'get' => httpallget(), 'post' => httpallpost()]);
+            HookHandler::hook("runevent_$module", ['type' => $type, 'baselink' => $baseLink, 'get' => httpallget(), 'post' => httpallpost()]);
             $navsection = $oldnavsection;
         }
 

--- a/src/Lotgd/Motd.php
+++ b/src/Lotgd/Motd.php
@@ -12,6 +12,7 @@ use Lotgd\Translator;
 use Lotgd\MySQL\Database;
 use Lotgd\Forms;
 use Lotgd\Nltoappon;
+use Lotgd\Modules\HookHandler;
 
 class Motd
 {
@@ -62,7 +63,7 @@ class Motd
         rawoutput("<a name='$anchor'>");
         rawoutput('<div class="motditem" style="margin-bottom: 15px;">');
         output_notl('<h4>%s</h4>', $subject, true);
-        modulehook('motd-item-intercept', ['id' => $id]);
+        HookHandler::hook('motd-item-intercept', ['id' => $id]);
         $body = Nltoappon::convert($body);
         output_notl('<div>%s</div>', $body, true);
         output_notl('<small>%s %s - %s</small>', Translator::translateInline('Posted by'), $author, $date, true);

--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -14,6 +14,7 @@ use Lotgd\Translator;
 use Lotgd\Nav\NavigationItem;
 use Lotgd\Nav\NavigationSection;
 use Lotgd\Nav\NavigationSubSection;
+use Lotgd\Modules\HookHandler;
 
 // Maintain state within the class instead of the global namespace
 
@@ -467,7 +468,7 @@ class Nav
                         $key_string = $headerKey;
                     }
                     $args = ['name' => "nh-{$key_string}", 'title' => ($key_string ? $key_string : 'Unnamed Navs')];
-                    $args = modulehook('collapse-nav{', $args);
+                    $args = HookHandler::hook('collapse-nav{', $args);
                     if (isset($args['content'])) {
                         $collapseheader = $args['content'];
                     }
@@ -507,7 +508,7 @@ class Nav
                     }
                 }
                 if ($tkey > '' && $section->collapse) {
-                    $args = modulehook('}collapse-nav');
+                    $args = HookHandler::hook('}collapse-nav');
                     if (isset($args['content'])) {
                         $collapsefooter = $args['content'];
                     }

--- a/src/Lotgd/Nav/SuperuserNav.php
+++ b/src/Lotgd/Nav/SuperuserNav.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lotgd\Nav;
 
 use Lotgd\Util\ScriptName;
+use Lotgd\Modules\HookHandler;
 
 /**
  * Navigation helpers for superuser areas.
@@ -22,13 +23,13 @@ class SuperuserNav
         if ($session['user']['superuser'] & ~ SU_DOESNT_GIVE_GROTTO) {
             $script = ScriptName::current();
             if ($script != 'superuser') {
-                $args = modulehook('grottonav');
+                $args = HookHandler::hook('grottonav');
                 if (!array_key_exists('handled', $args) || !$args['handled']) {
                     addnav('G?Return to the Grotto', 'superuser.php');
                 }
             }
         }
-        $args = modulehook('mundanenav');
+        $args = HookHandler::hook('mundanenav');
         if (!array_key_exists('handled', $args) || !$args['handled']) {
             addnav('M?Return to the Mundane', 'village.php');
         }

--- a/src/Lotgd/Nav/VillageNav.php
+++ b/src/Lotgd/Nav/VillageNav.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Lotgd\Nav;
 
+use Lotgd\Modules\HookHandler;
+
 /**
  * Navigation helper for returning to the village.
  */
@@ -16,7 +18,7 @@ class VillageNav
         if ($extra === false) {
             $extra = '';
         }
-        $args = modulehook('villagenav');
+        $args = HookHandler::hook('villagenav');
         if (array_key_exists('handled', $args) && $args['handled']) {
             return;
         }

--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -8,6 +8,7 @@ use Lotgd\Translator;
 use Lotgd\MySQL\Database;
 use Lotgd\GameLog;
 use Lotgd\ExpireChars;
+use Lotgd\Modules\HookHandler;
 
 class Newday
 {
@@ -109,7 +110,7 @@ class Newday
 
     public static function runOnce(): void
     {
-        modulehook('newday-runonce', []);
+        HookHandler::hook('newday-runonce', []);
 
         if (getsetting('usedatacache', 0)) {
             $path = getsetting('datacachepath', '/tmp');
@@ -150,7 +151,7 @@ class Newday
             }
             $pdks[$type] = (int) httppost($type);
         }
-        modulehook('pdkpointrecalc');
+        HookHandler::hook('pdkpointrecalc');
         $pdktotal = 0;
         foreach ($labels as $type => $label) {
             $head = explode(',', $label);
@@ -345,11 +346,11 @@ class Newday
             $vname = getsetting('villagename', LOCATION_FIELDS);
             $session['user']['race'] = $setrace;
             $session['user']['location'] = $vname;
-            modulehook('setrace');
+            HookHandler::hook('setrace');
             addnav('Continue', "newday.php?continue=1$resline");
         } else {
             output('Where do you recall growing up?`n`n');
-            modulehook('chooserace');
+            HookHandler::hook('chooserace');
         }
         if (navcount() == 0) {
             clearoutput();
@@ -376,12 +377,12 @@ class Newday
         $setspecialty = httpget('setspecialty');
         if ($setspecialty != '') {
             $session['user']['specialty'] = $setspecialty;
-            modulehook('set-specialty');
+            HookHandler::hook('set-specialty');
             addnav('Continue', "newday.php?continue=1$resline");
         } else {
             page_header('A little history about yourself');
             output('What do you recall doing as a child?`n`n');
-            modulehook('choose-specialty');
+            HookHandler::hook('choose-specialty');
         }
         if (navcount() == 0) {
             clearoutput();

--- a/src/Lotgd/Page/Footer.php
+++ b/src/Lotgd/Page/Footer.php
@@ -15,6 +15,7 @@ use Lotgd\Nav;
 use Lotgd\Accounts;
 use Lotgd\MySQL\Database;
 use Lotgd\Util\ScriptName;
+use Lotgd\Modules\HookHandler;
 
 class Footer
 {
@@ -73,7 +74,7 @@ class Footer
                 $session['needtoviewmotd'] = false;
             }
             $favicon = ['favicon-link' => $defaultFaviconLink];
-            $favicon        = modulehook('pageparts-favicon', $favicon);
+            $favicon        = HookHandler::hook('pageparts-favicon', $favicon);
             $pre_headscript = PageParts::canonicalLink() . $favicon['favicon-link'];
             if (isset($settings) && $settings->getSetting('ajax', 1) == 1 && isset($session['user']['prefs']['ajax']) && $session['user']['prefs']['ajax']) {
                 if (file_exists('async/setup.php')) {
@@ -145,7 +146,7 @@ class Footer
         } else {
             $motd_link = '';
         }
-        $motd_link = modulehook('motd-link', ['link' => $motd_link]);
+        $motd_link = HookHandler::hook('motd-link', ['link' => $motd_link]);
         $motd_link = $motd_link['link'];
 
         list($header, $footer) = PageParts::assembleMailLink($header, $footer);

--- a/src/Lotgd/Page/Header.php
+++ b/src/Lotgd/Page/Header.php
@@ -12,6 +12,7 @@ use Lotgd\Sanitize;
 use Lotgd\HolidayText;
 use Lotgd\Buffs;
 use Lotgd\Util\ScriptName;
+use Lotgd\Modules\HookHandler;
 
 class Header
 {
@@ -36,11 +37,11 @@ class Header
                 }
                 if (!PageParts::$runHeaders[$script]) {
                     if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
-                        modulehook('everyheader', ['script' => $script]);
+                        HookHandler::hook('everyheader', ['script' => $script]);
                     }
                     PageParts::$runHeaders[$script] = true;
                     if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
-                        modulehook("header-$script");
+                        HookHandler::hook("header-$script");
                     }
                 }
             }
@@ -80,7 +81,7 @@ class Header
         Translator::translatorSetup();
         Template::prepareTemplate();
 
-        modulehook('header-popup');
+        HookHandler::hook('header-popup');
 
         $arguments = func_get_args();
         if (!$arguments || count($arguments) === 0) {

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -26,6 +26,7 @@ use Lotgd\Sanitize;
 use Lotgd\Nav;
 use Lotgd\DateTime;
 use Lotgd\Settings;
+use Lotgd\Modules\HookHandler;
 
 class PageParts
 {
@@ -386,7 +387,7 @@ class PageParts
                 self::addCharStat("Creature", $playermount['mountname'] . "`0");
             }
 
-            modulehook("charstats");
+            HookHandler::hook("charstats");
 
             $charstat = self::getCharStats($buffs);
 
@@ -408,7 +409,7 @@ class PageParts
             if ($ret = Datacache::datacache($cacheKey)) {
             } else {
                 $onlinecount = 0;
-                $list = modulehook("onlinecharlist", array("count" => 0, "list" => ""));
+                $list = HookHandler::hook("onlinecharlist", array("count" => 0, "list" => ""));
                 if (isset($list['handled']) && $list['handled']) {
                     $onlinecount = $list['count'];
                     $ret = $list['list'];
@@ -425,7 +426,7 @@ class PageParts
                         $rows[] = $row;
                     }
                     Database::freeResult($result);
-                    $rows = modulehook("loggedin", $rows);
+                    $rows = HookHandler::hook("loggedin", $rows);
                     if ($mode === 0) {
                         $ret .= appoencode(sprintf(Translator::translateInline("`bOnline Characters (%s players):`b`n"), count($rows)));
                     } elseif ($mode === 1) {
@@ -741,7 +742,7 @@ class PageParts
                 $pets .= $color . $val . '`0';
             }
             $ret_args = array('petitioncount' => $pets);
-            $ret_args = modulehook('petitioncount', $ret_args);
+            $ret_args = HookHandler::hook('petitioncount', $ret_args);
             $pets = $ret_args['petitioncount'];
             $p .= $pets;
             $pcount = templatereplace('petitioncount', array('petitioncount' => appoencode($p, true)));
@@ -773,12 +774,12 @@ class PageParts
     public static function applyFooterHooks(string $header, string $footer, string $script): array
     {
         // Gather module hook results for footer replacements
-        $replacementbits = modulehook("footer-$script", []);
+        $replacementbits = HookHandler::hook("footer-$script", []);
         if ($script == 'runmodule' && (($module = httpget('module'))) > '') {
-            $replacementbits = modulehook("footer-$module", $replacementbits);
+            $replacementbits = HookHandler::hook("footer-$module", $replacementbits);
         }
         $replacementbits['__scriptfile__'] = $script;
-        $replacementbits = modulehook('everyfooter', $replacementbits);
+        $replacementbits = HookHandler::hook('everyfooter', $replacementbits);
         unset($replacementbits['__scriptfile__']);
 
         // Build a simple token => string mapping
@@ -795,7 +796,7 @@ class PageParts
      */
     public static function applyPopupFooterHooks(string $header, string $footer): array
     {
-        $replacementbits = modulehook('footer-popup', []);
+        $replacementbits = HookHandler::hook('footer-popup', []);
 
         $replacements = [];
         foreach ($replacementbits as $key => $val) {

--- a/src/Lotgd/PlayerFunctions.php
+++ b/src/Lotgd/PlayerFunctions.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\MySQL\Database;
+use Lotgd\Modules\HookHandler;
 
 class PlayerFunctions
 {
@@ -21,7 +22,7 @@ class PlayerFunctions
     public static function charCleanup(int $id, int $type): void
     {
         // Run module hooks for character deletion
-        modulehook('delete_character', ['acctid' => $id, 'deltype' => $type]);
+        HookHandler::hook('delete_character', ['acctid' => $id, 'deltype' => $type]);
 
         // Remove output cache records for this player
         Database::query('DELETE FROM ' . Database::prefix('accounts_output') . " WHERE acctid=$id;");
@@ -214,7 +215,7 @@ class PlayerFunctions
             $sql = 'SELECT acctid,laston,loggedin FROM ' . Database::prefix('accounts') . ' WHERE acctid=' . ((int)$player) . ';';
             $result = Database::query($sql);
             $row = Database::fetchAssoc($result);
-            $row = modulehook('is-player-online', $row);
+            $row = HookHandler::hook('is-player-online', $row);
             if (!$row) {
                 return false;
             }
@@ -245,7 +246,7 @@ class PlayerFunctions
             while ($user = Database::fetchAssoc($result)) {
                 $rows[] = $user;
             }
-            $rows = modulehook('warriorlist', $rows);
+            $rows = HookHandler::hook('warriorlist', $rows);
             foreach ($rows as $user) {
                 $users[$user['acctid']] = 1;
                 if (isset($user['laston']) && isset($user['loggedin'])) {

--- a/src/Lotgd/Pvp.php
+++ b/src/Lotgd/Pvp.php
@@ -13,6 +13,7 @@ use Lotgd\MySQL\Database;
 use Lotgd\DateTime;
 use Lotgd\Mail;
 use Lotgd\Util\ScriptName;
+use Lotgd\Modules\HookHandler;
 
 class Pvp
 {
@@ -38,7 +39,7 @@ class Pvp
                 output("`\$Warning!`^ Players are immune from Player vs Player (PvP) combat for their first %s days in the game or until they have earned %s experience, or until they attack another player.  If you choose to attack another player, you will lose this immunity!`n`n", $days, $exp);
             }
         }
-        modulehook('pvpwarning', ['dokill' => $dokill]);
+        HookHandler::hook('pvpwarning', ['dokill' => $dokill]);
     }
 
     /**
@@ -84,7 +85,7 @@ class Pvp
                 $row['creatureexp'] = round($row['creatureexp'], 0);
                 $row['playerstarthp'] = $session['user']['hitpoints'];
                 $row['fightstartdate'] = strtotime('now');
-                $row = modulehook('pvpadjust', $row);
+                $row = HookHandler::hook('pvpadjust', $row);
                 self::warn(true);
                 return $row;
             }
@@ -150,7 +151,7 @@ class Pvp
         debuglog("gained $winamount ({$badguy['creaturegold']} base) gold and $wonexp exp (loser lost $lostexp) for killing ", $badguy['acctid']);
 
         $args = ['pvpmessageadd' => '', 'handled' => false, 'badguy' => $badguy, 'options' => $options];
-        $args = modulehook('pvpwin', $args);
+        $args = HookHandler::hook('pvpwin', $args);
 
         if ($session['user']['sex'] == SEX_MALE) {
             $msg = "`2While you were in %s, `^%s`2 initiated an attack on you with his `^%s`2, and defeated you!`n`nYou noticed he had an initial hp of `^%s`2 and just before you died he had `^%s`2 remaining.`n`nAs a result, you lost `\$%s%%`2 of your experience (approximately %s points), and `^%s`2 gold.`n%s`nDon't you think it's time for some revenge?`n`n`b`7Technical Notes:`b`nAlthough you might not have been in %s`7 when you got this message, you were in %s`7 when the fight was started, which was at %s according to the server (the fight lasted about %s).";
@@ -215,7 +216,7 @@ class Pvp
         $lostexp = round($session['user']['experience'] * getsetting('pvpattlose', 15) / 100, 0);
 
         $args = ['pvpmsgadd' => '', 'taunt' => $taunt, 'handled' => false, 'badguy' => $badguy, 'options' => $options];
-        $args = modulehook('pvploss', $args);
+        $args = HookHandler::hook('pvploss', $args);
 
         $msg = '`^%s`2 attacked you while you were in %s`2, but you were victorious!`n`n';
         if ($row['level'] < $badguy['creaturelevel']) {
@@ -309,7 +310,7 @@ class Pvp
             $pvp[] = $row;
         }
 
-        $pvp = modulehook('pvpmodifytargets', $pvp);
+        $pvp = HookHandler::hook('pvpmodifytargets', $pvp);
 
         tlschema('pvp');
         $n = Translator::translateInline('Name');
@@ -389,7 +390,7 @@ class Pvp
             while ($row = Database::fetchAssoc($result)) {
                 $loc = $row['location'];
                 $count = $row['counter'];
-                $args = modulehook('pvpcount', ['count' => $count, 'loc' => $loc]);
+                $args = HookHandler::hook('pvpcount', ['count' => $count, 'loc' => $loc]);
                 if (isset($args['handled']) && $args['handled']) {
                     continue;
                 }

--- a/src/Lotgd/ServerFunctions.php
+++ b/src/Lotgd/ServerFunctions.php
@@ -10,6 +10,7 @@ namespace Lotgd;
 
 use Lotgd\MySQL\Database;
 use Lotgd\Settings;
+use Lotgd\Modules\HookHandler;
 
 class ServerFunctions
 {
@@ -99,7 +100,7 @@ class ServerFunctions
             $resetactions = count($sets) > 0 ? ',' . implode(',', $sets) : '';
             $sql = 'UPDATE ' . Database::prefix('accounts') . " SET dragonpoints=''$resetactions WHERE acctid=" . $row['acctid'];
             Database::query($sql);
-            modulehook('dragonpointreset', [$row]);
+            HookHandler::hook('dragonpointreset', [$row]);
         }
     }
 

--- a/src/Lotgd/Specialty.php
+++ b/src/Lotgd/Specialty.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use Lotgd\Modules\HookHandler;
+
 class Specialty
 {
     /**
@@ -23,7 +25,7 @@ class Specialty
         }
         tlschema('skills');
         if ($session['user']['specialty'] != '') {
-            modulehook('incrementspecialty', ['color' => $colorcode]);
+            HookHandler::hook('incrementspecialty', ['color' => $colorcode]);
         } else {
             output("`7You have no direction in the world, you should rest and make some important decisions about your life.`0`n");
         }

--- a/src/Lotgd/SuAccess.php
+++ b/src/Lotgd/SuAccess.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\MySQL\Database;
+use Lotgd\Modules\HookHandler;
 
 class SuAccess
 {
@@ -29,7 +30,7 @@ class SuAccess
         self::$pageLevel |= $level;
         rawoutput("<!--Su_Restricted-->");
         if ($session['user']['superuser'] & $level) {
-            $return = modulehook('check_su_access', ['enabled' => true, 'level' => $level]);
+            $return = HookHandler::hook('check_su_access', ['enabled' => true, 'level' => $level]);
             if ($return['enabled']) {
                 $session['user']['laston'] = date('Y-m-d H:i:s');
                 return;

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -10,6 +10,7 @@ namespace Lotgd;
 
 use Lotgd\ServerFunctions;
 use Lotgd\Cookies;
+use Lotgd\Modules\HookHandler;
 
 class Template
 {
@@ -265,7 +266,7 @@ class Template
             if ($fieldname != "") {
                 $template[$fieldname] = substr($val, strpos($val, "-->") + 3);
                 if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
-                    $args = modulehook("template-{$fieldname}", ['content' => $template[$fieldname]]);
+                    $args = HookHandler::hook("template-{$fieldname}", ['content' => $template[$fieldname]]);
                     if (is_array($args) && array_key_exists('content', $args)) {
                         $template[$fieldname] = $args['content'];
                     }

--- a/tests/CharStatsEmptySessionTest.php
+++ b/tests/CharStatsEmptySessionTest.php
@@ -11,6 +11,10 @@ use Lotgd\Tests\Stubs\Database;
 use Lotgd\Tests\Stubs\DummySettings;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 final class CharStatsEmptySessionTest extends TestCase
 {
     public function testCharStatsHandlesEmptySession(): void
@@ -19,6 +23,9 @@ final class CharStatsEmptySessionTest extends TestCase
         $modulehook_returns = [
             'onlinecharlist' => ['handled' => true, 'count' => 0, 'list' => ''],
         ];
+        if (! class_exists('Lotgd\\Modules\\HookHandler', false)) {
+            eval('namespace Lotgd\\Modules; class HookHandler { public static function hook($name, $data = [], $allowinactive = false, $only = false) { global $modulehook_returns; return $modulehook_returns[$name] ?? $data; } }');
+        }
         class_exists(Database::class);
         class_exists(DataCache::class);
         $session = [];

--- a/tests/PagePartsOnlineListTest.php
+++ b/tests/PagePartsOnlineListTest.php
@@ -11,12 +11,19 @@ use Lotgd\Tests\Stubs\Database;
 use Lotgd\Tests\Stubs\DummySettings;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 final class PagePartsOnlineListTest extends TestCase
 {
     protected function setUp(): void
     {
         global $session, $settings, $output, $modulehook_returns;
         $modulehook_returns = [];
+        if (! class_exists('Lotgd\\Modules\\HookHandler', false)) {
+            eval('namespace Lotgd\\Modules; class HookHandler { public static function hook($name, $data = [], $allowinactive = false, $only = false) { global $modulehook_returns; return $modulehook_returns[$name] ?? $data; } }');
+        }
         class_exists(Database::class);
         $session = ['loggedin' => false];
         $output = new Output();

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -7,6 +7,10 @@ namespace Lotgd\Tests;
 use Lotgd\Template;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 final class TemplateTest extends TestCase
 {
     protected function setUp(): void
@@ -43,6 +47,10 @@ final class TemplateTest extends TestCase
     public function testLoadTemplateAppliesModuleHookChanges(): void
     {
         global $modulehook_returns;
+
+        if (! class_exists('Lotgd\\Modules\\HookHandler', false)) {
+            eval('namespace Lotgd\\Modules; class HookHandler { public static function hook($name, $data = [], $allowinactive = false, $only = false) { global $modulehook_returns; return $modulehook_returns[$name] ?? $data; } }');
+        }
 
         $path = dirname(__DIR__) . '/templates/test_template.htm';
         file_put_contents($path, "<!--!test-->original");

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,3 +11,7 @@ require_once __DIR__ . '/Stubs/Functions.php';
 require_once realpath(__DIR__ . '/../src/Lotgd/Repository/AccountRepository.php');
 require_once realpath(__DIR__ . '/../src/Lotgd/Repository/SettingRepository.php');
 require_once realpath(__DIR__ . '/../src/Lotgd/Repository/ExtendedSettingRepository.php');
+class_exists(\Lotgd\DataCache::class);
+if (! class_exists('Lotgd\\Datacache', false)) {
+    class_alias(\Lotgd\DataCache::class, 'Lotgd\\Datacache');
+}


### PR DESCRIPTION
## Summary
- replace global `modulehook` calls with `HookHandler::hook`
- inject `Lotgd\Modules\HookHandler` across core classes
- adapt tests to stub `HookHandler` and alias `DataCache`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b9ac89480c83299cda42f3613880e1