### PR TITLE
Refactor Censor to use Settings and DataCache

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -57,16 +57,6 @@ parameters:
 			path: src/Lotgd/Buffs.php
 
 		-
-			message: "#^Function getsetting not found\\.$#"
-			count: 1
-			path: src/Lotgd/Censor.php
-
-		-
-			message: "#^Function updatedatacache not found\\.$#"
-			count: 1
-			path: src/Lotgd/Censor.php
-
-		-
 			message: "#^Variable \\$matches might not be defined\\.$#"
 			count: 6
 			path: src/Lotgd/Censor.php

--- a/src/Lotgd/Censor.php
+++ b/src/Lotgd/Censor.php
@@ -7,6 +7,9 @@ namespace Lotgd;
 use Lotgd\MySQL\Database;
 use Lotgd\Sanitize;
 use Lotgd\Modules\HookHandler;
+use Lotgd\Settings;
+use Lotgd\DataCache;
+use const \SU_EDIT_COMMENTS;
 
 class Censor
 {
@@ -25,7 +28,8 @@ class Censor
         $final_output = $input;
         $sanitized = Sanitize::fullSanitize($input);
         $mix_mask = str_pad('', strlen($sanitized), 'X');
-        if (getsetting('soap', 1)) {
+        $settings = Settings::getInstance();
+        if ($settings->getSetting('soap', 1)) {
             $search = self::nastyWordList();
             $exceptions = array_flip(self::goodWordList());
             $changed_content = false;
@@ -146,7 +150,7 @@ class Censor
         $search = "$start(" . trim($search) . ")+$end";
         $search = str_replace("$start()+$end", "", $search);
         $search = explode(" ", $search);
-        updatedatacache("nastywordlist", $search);
+        DataCache::updatedatacache('nastywordlist', $search);
 
         return $search;
     }


### PR DESCRIPTION
## Summary
- Use Settings and DataCache classes in `Censor`
- Import SU_EDIT_COMMENTS via `use const`
- Remove obsolete phpstan baseline ignores

## Testing
- `php -l src/Lotgd/Censor.php`
- `composer test`
- `composer static`


------
https://chatgpt.com/codex/tasks/task_e_68b9fe1def808329a4fa11124d62f730