### PR TITLE
Refactor output handling and translator utilities

### DIFF
--- a/bio.php
+++ b/bio.php
@@ -22,8 +22,10 @@ use Lotgd\MySQL\Database;
 use Lotgd\Sanitize;
 use Lotgd\DateTime;
 use Lotgd\Nltoappon;
+use Lotgd\Output;
 
 require_once("common.php");
+$output = Output::getInstance();
 
 $translator = Translator::getInstance();
 
@@ -156,10 +158,10 @@ if ($target = Database::fetchAssoc($result)) {
                 array_push($arguments, $val);
             }
             $news = $translator->sprintfTranslate(...$arguments);
-            $output->rawOutput(tlbutton_clear());
+            $output->rawOutput(Translator::clearButton());
         } else {
             $news = translate_inline($row['newstext']);
-            $output->rawOutput(tlbutton_clear());
+            $output->rawOutput(Translator::clearButton());
         }
         $translator->setSchema();
         if ($odate != $row['newsdate']) {

--- a/configuration.php
+++ b/configuration.php
@@ -7,6 +7,7 @@ use Lotgd\Nav\SuperuserNav;
 use Lotgd\DateTime;
 use Lotgd\Settings;
 use Lotgd\Forms;
+use Lotgd\Output;
 
 // translator ready
 // addnews ready
@@ -14,6 +15,7 @@ use Lotgd\Forms;
 
 
 require_once("common.php");
+$output = Output::getInstance();
 // legacy wrapper removed, instantiate settings directly
 $settings_extended = new Settings('settings_extended');
 
@@ -91,7 +93,7 @@ switch ($type_setting) {
                 }
                 $tmp = stripslashes(httppost("villagename"));
                 if ($tmp && $tmp != getsetting('villagename', LOCATION_FIELDS)) {
-                    debug("Updating village name -- moving players");
+                    $output->debug("Updating village name -- moving players");
                     $sql = "UPDATE " . Database::prefix("accounts") . " SET location='" .
                         httppost("villagename") . "' WHERE location='" .
                         addslashes(getsetting('villagename', LOCATION_FIELDS)) . "'";
@@ -103,7 +105,7 @@ switch ($type_setting) {
                 }
                 $tmp = stripslashes(httppost("innname"));
                 if ($tmp && $tmp != getsetting('innname', LOCATION_INN)) {
-                    debug("Updating inn name -- moving players");
+                    $output->debug("Updating inn name -- moving players");
                     $sql = "UPDATE " . Database::prefix("accounts") . " SET location='" .
                         httppost("innname") . "' WHERE location='" .
                         addslashes(getsetting('innname', LOCATION_INN)) . "'";
@@ -313,7 +315,7 @@ switch ($type_setting) {
                     );
                     $enum .= ",$i,$str";
                 }
-                rawoutput(tlbutton_clear());
+                $output->rawOutput(Translator::clearButton());
 
                 $secstonewday = secondstonextgameday($details);
                 $useful_vals = array(

--- a/lib/translator.php
+++ b/lib/translator.php
@@ -34,10 +34,6 @@ function tlbutton_pop()
 {
     return Translator::tlbuttonPop();
 }
-function tlbutton_clear()
-{
-    return Translator::tlbuttonClear();
-}
 function enable_translation($enable = true)
 {
     return Translator::enableTranslation($enable);

--- a/list.php
+++ b/list.php
@@ -15,8 +15,10 @@ use Lotgd\Page\Footer;
 use Lotgd\Nav\VillageNav;
 use Lotgd\Nav;
 use Lotgd\DateTime;
+use Lotgd\Output;
 
 require_once("common.php");
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema("list");
 
@@ -118,7 +120,7 @@ if ($page == "" && $op == "") {
     } else {
         $title = Translator::getInstance()->sprintfTranslate("Warriors of the realm");
     }
-    $output->rawOutput(tlbutton_clear());
+    $output->rawOutput(Translator::clearButton());
     $sql = "SELECT acctid,name,login,alive,hitpoints,location,race,sex,level,laston,loggedin,lastip,uniqueid FROM " . Database::prefix("accounts") . " WHERE locked=0 $search ORDER BY level DESC, dragonkills DESC, login ASC $limit";
     $result = Database::query($sql);
 }

--- a/motd.php
+++ b/motd.php
@@ -4,6 +4,7 @@ use Lotgd\Translator;
 
 use Lotgd\Commentary;
 use Lotgd\Accounts;
+use Lotgd\Output;
 
 // addnews ready
 // translator ready
@@ -11,6 +12,7 @@ use Lotgd\Accounts;
 define("ALLOW_ANONYMOUS", true);
 define("OVERRIDE_FORCED_NAV", true);
 require_once("common.php");
+$output = Output::getInstance();
 require_once("lib/nltoappon.php");
 require_once("lib/http.php");
 use Lotgd\Motd;
@@ -26,7 +28,7 @@ popup_header("LoGD Message of the Day (MoTD)");
 if ($session['user']['superuser'] & SU_POST_MOTD) {
     $addm = translate_inline("Add MoTD");
     $addp = translate_inline("Add Poll");
-    rawoutput(" [ <a href='motd.php?op=add'>$addm</a> | <a href='motd.php?op=addpoll'>$addp</a> ]<br/><br/>");
+    $output->rawOutput(" [ <a href='motd.php?op=add'>$addm</a> | <a href='motd.php?op=addpoll'>$addp</a> ]<br/><br/>");
 }
 
 if ($op == "vote") {
@@ -64,9 +66,9 @@ if ($op == "add" || $op == "addpoll" || $op == "del") {
             Motd::motdPollForm($id);
         } elseif ($op == "del") {
             Motd::motdDel($id);
-            output("`^Entry deleted.`0`n");
+            $output->output("`^Entry deleted.`0`n");
             $return = translate_inline("Return to MoTD");
-            rawoutput("<a href='motd.php'>$return</a>");
+            $output->rawOutput("<a href='motd.php'>$return</a>");
             addnav('', 'motd.php');
         }
     } else {
@@ -76,7 +78,7 @@ if ($op == "add" || $op == "addpoll" || $op == "del") {
                 "%s was penalized for attempting to defile the gods.",
                 $session['user']['name']
             );
-            output("You've attempted to defile the gods.  You are struck with a wand of forgetfulness.  Some of what you knew, you no longer know.");
+            $output->output("You've attempted to defile the gods.  You are struck with a wand of forgetfulness.  Some of what you knew, you no longer know.");
             Accounts::saveUser();
         }
     }
@@ -145,23 +147,23 @@ if ($op == "") {
 
     $result = Database::query("SELECT mid(motddate,1,7) AS d, count(*) AS c FROM " . Database::prefix("motd") . " GROUP BY d ORDER BY d DESC");
     $row = Database::fetchAssoc($result);
-    rawoutput("<form action='motd.php' method='POST'>");
-        rawoutput("<label for='month'>");
-        output("MoTD Archives:");
-        rawoutput("</label>");
-        rawoutput("<select name='month' id='month' onChange='this.form.submit();' >");
-    rawoutput("<option value=''>--Current--</option>");
+    $output->rawOutput("<form action='motd.php' method='POST'>");
+        $output->rawOutput("<label for='month'>");
+        $output->output("MoTD Archives:");
+        $output->rawOutput("</label>");
+        $output->rawOutput("<select name='month' id='month' onChange='this.form.submit();' >");
+    $output->rawOutput("<option value=''>--Current--</option>");
     while ($row = Database::fetchAssoc($result)) {
         $time = strtotime("{$row['d']}-01");
         $m = translate_inline(date("M", $time));
-        rawoutput("<option value='{$row['d']}'" . ($month_post == $row['d'] ? " selected" : "") . ">$m" . date(", Y", $time) . " ({$row['c']})</option>");
+        $output->rawOutput("<option value='{$row['d']}'" . ($month_post == $row['d'] ? " selected" : "") . ">$m" . date(", Y", $time) . " ({$row['c']})</option>");
     }
-    rawoutput("</select>" . tlbutton_clear());
+    $output->rawOutput("</select>" . Translator::clearButton());
     $showmore = translate_inline("Show more");
-    rawoutput("<input type='hidden' name='newcount' value='" . ($count + $newcount) . "'>");
-    rawoutput("<input type='submit' value='$showmore' name='proceed'  class='button'>");
-    rawoutput(" <input type='submit' value='" . translate_inline("Submit") . "' class='button'>");
-    rawoutput("</form>");
+    $output->rawOutput("<input type='hidden' name='newcount' value='" . ($count + $newcount) . "'>");
+    $output->rawOutput("<input type='submit' value='$showmore' name='proceed'  class='button'>");
+    $output->rawOutput(" <input type='submit' value='" . translate_inline("Submit") . "' class='button'>");
+    $output->rawOutput("</form>");
 
     Commentary::commentDisplay("`n`@Commentary:`0`n", "motd");
 }

--- a/news.php
+++ b/news.php
@@ -4,12 +4,14 @@ use Lotgd\Translator;
 
 use Lotgd\Motd;
 use Lotgd\Battle;
+use Lotgd\Output;
 
 // translator ready
 // addnews ready
 // mail ready
 define("ALLOW_ANONYMOUS", true);
 require_once("common.php");
+$output = Output::getInstance();
 require_once("lib/http.php");
 require_once("lib/villagenav.php");
 
@@ -68,14 +70,14 @@ while ($row = Database::fetchAssoc($result2)) {
             Motd::pollitem($row['motditem'], $row['motdtitle'], $row['motdbody'], $row['motdauthorname'], $row['motddate'], false);
     }
 }
-output_notl("`n");
-output("`c`b`!News for %s %s`0`b`c", $date, $pagestr);
+ $output->outputNotl("`n");
+$output->output("`c`b`!News for %s %s`0`b`c", $date, $pagestr);
 
 while ($row = Database::fetchAssoc($result)) {
-    output_notl("`c`2-=-`@=-=`2-=-`@=-=`2-=-`@=-=`2-=-`0`c");
+    $output->outputNotl("`c`2-=-`@=-=`2-=-`@=-=`2-=-`@=-=`2-=-`0`c");
     if ($session['user']['superuser'] & SU_EDIT_COMMENTS) {
         $del = translate_inline("Del");
-        rawoutput("[ <a href='superuser.php?op=newsdelete&newsid=" . $row['newsid'] . "&return=" . URLEncode($_SERVER['REQUEST_URI']) . "'>$del</a> ]&nbsp;");
+        $output->rawOutput("[ <a href='superuser.php?op=newsdelete&newsid=" . $row['newsid'] . "&return=" . URLEncode($_SERVER['REQUEST_URI']) . "'>$del</a> ]&nbsp;");
         addnav("", "superuser.php?op=newsdelete&newsid={$row['newsid']}&return=" . URLEncode($_SERVER['REQUEST_URI']));
     }
     $translator->setSchema($row['tlschema']);
@@ -87,18 +89,18 @@ while ($row = Database::fetchAssoc($result)) {
             array_push($arguments, $val);
         }
         $news = $translator->sprintfTranslate(...$arguments);
-        rawoutput(tlbutton_clear());
+        $output->rawOutput(Translator::clearButton());
     } else {
         $news = translate_inline($row['newstext']);
     }
     $translator->setSchema();
-    output_notl("`c" . $news . "`c`n");
+    $output->outputNotl("`c" . $news . "`c`n");
 }
 if (Database::numRows($result) == 0) {
-    output_notl("`c`2-=-`@=-=`2-=-`@=-=`2-=-`@=-=`2-=-`0`c");
-    output("`1`b`c Nothing of note happened this day.  All in all a boring day. `c`b`0");
+    $output->outputNotl("`c`2-=-`@=-=`2-=-`@=-=`2-=-`@=-=`2-=-`0`c");
+    $output->output("`1`b`c Nothing of note happened this day.  All in all a boring day. `c`b`0");
 }
