### PR TITLE
refactor: use Output and Template helpers

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,15 +61,6 @@ parameters:
 			count: 6
 			path: src/Lotgd/Censor.php
 
-		-
-			message: "#^Function appoencode not found\\.$#"
-			count: 1
-			path: src/Lotgd/CharStats.php
-
-		-
-			message: "#^Function templatereplace not found\\.$#"
-			count: 6
-			path: src/Lotgd/CharStats.php
 
 		-
 			message: "#^Function sprintf_translate not found\\.$#"
@@ -415,11 +406,6 @@ parameters:
 			message: "#^Variable \\$badguy might not be defined\\.$#"
 			count: 1
 			path: src/Lotgd/Forest/Outcomes.php
-
-		-
-			message: "#^Function appoencode not found\\.$#"
-			count: 1
-			path: src/Lotgd/Forms.php
 
 		-
 			message: "#^Function datacache not found\\.$#"
@@ -837,11 +823,6 @@ parameters:
 			path: src/Lotgd/MySQL/TableDescriptor.php
 
 		-
-			message: "#^Function appoencode not found\\.$#"
-			count: 4
-			path: src/Lotgd/Nav.php
-
-		-
 			message: "#^Function popup not found\\.$#"
 			count: 2
 			path: src/Lotgd/Nav.php
@@ -957,11 +938,6 @@ parameters:
 			path: src/Lotgd/Newday.php
 
 		-
-			message: "#^Function appoencode not found\\.$#"
-			count: 1
-			path: src/Lotgd/Output.php
-
-		-
 			message: "#^Function sanitize not found\\.$#"
 			count: 1
 			path: src/Lotgd/Output.php
@@ -992,11 +968,6 @@ parameters:
 			path: src/Lotgd/PageParts.php
 
 		-
-			message: "#^Function appoencode not found\\.$#"
-			count: 9
-			path: src/Lotgd/PageParts.php
-
-		-
 			message: "#^Function check_temp_stat not found\\.$#"
 			count: 19
 			path: src/Lotgd/PageParts.php
@@ -1008,11 +979,6 @@ parameters:
 
 		-
 			message: "#^Function httpget not found\\.$#"
-			count: 1
-			path: src/Lotgd/PageParts.php
-
-		-
-			message: "#^Function templatereplace not found\\.$#"
 			count: 1
 			path: src/Lotgd/PageParts.php
 

--- a/src/Lotgd/CharStats.php
+++ b/src/Lotgd/CharStats.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\Translator;
+use Lotgd\Template;
+use Lotgd\Output;
 
 class CharStats
 {
@@ -56,25 +58,26 @@ class CharStats
      */
     public function render(string $buffs): string
     {
-        $charstat_str = templatereplace('statstart');
+        $output = Output::getInstance();
+        $charstat_str = Template::templateReplace('statstart');
         foreach ($this->stats as $label => $section) {
             if (count($section)) {
                 $arr = ['title' => Translator::translateInline($label)];
-                $sectionhead = templatereplace('stathead', $arr);
+                $sectionhead = Template::templateReplace('stathead', $arr);
                 foreach ($section as $name => $val) {
                     if ($name == $label) {
                         $a2 = ['title' => Translator::translateInline("`0$name"), 'value' => "`^$val`0"];
-                        $charstat_str .= templatereplace('statbuff', $a2);
+                        $charstat_str .= Template::templateReplace('statbuff', $a2);
                     } else {
                         $a2 = ['title' => Translator::translateInline("`&$name`0"), 'value' => "`^$val`0"];
-                        $charstat_str .= $sectionhead . templatereplace('statrow', $a2);
+                        $charstat_str .= $sectionhead . Template::templateReplace('statrow', $a2);
                         $sectionhead = '';
                     }
                 }
             }
         }
-        $charstat_str .= templatereplace('statbuff', ['title' => Translator::translateInline('`0Buffs'), 'value' => $buffs]);
-        $charstat_str .= templatereplace('statend');
-        return appoencode($charstat_str, true);
+        $charstat_str .= Template::templateReplace('statbuff', ['title' => Translator::translateInline('`0Buffs'), 'value' => $buffs]);
+        $charstat_str .= Template::templateReplace('statend');
+        return $output->appoencode($charstat_str, true);
     }
 }

