### PR TITLE
Use Output class for commentary encoding

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15,10 +15,6 @@ parameters:
 			count: 3
 			path: src/Lotgd/Async/Handler/Commentary.php
 
-		-
-			message: "#^Function appoencode not found\\.$#"
-			count: 1
-			path: src/Lotgd/Async/Handler/Commentary.php
 
 		-
 			message: "#^Function getsetting not found\\.$#"

--- a/src/Lotgd/Async/Handler/Commentary.php
+++ b/src/Lotgd/Async/Handler/Commentary.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Lotgd\Async\Handler;
 
 use Lotgd\MySQL\Database;
-
 use Jaxon\Response\Response;
 use Lotgd\Commentary as CoreCommentary;
 use Lotgd\Util\ScriptName;
+use Lotgd\Output;
 use function Jaxon\jaxon;
 
 /**
@@ -65,11 +65,13 @@ class Commentary
             . "' ORDER BY commentid ASC";
         $result = Database::query($sql);
         $newId = $lastId;
+        /** @var Output $output */
+        global $output;
         while ($row = Database::fetchAssoc($result)) {
             $newId = $row['commentid'];
             $line = CoreCommentary::renderCommentLine($row, $linkbios);
             // Convert colour codes but preserve embedded HTML like profile links
-            $line = appoencode($line, true);
+            $line = $output->appoencode($line, true);
             $comments[] = "<div data-cid='{$row['commentid']}'>" . $line . '</div>';
         }
         Database::freeResult($result);


### PR DESCRIPTION
## Summary
- use `Lotgd\Output` for appoencoding commentary lines
- drop obsolete `appoencode` ignore from phpstan baseline

## Testing
- `php -l src/Lotgd/Async/Handler/Commentary.php`
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e5970d8483299d6a4519b9f83353