-output_notl("`c`2-=-`@=-=`2-=-`@=-=`2-=-`@=-=`2-=-`0`c");
+ $output->outputNotl("`c`2-=-`@=-=`2-=-`@=-=`2-=-`@=-=`2-=-`0`c");
 if (!$session['user']['loggedin']) {
     addnav("Login Screen", "index.php");
 } elseif ($session['user']['alive']) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,7 +67,7 @@ parameters:
 
 		-
 			message: "#^Function rawoutput not found\\.$#"
-			count: 11
+			count: 10
 			path: src/Lotgd/Commentary.php
 
 		-
@@ -87,11 +87,6 @@ parameters:
 
 		-
 			message: "#^Function soap not found\\.$#"
-			count: 1
-			path: src/Lotgd/Commentary.php
-
-		-
-			message: "#^Function tlbutton_clear not found\\.$#"
 			count: 1
 			path: src/Lotgd/Commentary.php
 

--- a/runmodule.php
+++ b/runmodule.php
@@ -15,8 +15,10 @@ use Lotgd\Modules;
 use Lotgd\Nav\VillageNav;
 use Lotgd\ForcedNavigation;
 use Lotgd\DateTime;
+use Lotgd\Output;
 
 require_once("common.php");
+$output = Output::getInstance();
 
 // Legacy Wrappers for Modules
 require_once("lib/http.php");
