### PR TITLE
feat: add async handler exception

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5,11 +5,6 @@ parameters:
 			count: 1
 			path: src/Lotgd/Accounts.php
 
-		-
-			message: "#^Caught class Lotgd\\\\Async\\\\Handler\\\\Exception not found\\.$#"
-			count: 3
-			path: src/Lotgd/Async/Handler/Commentary.php
-
 
 		-
 			message: "#^Variable \\$badguyatkmod might not be defined\\.$#"

--- a/src/Lotgd/Async/Handler/Exception.php
+++ b/src/Lotgd/Async/Handler/Exception.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Async\Handler;
+
+/**
+ * Base exception for asynchronous handlers.
+ */
+class Exception extends \Exception
+{
+}
+


### PR DESCRIPTION
## Summary
- add custom `Lotgd\Async\Handler\Exception`
- use async exception in commentary handler and rethrow failures
- drop phpstan baseline ignore for missing handler exception

## Testing
- `php -l src/Lotgd/Async/Handler/Exception.php`
- `php -l src/Lotgd/Async/Handler/Commentary.php`
- `composer test`
- `composer static`


------
https://chatgpt.com/codex/tasks/task_e_68ba11881e848329ae0ad05dd8cef22f