### PR TITLE
Use helper classes in async mail handler

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,26 +21,6 @@ parameters:
 			path: src/Lotgd/Async/Handler/Commentary.php
 
 		-
-			message: "#^Function getsetting not found\\.$#"
-			count: 1
-			path: src/Lotgd/Async/Handler/Mail.php
-
-		-
-			message: "#^Function maillink not found\\.$#"
-			count: 1
-			path: src/Lotgd/Async/Handler/Mail.php
-
-		-
-			message: "#^Function maillinktabtext not found\\.$#"
-			count: 1
-			path: src/Lotgd/Async/Handler/Mail.php
-
-		-
-			message: "#^Function translate_inline not found\\.$#"
-			count: 1
-			path: src/Lotgd/Async/Handler/Mail.php
-
-		-
 			message: "#^Function appoencode not found\\.$#"
 			count: 4
 			path: src/Lotgd/Async/Handler/Timeout.php

--- a/src/Lotgd/Async/Handler/Mail.php
+++ b/src/Lotgd/Async/Handler/Mail.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Lotgd\Async\Handler;
 
 use Lotgd\MySQL\Database;
-
+use Lotgd\PageParts;
+use Lotgd\Settings;
+use Lotgd\Translator;
 use Jaxon\Response\Response;
 use function Jaxon\jaxon;
 
@@ -19,15 +21,16 @@ class Mail
      */
     public function mailStatus(bool $args = false): Response
     {
-        global $session;
+        global $session, $settings;
 
         if ($args === false || empty($session['user']['acctid'])) {
             return jaxon()->newResponse();
         }
 
-        $timeoutSetting = getsetting('LOGINTIMEOUT', 360); // seconds
-        $new = maillink();
-        $tabtext = maillinktabtext();
+        $settings = $settings ?? new Settings();
+        $timeoutSetting = (int) $settings->getSetting('LOGINTIMEOUT', 360); // seconds
+        $new = PageParts::mailLink();
+        $tabtext = PageParts::mailLinkTabText();
 
         // Get the highest message ID for the current user there is
         $sql = 'SELECT MAX(messageid) AS lastid FROM ' . Database::prefix('mail')
@@ -48,7 +51,7 @@ class Mail
             return $objResponse;
         }
 
-        $tabtext = translate_inline('Legend of the Green Dragon', 'home')
+        $tabtext = Translator::translateInline('Legend of the Green Dragon', 'home')
             . ' - ' . $tabtext;
         $objResponse->script('document.title="' . $tabtext . '";');
         $objResponse->script('lotgdMailNotify(' . $lastMailId . ');');


### PR DESCRIPTION
## Summary
- Use `PageParts` helper methods for mail links in async handler
- Drop temporary mail link wrappers and PHPStan stubs
- Adapt mail status tests for PageParts and reset DB cache

## Testing
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e59aed8083298db693a2bc262aab