### PR TITLE
Refactor settings access to singleton

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -218,7 +218,7 @@ class Installer
      */
     public function stage10(): void
     {
-        global $session, $logd_version, $recommended_modules, $noinstallnavs, $stage, $DB_USEDATACACHE,$settings;
+        global $session, $logd_version, $recommended_modules, $noinstallnavs, $stage, $DB_USEDATACACHE;
         $this->output->output("`@`c`bSuperuser Accounts`b`c");
         $this->output->debug($logd_version, true);
         $sql = "SELECT login, password FROM " . Database::prefix("accounts") . " WHERE superuser & " . SU_MEGAUSER;
@@ -284,7 +284,7 @@ class Installer
      */
     public function stage11(): void
     {
-        global $session, $logd_version, $recommended_modules, $noinstallnavs, $stage, $DB_USEDATACACHE,$settings;
+        global $session, $logd_version, $recommended_modules, $noinstallnavs, $stage, $DB_USEDATACACHE;
         $this->output->output("`@`c`bAll Done!`b`c");
         $this->output->output("Your install of Legend of the Green Dragon has been completed!`n");
         $this->output->output("`nRemember us when you have hundreds of users on your server, enjoying the game.");
@@ -953,7 +953,7 @@ class Installer
      */
     public function stage7(): void
     {
-        global $session, $logd_version, $recommended_modules, $noinstallnavs, $stage, $DB_USEDATACACHE, $settings;
+        global $session, $logd_version, $recommended_modules, $noinstallnavs, $stage, $DB_USEDATACACHE;
         if ($session['dbinfo']['upgrade'] ?? false) {
             require __DIR__ . '/../data/installer_sqlstatements.php';
         }
@@ -1259,7 +1259,7 @@ class Installer
      */
     public function stage9(): void
     {
-        global $session, $logd_version, $recommended_modules, $noinstallnavs, $stage, $DB_USEDATACACHE, $DB_PREFIX, $settings;
+        global $session, $logd_version, $recommended_modules, $noinstallnavs, $stage, $DB_USEDATACACHE, $DB_PREFIX;
         $session['skipmodules'] = $session['skipmodules'] ?? false;
         $this->output->output("`@`c`bRunning Database Migrations`b`c");
         $this->output->output("`2The installer now uses Doctrine migrations to set up the database schema.`n");
@@ -1438,20 +1438,12 @@ class Installer
 
     private function getSetting(string $name, $default = '')
     {
-        global $settings;
-        if ($settings instanceof Settings) {
-            return $settings->getSetting($name, $default);
-        }
-        return $default;
+        return Settings::getInstance()->getSetting($name, $default);
     }
 
     private function saveSetting(string $name, $value): void
     {
-        global $settings;
-        if (! ($settings instanceof Settings)) {
-            $settings = new Settings('settings');
-        }
-        $settings->saveSetting($name, $value);
+        Settings::getInstance()->saveSetting($name, $value);
     }
 
     /**

--- a/lib/settings.php
+++ b/lib/settings.php
@@ -5,49 +5,30 @@ use Lotgd\MySQL\Database;
 
 function savesetting($settingname, $value)
 {
-    global $settings;
-    if (!($settings instanceof Settings)) {
-        $settings = new Settings('settings');
-    }
-    $settings->saveSetting($settingname, $value);
+    Settings::getInstance()->saveSetting($settingname, $value);
 }
 
 function loadsettings()
 {
-    global $settings;
     // settings are loaded on demand
 }
 
 function clearsettings()
 {
-    global $settings;
-    if ($settings instanceof Settings) {
-        $settings->clearSettings();
-    }
-    unset($settings);
-    $settings = new Settings('settings');
+    Settings::getInstance()->clearSettings();
+    Settings::setInstance(new Settings());
 }
 
 function getsetting($settingname, $default)
 {
-    global $settings;
-    if (!($settings instanceof Settings)) {
-        if (!Database::tableExists(Database::prefix('settings'))) {
-            return $default;
-        }
-
-        $settings = new Settings('settings');
+    if (!Database::tableExists(Database::prefix('settings'))) {
+        return $default;
     }
 
-    return $settings->getSetting($settingname, $default);
+    return Settings::getInstance()->getSetting($settingname, $default);
 }
 
 function get_admin_email($default = 'postmaster@localhost')
 {
-    global $settings;
-    if (!($settings instanceof Settings)) {
-        $settings = new Settings('settings');
-    }
-
-    return (string) $settings->getSetting('gameadminemail', $default);
+    return (string) Settings::getInstance()->getSetting('gameadminemail', $default);
 }

--- a/src/Lotgd/Async/Handler/Mail.php
+++ b/src/Lotgd/Async/Handler/Mail.php
@@ -21,13 +21,13 @@ class Mail
      */
     public function mailStatus(bool $args = false): Response
     {
-        global $session, $settings;
+        global $session;
+        $settings = Settings::getInstance();
 
         if ($args === false || empty($session['user']['acctid'])) {
             return jaxon()->newResponse();
         }
 
-        $settings = $settings ?? new Settings();
         $timeoutSetting = (int) $settings->getSetting('LOGINTIMEOUT', 360); // seconds
         $new = PageParts::mailLink();
         $tabtext = PageParts::mailLinkTabText();

--- a/src/Lotgd/Async/Handler/Timeout.php
+++ b/src/Lotgd/Async/Handler/Timeout.php
@@ -21,7 +21,8 @@ class Timeout
      */
     public function timeoutStatus(bool $args = false): Response
     {
-        global $session, $start_timeout_show_seconds, $never_timeout_if_browser_open, $settings, $output;
+        global $session, $start_timeout_show_seconds, $never_timeout_if_browser_open, $output;
+        $settings = Settings::getInstance();
 
         if ($args === false) {
             return jaxon()->newResponse();

--- a/src/Lotgd/Backtrace.php
+++ b/src/Lotgd/Backtrace.php
@@ -101,8 +101,7 @@ class Backtrace
      */
     public static function getType(mixed $in): string
     {
-        global $settings;
-        $charset = isset($settings) ? $settings->getSetting('charset', 'UTF-8') : 'UTF-8';
+        $charset = Settings::getInstance()->getSetting('charset', 'UTF-8');
         $return = '';
         if (is_string($in)) {
             $return .= "<span class='string'>\"";

--- a/src/Lotgd/DataCache.php
+++ b/src/Lotgd/DataCache.php
@@ -28,10 +28,11 @@ class DataCache
      */
     public static function datacache(string $name, int $duration = 60): mixed
     {
-        global $datacache, $settings;
-        if (!isset($settings)) {
-            return false; // not yet setup most likely
+        global $datacache;
+        if (! Settings::hasInstance()) {
+            return false;
         }
+        $settings = Settings::getInstance();
 
         if ($settings->getSetting('usedatacache', 0)) {
             if (isset(self::$cache[$name])) {
@@ -58,10 +59,10 @@ class DataCache
      */
     public static function updatedatacache(string $name, mixed $data): bool
     {
-        global $settings;
-        if (!isset($settings)) {
+        if (! Settings::hasInstance()) {
             return false;
         }
+        $settings = Settings::getInstance();
         if ($settings->getSetting('usedatacache', 0)) {
             $base = $settings->getSetting('datacachepath', '/tmp');
             if (file_exists($base) && !is_dir($base)) {
@@ -105,10 +106,10 @@ class DataCache
      */
     public static function invalidatedatacache(string $name, bool $withpath = true): void
     {
-        global $settings;
-        if (!isset($settings)) {
+        if (! Settings::hasInstance()) {
             return;
         }
+        $settings = Settings::getInstance();
         if ($settings->getSetting('usedatacache', 0)) {
             $fullname = $withpath ? self::makecachetempname($name) : $name;
             if (file_exists($fullname)) {
@@ -125,10 +126,10 @@ class DataCache
      */
     public static function massinvalidate(string $name = ''): void
     {
-        global $settings;
-        if (!isset($settings)) {
+        if (! Settings::hasInstance()) {
             return;
         }
+        $settings = Settings::getInstance();
         if ($settings->getSetting('usedatacache', 0)) {
             $name = DATACACHE_FILENAME_PREFIX . $name;
             if (self::$path == '') {
@@ -151,10 +152,10 @@ class DataCache
      */
     public static function makecachetempname(string $name): string
     {
-        global $settings;
-        if (!isset($settings)) {
+        if (! Settings::hasInstance()) {
             return '';
         }
+        $settings = Settings::getInstance();
         if (self::$path == '') {
             self::$path = $settings->getSetting('datacachepath', '/tmp');
         }

--- a/src/Lotgd/DateTime.php
+++ b/src/Lotgd/DateTime.php
@@ -121,7 +121,7 @@ class DateTime
 
     public static function getGameTime(): string
     {
-        global $settings;
+        $settings = Settings::getInstance();
         return gmdate($settings->getSetting('gametime', 'g:i a'), self::gametime());
     }
 
@@ -133,7 +133,7 @@ class DateTime
 
     public static function convertGameTime(int $intime, bool $debug = false): int
     {
-        global $settings;
+        $settings = Settings::getInstance();
         $intime -= $settings->getSetting('gameoffsetseconds', 0);
         $epoch = strtotime($settings->getSetting('game_epoch', gmdate('Y-m-d 00:00:00 O', strtotime('-30 days'))));
         $now = strtotime(gmdate('Y-m-d H:i:s O', $intime));
@@ -146,7 +146,7 @@ class DateTime
 
     public static function gameTimeDetails(): array
     {
-        global $settings;
+        $settings = Settings::getInstance();
         $ret = [];
         $ret['now'] = date('Y-m-d 00:00:00');
         $ret['gametime'] = self::gametime();

--- a/src/Lotgd/ErrorHandler.php
+++ b/src/Lotgd/ErrorHandler.php
@@ -54,18 +54,14 @@ class ErrorHandler
      */
     public static function handleError(int $errno, string $errstr, string $errfile, int $errline): void
     {
-        global $session, $settings;
+        global $session;
         static $inErrorHandler = 0;
 
-        if (!error_reporting()) {
+        if (! error_reporting()) {
             return; // @ operator used
         }
         ini_set('display_errors', '1');
-        $hasSettings = is_object($settings) && method_exists($settings, 'getSetting');
-        if (!$settings instanceof Settings && !$hasSettings) {
-            $settings = new Settings('settings');
-            $hasSettings = true;
-        }
+        $settings = Settings::getInstance();
         $inErrorHandler++;
         if ($inErrorHandler > 1) {
             if ($errno & (E_USER_WARNING | E_WARNING)) {
@@ -79,7 +75,7 @@ class ErrorHandler
         switch ($errno) {
             case E_NOTICE:
             case E_USER_NOTICE:
-                $showNotices = $hasSettings ? $settings->getSetting('show_notices', 0) : 0;
+                $showNotices = $settings->getSetting('show_notices', 0);
                 if ($showNotices && ($session['user']['superuser'] & SU_SHOW_PHPNOTICE)) {
                     debug("PHP Notice: \"$errstr\"<br>in <b>$errfile</b> at <b>$errline</b>.");
                 }
@@ -95,7 +91,7 @@ class ErrorHandler
                 } else {
                     $backtrace = '';
                 }
-                if ($hasSettings && !empty($settings->getSetting('notify_on_warn', 0))) {
+                if (! empty($settings->getSetting('notify_on_warn', 0))) {
                     self::errorNotify($errno, $errstr, $errfile, $errline, $backtrace);
                 }
                 break;
@@ -103,7 +99,7 @@ class ErrorHandler
             case E_USER_ERROR:
                 $backtrace = Backtrace::show();
                 self::renderError($errstr, $errfile, $errline, $backtrace);
-                if ($hasSettings && !empty($settings->getSetting('notify_on_error', 0))) {
+                if (! empty($settings->getSetting('notify_on_error', 0))) {
                     self::errorNotify($errno, $errstr, $errfile, $errline, $backtrace);
                 }
                 die();
@@ -137,25 +133,21 @@ class ErrorHandler
      */
     public static function errorNotify(int $errno, $errstr, string $errfile, int $errline, string $backtrace): void
     {
-        global $session, $settings;
-        $hasSettings = is_object($settings) && method_exists($settings, 'getSetting');
-        if (!$settings instanceof Settings && !$hasSettings) {
-            $settings = new Settings('settings');
-            $hasSettings = true;
-        }
+        global $session;
+        $settings = Settings::getInstance();
 
         $msg = is_string($errstr) ? $errstr : json_encode($errstr);
         if (strlen($msg) <= 0) {
             return;
         }
 
-        $addressList = $hasSettings ? (string) $settings->getSetting('notify_address', '') : '';
+        $addressList = (string) $settings->getSetting('notify_address', '');
         $sendto = array_filter(array_map('trim', explode(';', $addressList)));
         if (empty($sendto)) {
             $sendto = [$settings->getSetting('gameadminemail', 'postmaster@localhost')];
         }
 
-        $howoften = $hasSettings ? (int) $settings->getSetting('notify_every', 30) : 30;
+        $howoften = (int) $settings->getSetting('notify_every', 30);
         $data = DataCache::datacache('error_notify', 86400);
         if (!is_array($data)) {
             $data = ['firstrun' => false, 'errors' => []];
@@ -196,9 +188,7 @@ class ErrorHandler
                 $body = $html_text;
                 foreach ($sendto as $email) {
                     debug("Notifying $email of this error.");
-                    $admin = $hasSettings
-                        ? $settings->getSetting('gameadminemail', 'postmaster@localhost')
-                        : 'postmaster@localhost';
+                    $admin = $settings->getSetting('gameadminemail', 'postmaster@localhost');
                     $from = [$admin => $admin];
                     \Lotgd\Mail::send([$email => $email], $body, $subject, $from, false, 'text/html');
                 }
@@ -208,7 +198,7 @@ class ErrorHandler
             }
         }
         if ($settings->getSetting('usedatacache', 0)
-            && !DataCache::updatedatacache('error_notify', $data)) {
+            && ! DataCache::updatedatacache('error_notify', $data)) {
             error_log('Unable to write datacache for error_notify');
         }
         debug($data);
@@ -222,18 +212,11 @@ class ErrorHandler
      */
     public static function handleException(\Throwable $exception): void
     {
-        global $settings;
-
         $trace = Backtrace::show($exception->getTrace());
         self::renderError($exception->getMessage(), $exception->getFile(), $exception->getLine(), $trace);
 
-        $hasSettings = is_object($settings) && method_exists($settings, 'getSetting');
-        if (!$settings instanceof Settings && !$hasSettings) {
-            $settings = new Settings('settings');
-            $hasSettings = true;
-        }
-
-        $notify = $hasSettings ? (bool) $settings->getSetting('notify_on_error', 0) : false;
+        $settings = Settings::getInstance();
+        $notify = (bool) $settings->getSetting('notify_on_error', 0);
 
         if ($notify) {
             self::errorNotify(E_ERROR, $exception->getMessage(), $exception->getFile(), $exception->getLine(), $trace);

--- a/src/Lotgd/ExpireChars.php
+++ b/src/Lotgd/ExpireChars.php
@@ -41,7 +41,7 @@ class ExpireChars
      */
     private static function needsExpiration(): bool
     {
-        global $settings;
+        $settings = Settings::getInstance();
         $lastExpire = strtotime($settings->getSetting('last_char_expire', DATETIME_DATEMIN));
         if ($lastExpire >= strtotime('-23 hours')) {
             return false;
@@ -56,10 +56,10 @@ class ExpireChars
      */
     private static function cleanupExpiredAccounts(): void
     {
-        global $settings;
-        $old = (int)$settings->getSetting('expireoldacct', 45);
-        $new = (int)$settings->getSetting('expirenewacct', 10);
-        $trash = (int)$settings->getSetting('expiretrashacct', 1);
+        $settings = Settings::getInstance();
+        $old = (int) $settings->getSetting('expireoldacct', 45);
+        $new = (int) $settings->getSetting('expirenewacct', 10);
+        $trash = (int) $settings->getSetting('expiretrashacct', 1);
 
         $rows = self::fetchAccountsToExpire($old, $new, $trash);
         if (empty($rows)) {
@@ -148,8 +148,8 @@ class ExpireChars
      */
     private static function notifyUpcomingExpirations(): void
     {
-        global $settings;
-        $old = max(1, ((int)$settings->getSetting('expireoldacct', 45)) - ((int)$settings->getSetting('notifydaysbeforedeletion', 5)));
+        $settings = Settings::getInstance();
+        $old = max(1, ((int) $settings->getSetting('expireoldacct', 45)) - ((int) $settings->getSetting('notifydaysbeforedeletion', 5)));
         $sql = 'SELECT login,acctid,emailaddress FROM ' . Database::prefix('accounts') .
             " WHERE 1=0 " . ($old > 0 ? "OR (laston < '" . date('Y-m-d H:i:s', strtotime("-$old days")) . "')" : '') .
             " AND emailaddress!='' AND sentnotice=0 AND (superuser&" . NO_ACCOUNT_EXPIRATION . ')=0';

--- a/src/Lotgd/Forest/Outcomes.php
+++ b/src/Lotgd/Forest/Outcomes.php
@@ -27,7 +27,8 @@ class Outcomes
      */
     public static function victory(array $enemies, bool|string $denyflawless = false): void
     {
-        global $session, $options, $settings;
+        global $session, $options;
+        $settings = Settings::getInstance();
         $diddamage = false;
         $creaturelevel = 0;
         $gold = 0;
@@ -143,7 +144,8 @@ class Outcomes
      */
     public static function defeat(array $enemies, string $where = 'in the forest'): void
     {
-        global $session, $settings;
+        global $session;
+        $settings = Settings::getInstance();
         $percent = $settings->getSetting('forestexploss', 10);
         Nav::add('Daily news', 'news.php');
         $names = [];
@@ -192,7 +194,8 @@ class Outcomes
      */
     public static function buffBadguy(array $badguy): array
     {
-        global $session, $settings;
+        global $session;
+        $settings = Settings::getInstance();
         static $dk = false;
         if ($dk === false) {
             $dk = get_player_dragonkillmod(true);

--- a/src/Lotgd/Mail.php
+++ b/src/Lotgd/Mail.php
@@ -19,17 +19,12 @@ use PHPMailer\PHPMailer\PHPMailer;
 
 class Mail
 {
-    private static $settings = null;
+    private static ?Settings $settings = null;
 
-    private static function getSettings()
+    private static function getSettings(): Settings
     {
-        global $settings;
-        if (is_object($settings) && method_exists($settings, 'getSetting')) {
-            return $settings;
-        }
-
-        if (! is_object(self::$settings)) {
-            self::$settings = new Settings();
+        if (! self::$settings instanceof Settings) {
+            self::$settings = Settings::getInstance();
         }
 
         return self::$settings;

--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -543,7 +543,7 @@ class Nav
      */
     public static function privateAddNav($text, string|false|null $link = false, $priv = false, $pop = false, $popsize = '500x300')
     {
-        global $nav, $session, $REQUEST_URI, $notranslate, $settings;
+        global $nav, $session, $REQUEST_URI, $notranslate;
 
         if ($link !== false) {
             $link = (string) $link;

--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -35,7 +35,7 @@ class Newday
 
     public static function commentCleanup(): void
     {
-        global $settings;
+        $settings = Settings::getInstance();
 
         $timestamp = self::calculateExpirationTimestamp('2 month');
         Database::query('DELETE FROM ' . Database::prefix('referers') . " WHERE last < '$timestamp'");
@@ -48,7 +48,7 @@ class Newday
         if ($ok) {
             $sql = 'DELETE FROM ' . Database::prefix('debuglog') . " WHERE date <'$timestamp'";
             Database::query($sql);
-            $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expiredebuglog', 18) . ' days');
+        $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expiredebuglog', 18) . ' days');
             $sql = 'DELETE FROM ' . Database::prefix('debuglog_archive') . " WHERE date <'$timestamp'";
             if ($settings->getSetting('expiredebuglog', 18) > 0) {
                 Database::query($sql);
@@ -112,7 +112,7 @@ class Newday
 
     public static function runOnce(): void
     {
-        global $settings;
+        $settings = Settings::getInstance();
 
         HookHandler::hook('newday-runonce', []);
 
@@ -136,7 +136,7 @@ class Newday
             }
         }
 
-        if (!$settings->getSetting('newdaycron', 0)) {
+        if (! $settings->getSetting('newdaycron', 0)) {
             self::dbCleanup();
             self::commentCleanup();
             self::charCleanup();
@@ -344,7 +344,8 @@ class Newday
 
     public static function setRace(string $resline): void
     {
-        global $session, $settings;
+        global $session;
+        $settings = Settings::getInstance();
         $setrace = httpget('setrace');
         if ($setrace != '') {
             $vname = $settings->getSetting('villagename', LOCATION_FIELDS);

--- a/src/Lotgd/Output.php
+++ b/src/Lotgd/Output.php
@@ -237,12 +237,7 @@ class Output
      */
     public function appoencode($data, $priv = false)
     {
-        global $settings;
-        if (!isset($settings)) {
-            $charset = 'UTF-8';
-        } else {
-            $charset = $settings->getSetting('charset', 'UTF-8');
-        }
+        $charset = Settings::getInstance()->getSetting('charset', 'UTF-8');
         $start = 0;
         $out   = '';
         if (($pos = strpos($data, '`')) !== false) {

--- a/src/Lotgd/Page/Header.php
+++ b/src/Lotgd/Page/Header.php
@@ -18,7 +18,8 @@ class Header
 {
     public static function pageHeader(...$args): void
     {
-        global $header, $SCRIPT_NAME, $session, $template, $settings;
+        global $header, $SCRIPT_NAME, $session, $template;
+        $settings = Settings::getInstance();
 
         PageParts::$noPopups['login.php'] = true;
         PageParts::$noPopups['motd.php'] = true;
@@ -69,7 +70,7 @@ class Header
             $header = str_replace('{meta_description}', $metaDesc, $header);
         }
         $header .= Translator::tlbuttonPop();
-        if (isset($settings) && $settings->getSetting('debug', 0)) {
+        if ($settings->getSetting('debug', 0)) {
             $session['debugstart'] = microtime();
         }
     }

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -210,7 +210,8 @@ class PageParts
  */
     public static function charStats(): string
     {
-        global $session, $playermount, $companions, $settings;
+        global $session, $playermount, $companions;
+        $settings = Settings::getInstance();
         if (defined("IS_INSTALLER") && IS_INSTALLER === true) {
             return "";
         }
@@ -830,11 +831,10 @@ class PageParts
      */
     public static function canonicalLink(): string
     {
-        global $REQUEST_URI, $SCRIPT_NAME, $settings;
+        global $REQUEST_URI, $SCRIPT_NAME;
+        $settings = Settings::getInstance();
 
-        $serverUrl = isset($settings)
-            ? rtrim($settings->getSetting('serverurl', 'http://' . $_SERVER['HTTP_HOST']), '/')
-            : 'http://' . $_SERVER['HTTP_HOST'];
+        $serverUrl = rtrim($settings->getSetting('serverurl', 'http://' . $_SERVER['HTTP_HOST']), '/');
 
         $uri = $REQUEST_URI ?? '';
         if ($uri === '') {
@@ -934,7 +934,8 @@ class PageParts
      */
     public static function computePageGenerationStats(float $pagestarttime): string
     {
-        global $session, $settings, $SCRIPT_NAME;
+        global $session, $SCRIPT_NAME;
+        $settings = Settings::getInstance();
 
         $gentime = DateTime::getMicroTime() - $pagestarttime;
         if (!isset($session['user']['gentime'])) {
@@ -945,7 +946,7 @@ class PageParts
             $session['user']['gentimecount'] = 0;
         }
         $session['user']['gentimecount']++;
-        if (isset($settings) && $settings->getSetting('debug', 0)) {
+        if ($settings->getSetting('debug', 0)) {
             $sql = "INSERT INTO " . Database::prefix('debug') . " VALUES (0,'pagegentime','runtime','$SCRIPT_NAME','" . ($gentime) . "');";
             Database::query($sql);
             $sql = "INSERT INTO " . Database::prefix('debug') . " VALUES (0,'pagegentime','dbtime','$SCRIPT_NAME','" . (round(Database::getInfo('querytime', 0), 3)) . "');";

--- a/src/Lotgd/PullUrl.php
+++ b/src/Lotgd/PullUrl.php
@@ -24,10 +24,8 @@ class PullUrl
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         $val = 5;
         if (defined('DB_CONNECTED') && DB_CONNECTED === true) {
-            global $settings;
-            if ($settings instanceof Settings) {
-                $val = $settings->getSetting('curltimeout', 5);
-            }
+            $settings = Settings::getInstance();
+            $val = $settings->getSetting('curltimeout', 5);
         }
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $val);
         curl_setopt($ch, CURLOPT_TIMEOUT, $val);

--- a/src/Lotgd/Redirect.php
+++ b/src/Lotgd/Redirect.php
@@ -21,15 +21,12 @@ class Redirect
      */
     public static function redirect(string $location, string|bool $reason = false): void
     {
-        global $session, $REQUEST_URI, $settings;
+        global $session, $REQUEST_URI;
+        $settings = Settings::getInstance();
         if (strpos($location, 'badnav.php') === false) {
             $session['allowednavs'] = [];
             Nav::add('', $location);
-            if (isset($settings) && $settings instanceof Settings) {
-                $charset = $settings->getSetting('charset', 'UTF-8');
-            } else {
-                $charset = 'UTF-8'; // Default charset if settings not available
-            }
+            $charset = $settings->getSetting('charset', 'UTF-8');
             $failoutput = new Output();
             $failoutput->outputNotl("`lWhoops, your navigation is broken. Hopefully we can restore it.`n`n");
             $failoutput->outputNotl('`$');

--- a/src/Lotgd/ServerFunctions.php
+++ b/src/Lotgd/ServerFunctions.php
@@ -21,7 +21,7 @@ class ServerFunctions
      */
     public static function isTheServerFull(): bool
     {
-        global $settings;
+        $settings = Settings::getInstance();
         if (abs($settings->getSetting('OnlineCountLast', 0) - strtotime('now')) > 60) {
             $sql = "SELECT count(acctid) as counter FROM " . Database::prefix('accounts') . " WHERE locked=0 AND loggedin=1 AND laston>'" . date('Y-m-d H:i:s', strtotime('-' . $settings->getSetting('LOGINTIMEOUT', 900) . ' seconds')) . "'";
             $result = Database::query($sql);

--- a/src/Lotgd/Settings.php
+++ b/src/Lotgd/Settings.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Exception\TableNotFoundException;
 
 class Settings
 {
+    private static ?self $instance = null;
     private string $tablename;
     /** @var array|null */
     private $settings = null;
@@ -21,11 +22,11 @@ class Settings
     /**
      * Initialize the settings handler.
      *
-     * @param string|false $tablename Optional table name
+     * @param string $tablename Optional table name
      */
-    public function __construct(string|false $tablename = false)
+    public function __construct(string $tablename = 'settings')
     {
-        $this->tablename = $tablename === false ? Database::prefix('settings') : Database::prefix($tablename);
+        $this->tablename = Database::prefix($tablename);
         $this->settings = null;
         $this->loadSettings();
     }
@@ -35,11 +36,25 @@ class Settings
      */
     public static function getInstance(): self
     {
-        global $settings;
-        if (!$settings instanceof self) {
-            $settings = new self('settings');
+        if (! self::$instance instanceof self) {
+            if (isset($GLOBALS['settings']) && $GLOBALS['settings'] instanceof self) {
+                self::$instance = $GLOBALS['settings'];
+            } else {
+                self::$instance = new self();
+            }
         }
-        return $settings;
+
+        return self::$instance;
+    }
+
+    public static function setInstance(?self $instance): void
+    {
+        self::$instance = $instance;
+    }
+
+    public static function hasInstance(): bool
+    {
+        return self::$instance instanceof self;
     }
 
     /**

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -66,8 +66,8 @@ class Template
      */
     public static function prepareTemplate(bool $force = false): void
     {
-        global $settings;
-        if (!$force) {
+        $settings = Settings::getInstance();
+        if (! $force) {
             if (defined('TEMPLATE_IS_PREPARED')) {
                 return;
             }
@@ -86,14 +86,7 @@ class Template
             [$templateType, $templatename] = explode(':', $templatename, 2);
         }
         if ($templatename == '' || (!file_exists("templates/$templatename") && !is_dir("templates_twig/$templatename"))) {
-            if (isset($settings) && $settings instanceof Settings) {
-                // Pull the skin from settings (the distribution ships with DEFAULT_TEMPLATE).
-                // Administrators can change this via the 'defaultskin' setting.
-                $templatename = $settings->getSetting('defaultskin', DEFAULT_TEMPLATE);
-            } else {
-                // Use DEFAULT_TEMPLATE when settings are unavailable
-                $templatename = DEFAULT_TEMPLATE;
-            }
+            $templatename = $settings->getSetting('defaultskin', DEFAULT_TEMPLATE);
             if (strpos($templatename, ':') !== false) {
                 [$templateType, $templatename] = explode(':', $templatename, 2);
             }
@@ -108,9 +101,7 @@ class Template
         if ($templateType === 'twig' || is_dir("templates_twig/$templatename")) {
             // Initialize Twig environment for Twig templates
             $cachePath = null;
-            if ($settings instanceof Settings) {
-                $cachePath = $settings->getSetting('datacachepath', '/tmp');
-            }
+            $cachePath = $settings->getSetting('datacachepath', '/tmp');
             TwigTemplate::init($templatename, $cachePath);
             $template = [];
         } else {

--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -29,16 +29,12 @@ class Translator
      */
     public static function translatorSetup(): void
     {
-        global $settings;
+        $settings = Settings::getInstance();
         //Determine what language to use
         if (defined("TRANSLATOR_IS_SET_UP")) {
             return;
         }
         define("TRANSLATOR_IS_SET_UP", true);
-
-        if (!isset($settings)) {
-            return; // not yet setup most likely
-        }
 
         global $language, $session;
         $language = "";
@@ -77,12 +73,12 @@ class Translator
      */
     public static function translate(string|array $indata, string|false|null $namespace = false): string|array
     {
-        global $session,$settings;
+        global $session;
+        $settings = Settings::getInstance();
 
         if (
-            !self::$translation_is_enabled
-            || !isset($settings)
-            || $settings->getSetting("enabletranslation", true) == false
+            ! self::$translation_is_enabled
+            || $settings->getSetting('enabletranslation', true) == false
         ) {
             return $indata;
         }
@@ -551,12 +547,10 @@ class Translator
      */
     public static function translatorCheckCollectTexts(): void
     {
-        global $session, $settings;
-        if (!isset($settings)) {
-            return; // not yet setup most likely
-        }
+        global $session;
+        $settings = Settings::getInstance();
 
-        $tlmax = $settings->getSetting("tl_maxallowed", 0);
+        $tlmax = $settings->getSetting('tl_maxallowed', 0);
 
         if ($settings->getSetting("permacollect", 0)) {
             $settings->saveSetting("collecttexts", 1);


### PR DESCRIPTION
## Summary
- add singleton instance management to `Settings`
- replace global `$settings` usage with `Settings::getInstance()` across codebase
- update data cache and helper utilities to rely on centralized settings

## Testing
- `composer test` *(fails: Failed asserting that false is identical to Array &0 (0 => 50.0 1 => 100.0 2 => 150.0 ))*


------
https://chatgpt.com/codex/tasks/task_e_68ba0073a2f4832983771e098ff073b1