--- a/src/Lotgd/Forms.php
+++ b/src/Lotgd/Forms.php
@@ -7,6 +7,7 @@ namespace Lotgd;
 use Lotgd\Translator;
 use Lotgd\DumpItem;
 use Lotgd\Modules\HookHandler;
+use Lotgd\Output;
 
 class Forms
 {
@@ -21,14 +22,15 @@ class Forms
         array|bool $info = false,
         bool $scriptOutput = true
     ): string {
-        global $schema, $session, $output;
+        global $schema, $session;
+        $output = Output::getInstance();
 
         $talkline = Translator::translateInline($talkline, $schema);
         $youhave = Translator::translateInline('You have ');
         $charsleft = Translator::translateInline(' characters left.');
         $startdiv = $startdiv === false ? '' : $startdiv;
 
-        $encodedStart = addslashes(appoencode($startdiv));
+        $encodedStart = addslashes($output->appoencode($startdiv));
         $maxChars = (int) getsetting('maxchars', 200);
 
         $script = <<<JS

--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -544,6 +544,7 @@ class Nav
     public static function privateAddNav($text, string|false|null $link = false, $priv = false, $pop = false, $popsize = '500x300')
     {
         global $nav, $session, $REQUEST_URI, $notranslate;
+        $output = Output::getInstance();
 
         if ($link !== false) {
             $link = (string) $link;
@@ -597,10 +598,10 @@ class Nav
         Output::getInstance()->closeOpenFont();
         if ($link === false) {
             $text = HolidayText::holidayize($text, 'nav');
-            $thisnav .= Translator::tlbuttonPop() . Template::templateReplace('navhead', ['title' => appoencode($text, $priv)]);
+            $thisnav .= Translator::tlbuttonPop() . Template::templateReplace('navhead', ['title' => $output->appoencode($text, $priv)]);
         } elseif ($link === '') {
             $text = HolidayText::holidayize($text, 'nav');
-            $thisnav .= Translator::tlbuttonPop() . Template::templateReplace('navhelp', ['text' => appoencode($text, $priv)]);
+            $thisnav .= Translator::tlbuttonPop() . Template::templateReplace('navhelp', ['text' => $output->appoencode($text, $priv)]);
         } elseif ($link == '!!!addraw!!!') {
             $thisnav .= $text;
         } else {
@@ -724,7 +725,7 @@ class Nav
                     $text = preg_replace('/^`0+/', '', $text);
                 }
                 $n = Template::templateReplace('navitem', [
-                    'text' => appoencode($text, $priv),
+                    'text' => $output->appoencode($text, $priv),
                     'link' => $link . ($pop != true ? $extra : ''),
                     'accesskey' => $keyrep,
                     'popup' => ($pop == true ? "target='_blank'" . ($popsize > '' ? " onClick=\"" . popup($link, $popsize) . "; return false;\"" : '') : ''),
@@ -752,6 +753,7 @@ class Nav
     private static function privateAddSubHeader($text, bool $priv = false): string
     {
         global $nav, $session, $notranslate;
+        $output = Output::getInstance();
         $link = false;
         $thisnav = '';
         $unschema = 0;
@@ -787,7 +789,7 @@ class Nav
             }
         }
         $text = HolidayText::holidayize($text, 'nav');
-        $thisnav .= Translator::tlbuttonPop() . Template::templateReplace('navheadsub', ['title' => appoencode($text, $priv)]);
+        $thisnav .= Translator::tlbuttonPop() . Template::templateReplace('navheadsub', ['title' => $output->appoencode($text, $priv)]);
         if ($unschema) {
             tlschema();
         }

--- a/src/Lotgd/Output.php
+++ b/src/Lotgd/Output.php
@@ -211,7 +211,7 @@ class Output
 
         if ($force || (isset($session['user']['superuser']) && ($session['user']['superuser'] & SU_DEBUG_OUTPUT))) {
             if (is_array($text)) {
-                $text = appoencode(DumpItem::dump($text), true);
+                $text = $this->appoencode(DumpItem::dump($text), true);
             }
 
             $origin = $mostrecentmodule ?? '';

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -26,6 +26,7 @@ use Lotgd\Sanitize;
 use Lotgd\Nav;
 use Lotgd\DateTime;
 use Lotgd\Settings;
+use Lotgd\Output;
 use Lotgd\Modules\HookHandler;
 
 class PageParts
@@ -211,6 +212,7 @@ class PageParts
     public static function charStats(): string
     {
         global $session, $playermount, $companions;
+        $output = Output::getInstance();
         if (defined("IS_INSTALLER") && IS_INSTALLER === true) {
             return "";
         }
@@ -286,16 +288,16 @@ class PageParts
                         //$n = Translator::translateInline(str_replace("`%","`%%",$val['name']));
                         $b = Translator::translateInline("`#%s `7(%s rounds left)`n", "buffs");
                         $b = sprintf($b, $val['name'], $val['rounds']);
-                        $buffs .= appoencode($b, true);
+                        $buffs .= $output->appoencode($b, true);
                     } else {
-                        $buffs .= appoencode("`#{$val['name']}`n", true);
+                        $buffs .= $output->appoencode("`#{$val['name']}`n", true);
                     }
                     tlschema();
                     $buffcount++;
                 }
             }
             if ($buffcount == 0) {
-                $buffs .= appoencode(Translator::translateInline("`^None`0"), true);
+                $buffs .= $output->appoencode(Translator::translateInline("`^None`0"), true);
             }
 
             $atk = round($atk, 2);
@@ -428,19 +430,19 @@ class PageParts
                     Database::freeResult($result);
                     $rows = HookHandler::hook("loggedin", $rows);
                     if ($mode === 0) {
-                        $ret .= appoencode(sprintf(Translator::translateInline("`bOnline Characters (%s players):`b`n"), count($rows)));
+                        $ret .= $output->appoencode(sprintf(Translator::translateInline("`bOnline Characters (%s players):`b`n"), count($rows)));
                     } elseif ($mode === 1) {
                         $timeLabel = DateTime::readableTime($loginTimeout, false);
-                        $ret .= appoencode(sprintf(Translator::translateInline("`bOnline Characters in the last %s:`b`n"), $timeLabel));
+                        $ret .= $output->appoencode(sprintf(Translator::translateInline("`bOnline Characters in the last %s:`b`n"), $timeLabel));
                     } else {
-                        $ret .= appoencode(sprintf(Translator::translateInline("`bOnline Characters last %s minutes:`b`n"), $minutes));
+                        $ret .= $output->appoencode(sprintf(Translator::translateInline("`bOnline Characters last %s minutes:`b`n"), $minutes));
                     }
                     foreach ($rows as $row) {
-                        $ret .= appoencode("`^{$row['name']}`n");
+                        $ret .= $output->appoencode("`^{$row['name']}`n");
                         $onlinecount++;
                     }
                     if ($onlinecount == 0) {
-                        $ret .= appoencode(Translator::translateInline("`iNone`i"));
+                        $ret .= $output->appoencode(Translator::translateInline("`iNone`i"));
                     }
                 }
                 if (Settings::hasInstance()) {
@@ -498,6 +500,7 @@ class PageParts
     private static function getMailCounts(): ?array
     {
         global $session;
+        $output = Output::getInstance();
         static $counts = null;
 
         if ($counts !== null) {
@@ -708,6 +711,7 @@ class PageParts
     public static function assemblePetitionDisplay(string $header, string $footer): array
     {
         global $session;
+        $output = Output::getInstance();
 
         $pcount = '';
         if (isset($session['user']['superuser']) && $session['user']['superuser'] & SU_EDIT_PETITIONS) {
@@ -746,7 +750,7 @@ class PageParts
             $ret_args = HookHandler::hook('petitioncount', $ret_args);
             $pets = $ret_args['petitioncount'];
             $p .= $pets;
-            $pcount = templatereplace('petitioncount', array('petitioncount' => appoencode($p, true)));
+            $pcount = Template::templateReplace('petitioncount', ['petitioncount' => $output->appoencode($p, true)]);
         }
 
         return self::replaceHeaderFooterTokens(


### PR DESCRIPTION
## Summary
- replace legacy `appoencode` calls with `Output` class usage
- swap `templatereplace` for `Template::templateReplace`
- clean up PHPStan baseline for updated files

## Testing
- `composer test`
- `composer static`


------
https://chatgpt.com/codex/tasks/task_e_68ba0a335e4c8329a8a956413d65bf79