### PR TITLE
Refactor DateTime to use service classes

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -232,31 +232,6 @@ parameters:
 			count: 4
 			path: src/Lotgd/Config/user_account.php
 
-		-
-			message: "#^Function addnav not found\\.$#"
-			count: 1
-			path: src/Lotgd/DateTime.php
-
-		-
-			message: "#^Function output_notl not found\\.$#"
-			count: 1
-			path: src/Lotgd/DateTime.php
-
-		-
-			message: "#^Function rawoutput not found\\.$#"
-			count: 1
-			path: src/Lotgd/DateTime.php
-
-		-
-			message: "#^Function redirect not found\\.$#"
-			count: 1
-			path: src/Lotgd/DateTime.php
-
-
-		-
-			message: "#^Function tlbutton_clear not found\\.$#"
-			count: 1
-			path: src/Lotgd/DateTime.php
 
 
 		-

--- a/src/Lotgd/DateTime.php
+++ b/src/Lotgd/DateTime.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
-use Lotgd\Translator;
+use Lotgd\Nav;
+use Lotgd\Output;
+use Lotgd\Redirect;
 use Lotgd\Settings;
+use Lotgd\Translator;
 
 use const \DATETIME_DATEMIN;
 use const \DATETIME_TODAY;
@@ -88,7 +91,7 @@ class DateTime
             $laston = Translator::translateInline('Never');
         } else {
             $laston = Translator::sprintfTranslate('%s days', round((strtotime('now') - strtotime($indate)) / 86400, 0));
-            rawoutput(tlbutton_clear());
+            Output::getInstance()->rawOutput(Translator::tlbuttonClear());
         }
         Translator::tlschema();
         return $laston;
@@ -98,13 +101,13 @@ class DateTime
     {
         global $session, $revertsession, $REQUEST_URI;
         if ($session['user']['loggedin']) {
-            output_notl('<!--CheckNewDay()-->', true);
+            Output::getInstance()->outputNotl('<!--CheckNewDay()-->', true);
             if (self::isNewDay()) {
                 $session = $revertsession;
                 $session['user']['restorepage'] = $REQUEST_URI;
                 $session['allowednavs'] = [];
-                addnav('', 'newday.php');
-                redirect('newday.php');
+                Nav::add('', 'newday.php');
+                Redirect::redirect('newday.php');
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace global wrappers in DateTime with Nav, Output, Redirect class calls
- drop phpstan ignores for DateTime wrapper functions
- remove redundant Navigation singleton wrapper

## Testing
- `php -l src/Lotgd/DateTime.php`
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ba1251d65c8329aafa8af37b1ed7f3