### PR TITLE
Initialize matches array in Censor

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -57,12 +57,6 @@ parameters:
 			path: src/Lotgd/Buffs.php
 
 		-
-			message: "#^Variable \\$matches might not be defined\\.$#"
-			count: 6
-			path: src/Lotgd/Censor.php
-
-
-		-
 			message: "#^Function sprintf_translate not found\\.$#"
 			count: 3
 			path: src/Lotgd/CheckBan.php

--- a/src/Lotgd/Censor.php
+++ b/src/Lotgd/Censor.php
@@ -34,6 +34,7 @@ class Censor
             $exceptions = array_flip(self::goodWordList());
             $changed_content = false;
             foreach ($search as $word) {
+                $matches = [];
                 do {
                     if ($word > '') {
                         $times = preg_match_all($word, $sanitized, $matches);


### PR DESCRIPTION
## Summary
- define `$matches` before invoking `preg_match_all`
- drop PHPStan baseline ignore for undefined `$matches`

## Testing
- `php -l src/Lotgd/Censor.php`
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ba11aa31288329bed0d89091f204c9