### PR TITLE
refactor: use class methods in timeout handler

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,26 +41,6 @@ parameters:
 			path: src/Lotgd/Async/Handler/Mail.php
 
 		-
-			message: "#^Function appoencode not found\\.$#"
-			count: 4
-			path: src/Lotgd/Async/Handler/Timeout.php
-
-		-
-			message: "#^Function getsetting not found\\.$#"
-			count: 1
-			path: src/Lotgd/Async/Handler/Timeout.php
-
-		-
-			message: "#^Function sprintf_translate not found\\.$#"
-			count: 2
-			path: src/Lotgd/Async/Handler/Timeout.php
-
-		-
-			message: "#^Function translate_inline not found\\.$#"
-			count: 3
-			path: src/Lotgd/Async/Handler/Timeout.php
-
-		-
 			message: "#^Constant SU_DEVELOPER not found\\.$#"
 			count: 2
 			path: src/Lotgd/Battle.php


### PR DESCRIPTION
## Summary
- refactor timeout handler to use class and translator helpers
- clean up phpstan baseline for timeout handler

## Testing
- `composer test`
- `composer static`

------
https://chatgpt.com/codex/tasks/task_e_68b9e5a5cae08329937da70b04fdb55c