@@ -52,7 +54,7 @@ if (Modules::inject($module, Http::get('admin') ? true : false)) {
         $endtime = DateTime::getMicroTime();
     if (($endtime - $starttime >= 1.00 && ($session['user']['superuser'] & SU_DEBUG_OUTPUT))) {
         //On a side note, you won't ever see this text. A normal module calls page_footer(), which ends execution here....
-        debug("Slow Module (" . round($endtime - $starttime, 2) . "s): $mostrecentmodule`n");
+        $output->debug("Slow Module (" . round($endtime - $starttime, 2) . "s): $mostrecentmodule`n");
         $stats = array (
             "modulename" => $mostrecentmodule,
             "date" => date("Y-m-d H:i:s"),
@@ -74,6 +76,6 @@ if (Modules::inject($module, Http::get('admin') ? true : false)) {
     } else {
         addnav("L?Return to the Login", "index.php");
     }
-    output("You are attempting to use a module which is no longer active, or has been uninstalled.");
+    $output->output("You are attempting to use a module which is no longer active, or has been uninstalled.");
         page_footer();
 }

--- a/shades.php
+++ b/shades.php
@@ -2,12 +2,15 @@
 
 use Lotgd\Commentary;
 use Lotgd\Translator;
+use Lotgd\Output;
+use Lotgd\Nav;
+use Lotgd\Redirect;
 
 // translator ready
 // addnews ready
 // mail ready
 require_once("common.php");
-
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema("shades");
 
@@ -16,21 +19,21 @@ Commentary::addCommentary();
 checkday();
 
 if ($session['user']['alive']) {
-    redirect("village.php");
+    Redirect::redirect("village.php");
 }
-output("`\$You walk among the dead now, you are a shade. ");
-output("Everywhere around you are the souls of those who have fallen in battle, in old age, and in grievous accidents. ");
-output("Each bears telltale signs of the means by which they met their end.`n`n");
-output("Their souls whisper their torments, haunting your mind with their despair:`n");
+$output->output("`\$You walk among the dead now, you are a shade. ");
+$output->output("Everywhere around you are the souls of those who have fallen in battle, in old age, and in grievous accidents. ");
+$output->output("Each bears telltale signs of the means by which they met their end.`n`n");
+$output->output("Their souls whisper their torments, haunting your mind with their despair:`n");
 
-output("`nA sepulchral voice intones, \"`QIt is now %s in the world above.`\$\"`n`n", getgametime());
-addnav("Log Out");
-addnav("Log out", "login.php?op=logout");
+$output->output("`nA sepulchral voice intones, \"`QIt is now %s in the world above.`\$\"`n`n", getgametime());
+Nav::add("Log Out");
+Nav::add("Log out", "login.php?op=logout");
 
-addnav("Places");
-addnav("The Graveyard", "graveyard.php");
+Nav::add("Places");
+Nav::add("The Graveyard", "graveyard.php");
 
-addnav("Return to the news", "news.php");
+Nav::add("Return to the news", "news.php");
 
 modulehook("shades", array()); // if this is too low, you can use footer-shades...
 
@@ -41,22 +44,22 @@ Translator::getInstance()->setSchema("nav");
 // the mute module blocks players from speaking until they
 // read the FAQs, and if they first try to speak when dead
 // there is no way for them to unmute themselves without this link.
-addnav("Other");
-addnav("??F.A.Q. (Frequently Asked Questions)", "petition.php?op=faq", false, true);
-addnav("A?Account Info", "account.php");
-addnav("P?Preferences", "prefs.php");
+Nav::add("Other");
+Nav::add("??F.A.Q. (Frequently Asked Questions)", "petition.php?op=faq", false, true);
+Nav::add("A?Account Info", "account.php");
+Nav::add("P?Preferences", "prefs.php");
 
 if ($session['user']['superuser'] & SU_EDIT_COMMENTS) {
-    addnav("Superuser");
-    addnav(",?Comment Moderation", "moderate.php");
+    Nav::add("Superuser");
+    Nav::add(",?Comment Moderation", "moderate.php");
 }
 if ($session['user']['superuser'] & ~SU_DOESNT_GIVE_GROTTO) {
-    addnav("Superuser");
-    addnav("X?Superuser Grotto", "superuser.php");
+    Nav::add("Superuser");
+    Nav::add("X?Superuser Grotto", "superuser.php");
 }
 if ($session['user']['superuser'] & SU_INFINITE_DAYS) {
-    addnav("Superuser");
-    addnav("/?New Day", "newday.php");
+    Nav::add("Superuser");
+    Nav::add("/?New Day", "newday.php");
 }
 
 Translator::getInstance()->setSchema();

--- a/src/Lotgd/Commentary.php
+++ b/src/Lotgd/Commentary.php
@@ -9,6 +9,7 @@ use Lotgd\MySQL\Database;
 use Lotgd\Util\ScriptName;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Translator;
+use Lotgd\Output;
 
 class Commentary
 {
@@ -49,7 +50,7 @@ class Commentary
         }
         $translator->setSchema();
         self::$comsecs = HookHandler::hook('moderate', self::$comsecs);
-        rawoutput(tlbutton_clear());
+        Output::getInstance()->rawOutput(Translator::clearButton());
         return self::$comsecs;
     }
 

--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -8,6 +8,7 @@ use Lotgd\Settings;
 use Lotgd\MySQL\Database;
 use Lotgd\Sanitize;
 use Lotgd\Cookies;
+use Lotgd\Output;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 
 
@@ -300,8 +301,8 @@ class Translator
             return $in;
         }
         $out = self::translate($in, $namespace);
