### PR TITLE
Add PHPStan static analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
           php-version: '8.3'
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-interaction
+      - name: Run static analysis
+        run: composer static
 #      - name: Run PHPCS
 #        run: composer lint
       - name: Lint PHP files

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "squizlabs/php_codesniffer": "^3.7"
+        "squizlabs/php_codesniffer": "^3.7",
+        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan-doctrine": "^1.5"
     },
     "autoload": {
         "psr-4": {
@@ -29,7 +31,8 @@
     "scripts": {
         "test": "phpunit --configuration phpunit.xml",
         "lint": "phpcs .",
-        "lint:fix": "phpcbf ."
+        "lint:fix": "phpcbf .",
+        "static": "phpstan analyse --memory-limit=1G"
     },
     "extra": {
         "merge-plugin": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e57f005980385a2d7e114a3033d982d1",
+    "content-hash": "b62c668384f29025770ec1ef7a614e09",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -354,16 +354,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "3.10.0",
+            "version": "3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "1cf840d696373ea0d58ad0a8875c0fadcfc67214"
+                "reference": "3626601014388095d3af9de7e9e958623b7ef005"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/1cf840d696373ea0d58ad0a8875c0fadcfc67214",
-                "reference": "1cf840d696373ea0d58ad0a8875c0fadcfc67214",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/3626601014388095d3af9de7e9e958623b7ef005",
+                "reference": "3626601014388095d3af9de7e9e958623b7ef005",
                 "shasum": ""
             },
             "require": {
@@ -448,7 +448,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/3.10.0"
+                "source": "https://github.com/doctrine/dbal/tree/3.10.1"
             },
             "funding": [
                 {
@@ -464,7 +464,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-10T21:11:04+00:00"
+            "time": "2025-08-05T12:18:06+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -607,33 +607,32 @@
         },
         {
             "name": "doctrine/inflector",
-            "version": "2.0.10",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc"
+                "reference": "6d6c96277ea252fc1304627204c3d5e6e15faa3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/5817d0659c5b50c9b950feb9af7b9668e2c436bc",
-                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/6d6c96277ea252fc1304627204c3d5e6e15faa3b",
+                "reference": "6d6c96277ea252fc1304627204c3d5e6e15faa3b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^11.0",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpstan/phpstan-strict-rules": "^1.3",
-                "phpunit/phpunit": "^8.5 || ^9.5",
-                "vimeo/psalm": "^4.25 || ^5.4"
+                "doctrine/coding-standard": "^12.0 || ^13.0",
+                "phpstan/phpstan": "^1.12 || ^2.0",
+                "phpstan/phpstan-phpunit": "^1.4 || ^2.0",
+                "phpstan/phpstan-strict-rules": "^1.6 || ^2.0",
+                "phpunit/phpunit": "^8.5 || ^12.2"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Inflector\\": "lib/Doctrine/Inflector"
+                    "Doctrine\\Inflector\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -678,7 +677,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/2.0.10"
+                "source": "https://github.com/doctrine/inflector/tree/2.1.0"
             },
             "funding": [
                 {
@@ -694,7 +693,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-18T20:23:39+00:00"
+            "time": "2025-08-10T19:31:58+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -845,16 +844,16 @@
         },
         {
             "name": "doctrine/migrations",
-            "version": "3.9.2",
+            "version": "3.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/migrations.git",
-                "reference": "fa94c6f06b1bc6d4759481ec20b8b81d13e861be"
+                "reference": "1b88fcb812f2cd6e77c83d16db60e3cf1e35c66c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/fa94c6f06b1bc6d4759481ec20b8b81d13e861be",
-                "reference": "fa94c6f06b1bc6d4759481ec20b8b81d13e861be",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/1b88fcb812f2cd6e77c83d16db60e3cf1e35c66c",
+                "reference": "1b88fcb812f2cd6e77c83d16db60e3cf1e35c66c",
                 "shasum": ""
             },
             "require": {
@@ -928,7 +927,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/migrations/issues",
-                "source": "https://github.com/doctrine/migrations/tree/3.9.2"
+                "source": "https://github.com/doctrine/migrations/tree/3.9.4"
             },
             "funding": [
                 {
@@ -944,20 +943,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-29T11:36:14+00:00"
+            "time": "2025-08-19T06:41:07+00:00"
         },
         {
             "name": "doctrine/orm",
-            "version": "2.20.5",
+            "version": "2.20.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "6307b4fa7d7e3845a756106977e3b48907622098"
+                "reference": "c322c71cd40da12d255dabd7b6ce0d9cf208a5d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/6307b4fa7d7e3845a756106977e3b48907622098",
-                "reference": "6307b4fa7d7e3845a756106977e3b48907622098",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/c322c71cd40da12d255dabd7b6ce0d9cf208a5d5",
+                "reference": "c322c71cd40da12d255dabd7b6ce0d9cf208a5d5",
                 "shasum": ""
             },
             "require": {
@@ -1044,9 +1043,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/2.20.5"
+                "source": "https://github.com/doctrine/orm/tree/2.20.6"
             },
-            "time": "2025-06-24T17:50:46+00:00"
+            "time": "2025-08-08T06:55:44+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -2109,16 +2108,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "5f360ebc65c55265a74d23d7fe27f957870158a1"
+                "reference": "cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/5f360ebc65c55265a74d23d7fe27f957870158a1",
-                "reference": "5f360ebc65c55265a74d23d7fe27f957870158a1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7",
+                "reference": "cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7",
                 "shasum": ""
             },
             "require": {
@@ -2183,7 +2182,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.3.2"
+                "source": "https://github.com/symfony/console/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -2203,7 +2202,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-30T17:13:41+00:00"
+            "time": "2025-08-25T06:35:40+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2274,7 +2273,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -2333,7 +2332,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -2345,6 +2344,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -2353,16 +2356,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe"
+                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
-                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
                 "shasum": ""
             },
             "require": {
@@ -2411,7 +2414,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -2423,15 +2426,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2025-06-27T09:58:17+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -2492,7 +2499,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -2504,6 +2511,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -2512,7 +2523,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -2573,7 +2584,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -2582,6 +2593,10 @@
                 },
                 {
                     "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
                     "type": "github"
                 },
                 {
@@ -2658,7 +2673,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -2718,7 +2733,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -2730,6 +2745,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -2738,16 +2757,16 @@
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "000df7860439609837bbe28670b0be15783b7fbf"
+                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/000df7860439609837bbe28670b0be15783b7fbf",
-                "reference": "000df7860439609837bbe28670b0be15783b7fbf",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/d8ced4d875142b6a7426000426b8abc631d6b191",
+                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191",
                 "shasum": ""
             },
             "require": {
@@ -2794,7 +2813,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -2806,11 +2825,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-20T12:04:08+00:00"
+            "time": "2025-06-24T13:30:11+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -2959,16 +2982,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "42f505aff654e62ac7ac2ce21033818297ca89ca"
+                "reference": "17a426cce5fd1f0901fefa9b2a490d0038fd3c9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/42f505aff654e62ac7ac2ce21033818297ca89ca",
-                "reference": "42f505aff654e62ac7ac2ce21033818297ca89ca",
+                "url": "https://api.github.com/repos/symfony/string/zipball/17a426cce5fd1f0901fefa9b2a490d0038fd3c9c",
+                "reference": "17a426cce5fd1f0901fefa9b2a490d0038fd3c9c",
                 "shasum": ""
             },
             "require": {
@@ -3026,7 +3049,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.3.2"
+                "source": "https://github.com/symfony/string/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -3046,20 +3069,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-10T08:47:49+00:00"
+            "time": "2025-08-25T06:35:40+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "05b3e90654c097817325d6abd284f7938b05f467"
+                "reference": "d4dfcd2a822cbedd7612eb6fbd260e46f87b7137"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/05b3e90654c097817325d6abd284f7938b05f467",
-                "reference": "05b3e90654c097817325d6abd284f7938b05f467",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/d4dfcd2a822cbedd7612eb6fbd260e46f87b7137",
+                "reference": "d4dfcd2a822cbedd7612eb6fbd260e46f87b7137",
                 "shasum": ""
             },
             "require": {
@@ -3107,7 +3130,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.3.2"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -3127,7 +3150,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-10T08:47:49+00:00"
+            "time": "2025-08-18T13:10:53+00:00"
         },
         {
             "name": "tedivm/jshrink",
@@ -3388,16 +3411,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.0",
+            "version": "v5.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56"
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/221b0d0fdf1369c71047ad1d18bb5880017bbc56",
-                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
                 "shasum": ""
             },
             "require": {
@@ -3416,7 +3439,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -3440,9 +3463,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
             },
-            "time": "2025-07-27T20:03:57+00:00"
+            "time": "2025-08-13T20:13:15+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -3561,6 +3584,136 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.12.28",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-17T17:15:39+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-doctrine",
+            "version": "1.5.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-doctrine.git",
+                "reference": "231d3f795ed5ef54c98961fd3958868cbe091207"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/231d3f795ed5ef54c98961fd3958868cbe091207",
+                "reference": "231d3f795ed5ef54c98961fd3958868cbe091207",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.12.12"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.0",
+                "doctrine/common": "<2.7",
+                "doctrine/mongodb-odm": "<1.2",
+                "doctrine/orm": "<2.5",
+                "doctrine/persistence": "<1.3"
+            },
+            "require-dev": {
+                "cache/array-adapter": "^1.1",
+                "composer/semver": "^3.3.2",
+                "cweagans/composer-patches": "^1.7.3",
+                "doctrine/annotations": "^1.11 || ^2.0",
+                "doctrine/collections": "^1.6 || ^2.1",
+                "doctrine/common": "^2.7 || ^3.0",
+                "doctrine/dbal": "^2.13.8 || ^3.3.3",
+                "doctrine/lexer": "^2.0 || ^3.0",
+                "doctrine/mongodb-odm": "^1.3 || ^2.4.3",
+                "doctrine/orm": "^2.16.0",
+                "doctrine/persistence": "^2.2.1 || ^3.2",
+                "gedmo/doctrine-extensions": "^3.8",
+                "nesbot/carbon": "^2.49",
+                "nikic/php-parser": "^4.13.2",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.3.13",
+                "phpstan/phpstan-strict-rules": "^1.5.1",
+                "phpunit/phpunit": "^9.6.20",
+                "ramsey/uuid": "^4.2",
+                "symfony/cache": "^5.4"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Doctrine extensions for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/1.5.7"
+            },
+            "time": "2024-12-02T16:47:26+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3883,16 +4036,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.23",
+            "version": "9.6.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "43d2cb18d0675c38bd44982a5d1d88f6d53d8d95"
+                "reference": "049c011e01be805202d8eebedef49f769a8ec7b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/43d2cb18d0675c38bd44982a5d1d88f6d53d8d95",
-                "reference": "43d2cb18d0675c38bd44982a5d1d88f6d53d8d95",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/049c011e01be805202d8eebedef49f769a8ec7b7",
+                "reference": "049c011e01be805202d8eebedef49f769a8ec7b7",
                 "shasum": ""
             },
             "require": {
@@ -3903,7 +4056,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.13.1",
+                "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
@@ -3914,11 +4067,11 @@
                 "phpunit/php-timer": "^5.0.3",
                 "sebastian/cli-parser": "^1.0.2",
                 "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.8",
+                "sebastian/comparator": "^4.0.9",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
                 "sebastian/exporter": "^4.0.6",
-                "sebastian/global-state": "^5.0.7",
+                "sebastian/global-state": "^5.0.8",
                 "sebastian/object-enumerator": "^4.0.4",
                 "sebastian/resource-operations": "^3.0.4",
                 "sebastian/type": "^3.2.1",
@@ -3966,7 +4119,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.23"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.25"
             },
             "funding": [
                 {
@@ -3990,7 +4143,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-02T06:40:34+00:00"
+            "time": "2025-08-20T14:38:31+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4161,16 +4314,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "4.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
                 "shasum": ""
             },
             "require": {
@@ -4223,15 +4376,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2025-08-10T06:51:50+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -4498,16 +4663,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.7",
+            "version": "5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
                 "shasum": ""
             },
             "require": {
@@ -4550,15 +4715,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T06:35:11+00:00"
+            "time": "2025-08-10T07:10:35+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -4731,16 +4908,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
                 "shasum": ""
             },
             "require": {
@@ -4782,15 +4959,27 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
+            "time": "2025-08-10T06:57:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -5092,11 +5281,11 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3.0"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,1971 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Constant DATETIME_DATEMIN not found\\.$#"
+			count: 1
+			path: src/Lotgd/Accounts.php
+
+		-
+			message: "#^Static method Lotgd\\\\MySQL\\\\Database\\:\\:affectedRows\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: src/Lotgd/Accounts.php
+
+		-
+			message: "#^Caught class Lotgd\\\\Async\\\\Handler\\\\Exception not found\\.$#"
+			count: 3
+			path: src/Lotgd/Async/Handler/Commentary.php
+
+		-
+			message: "#^Function appoencode not found\\.$#"
+			count: 1
+			path: src/Lotgd/Async/Handler/Commentary.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 1
+			path: src/Lotgd/Async/Handler/Mail.php
+
+		-
+			message: "#^Function maillink not found\\.$#"
+			count: 1
+			path: src/Lotgd/Async/Handler/Mail.php
+
+		-
+			message: "#^Function maillinktabtext not found\\.$#"
+			count: 1
+			path: src/Lotgd/Async/Handler/Mail.php
+
+		-
+			message: "#^Function translate_inline not found\\.$#"
+			count: 1
+			path: src/Lotgd/Async/Handler/Mail.php
+
+		-
+			message: "#^Function appoencode not found\\.$#"
+			count: 4
+			path: src/Lotgd/Async/Handler/Timeout.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 1
+			path: src/Lotgd/Async/Handler/Timeout.php
+
+		-
+			message: "#^Function sprintf_translate not found\\.$#"
+			count: 2
+			path: src/Lotgd/Async/Handler/Timeout.php
+
+		-
+			message: "#^Function translate_inline not found\\.$#"
+			count: 3
+			path: src/Lotgd/Async/Handler/Timeout.php
+
+		-
+			message: "#^Constant SU_DEVELOPER not found\\.$#"
+			count: 2
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Function addnav not found\\.$#"
+			count: 13
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Function appoencode not found\\.$#"
+			count: 2
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Function e_rand not found\\.$#"
+			count: 6
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Function get_player_attack not found\\.$#"
+			count: 2
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Function get_player_defense not found\\.$#"
+			count: 1
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Function get_player_physical_resistance not found\\.$#"
+			count: 2
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 6
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Function output not found\\.$#"
+			count: 38
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Function output_notl not found\\.$#"
+			count: 9
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Function rawoutput not found\\.$#"
+			count: 22
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Function sanitize_mb not found\\.$#"
+			count: 1
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Function sprintf_translate not found\\.$#"
+			count: 1
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 28
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Variable \\$badguyatkmod might not be defined\\.$#"
+			count: 1
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Variable \\$barDisplay might not be defined\\.$#"
+			count: 1
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Variable \\$creaturedmg in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 2
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Variable \\$defmod might not be defined\\.$#"
+			count: 1
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Variable \\$healthtext might not be defined\\.$#"
+			count: 2
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Variable \\$rounds might not be defined\\.$#"
+			count: 1
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Variable \\$scrip in empty\\(\\) is never defined\\.$#"
+			count: 1
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Variable \\$selfdmg in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 2
+			path: src/Lotgd/Battle.php
+
+		-
+			message: "#^Function apply_temp_stat not found\\.$#"
+			count: 2
+			path: src/Lotgd/Buffs.php
+
+		-
+			message: "#^Function createstring not found\\.$#"
+			count: 3
+			path: src/Lotgd/Buffs.php
+
+		-
+			message: "#^Function debug not found\\.$#"
+			count: 3
+			path: src/Lotgd/Buffs.php
+
+		-
+			message: "#^Function e_rand not found\\.$#"
+			count: 1
+			path: src/Lotgd/Buffs.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 3
+			path: src/Lotgd/Buffs.php
+
+		-
+			message: "#^Function output not found\\.$#"
+			count: 10
+			path: src/Lotgd/Buffs.php
+
+		-
+			message: "#^Function output_notl not found\\.$#"
+			count: 8
+			path: src/Lotgd/Buffs.php
+
+		-
+			message: "#^Function sprintf_translate not found\\.$#"
+			count: 8
+			path: src/Lotgd/Buffs.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 22
+			path: src/Lotgd/Buffs.php
+
+		-
+			message: "#^Variable \\$msg might not be defined\\.$#"
+			count: 2
+			path: src/Lotgd/Buffs.php
+
+		-
+			message: "#^Constant SU_EDIT_COMMENTS not found\\.$#"
+			count: 1
+			path: src/Lotgd/Censor.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 1
+			path: src/Lotgd/Censor.php
+
+		-
+			message: "#^Function updatedatacache not found\\.$#"
+			count: 1
+			path: src/Lotgd/Censor.php
+
+		-
+			message: "#^Variable \\$matches might not be defined\\.$#"
+			count: 6
+			path: src/Lotgd/Censor.php
+
+		-
+			message: "#^Function appoencode not found\\.$#"
+			count: 1
+			path: src/Lotgd/CharStats.php
+
+		-
+			message: "#^Function templatereplace not found\\.$#"
+			count: 6
+			path: src/Lotgd/CharStats.php
+
+		-
+			message: "#^Constant DATETIME_DATEMAX not found\\.$#"
+			count: 2
+			path: src/Lotgd/CheckBan.php
+
+		-
+			message: "#^Constant SU_DOESNT_GIVE_GROTTO not found\\.$#"
+			count: 1
+			path: src/Lotgd/CheckBan.php
+
+		-
+			message: "#^Function sprintf_translate not found\\.$#"
+			count: 3
+			path: src/Lotgd/CheckBan.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 2
+			path: src/Lotgd/CheckBan.php
+
+		-
+			message: "#^Constant DATETIME_DATEMIN not found\\.$#"
+			count: 1
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Constant LOCATION_FIELDS not found\\.$#"
+			count: 2
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Constant LOCATION_INN not found\\.$#"
+			count: 2
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Constant SU_DOESNT_GIVE_GROTTO not found\\.$#"
+			count: 3
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Constant SU_EDIT_COMMENTS not found\\.$#"
+			count: 4
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Constant SU_IS_GAMEMASTER not found\\.$#"
+			count: 7
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Constant SU_MEGAUSER not found\\.$#"
+			count: 2
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function addnav not found\\.$#"
+			count: 8
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function appendcount not found\\.$#"
+			count: 1
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function appendlink not found\\.$#"
+			count: 1
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function cmd_sanitize not found\\.$#"
+			count: 1
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function color_sanitize not found\\.$#"
+			count: 2
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function comment_sanitize not found\\.$#"
+			count: 1
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function comscroll_sanitize not found\\.$#"
+			count: 5
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function debug not found\\.$#"
+			count: 1
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 25
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function httpget not found\\.$#"
+			count: 4
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function httppost not found\\.$#"
+			count: 5
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function invalidatedatacache not found\\.$#"
+			count: 4
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function output not found\\.$#"
+			count: 10
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function output_notl not found\\.$#"
+			count: 16
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function rawoutput not found\\.$#"
+			count: 11
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function redirect not found\\.$#"
+			count: 1
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function reltime not found\\.$#"
+			count: 1
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function sanitize_mb not found\\.$#"
+			count: 1
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function soap not found\\.$#"
+			count: 1
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function sprintf_translate not found\\.$#"
+			count: 1
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function tlbutton_clear not found\\.$#"
+			count: 1
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 10
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Instantiated class Lotgd\\\\output_collector not found\\.$#"
+			count: 1
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Variable \\$commentids might not be defined\\.$#"
+			count: 2
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Variable \\$op might not be defined\\.$#"
+			count: 1
+			path: src/Lotgd/Commentary.php
+
+		-
+			message: "#^Constant SU_ANYONE_CAN_SET not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/configuration.php
+
+		-
+			message: "#^Constant SU_DEBUG_OUTPUT not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/configuration.php
+
+		-
+			message: "#^Constant SU_DEVELOPER not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/configuration.php
+
+		-
+			message: "#^Constant SU_INFINITE_DAYS not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/configuration.php
+
+		-
+			message: "#^Constant SU_VIEW_SOURCE not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/configuration.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/configuration.php
+
+		-
+			message: "#^Variable \\$session might not be defined\\.$#"
+			count: 1
+			path: src/Lotgd/Config/configuration.php
+
+		-
+			message: "#^Constant SU_DEBUG_OUTPUT not found\\.$#"
+			count: 2
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_DEVELOPER not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_EDIT_COMMENTS not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_EDIT_CONFIG not found\\.$#"
+			count: 2
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_EDIT_DONATIONS not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_EDIT_USERS not found\\.$#"
+			count: 2
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_HIDE_FROM_LEADERBOARD not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_INFINITE_DAYS not found\\.$#"
+			count: 3
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_IS_BANMASTER not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_MEGAUSER not found\\.$#"
+			count: 2
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_NEVER_EXPIRE not found\\.$#"
+			count: 2
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_OVERRIDE_YOM_WARNING not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_POST_MOTD not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_RAW_SQL not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_SHOW_PHPNOTICE not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_VIEW_SOURCE not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/constants.php
+
+		-
+			message: "#^Constant SU_ANYONE_CAN_SET not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_AUDIT_MODERATION not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_DEBUG_OUTPUT not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_DEVELOPER not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_EDIT_COMMENTS not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_EDIT_CONFIG not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_EDIT_CREATURES not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_EDIT_DONATIONS not found\\.$#"
+			count: 2
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_EDIT_EQUIPMENT not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_EDIT_MOUNTS not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_EDIT_PAYLOG not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_EDIT_PETITIONS not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_EDIT_RIDDLES not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_EDIT_USERS not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_GIVE_GROTTO not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_INFINITE_DAYS not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_IS_BANMASTER not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_IS_GAMEMASTER not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_IS_TRANSLATOR not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_MANAGE_MODULES not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_MEGAUSER not found\\.$#"
+			count: 3
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_MODERATE_CLANS not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_NEVER_EXPIRE not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_OVERRIDE_YOM_WARNING not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_POST_MOTD not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_RAW_SQL not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_SHOW_PHPNOTICE not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant SU_VIEW_SOURCE not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 2
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Function translate_inline not found\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Variable \\$enum might not be defined\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Variable \\$mounts might not be defined\\.$#"
+			count: 1
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Variable \\$session might not be defined\\.$#"
+			count: 4
+			path: src/Lotgd/Config/user_account.php
+
+		-
+			message: "#^Constant DATETIME_DATEMIN not found\\.$#"
+			count: 2
+			path: src/Lotgd/DateTime.php
+
+		-
+			message: "#^Constant DATETIME_TODAY not found\\.$#"
+			count: 1
+			path: src/Lotgd/DateTime.php
+
+		-
+			message: "#^Function addnav not found\\.$#"
+			count: 1
+			path: src/Lotgd/DateTime.php
+
+		-
+			message: "#^Function output_notl not found\\.$#"
+			count: 1
+			path: src/Lotgd/DateTime.php
+
+		-
+			message: "#^Function rawoutput not found\\.$#"
+			count: 1
+			path: src/Lotgd/DateTime.php
+
+		-
+			message: "#^Function redirect not found\\.$#"
+			count: 1
+			path: src/Lotgd/DateTime.php
+
+		-
+			message: "#^Function sprintf_translate not found\\.$#"
+			count: 1
+			path: src/Lotgd/DateTime.php
+
+		-
+			message: "#^Function tlbutton_clear not found\\.$#"
+			count: 1
+			path: src/Lotgd/DateTime.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 2
+			path: src/Lotgd/DateTime.php
+
+		-
+			message: "#^Function e_rand not found\\.$#"
+			count: 2
+			path: src/Lotgd/DeathMessage.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 1
+			path: src/Lotgd/DumpItem.php
+
+		-
+			message: "#^Constant SU_DEBUG_OUTPUT not found\\.$#"
+			count: 2
+			path: src/Lotgd/ErrorHandler.php
+
+		-
+			message: "#^Constant SU_SHOW_PHPNOTICE not found\\.$#"
+			count: 1
+			path: src/Lotgd/ErrorHandler.php
+
+		-
+			message: "#^Function debug not found\\.$#"
+			count: 6
+			path: src/Lotgd/ErrorHandler.php
+
+		-
+			message: "#^Function rawoutput not found\\.$#"
+			count: 1
+			path: src/Lotgd/ErrorHandler.php
+
+		-
+			message: "#^Constant SU_DEBUG_OUTPUT not found\\.$#"
+			count: 1
+			path: src/Lotgd/Events.php
+
+		-
+			message: "#^Constant SU_DEVELOPER not found\\.$#"
+			count: 1
+			path: src/Lotgd/Events.php
+
+		-
+			message: "#^Function checknavs not found\\.$#"
+			count: 1
+			path: src/Lotgd/Events.php
+
+		-
+			message: "#^Function getmicrotime not found\\.$#"
+			count: 2
+			path: src/Lotgd/Events.php
+
+		-
+			message: "#^Function module_do_event not found\\.$#"
+			count: 1
+			path: src/Lotgd/Events.php
+
+		-
+			message: "#^Function page_footer not found\\.$#"
+			count: 1
+			path: src/Lotgd/Events.php
+
+		-
+			message: "#^Function page_header not found\\.$#"
+			count: 1
+			path: src/Lotgd/Events.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 2
+			path: src/Lotgd/Events.php
+
+		-
+			message: "#^Undefined variable\\: \\$hookname$#"
+			count: 1
+			path: src/Lotgd/Events.php
+
+		-
+			message: "#^Undefined variable\\: \\$row$#"
+			count: 1
+			path: src/Lotgd/Events.php
+
+		-
+			message: "#^Constant CHAR_DELETE_AUTO not found\\.$#"
+			count: 1
+			path: src/Lotgd/ExpireChars.php
+
+		-
+			message: "#^Constant DATETIME_DATEMIN not found\\.$#"
+			count: 1
+			path: src/Lotgd/ExpireChars.php
+
+		-
+			message: "#^Constant NO_ACCOUNT_EXPIRATION not found\\.$#"
+			count: 2
+			path: src/Lotgd/ExpireChars.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 1
+			path: src/Lotgd/ForcedNavigation.php
+
+		-
+			message: "#^Function redirect not found\\.$#"
+			count: 4
+			path: src/Lotgd/ForcedNavigation.php
+
+		-
+			message: "#^Function addnav not found\\.$#"
+			count: 10
+			path: src/Lotgd/Forest.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 3
+			path: src/Lotgd/Forest.php
+
+		-
+			message: "#^Function module_display_events not found\\.$#"
+			count: 1
+			path: src/Lotgd/Forest.php
+
+		-
+			message: "#^Function output not found\\.$#"
+			count: 5
+			path: src/Lotgd/Forest.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 2
+			path: src/Lotgd/Forest.php
+
+		-
+			message: "#^Function debug not found\\.$#"
+			count: 4
+			path: src/Lotgd/Forest/Outcomes.php
+
+		-
+			message: "#^Function debuglog not found\\.$#"
+			count: 3
+			path: src/Lotgd/Forest/Outcomes.php
+
+		-
+			message: "#^Function e_rand not found\\.$#"
+			count: 1
+			path: src/Lotgd/Forest/Outcomes.php
+
+		-
+			message: "#^Function get_player_dragonkillmod not found\\.$#"
+			count: 1
+			path: src/Lotgd/Forest/Outcomes.php
+
+		-
+			message: "#^Function output not found\\.$#"
+			count: 19
+			path: src/Lotgd/Forest/Outcomes.php
+
+		-
+			message: "#^Function output_notl not found\\.$#"
+			count: 2
+			path: src/Lotgd/Forest/Outcomes.php
+
+		-
+			message: "#^Function page_footer not found\\.$#"
+			count: 1
+			path: src/Lotgd/Forest/Outcomes.php
+
+		-
+			message: "#^Function r_rand not found\\.$#"
+			count: 6
+			path: src/Lotgd/Forest/Outcomes.php
+
+		-
+			message: "#^Variable \\$badguy might not be defined\\.$#"
+			count: 1
+			path: src/Lotgd/Forest/Outcomes.php
+
+		-
+			message: "#^Constant LOCATION_FIELDS not found\\.$#"
+			count: 1
+			path: src/Lotgd/Forms.php
+
+		-
+			message: "#^Constant SU_IS_GAMEMASTER not found\\.$#"
+			count: 1
+			path: src/Lotgd/Forms.php
+
+		-
+			message: "#^Function appoencode not found\\.$#"
+			count: 1
+			path: src/Lotgd/Forms.php
+
+		-
+			message: "#^Function datacache not found\\.$#"
+			count: 1
+			path: src/Lotgd/Forms.php
+
+		-
+			message: "#^Function debug not found\\.$#"
+			count: 1
+			path: src/Lotgd/Forms.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 29
+			path: src/Lotgd/Forms.php
+
+		-
+			message: "#^Function httppost not found\\.$#"
+			count: 1
+			path: src/Lotgd/Forms.php
+
+		-
+			message: "#^Function output not found\\.$#"
+			count: 1
+			path: src/Lotgd/Forms.php
+
+		-
+			message: "#^Function output_notl not found\\.$#"
+			count: 6
+			path: src/Lotgd/Forms.php
+
+		-
+			message: "#^Function rawoutput not found\\.$#"
+			count: 68
+			path: src/Lotgd/Forms.php
+
+		-
+			message: "#^Function tlbutton_pop not found\\.$#"
+			count: 1
+			path: src/Lotgd/Forms.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 6
+			path: src/Lotgd/Forms.php
+
+		-
+			message: "#^Function translate not found\\.$#"
+			count: 2
+			path: src/Lotgd/Forms.php
+
+		-
+			message: "#^Function updatedatacache not found\\.$#"
+			count: 1
+			path: src/Lotgd/Forms.php
+
+		-
+			message: "#^Static method Lotgd\\\\Forms\\:\\:renderField\\(\\) invoked with 8 parameters, 7 required\\.$#"
+			count: 1
+			path: src/Lotgd/Forms.php
+
+		-
+			message: "#^Constant SU_DOESNT_GIVE_GROTTO not found\\.$#"
+			count: 1
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Constant SU_EDIT_COMMENTS not found\\.$#"
+			count: 3
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Constant SU_EDIT_USERS not found\\.$#"
+			count: 1
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Function addnav not found\\.$#"
+			count: 9
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Function appendcount not found\\.$#"
+			count: 1
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Function appendlink not found\\.$#"
+			count: 1
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Function comment_sanitize not found\\.$#"
+			count: 1
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Function comscroll_sanitize not found\\.$#"
+			count: 4
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Function debug not found\\.$#"
+			count: 1
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Function full_sanitize not found\\.$#"
+			count: 1
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 19
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Function httpget not found\\.$#"
+			count: 2
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Function output not found\\.$#"
+			count: 6
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Function output_notl not found\\.$#"
+			count: 18
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Function rawoutput not found\\.$#"
+			count: 5
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Function reltime not found\\.$#"
+			count: 1
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 2
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Variable \\$auth might not be defined\\.$#"
+			count: 2
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Variable \\$commentids might not be defined\\.$#"
+			count: 4
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Variable \\$op might not be defined\\.$#"
+			count: 3
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Variable \\$rawc might not be defined\\.$#"
+			count: 2
+			path: src/Lotgd/Moderate.php
+
+		-
+			message: "#^Constant DATETIME_DATEMIN not found\\.$#"
+			count: 1
+			path: src/Lotgd/ModuleManager.php
+
+		-
+			message: "#^Function activate_module not found\\.$#"
+			count: 1
+			path: src/Lotgd/ModuleManager.php
+
+		-
+			message: "#^Function deactivate_module not found\\.$#"
+			count: 1
+			path: src/Lotgd/ModuleManager.php
+
+		-
+			message: "#^Function get_module_install_status not found\\.$#"
+			count: 2
+			path: src/Lotgd/ModuleManager.php
+
+		-
+			message: "#^Function injectmodule not found\\.$#"
+			count: 2
+			path: src/Lotgd/ModuleManager.php
+
+		-
+			message: "#^Function install_module not found\\.$#"
+			count: 1
+			path: src/Lotgd/ModuleManager.php
+
+		-
+			message: "#^Function invalidatedatacache not found\\.$#"
+			count: 5
+			path: src/Lotgd/ModuleManager.php
+
+		-
+			message: "#^Function massinvalidate not found\\.$#"
+			count: 11
+			path: src/Lotgd/ModuleManager.php
+
+		-
+			message: "#^Function uninstall_module not found\\.$#"
+			count: 1
+			path: src/Lotgd/ModuleManager.php
+
+		-
+			message: "#^Constant MODULE_ACTIVE not found\\.$#"
+			count: 2
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Constant MODULE_FILE_NOT_PRESENT not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Constant MODULE_INJECTED not found\\.$#"
+			count: 4
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Constant MODULE_INSTALLED not found\\.$#"
+			count: 2
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Constant MODULE_NOT_INSTALLED not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Constant MODULE_NO_INFO not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Constant MODULE_VERSION_OK not found\\.$#"
+			count: 3
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Constant MODULE_VERSION_TOO_LOW not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Constant SU_DEBUG_OUTPUT not found\\.$#"
+			count: 3
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Constant SU_DEVELOPER not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function addnav not found\\.$#"
+			count: 2
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function addnav_notl not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function debug not found\\.$#"
+			count: 7
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function e_rand not found\\.$#"
+			count: 2
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function getmicrotime not found\\.$#"
+			count: 2
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 2
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function httpallget not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function httpallpost not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function httpget not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function httpset not found\\.$#"
+			count: 2
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function invalidatedatacache not found\\.$#"
+			count: 16
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function massinvalidate not found\\.$#"
+			count: 3
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function module_compare_versions not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function module_condition not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function module_wipehooks not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function modulename_sanitize not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function output not found\\.$#"
+			count: 3
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function output_notl not found\\.$#"
+			count: 2
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function r_rand not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function rawoutput not found\\.$#"
+			count: 17
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Static method Lotgd\\\\MySQL\\\\Database\\:\\:affectedRows\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Variable \\$exists might not be defined\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Variable \\$filename might not be defined\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Variable \\$link might not be defined\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Variable \\$ns might not be defined\\.$#"
+			count: 3
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Variable \\$res might not be defined\\.$#"
+			count: 1
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Variable \\$result might not be defined\\.$#"
+			count: 2
+			path: src/Lotgd/Modules.php
+
+		-
+			message: "#^Function debug not found\\.$#"
+			count: 1
+			path: src/Lotgd/Modules/Installer.php
+
+		-
+			message: "#^Function invalidatedatacache not found\\.$#"
+			count: 7
+			path: src/Lotgd/Modules/Installer.php
+
+		-
+			message: "#^Function massinvalidate not found\\.$#"
+			count: 6
+			path: src/Lotgd/Modules/Installer.php
+
+		-
+			message: "#^Function output not found\\.$#"
+			count: 9
+			path: src/Lotgd/Modules/Installer.php
+
+		-
+			message: "#^Constant SU_POST_MOTD not found\\.$#"
+			count: 1
+			path: src/Lotgd/Motd.php
+
+		-
+			message: "#^Function addnav not found\\.$#"
+			count: 2
+			path: src/Lotgd/Motd.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 2
+			path: src/Lotgd/Motd.php
+
+		-
+			message: "#^Function httppost not found\\.$#"
+			count: 10
+			path: src/Lotgd/Motd.php
+
+		-
+			message: "#^Function invalidatedatacache not found\\.$#"
+			count: 7
+			path: src/Lotgd/Motd.php
+
+		-
+			message: "#^Function output not found\\.$#"
+			count: 5
+			path: src/Lotgd/Motd.php
+
+		-
+			message: "#^Function output_notl not found\\.$#"
+			count: 7
+			path: src/Lotgd/Motd.php
+
+		-
+			message: "#^Function rawoutput not found\\.$#"
+			count: 26
+			path: src/Lotgd/Motd.php
+
+		-
+			message: "#^Function sprintf_translate not found\\.$#"
+			count: 2
+			path: src/Lotgd/MountName.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 2
+			path: src/Lotgd/MountName.php
+
+		-
+			message: "#^Constant SU_DEBUG_OUTPUT not found\\.$#"
+			count: 1
+			path: src/Lotgd/MySQL/Database.php
+
+		-
+			message: "#^Constant SU_DEVELOPER not found\\.$#"
+			count: 1
+			path: src/Lotgd/MySQL/Database.php
+
+		-
+			message: "#^Function debug not found\\.$#"
+			count: 1
+			path: src/Lotgd/MySQL/Database.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 2
+			path: src/Lotgd/MySQL/Database.php
+
+		-
+			message: "#^Variable \\$affected on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: src/Lotgd/MySQL/Database.php
+
+		-
+			message: "#^Constant DATETIME_DATEMIN not found\\.$#"
+			count: 1
+			path: src/Lotgd/MySQL/TableDescriptor.php
+
+		-
+			message: "#^Function output not found\\.$#"
+			count: 1
+			path: src/Lotgd/MySQL/TableDescriptor.php
+
+		-
+			message: "#^Used constant DATETIME_DATEMIN not found\\.$#"
+			count: 1
+			path: src/Lotgd/MySQL/TableDescriptor.php
+
+		-
+			message: "#^Function appoencode not found\\.$#"
+			count: 4
+			path: src/Lotgd/Nav.php
+
+		-
+			message: "#^Function popup not found\\.$#"
+			count: 2
+			path: src/Lotgd/Nav.php
+
+		-
+			message: "#^Function sanitize not found\\.$#"
+			count: 8
+			path: src/Lotgd/Nav.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 8
+			path: src/Lotgd/Nav.php
+
+		-
+			message: "#^Function translate not found\\.$#"
+			count: 2
+			path: src/Lotgd/Nav.php
+
+		-
+			message: "#^Constant SU_DOESNT_GIVE_GROTTO not found\\.$#"
+			count: 1
+			path: src/Lotgd/Nav/SuperuserNav.php
+
+		-
+			message: "#^Function addnav not found\\.$#"
+			count: 3
+			path: src/Lotgd/Nav/SuperuserNav.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 2
+			path: src/Lotgd/Nav/SuperuserNav.php
+
+		-
+			message: "#^Function addnav not found\\.$#"
+			count: 2
+			path: src/Lotgd/Nav/VillageNav.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 2
+			path: src/Lotgd/Nav/VillageNav.php
+
+		-
+			message: "#^Constant LOCATION_FIELDS not found\\.$#"
+			count: 1
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Constant SU_MANAGE_MODULES not found\\.$#"
+			count: 2
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Constant SU_MEGAUSER not found\\.$#"
+			count: 2
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Function addnav not found\\.$#"
+			count: 8
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Function appendcount not found\\.$#"
+			count: 1
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Function clearoutput not found\\.$#"
+			count: 2
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Function getmicrotime not found\\.$#"
+			count: 2
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Function httpget not found\\.$#"
+			count: 2
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Function httppost not found\\.$#"
+			count: 1
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Function massinvalidate not found\\.$#"
+			count: 1
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Function navcount not found\\.$#"
+			count: 2
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Function output not found\\.$#"
+			count: 24
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Function output_notl not found\\.$#"
+			count: 3
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Function page_footer not found\\.$#"
+			count: 4
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Function page_header not found\\.$#"
+			count: 6
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Function rawoutput not found\\.$#"
+			count: 22
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Function savesetting not found\\.$#"
+			count: 1
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Variable \\$type in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: src/Lotgd/Newday.php
+
+		-
+			message: "#^Constant SU_DEBUG_OUTPUT not found\\.$#"
+			count: 1
+			path: src/Lotgd/Output.php
+
+		-
+			message: "#^Function appoencode not found\\.$#"
+			count: 1
+			path: src/Lotgd/Output.php
+
+		-
+			message: "#^Function sanitize not found\\.$#"
+			count: 1
+			path: src/Lotgd/Output.php
+
+		-
+			message: "#^Class Lotgd\\\\DataCache referenced with incorrect case\\: Lotgd\\\\Datacache\\.$#"
+			count: 1
+			path: src/Lotgd/Page/CharStats.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 2
+			path: src/Lotgd/Page/Footer.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 4
+			path: src/Lotgd/Page/Header.php
+
+		-
+			message: "#^Class Lotgd\\\\DataCache referenced with incorrect case\\: Lotgd\\\\Datacache\\.$#"
+			count: 2
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Constant RACE_UNKNOWN not found\\.$#"
+			count: 3
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Constant SU_DEBUG_OUTPUT not found\\.$#"
+			count: 1
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Constant SU_EDIT_PETITIONS not found\\.$#"
+			count: 1
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Constant SU_EDIT_USERS not found\\.$#"
+			count: 1
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Constant SU_MANAGE_MODULES not found\\.$#"
+			count: 1
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Function addnav not found\\.$#"
+			count: 3
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Function appoencode not found\\.$#"
+			count: 9
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Function check_temp_stat not found\\.$#"
+			count: 19
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 6
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Function httpget not found\\.$#"
+			count: 1
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Function templatereplace not found\\.$#"
+			count: 1
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 2
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Variable \\$maillink_add_after on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Variable \\$maillink_add_pre on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Variable \\$minutes might not be defined\\.$#"
+			count: 1
+			path: src/Lotgd/PageParts.php
+
+		-
+			message: "#^Constant INT_MAX not found\\.$#"
+			count: 1
+			path: src/Lotgd/Partner.php
+
+		-
+			message: "#^Constant SEX_MALE not found\\.$#"
+			count: 3
+			path: src/Lotgd/Partner.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 6
+			path: src/Lotgd/Partner.php
+
+		-
+			message: "#^Function httpallget not found\\.$#"
+			count: 1
+			path: src/Lotgd/PhpGenericEnvironment.php
+
+		-
+			message: "#^Constant CLAN_APPLICANT not found\\.$#"
+			count: 1
+			path: src/Lotgd/PlayerFunctions.php
+
+		-
+			message: "#^Constant CLAN_FOUNDER not found\\.$#"
+			count: 2
+			path: src/Lotgd/PlayerFunctions.php
+
+		-
+			message: "#^Constant CLAN_LEADER not found\\.$#"
+			count: 4
+			path: src/Lotgd/PlayerFunctions.php
+
+		-
+			message: "#^Constant DATETIME_DATEMIN not found\\.$#"
+			count: 1
+			path: src/Lotgd/PlayerFunctions.php
+
+		-
+			message: "#^Constant SEX_MALE not found\\.$#"
+			count: 1
+			path: src/Lotgd/PlayerFunctions.php
+
+		-
+			message: "#^Function debug not found\\.$#"
+			count: 2
+			path: src/Lotgd/PlayerFunctions.php
+
+		-
+			message: "#^Function e_rand not found\\.$#"
+			count: 1
+			path: src/Lotgd/PlayerFunctions.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 9
+			path: src/Lotgd/PlayerFunctions.php
+
+		-
+			message: "#^Function module_delete_userprefs not found\\.$#"
+			count: 1
+			path: src/Lotgd/PlayerFunctions.php
+
+		-
+			message: "#^Function sprintf_translate not found\\.$#"
+			count: 2
+			path: src/Lotgd/PlayerFunctions.php
+
+		-
+			message: "#^Function debug not found\\.$#"
+			count: 5
+			path: src/Lotgd/PullUrl.php
+
+		-
+			message: "#^Constant CLAN_APPLICANT not found\\.$#"
+			count: 1
+			path: src/Lotgd/Pvp.php
+
+		-
+			message: "#^Constant SEX_MALE not found\\.$#"
+			count: 1
+			path: src/Lotgd/Pvp.php
+
+		-
+			message: "#^Function addnav not found\\.$#"
+			count: 3
+			path: src/Lotgd/Pvp.php
+
+		-
+			message: "#^Function debuglog not found\\.$#"
+			count: 4
+			path: src/Lotgd/Pvp.php
+
+		-
+			message: "#^Function get_player_attack not found\\.$#"
+			count: 1
+			path: src/Lotgd/Pvp.php
+
+		-
+			message: "#^Function get_player_defense not found\\.$#"
+			count: 1
+			path: src/Lotgd/Pvp.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 20
+			path: src/Lotgd/Pvp.php
+
+		-
+			message: "#^Function output not found\\.$#"
+			count: 24
+			path: src/Lotgd/Pvp.php
+
+		-
+			message: "#^Function output_notl not found\\.$#"
+			count: 5
+			path: src/Lotgd/Pvp.php
+
+		-
+			message: "#^Function rawoutput not found\\.$#"
+			count: 14
+			path: src/Lotgd/Pvp.php
+
+		-
+			message: "#^Function reltime not found\\.$#"
+			count: 1
+			path: src/Lotgd/Pvp.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 2
+			path: src/Lotgd/Pvp.php
+
+		-
+			message: "#^Constant CLAN_APPLICANT not found\\.$#"
+			count: 1
+			path: src/Lotgd/Repository/ClanRepository.php
+
+		-
+			message: "#^Constant CLAN_LEADER not found\\.$#"
+			count: 1
+			path: src/Lotgd/Repository/ClanRepository.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 5
+			path: src/Lotgd/Sanitize.php
+
+		-
+			message: "#^Variable \\$defaults on left side of \\?\\? is never defined\\.$#"
+			count: 1
+			path: src/Lotgd/Settings.php
+
+		-
+			message: "#^Function output not found\\.$#"
+			count: 1
+			path: src/Lotgd/Specialty.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 2
+			path: src/Lotgd/Specialty.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 1
+			path: src/Lotgd/Spell.php
+
+		-
+			message: "#^Constant SU_EDIT_USERS not found\\.$#"
+			count: 1
+			path: src/Lotgd/SuAccess.php
+
+		-
+			message: "#^Function addnav not found\\.$#"
+			count: 2
+			path: src/Lotgd/SuAccess.php
+
+		-
+			message: "#^Function clearnav not found\\.$#"
+			count: 1
+			path: src/Lotgd/SuAccess.php
+
+		-
+			message: "#^Function debuglog not found\\.$#"
+			count: 1
+			path: src/Lotgd/SuAccess.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 1
+			path: src/Lotgd/SuAccess.php
+
+		-
+			message: "#^Function page_footer not found\\.$#"
+			count: 2
+			path: src/Lotgd/SuAccess.php
+
+		-
+			message: "#^Function page_header not found\\.$#"
+			count: 2
+			path: src/Lotgd/SuAccess.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 2
+			path: src/Lotgd/SuAccess.php
+
+		-
+			message: "#^Constant DEFAULT_TEMPLATE not found\\.$#"
+			count: 5
+			path: src/Lotgd/Template.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 1
+			path: src/Lotgd/Template.php
+
+		-
+			message: "#^Variable \\$template might not be defined\\.$#"
+			count: 1
+			path: src/Lotgd/Template.php
+
+		-
+			message: "#^Constant LANGUAGE not found\\.$#"
+			count: 1
+			path: src/Lotgd/Translator.php
+
+		-
+			message: "#^Constant SU_IS_TRANSLATOR not found\\.$#"
+			count: 3
+			path: src/Lotgd/Translator.php
+
+		-
+			message: "#^Function getsetting not found\\.$#"
+			count: 2
+			path: src/Lotgd/Translator.php
+
+		-
+			message: "#^Function popup not found\\.$#"
+			count: 1
+			path: src/Lotgd/Translator.php
+
+		-
+			message: "#^Function tlschema not found\\.$#"
+			count: 4
+			path: src/Lotgd/Translator.php
+
+		-
+			message: "#^Undefined variable\\: \\$settings$#"
+			count: 1
+			path: src/Lotgd/Translator.php
+
+		-
+			message: "#^Variable \\$namespace in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: src/Lotgd/Translator.php
+
+		-
+			message: "#^Variable \\$settings in isset\\(\\) is never defined\\.$#"
+			count: 1
+			path: src/Lotgd/Translator.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,12 @@
+includes:
+    - vendor/phpstan/phpstan-doctrine/extension.neon
+    - vendor/phpstan/phpstan-doctrine/rules.neon
+    - phpstan-baseline.neon
+
+parameters:
+    level: 1
+    paths:
+        - src
+        - src/Lotgd/Entity
+    bootstrapFiles:
+        - vendor/autoload.php


### PR DESCRIPTION
## Summary
- add PHPStan with Doctrine extension and baseline
- run PHPStan via composer `static` script
- execute static analysis in CI workflow

## Testing
- `composer install --no-interaction`
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e04f4f14832998b5f0844394f79a