### PR TITLE
Remove unused argument from affectedRows call

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Static method Lotgd\\\\MySQL\\\\Database\\:\\:affectedRows\\(\\) invoked with 1 parameter, 0 required\\.$#"
-			count: 1
-			path: src/Lotgd/Accounts.php
-
-		-
 			message: "#^Caught class Lotgd\\\\Async\\\\Handler\\\\Exception not found\\.$#"
 			count: 3
 			path: src/Lotgd/Async/Handler/Commentary.php

--- a/src/Lotgd/Accounts.php
+++ b/src/Lotgd/Accounts.php
@@ -151,8 +151,8 @@ class Accounts
             if (isset($session['output']) && $session['output']) {
                 $sql_output = 'UPDATE ' . Database::prefix('accounts_output') .
                     " SET output='" . addslashes(gzcompress($session['output'], 1)) . "' WHERE acctid={$session['user']['acctid']};";
-                $result = Database::query($sql_output);
-                if (Database::affectedRows($result) < 1) {
+                Database::query($sql_output);
+                if (Database::affectedRows() < 1) {
                     $sql_output = 'REPLACE INTO ' . Database::prefix('accounts_output') .
                         " VALUES ({$session['user']['acctid']},'" . addslashes(gzcompress($session['output'], 1)) . "');";
                     Database::query($sql_output);


### PR DESCRIPTION
## Summary
- stop passing the query result into `Database::affectedRows()` in Accounts
- drop now-unused PHPStan baseline ignore

## Testing
- `php -l src/Lotgd/Accounts.php`
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ba1179edac8329bf2474603ad9b8cc