-        if (function_exists('rawoutput')) {
-            \rawoutput(self::tlbuttonClear());
+        if (class_exists(Output::class)) {
+            Output::getInstance()->rawOutput(self::clearButton());
         }
         return $out;
     }
@@ -365,7 +366,7 @@ class Translator
             return $in;
         }
         $out = self::translate($in);
-        return self::tlbuttonClear() . $out;
+        return self::clearButton() . $out;
     }
 
     /**
@@ -500,19 +501,26 @@ class Translator
 
     /**
      * Clear and return all queued translator buttons.
-     *
-     * @return string Buttons HTML
      */
-    public static function tlbuttonClear(): string
+    public static function clearButton(): string
     {
         global $session;
         if (isset($session['user']['superuser']) && ($session['user']['superuser'] & SU_IS_TRANSLATOR)) {
                 $return = self::tlbuttonPop() . join("", self::$translatorbuttons);
-                self::$translatorbuttons = array();
+                self::$translatorbuttons = [];
+
                 return $return;
-        } else {
-                return "";
         }
+
+        return "";
+    }
+
+    /**
+     * @deprecated Use clearButton() instead.
+     */
+    public static function tlbuttonClear(): string
+    {
+        return self::clearButton();
     }
 
 

--- a/train.php
+++ b/train.php
@@ -7,11 +7,13 @@ use Lotgd\Nav\SuperuserNav;
 use Lotgd\Substitute;
 use Lotgd\Battle;
 use Lotgd\Mail;
