### PR TITLE
Initialize msg before conditional usage

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,10 +51,6 @@ parameters:
 			count: 2
 			path: src/Lotgd/Battle.php
 
-		-
-			message: "#^Variable \\$msg might not be defined\\.$#"
-			count: 2
-			path: src/Lotgd/Buffs.php
 
 		-
 			message: "#^Variable \\$matches might not be defined\\.$#"

--- a/src/Lotgd/Buffs.php
+++ b/src/Lotgd/Buffs.php
@@ -448,6 +448,7 @@ class Buffs
                 }
                 $session['user']['hitpoints'] += $hptoregen;
                 $hptoregen = abs($hptoregen);
+                $msg = '';
                 if ($hptoregen == 0) {
                     $msg = (isset($buff['effectnodmgmsg']) ? $buff['effectnodmgmsg'] : Translator::translateInline('No damage, hosé'));
                 } else {
@@ -529,6 +530,7 @@ class Buffs
                     } elseif ($who == 1) {
                         $session['user']['hitpoints'] -= $damage;
                     }
+                    $msg = '';
                     if ($damage < 0) {
                         if (isset($buff['effectfailmsg'])) {
                             $msg = $buff['effectfailmsg'];
@@ -581,6 +583,7 @@ class Buffs
             if ($healhp < 0) {
                 $healhp = 0;
             }
+            $msg = '';
             if ($healhp == 0) {
                 $msg = (isset($buff['effectnodmgmsg']) ? $buff['effectnodmgmsg'] : '');
             } else {


### PR DESCRIPTION
## Summary
- Initialize `$msg` before conditional logic in Buffs to prevent undefined variable warnings
- Remove obsolete PHPStan baseline ignore for `$msg`

## Testing
- `php -l src/Lotgd/Buffs.php`
- `vendor/bin/phpstan analyse --memory-limit=1G`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ba11a494588329aca5765fd93c44fd