### PR TITLE
Refactor event handling to service classes

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -151,41 +151,6 @@ parameters:
 			path: src/Lotgd/ErrorHandler.php
 
 		-
-			message: "#^Function checknavs not found\\.$#"
-			count: 1
-			path: src/Lotgd/Events.php
-
-		-
-			message: "#^Function getmicrotime not found\\.$#"
-			count: 2
-			path: src/Lotgd/Events.php
-
-		-
-			message: "#^Function module_do_event not found\\.$#"
-			count: 1
-			path: src/Lotgd/Events.php
-
-		-
-			message: "#^Function page_footer not found\\.$#"
-			count: 1
-			path: src/Lotgd/Events.php
-
-		-
-			message: "#^Function page_header not found\\.$#"
-			count: 1
-			path: src/Lotgd/Events.php
-
-		-
-			message: "#^Undefined variable\\: \\$hookname$#"
-			count: 1
-			path: src/Lotgd/Events.php
-
-		-
-			message: "#^Undefined variable\\: \\$row$#"
-			count: 1
-			path: src/Lotgd/Events.php
-
-		-
 			message: "#^Function redirect not found\\.$#"
 			count: 4
 			path: src/Lotgd/ForcedNavigation.php

--- a/src/Lotgd/Events.php
+++ b/src/Lotgd/Events.php
@@ -8,9 +8,15 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use Lotgd\DateTime;
 use Lotgd\Http;
-use Lotgd\Util\ScriptName;
+use Lotgd\Modules\HookHandler;
+use Lotgd\Nav;
+use Lotgd\Output;
+use Lotgd\Page\Footer;
+use Lotgd\Page\Header;
 use Lotgd\Translator;
+use Lotgd\Util\ScriptName;
 
 class Events
 {
@@ -34,7 +40,8 @@ class Events
                 //debug("Base link was specified as $baseLink");
                 //debug(debug_backtrace());
         }
-        global $session, $playermount, $badguy, $output;
+        global $session, $playermount, $badguy;
+        $output = Output::getInstance();
         $skipdesc = false;
 
         Translator::getInstance()->setSchema("events");
@@ -56,22 +63,24 @@ class Events
             $specialinc = $session['user']['specialinc'];
             $session['user']['specialinc'] = "";
             if ($needHeader !== null) {
-                    page_header($needHeader);
+                    Header::pageHeader($needHeader);
             }
 
             $output->output("`^`c`bSomething Special!`c`b`0");
             if (strchr($specialinc, ":")) {
                 $array = explode(":", $specialinc);
-                $starttime = getmicrotime();
-                module_do_event($location, $array[1], $allowinactive, $baseLink);
-                $endtime = getmicrotime();
+                $starttime = DateTime::getMicroTime();
+                $hookname = '';
+                $row = ['modulename' => $array[1]];
+                HookHandler::doEvent($location, $array[1], $allowinactive, $baseLink);
+                $endtime = DateTime::getMicroTime();
                 if (($endtime - $starttime >= 1.00 && ($session['user']['superuser'] & SU_DEBUG_OUTPUT))) {
                     $output->debug("Slow Event (" . round($endtime - $starttime, 2) . "s): $hookname - {$row['modulename']}`n");
                 }
             }
-            if (checknavs()) {
+            if (Nav::checkNavs()) {
                 // The page rendered some linkage, so we just want to exit.
-                page_footer();
+                Footer::pageFooter();
             } else {
                 $skipdesc = true;
                 $session['user']['specialinc'] = "";


### PR DESCRIPTION
## Summary
- Replace global calls in Events with service methods
- Initialize unassigned variables and use singleton dependencies
- Regenerate PHPStan baseline

## Testing
- `composer test`
- `composer static`


------
https://chatgpt.com/codex/tasks/task_e_68ba211173448329837dd19feffe1473