+use Lotgd\Output;
 
 //addnews ready
 // mail ready
 // translator ready
 require_once("common.php");
+$output = Output::getInstance();
 require_once("lib/increment_specialty.php");
 require_once("lib/http.php");
 require_once("lib/villagenav.php");
@@ -107,10 +109,10 @@ if (Database::numRows($result) > 0 && $session['user']['level'] < getsetting('ma
                 $defflux = min($defflux, round($dk * .25));
 
                 $hpflux = ($dk - ($atkflux + $defflux)) * 5;
-                debug("DEBUG: $dk modification points total.`n");
-                debug("DEBUG: +$atkflux allocated to attack.`n");
-                debug("DEBUG: +$defflux allocated to defense.`n");
-                debug("DEBUG: +" . ($hpflux / 5) . "*5 to hitpoints`n");
+                $output->debug("DEBUG: $dk modification points total.`n");
+                $output->debug("DEBUG: +$atkflux allocated to attack.`n");
+                $output->debug("DEBUG: +$defflux allocated to defense.`n");
+                $output->debug("DEBUG: +" . ($hpflux / 5) . "*5 to hitpoints`n");
                 calculate_buff_fields();
 
                 $master['creatureattack'] += $atkflux;


### PR DESCRIPTION
## Summary
- replace legacy translation button APIs with `Translator::clearButton()`
- adopt `Output` singleton for rendering and debugging
- update core pages to use `Nav::add` and `Redirect::redirect`
- regenerate PHPStan baseline

## Testing
- `composer test`
- `composer static`


------
https://chatgpt.com/codex/tasks/task_e_68ba95df91908329938058ccec19909e