### PR TITLE
refactor: use Output object in Lotgd library

### DIFF
--- a/src/Lotgd/EDom.php
+++ b/src/Lotgd/EDom.php
@@ -14,6 +14,7 @@ class EDom
      */
     public static function includeScript(): void
     {
-        rawoutput("<script src='src/Lotgd/e_dom.js' defer></script>");
+        global $output;
+        $output->rawOutput("<script src='src/Lotgd/e_dom.js' defer></script>");
     }
 }

--- a/src/Lotgd/Events.php
+++ b/src/Lotgd/Events.php
@@ -33,7 +33,7 @@ class Events
                 //debug("Base link was specified as $baseLink");
                 //debug(debug_backtrace());
         }
-        global $session, $playermount, $badguy;
+        global $session, $playermount, $badguy, $output;
         $skipdesc = false;
 
         tlschema("events");
@@ -58,14 +58,14 @@ class Events
                     page_header($needHeader);
             }
 
-            output("`^`c`bSomething Special!`c`b`0");
+            $output->output("`^`c`bSomething Special!`c`b`0");
             if (strchr($specialinc, ":")) {
                 $array = explode(":", $specialinc);
                 $starttime = getmicrotime();
                 module_do_event($location, $array[1], $allowinactive, $baseLink);
                 $endtime = getmicrotime();
                 if (($endtime - $starttime >= 1.00 && ($session['user']['superuser'] & SU_DEBUG_OUTPUT))) {
-                    debug("Slow Event (" . round($endtime - $starttime, 2) . "s): $hookname - {$row['modulename']}`n");
+                    $output->debug("Slow Event (" . round($endtime - $starttime, 2) . "s): $hookname - {$row['modulename']}`n");
                 }
             }
             if (checknavs()) {

--- a/src/Lotgd/ForcedNavigation.php
+++ b/src/Lotgd/ForcedNavigation.php
@@ -17,8 +17,8 @@ class ForcedNavigation
      */
     public static function doForcedNav(bool $anonymous, bool $overrideforced): void
     {
-        global $session, $REQUEST_URI;
-        rawoutput("<!--\nAllowAnonymous: " . ($anonymous ? "True" : "False") . "\nOverride Forced Nav: " . ($overrideforced ? "True" : "False") . "\n-->");
+        global $session, $REQUEST_URI, $output;
+        $output->rawOutput("<!--\nAllowAnonymous: " . ($anonymous ? "True" : "False") . "\nOverride Forced Nav: " . ($overrideforced ? "True" : "False") . "\n-->");
         if (isset($session['loggedin']) && $session['loggedin']) {
             $sql = "SELECT * FROM " . Database::prefix('accounts') . " WHERE acctid='" . $session['user']['acctid'] . "'";
             $result = Database::query($sql);

--- a/src/Lotgd/SuAccess.php
+++ b/src/Lotgd/SuAccess.php
@@ -26,9 +26,9 @@ class SuAccess
      */
     public static function check(int $level): void
     {
-        global $session;
+        global $session, $output;
         self::$pageLevel |= $level;
-        rawoutput("<!--Su_Restricted-->");
+        $output->rawOutput("<!--Su_Restricted-->");
         if ($session['user']['superuser'] & $level) {
             $return = HookHandler::hook('check_su_access', ['enabled' => true, 'level' => $level]);
             if ($return['enabled']) {
@@ -36,8 +36,8 @@ class SuAccess
                 return;
             }
             page_header('Oops.');
-            output("Looks like you're probably an admin with appropriate permissions to perform this action, but a module is preventing you from doing so.");
-            output('Sorry about that!');
+            $output->output("Looks like you're probably an admin with appropriate permissions to perform this action, but a module is preventing you from doing so.");
+            $output->output('Sorry about that!');
             tlschema('nav');
             addnav('M?Return to the Mundane', 'village.php');
             tlschema();
@@ -46,8 +46,8 @@ class SuAccess
         clearnav();
         $session['output'] = '';
         page_header('INFIDEL!');
-        output('For attempting to defile the gods, you have been smitten down!`n`n');
-        output("%s`\$, Overlord of Death`) appears before you in a vision, seizing your mind with his, and wordlessly telling you that he finds no favor with you.`n`n", getsetting('deathoverlord', '`$Ramius'));
+        $output->output('For attempting to defile the gods, you have been smitten down!`n`n');
+        $output->output("%s`\$, Overlord of Death`) appears before you in a vision, seizing your mind with his, and wordlessly telling you that he finds no favor with you.`n`n", getsetting('deathoverlord', '`$Ramius'));
         AddNews::add("`&%s was smitten down for attempting to defile the gods (they tried to hack superuser pages).", $session['user']['name']);
         debuglog("Lost {$session['user']['gold']} and " . ($session['user']['experience'] * 0.25) . " experience trying to hack superuser pages.");
         $session['user']['hitpoints'] = 0;


### PR DESCRIPTION
## Summary
- replace legacy `rawoutput`/`output` calls with `Lotgd\Output` usage in several core classes
- centralize access control messaging in `SuAccess` via Output instance
- utilize `Output` for event logging and DOM helper inclusion

## Testing
- `php -l src/Lotgd/ForcedNavigation.php`
- `php -l src/Lotgd/EDom.php`
- `php -l src/Lotgd/SuAccess.php`
- `php -l src/Lotgd/Censor.php`
- `php -l src/Lotgd/Events.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c37b211483299ed340b8d430f5e7