### PR TITLE
Refactor to use service-based navigation, output, and randomness

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,547 +1,467 @@
 parameters:
-	ignoreErrors:
-		-
-			message: "#^Variable \\$session might not be defined\\.$#"
-			count: 1
-			path: src/Lotgd/Config/configuration.php
-
-		-
-			message: "#^Function translate_inline not found\\.$#"
-			count: 1
-			path: src/Lotgd/Config/user_account.php
-
-		-
-			message: "#^Variable \\$enum might not be defined\\.$#"
-			count: 1
-			path: src/Lotgd/Config/user_account.php
-
-		-
-			message: "#^Variable \\$mounts might not be defined\\.$#"
-			count: 1
-			path: src/Lotgd/Config/user_account.php
-
-		-
-			message: "#^Variable \\$session might not be defined\\.$#"
-			count: 4
-			path: src/Lotgd/Config/user_account.php
-
-		-
-			message: "#^Function e_rand not found\\.$#"
-			count: 2
-			path: src/Lotgd/DeathMessage.php
-
-		-
-			message: "#^Function rawoutput not found\\.$#"
-			count: 1
-			path: src/Lotgd/ErrorHandler.php
-
-		-
-			message: "#^Function redirect not found\\.$#"
-			count: 4
-			path: src/Lotgd/ForcedNavigation.php
-
-		-
-			message: "#^Function addnav not found\\.$#"
-			count: 10
-			path: src/Lotgd/Forest.php
-
-		-
-			message: "#^Function module_display_events not found\\.$#"
-			count: 1
-			path: src/Lotgd/Forest.php
-
-		-
-			message: "#^Function output not found\\.$#"
-			count: 5
-			path: src/Lotgd/Forest.php
-
-		-
-			message: "#^Function debuglog not found\\.$#"
-			count: 3
-			path: src/Lotgd/Forest/Outcomes.php
-
-		-
-			message: "#^Function e_rand not found\\.$#"
-			count: 1
-			path: src/Lotgd/Forest/Outcomes.php
-
-		-
-			message: "#^Function get_player_dragonkillmod not found\\.$#"
-			count: 1
-			path: src/Lotgd/Forest/Outcomes.php
-
-		-
-			message: "#^Function output not found\\.$#"
-			count: 19
-			path: src/Lotgd/Forest/Outcomes.php
-
-		-
-			message: "#^Function output_notl not found\\.$#"
-			count: 2
-			path: src/Lotgd/Forest/Outcomes.php
-
-		-
-			message: "#^Function page_footer not found\\.$#"
-			count: 1
-			path: src/Lotgd/Forest/Outcomes.php
-
-		-
-			message: "#^Function r_rand not found\\.$#"
-			count: 6
-			path: src/Lotgd/Forest/Outcomes.php
-
-		-
-			message: "#^Variable \\$badguy might not be defined\\.$#"
-			count: 1
-			path: src/Lotgd/Forest/Outcomes.php
-
-		-
-			message: "#^Function datacache not found\\.$#"
-			count: 1
-			path: src/Lotgd/Forms.php
-
-		-
-			message: "#^Function httppost not found\\.$#"
-			count: 1
-			path: src/Lotgd/Forms.php
-
-		-
-			message: "#^Function output not found\\.$#"
-			count: 1
-			path: src/Lotgd/Forms.php
-
-		-
-			message: "#^Function output_notl not found\\.$#"
-			count: 6
-			path: src/Lotgd/Forms.php
-
-		-
-			message: "#^Function rawoutput not found\\.$#"
-			count: 68
-			path: src/Lotgd/Forms.php
-
-		-
-			message: "#^Function tlbutton_pop not found\\.$#"
-			count: 1
-			path: src/Lotgd/Forms.php
-
-		-
-			message: "#^Function translate not found\\.$#"
-			count: 2
-			path: src/Lotgd/Forms.php
-
-		-
-			message: "#^Function updatedatacache not found\\.$#"
-			count: 1
-			path: src/Lotgd/Forms.php
-
-		-
-			message: "#^Static method Lotgd\\\\Forms\\:\\:renderField\\(\\) invoked with 8 parameters, 7 required\\.$#"
-			count: 1
-			path: src/Lotgd/Forms.php
-
-
-		-
-			message: "#^Function addnav not found\\.$#"
-			count: 2
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function addnav_notl not found\\.$#"
-			count: 1
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function e_rand not found\\.$#"
-			count: 2
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function getmicrotime not found\\.$#"
-			count: 2
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function httpallget not found\\.$#"
-			count: 1
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function httpallpost not found\\.$#"
-			count: 1
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function httpget not found\\.$#"
-			count: 1
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function httpset not found\\.$#"
-			count: 2
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function module_compare_versions not found\\.$#"
-			count: 1
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function module_condition not found\\.$#"
-			count: 1
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function module_wipehooks not found\\.$#"
-			count: 1
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function modulename_sanitize not found\\.$#"
-			count: 1
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function output not found\\.$#"
-			count: 3
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function output_notl not found\\.$#"
-			count: 2
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function r_rand not found\\.$#"
-			count: 1
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function rawoutput not found\\.$#"
-			count: 17
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Variable \\$exists might not be defined\\.$#"
-			count: 1
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Variable \\$filename might not be defined\\.$#"
-			count: 1
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Variable \\$link might not be defined\\.$#"
-			count: 1
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Variable \\$ns might not be defined\\.$#"
-			count: 3
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Variable \\$res might not be defined\\.$#"
-			count: 1
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Variable \\$result might not be defined\\.$#"
-			count: 2
-			path: src/Lotgd/Modules.php
-
-		-
-			message: "#^Function output not found\\.$#"
-			count: 9
-			path: src/Lotgd/Modules/Installer.php
-
-		-
-			message: "#^Function addnav not found\\.$#"
-			count: 2
-			path: src/Lotgd/Motd.php
-
-		-
-			message: "#^Function httppost not found\\.$#"
-			count: 10
-			path: src/Lotgd/Motd.php
-
-		-
-			message: "#^Function output not found\\.$#"
-			count: 5
-			path: src/Lotgd/Motd.php
-
-		-
-			message: "#^Function output_notl not found\\.$#"
-			count: 7
-			path: src/Lotgd/Motd.php
-
-		-
-			message: "#^Function rawoutput not found\\.$#"
-			count: 26
-			path: src/Lotgd/Motd.php
-
-		-
-			message: "#^Variable \\$affected on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: src/Lotgd/MySQL/Database.php
-
-		-
-			message: "#^Function output not found\\.$#"
-			count: 1
-			path: src/Lotgd/MySQL/TableDescriptor.php
-
-		-
-			message: "#^Function popup not found\\.$#"
-			count: 2
-			path: src/Lotgd/Nav.php
-
-		-
-			message: "#^Function sanitize not found\\.$#"
-			count: 8
-			path: src/Lotgd/Nav.php
-
-		-
-			message: "#^Function translate not found\\.$#"
-			count: 2
-			path: src/Lotgd/Nav.php
-
-		-
-			message: "#^Function addnav not found\\.$#"
-			count: 3
-			path: src/Lotgd/Nav/SuperuserNav.php
-
-		-
-			message: "#^Function addnav not found\\.$#"
-			count: 2
-			path: src/Lotgd/Nav/VillageNav.php
-
-		-
-			message: "#^Function addnav not found\\.$#"
-			count: 8
-			path: src/Lotgd/Newday.php
-
-		-
-			message: "#^Function appendcount not found\\.$#"
-			count: 1
-			path: src/Lotgd/Newday.php
-
-		-
-			message: "#^Function clearoutput not found\\.$#"
-			count: 2
-			path: src/Lotgd/Newday.php
-
-		-
-			message: "#^Function getmicrotime not found\\.$#"
-			count: 2
-			path: src/Lotgd/Newday.php
-
-		-
-			message: "#^Function httpget not found\\.$#"
-			count: 2
-			path: src/Lotgd/Newday.php
-
-		-
-			message: "#^Function httppost not found\\.$#"
-			count: 1
-			path: src/Lotgd/Newday.php
-
-		-
-			message: "#^Function navcount not found\\.$#"
-			count: 2
-			path: src/Lotgd/Newday.php
-
-		-
-			message: "#^Function output not found\\.$#"
-			count: 24
-			path: src/Lotgd/Newday.php
-
-		-
-			message: "#^Function output_notl not found\\.$#"
-			count: 3
-			path: src/Lotgd/Newday.php
-
-		-
-			message: "#^Function page_footer not found\\.$#"
-			count: 4
-			path: src/Lotgd/Newday.php
-
-		-
-			message: "#^Function page_header not found\\.$#"
-			count: 6
-			path: src/Lotgd/Newday.php
-
-		-
-			message: "#^Function rawoutput not found\\.$#"
-			count: 22
-			path: src/Lotgd/Newday.php
-
-		-
-			message: "#^Function savesetting not found\\.$#"
-			count: 1
-			path: src/Lotgd/Newday.php
-
-		-
-			message: "#^Variable \\$type in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: src/Lotgd/Newday.php
-
-		-
-			message: "#^Function sanitize not found\\.$#"
-			count: 1
-			path: src/Lotgd/Output.php
-
-		-
-			message: "#^Class Lotgd\\\\DataCache referenced with incorrect case\\: Lotgd\\\\Datacache\\.$#"
-			count: 1
-			path: src/Lotgd/Page/CharStats.php
-
-		-
-			message: "#^Class Lotgd\\\\DataCache referenced with incorrect case\\: Lotgd\\\\Datacache\\.$#"
-			count: 2
-			path: src/Lotgd/PageParts.php
-
-		-
-			message: "#^Function addnav not found\\.$#"
-			count: 3
-			path: src/Lotgd/PageParts.php
-
-		-
-			message: "#^Function check_temp_stat not found\\.$#"
-			count: 19
-			path: src/Lotgd/PageParts.php
-
-		-
-			message: "#^Function httpget not found\\.$#"
-			count: 1
-			path: src/Lotgd/PageParts.php
-
-		-
-			message: "#^Variable \\$maillink_add_after on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: src/Lotgd/PageParts.php
-
-		-
-			message: "#^Variable \\$maillink_add_pre on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: src/Lotgd/PageParts.php
-
-		-
-			message: "#^Variable \\$minutes might not be defined\\.$#"
-			count: 1
-			path: src/Lotgd/PageParts.php
-
-		-
-			message: "#^Function httpallget not found\\.$#"
-			count: 1
-			path: src/Lotgd/PhpGenericEnvironment.php
-
-		-
-			message: "#^Function e_rand not found\\.$#"
-			count: 1
-			path: src/Lotgd/PlayerFunctions.php
-
-		-
-			message: "#^Function module_delete_userprefs not found\\.$#"
-			count: 1
-			path: src/Lotgd/PlayerFunctions.php
-
-		-
-			message: "#^Function addnav not found\\.$#"
-			count: 3
-			path: src/Lotgd/Pvp.php
-
-		-
-			message: "#^Function debuglog not found\\.$#"
-			count: 4
-			path: src/Lotgd/Pvp.php
-
-		-
-			message: "#^Function get_player_attack not found\\.$#"
-			count: 1
-			path: src/Lotgd/Pvp.php
-
-		-
-			message: "#^Function get_player_defense not found\\.$#"
-			count: 1
-			path: src/Lotgd/Pvp.php
-
-		-
-			message: "#^Function output not found\\.$#"
-			count: 24
-			path: src/Lotgd/Pvp.php
-
-		-
-			message: "#^Function output_notl not found\\.$#"
-			count: 5
-			path: src/Lotgd/Pvp.php
-
-		-
-			message: "#^Function rawoutput not found\\.$#"
-			count: 14
-			path: src/Lotgd/Pvp.php
-
-		-
-			message: "#^Function reltime not found\\.$#"
-			count: 1
-			path: src/Lotgd/Pvp.php
-
-		-
-			message: "#^Variable \\$defaults on left side of \\?\\? is never defined\\.$#"
-			count: 1
-			path: src/Lotgd/Settings.php
-
-		-
-			message: "#^Function output not found\\.$#"
-			count: 1
-			path: src/Lotgd/Specialty.php
-
-		-
-			message: "#^Function addnav not found\\.$#"
-			count: 2
-			path: src/Lotgd/SuAccess.php
-
-		-
-			message: "#^Function clearnav not found\\.$#"
-			count: 1
-			path: src/Lotgd/SuAccess.php
-
-		-
-			message: "#^Function debuglog not found\\.$#"
-			count: 1
-			path: src/Lotgd/SuAccess.php
-
-		-
-			message: "#^Function page_footer not found\\.$#"
-			count: 2
-			path: src/Lotgd/SuAccess.php
-
-		-
-			message: "#^Function page_header not found\\.$#"
-			count: 2
-			path: src/Lotgd/SuAccess.php
-
-		-
-			message: "#^Variable \\$template might not be defined\\.$#"
-			count: 1
-			path: src/Lotgd/Template.php
-
-		-
-			message: "#^Function popup not found\\.$#"
-			count: 1
-			path: src/Lotgd/Translator.php
-
-		-
-			message: "#^Undefined variable\\: \\$settings$#"
-			count: 1
-			path: src/Lotgd/Translator.php
-
-		-
-			message: "#^Variable \\$namespace in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: src/Lotgd/Translator.php
-
-		-
-			message: "#^Variable \\$settings in isset\\(\\) is never defined\\.$#"
-			count: 1
-			path: src/Lotgd/Translator.php
+        ignoreErrors:
+                -
+                        message: "#^Variable \\$session might not be defined\\.$#"
+                        count: 1
+                        path: src/Lotgd/Config/configuration.php
+
+                -
+                        message: "#^Function translate_inline not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Config/user_account.php
+
+                -
+                        message: "#^Variable \\$enum might not be defined\\.$#"
+                        count: 1
+                        path: src/Lotgd/Config/user_account.php
+
+                -
+                        message: "#^Variable \\$mounts might not be defined\\.$#"
+                        count: 1
+                        path: src/Lotgd/Config/user_account.php
+
+                -
+                        message: "#^Variable \\$session might not be defined\\.$#"
+                        count: 4
+                        path: src/Lotgd/Config/user_account.php
+
+                -
+                        message: "#^Function rawoutput not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/ErrorHandler.php
+
+                -
+                        message: "#^Function redirect not found\\.$#"
+                        count: 4
+                        path: src/Lotgd/ForcedNavigation.php
+
+                -
+                        message: "#^Function module_display_events not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Forest.php
+
+                -
+                        message: "#^Function debuglog not found\\.$#"
+                        count: 3
+                        path: src/Lotgd/Forest/Outcomes.php
+
+                -
+                        message: "#^Function get_player_dragonkillmod not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Forest/Outcomes.php
+
+                -
+                        message: "#^Function page_footer not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Forest/Outcomes.php
+
+                -
+                        message: "#^Function datacache not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Forms.php
+
+                -
+                        message: "#^Function httppost not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Forms.php
+
+                -
+                        message: "#^Function output not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Forms.php
+
+                -
+                        message: "#^Function output_notl not found\\.$#"
+                        count: 6
+                        path: src/Lotgd/Forms.php
+
+                -
+                        message: "#^Function rawoutput not found\\.$#"
+                        count: 68
+                        path: src/Lotgd/Forms.php
+
+                -
+                        message: "#^Function tlbutton_pop not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Forms.php
+
+                -
+                        message: "#^Function translate not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/Forms.php
+
+                -
+                        message: "#^Function updatedatacache not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Forms.php
+
+                -
+                        message: "#^Static method Lotgd\\\\Forms\\:\\:renderField\\(\\) invoked with 8 parameters, 7 required\\.$#"
+                        count: 1
+                        path: src/Lotgd/Forms.php
+
+
+                -
+                        message: "#^Function addnav not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function addnav_notl not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function e_rand not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function getmicrotime not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function httpallget not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function httpallpost not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function httpget not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function httpset not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function module_compare_versions not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function module_condition not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function module_wipehooks not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function modulename_sanitize not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function output not found\\.$#"
+                        count: 3
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function output_notl not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function r_rand not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function rawoutput not found\\.$#"
+                        count: 17
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Variable \\$exists might not be defined\\.$#"
+                        count: 1
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Variable \\$filename might not be defined\\.$#"
+                        count: 1
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Variable \\$link might not be defined\\.$#"
+                        count: 1
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Variable \\$ns might not be defined\\.$#"
+                        count: 3
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Variable \\$res might not be defined\\.$#"
+                        count: 1
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Variable \\$result might not be defined\\.$#"
+                        count: 2
+                        path: src/Lotgd/Modules.php
+
+                -
+                        message: "#^Function output not found\\.$#"
+                        count: 9
+                        path: src/Lotgd/Modules/Installer.php
+
+                -
+                        message: "#^Function addnav not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/Motd.php
+
+                -
+                        message: "#^Function httppost not found\\.$#"
+                        count: 10
+                        path: src/Lotgd/Motd.php
+
+                -
+                        message: "#^Function output not found\\.$#"
+                        count: 5
+                        path: src/Lotgd/Motd.php
+
+                -
+                        message: "#^Function output_notl not found\\.$#"
+                        count: 7
+                        path: src/Lotgd/Motd.php
+
+                -
+                        message: "#^Function rawoutput not found\\.$#"
+                        count: 26
+                        path: src/Lotgd/Motd.php
+
+                -
+                        message: "#^Variable \\$affected on left side of \\?\\? always exists and is not nullable\\.$#"
+                        count: 1
+                        path: src/Lotgd/MySQL/Database.php
+
+                -
+                        message: "#^Function output not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/MySQL/TableDescriptor.php
+
+                -
+                        message: "#^Function popup not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/Nav.php
+
+                -
+                        message: "#^Function sanitize not found\\.$#"
+                        count: 8
+                        path: src/Lotgd/Nav.php
+
+                -
+                        message: "#^Function translate not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/Nav.php
+
+                -
+                        message: "#^Function addnav not found\\.$#"
+                        count: 3
+                        path: src/Lotgd/Nav/SuperuserNav.php
+
+                -
+                        message: "#^Function addnav not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/Nav/VillageNav.php
+
+                -
+                        message: "#^Function appendcount not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Newday.php
+
+                -
+                        message: "#^Function clearoutput not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/Newday.php
+
+                -
+                        message: "#^Function getmicrotime not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/Newday.php
+
+                -
+                        message: "#^Function httpget not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/Newday.php
+
+                -
+                        message: "#^Function httppost not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Newday.php
+
+                -
+                        message: "#^Function navcount not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/Newday.php
+
+                -
+                        message: "#^Function page_footer not found\\.$#"
+                        count: 4
+                        path: src/Lotgd/Newday.php
+
+                -
+                        message: "#^Function page_header not found\\.$#"
+                        count: 6
+                        path: src/Lotgd/Newday.php
+
+                -
+                        message: "#^Function rawoutput not found\\.$#"
+                        count: 22
+                        path: src/Lotgd/Newday.php
+
+                -
+                        message: "#^Function savesetting not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Newday.php
+
+                -
+                        message: "#^Variable \\$type in isset\\(\\) always exists and is not nullable\\.$#"
+                        count: 1
+                        path: src/Lotgd/Newday.php
+
+                -
+                        message: "#^Function sanitize not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Output.php
+
+                -
+                        message: "#^Class Lotgd\\\\DataCache referenced with incorrect case\\: Lotgd\\\\Datacache\\.$#"
+                        count: 1
+                        path: src/Lotgd/Page/CharStats.php
+
+                -
+                        message: "#^Class Lotgd\\\\DataCache referenced with incorrect case\\: Lotgd\\\\Datacache\\.$#"
+                        count: 2
+                        path: src/Lotgd/PageParts.php
+
+                -
+                        message: "#^Function addnav not found\\.$#"
+                        count: 3
+                        path: src/Lotgd/PageParts.php
+
+                -
+                        message: "#^Function check_temp_stat not found\\.$#"
+                        count: 19
+                        path: src/Lotgd/PageParts.php
+
+                -
+                        message: "#^Function httpget not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/PageParts.php
+
+                -
+                        message: "#^Variable \\$maillink_add_after on left side of \\?\\? always exists and is not nullable\\.$#"
+                        count: 1
+                        path: src/Lotgd/PageParts.php
+
+                -
+                        message: "#^Variable \\$maillink_add_pre on left side of \\?\\? always exists and is not nullable\\.$#"
+                        count: 1
+                        path: src/Lotgd/PageParts.php
+
+                -
+                        message: "#^Variable \\$minutes might not be defined\\.$#"
+                        count: 1
+                        path: src/Lotgd/PageParts.php
+
+                -
+                        message: "#^Function httpallget not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/PhpGenericEnvironment.php
+
+                -
+                        message: "#^Function debuglog not found\\.$#"
+                        count: 4
+                        path: src/Lotgd/Pvp.php
+
+                -
+                        message: "#^Function get_player_attack not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Pvp.php
+
+                -
+                        message: "#^Function get_player_defense not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Pvp.php
+
+                -
+                        message: "#^Function rawoutput not found\\.$#"
+                        count: 14
+                        path: src/Lotgd/Pvp.php
+
+                -
+                        message: "#^Function reltime not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Pvp.php
+
+                -
+                        message: "#^Variable \\$defaults on left side of \\?\\? is never defined\\.$#"
+                        count: 1
+                        path: src/Lotgd/Settings.php
+
+                -
+                        message: "#^Function output not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Specialty.php
+
+                -
+                        message: "#^Function addnav not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/SuAccess.php
+
+                -
+                        message: "#^Function clearnav not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/SuAccess.php
+
+                -
+                        message: "#^Function debuglog not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/SuAccess.php
+
+                -
+                        message: "#^Function page_footer not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/SuAccess.php
+
+                -
+                        message: "#^Function page_header not found\\.$#"
+                        count: 2
+                        path: src/Lotgd/SuAccess.php
+
+                -
+                        message: "#^Variable \\$template might not be defined\\.$#"
+                        count: 1
+                        path: src/Lotgd/Template.php
+
+                -
+                        message: "#^Function popup not found\\.$#"
+                        count: 1
+                        path: src/Lotgd/Translator.php
+
+                -
+                        message: "#^Undefined variable\\: \\$settings$#"
+                        count: 1
+                        path: src/Lotgd/Translator.php
+
+                -
+                        message: "#^Variable \\$namespace in isset\\(\\) always exists and is not nullable\\.$#"
+                        count: 1
+                        path: src/Lotgd/Translator.php
+
+                -
+                        message: "#^Variable \\$settings in isset\\(\\) is never defined\\.$#"
+                        count: 1
+                        path: src/Lotgd/Translator.php

--- a/src/Lotgd/DeathMessage.php
+++ b/src/Lotgd/DeathMessage.php
@@ -10,6 +10,7 @@ namespace Lotgd;
 
 use Lotgd\MySQL\Database;
 use Lotgd\Substitute;
+use Lotgd\Random;
 
 class DeathMessage
 {
@@ -26,7 +27,7 @@ class DeathMessage
     {
         global $session, $badguy;
         $where = ($forest ? 'WHERE forest=1' : 'WHERE graveyard=1');
-        $sql = 'SELECT deathmessage,taunt FROM ' . Database::prefix('deathmessages') . " $where ORDER BY rand(" . e_rand() . ') LIMIT 1';
+        $sql = 'SELECT deathmessage,taunt FROM ' . Database::prefix('deathmessages') . " $where ORDER BY rand(" . Random::getInstance()->e_rand() . ') LIMIT 1';
         $result = Database::query($sql);
         if ($result) {
             $row = Database::fetchAssoc($result);
@@ -53,7 +54,7 @@ class DeathMessage
     {
         global $session, $badguy;
         $where = ($forest ? 'WHERE forest=1' : 'WHERE graveyard=1');
-        $sql = 'SELECT deathmessage,taunt FROM ' . Database::prefix('deathmessages') . " $where ORDER BY rand(" . e_rand() . ') LIMIT 1';
+        $sql = 'SELECT deathmessage,taunt FROM ' . Database::prefix('deathmessages') . " $where ORDER BY rand(" . Random::getInstance()->e_rand() . ') LIMIT 1';
         $result = Database::query($sql);
         if ($result) {
             $row = Database::fetchAssoc($result);

--- a/src/Lotgd/Forest.php
+++ b/src/Lotgd/Forest.php
@@ -7,9 +7,11 @@ declare(strict_types=1);
  */
 
 namespace Lotgd;
-use Lotgd\Settings;
 
+use Lotgd\Nav as Navigation;
 use Lotgd\Nav\VillageNav;
+use Lotgd\Output;
+use Lotgd\Settings;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Translator;
 
@@ -26,22 +28,24 @@ class Forest
 
         Translator::getInstance()->setSchema('forest');
 
-        addnav('Navigation');
+        $output = Output::getInstance();
+
+        Navigation::add('Navigation');
         VillageNav::render();
-        addnav('Heal');
-        addnav('H?Healer\'s Hut', 'healer.php');
-        addnav('Fight');
-        addnav('L?Look for Something to Kill', 'forest.php?op=search');
+        Navigation::add('Heal');
+        Navigation::add('H?Healer\'s Hut', 'healer.php');
+        Navigation::add('Fight');
+        Navigation::add('L?Look for Something to Kill', 'forest.php?op=search');
         if ($session['user']['level'] > 1) {
-            addnav('S?Go Slumming', 'forest.php?op=search&type=slum');
+            Navigation::add('S?Go Slumming', 'forest.php?op=search&type=slum');
         }
-        addnav('T?Go Thrillseeking', 'forest.php?op=search&type=thrill');
+        Navigation::add('T?Go Thrillseeking', 'forest.php?op=search&type=thrill');
         if ($settings->getSetting('suicide', 0)) {
             if ($settings->getSetting('suicidedk', 10) <= $session['user']['dragonkills']) {
-                addnav("*?Search `\$Suicidally`0", 'forest.php?op=search&type=suicide');
+                Navigation::add("*?Search `\$Suicidally`0", 'forest.php?op=search&type=suicide');
             }
         }
-        addnav('Other');
+        Navigation::add('Other');
         if ($session['user']['level'] >= $settings->getSetting('maxlevel', 15) && $session['user']['seendragon'] == 0) {
             $isforest = 0;
             $vloc = HookHandler::hook('validforestloc', []);
@@ -52,15 +56,15 @@ class Forest
                 }
             }
             if ($isforest || count($vloc) == 0) {
-                addnav('G?`@Seek Out the Green Dragon', 'forest.php?op=dragon');
+                Navigation::add('G?`@Seek Out the Green Dragon', 'forest.php?op=dragon');
             }
         }
         if (!$noshowmessage) {
-            output('`c`7`bThe Forest`b`0`c');
-            output('The Forest, home to evil creatures and evildoers of all sorts.`n`n');
-            output('The thick foliage of the forest restricts your view to only a few yards in most places.');
-            output('The paths would be imperceptible except for your trained eye.');
-            output('You move as silently as a soft breeze across the thick moss covering the ground, wary to avoid stepping on a twig or any of the numerous pieces of bleached bone that populate the forest floor, lest you betray your presence to one of the vile beasts that wander the forest.`n');
+            $output->output('`c`7`bThe Forest`b`0`c');
+            $output->output('The Forest, home to evil creatures and evildoers of all sorts.`n`n');
+            $output->output('The thick foliage of the forest restricts your view to only a few yards in most places.');
+            $output->output('The paths would be imperceptible except for your trained eye.');
+            $output->output('You move as silently as a soft breeze across the thick moss covering the ground, wary to avoid stepping on a twig or any of the numerous pieces of bleached bone that populate the forest floor, lest you betray your presence to one of the vile beasts that wander the forest.`n');
             HookHandler::hook('forest-desc');
         }
         HookHandler::hook('forest', []);

--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -10,6 +10,9 @@ use Lotgd\GameLog;
 use Lotgd\ExpireChars;
 use Lotgd\Modules\HookHandler;
 use Lotgd\DataCache;
+use Lotgd\Settings;
+use Lotgd\Output;
+use Lotgd\Nav as Navigation;
 
 class Newday
 {
@@ -190,7 +193,7 @@ class Newday
                 }
             }
         } else {
-            output("`\$Error: Please spend the correct total amount of dragon points.`n`n");
+            Output::getInstance()->output("`\$Error: Please spend the correct total amount of dragon points.`n`n");
         }
     }
 
@@ -199,11 +202,12 @@ class Newday
         global $session;
         if ($dkills - $dp > 1) {
             page_header('Dragon Points');
-            output("`@You earn one dragon point each time you slay the dragon.");
-            output('Advancements made by spending dragon points are permanent!');
-            output("`n`nYou have `^%s`@ unspent dragon points.", $dkills - $dp);
-            output('How do you wish to spend them?`n`n');
-            output('Be sure that your allocations add up to your total unspent dragon points.');
+            $output = Output::getInstance();
+            $output->output("`@You earn one dragon point each time you slay the dragon.");
+            $output->output('Advancements made by spending dragon points are permanent!');
+            $output->output("`n`nYou have `^%s`@ unspent dragon points.", $dkills - $dp);
+            $output->output('How do you wish to spend them?`n`n');
+            $output->output('Be sure that your allocations add up to your total unspent dragon points.');
             $text = "<script type='text/javascript' language='Javascript'>\n";
             $text .= "<!--\n";
             $text .= "function pointsLeft() {\n";
@@ -248,23 +252,23 @@ class Newday
             $text .= "// -->\n";
             $text .= "</script>\n";
             rawoutput($text);
-            addnav('Reset', "newday.php?pdk=0$resline");
+            Navigation::add('Reset', "newday.php?pdk=0$resline");
             $link = appendcount("newday.php?pdk=1$resline");
             rawoutput("<form id='dkForm' action='$link' method='POST'>");
-            addnav('', $link);
+            Navigation::add('', $link);
             rawoutput("<br><table cellpadding='0' cellspacing='0' border='0' width='200'>");
             foreach ($labels as $type => $label) {
                 $head = explode(',', $label);
                 if (count($head) > 1) {
                     rawoutput("<tr><td colspan='2' nowrap>");
-                    output("`b`4%s`0`b`n", Translator::translateInline($head[0]));
+                    $output->output("`b`4%s`0`b`n", Translator::translateInline($head[0]));
                     rawoutput("</td></tr>");
                     continue;
                 }
                 if (isset($canbuy[$type]) && $canbuy[$type]) {
                     rawoutput("<tr><td nowrap>");
-                    output($label);
-                    output_notl(":");
+                    $output->output($label);
+                    $output->outputNotl(":");
                     rawoutput("</td><td>");
                     rawoutput("<input id='$type' name='$type' size='4' maxlength='4' value='{$canbuy[$type]}' onKeyUp='pointsLeft();' onBlur='pointsLeft();' onFocus='pointsLeft();'>");
                     rawoutput("</td></tr>");
@@ -296,18 +300,19 @@ class Newday
             foreach ($labels as $type => $label) {
                 $head = explode(',', $label);
                 if (count($head) > 1) {
-                    addnav($head[0]);
+                    Navigation::add($head[0]);
                     continue;
                 }
                 $dist[$type] = 0;
                 if (isset($canbuy[$type]) && $canbuy[$type]) {
-                    addnav($label, "newday.php?dk=$type$resline");
+                    Navigation::add($label, "newday.php?dk=$type$resline");
                 }
             }
-            output("`@You have `&1`@ unspent dragon point.");
-            output('How do you wish to spend it?`n`n');
-            output('You earn one dragon point each time you slay the dragon.');
-            output('Advancements made by spending dragon points are permanent!');
+            $output = Output::getInstance();
+            $output->output("`@You have `&1`@ unspent dragon point.");
+            $output->output('How do you wish to spend it?`n`n');
+            $output->output('You earn one dragon point each time you slay the dragon.');
+            $output->output('Advancements made by spending dragon points are permanent!');
             $player_dkpoints = count($session['user']['dragonpoints']);
             for ($i = 0; $i < $player_dkpoints; $i++) {
                 if (isset($dist[$session['user']['dragonpoints'][$i]])) {
@@ -316,7 +321,7 @@ class Newday
                     $dist['unknown']++;
                 }
             }
-            output("`n`nCurrently, the dragon points you have already spent are distributed in the following manner.");
+            $output->output("`n`nCurrently, the dragon points you have already spent are distributed in the following manner.");
             rawoutput('<blockquote><table>');
             foreach ($labels as $type => $label) {
                 $head = explode(',', $label);
@@ -325,7 +330,7 @@ class Newday
                 }
                 if (count($head) > 1) {
                     rawoutput("<tr><td colspan='2' nowrap>");
-                    output("`b`4%s`0`b`n", Translator::translateInline($head[0]));
+                    $output->output("`b`4%s`0`b`n", Translator::translateInline($head[0]));
                     rawoutput('</td></tr>');
                     continue;
                 }
@@ -333,10 +338,10 @@ class Newday
                     continue;
                 }
                 rawoutput('<tr><td nowrap>');
-                output($label);
-                output_notl(':');
+                $output->output($label);
+                $output->outputNotl(':');
                 rawoutput('</td><td>&nbsp;&nbsp;</td><td>');
-                output_notl("`@%s", $dist[$type]);
+                $output->outputNotl("`@%s", $dist[$type]);
                 rawoutput('</td></tr>');
             }
             rawoutput('</table></blockquote>');
@@ -347,29 +352,30 @@ class Newday
     {
         global $session;
         $settings = Settings::getInstance();
+        $output = Output::getInstance();
         $setrace = httpget('setrace');
         if ($setrace != '') {
             $vname = $settings->getSetting('villagename', LOCATION_FIELDS);
             $session['user']['race'] = $setrace;
             $session['user']['location'] = $vname;
             HookHandler::hook('setrace');
-            addnav('Continue', "newday.php?continue=1$resline");
+            Navigation::add('Continue', "newday.php?continue=1$resline");
         } else {
-            output('Where do you recall growing up?`n`n');
+            $output->output('Where do you recall growing up?`n`n');
             HookHandler::hook('chooserace');
         }
         if (navcount() == 0) {
             clearoutput();
             page_header('No Races Installed');
-            output("No races were installed in this game.");
-            output("So we'll call you a 'human' and get on with it.");
+            $output->output("No races were installed in this game.");
+            $output->output("So we'll call you a 'human' and get on with it.");
             if ($session['user']['superuser'] & (SU_MEGAUSER | SU_MANAGE_MODULES)) {
-                output('You should go into the module manager off of the super user grotto, install and activate some races.');
+                $output->output('You should go into the module manager off of the super user grotto, install and activate some races.');
             } else {
-                output("You might want to ask your admin to install some races, they're really quite fun.");
+                $output->output("You might want to ask your admin to install some races, they're really quite fun.");
             }
             $session['user']['race'] = 'Human';
-            addnav('Continue', "newday.php?continue=1$resline");
+            Navigation::add('Continue', "newday.php?continue=1$resline");
             page_footer();
         } else {
             page_header('A little history about yourself');
@@ -380,27 +386,28 @@ class Newday
     public static function setSpecialty(string $resline): void
     {
         global $session;
+        $output = Output::getInstance();
         $setspecialty = httpget('setspecialty');
         if ($setspecialty != '') {
             $session['user']['specialty'] = $setspecialty;
             HookHandler::hook('set-specialty');
-            addnav('Continue', "newday.php?continue=1$resline");
+            Navigation::add('Continue', "newday.php?continue=1$resline");
         } else {
             page_header('A little history about yourself');
-            output('What do you recall doing as a child?`n`n');
+            $output->output('What do you recall doing as a child?`n`n');
             HookHandler::hook('choose-specialty');
         }
         if (navcount() == 0) {
             clearoutput();
             page_header('No Specialties Installed');
-            output("Since there are no suitable specialties available, we'll make you a student of the mystical powers and get on with it.");
+            $output->output("Since there are no suitable specialties available, we'll make you a student of the mystical powers and get on with it.");
             if ($session['user']['superuser'] & (SU_MEGAUSER | SU_MANAGE_MODULES)) {
-                output('You should go into the module manager off of the super user grotto, install and activate some specialties.');
+                $output->output('You should go into the module manager off of the super user grotto, install and activate some specialties.');
             } else {
-                output('You might want to ask your admin to install some specialties, as they are quite fun (and helpful).');
+                $output->output('You might want to ask your admin to install some specialties, as they are quite fun (and helpful).');
             }
             $session['user']['specialty'] = 'MP';
-            addnav('Continue', "newday.php?continue=1$resline");
+            Navigation::add('Continue', "newday.php?continue=1$resline");
             page_footer();
         } else {
             page_footer();

--- a/src/Lotgd/PlayerFunctions.php
+++ b/src/Lotgd/PlayerFunctions.php
@@ -13,6 +13,7 @@ use Lotgd\MySQL\Database;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Translator;
 use Lotgd\Output;
+use Lotgd\Random;
 
 class PlayerFunctions
 {
@@ -66,7 +67,7 @@ class PlayerFunctions
         }
 
         // Remove module user preferences
-        module_delete_userprefs($id);
+        HookHandler::deleteUserPrefs($id);
     }
 
     /**
@@ -461,7 +462,7 @@ class PlayerFunctions
             $useref = "AND ref='$ref'";
             $targetdk = $refdk;
         }
-        $sql = 'SELECT male,female FROM ' . Database::prefix('titles') . " WHERE dk='$targetdk' $useref ORDER BY RAND(" . e_rand() . ") LIMIT 1";
+        $sql = 'SELECT male,female FROM ' . Database::prefix('titles') . " WHERE dk='$targetdk' $useref ORDER BY RAND(" . Random::getInstance()->e_rand() . ") LIMIT 1";
         $res = Database::query($sql);
         $row = ['male' => 'God', 'female' => 'Goddess'];
         if (Database::numRows($res) != 0) {

--- a/src/Lotgd/Random.php
+++ b/src/Lotgd/Random.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd;
+
+/**
+ * Random number utilities.
+ *
+ * Provides instance methods corresponding to legacy random helper
+ * functions e_rand() and r_rand() for integer and float values.
+ */
+class Random
+{
+    private static ?self $instance = null;
+
+    /**
+     * Retrieve the singleton instance.
+     */
+    public static function getInstance(): self
+    {
+        return self::$instance ??= new self();
+    }
+
+    /**
+     * Random integer helper.
+     *
+     * Mirrors the behaviour of legacy e_rand().
+     */
+    public function e_rand(?int $min = null, ?int $max = null): int
+    {
+        if ($min === null) {
+            return random_int(0, mt_getrandmax());
+        }
+
+        $min = (int) round($min);
+
+        if ($max === null) {
+            return random_int(0, $min);
+        }
+
+        $max = (int) round($max);
+
+        if ($min === $max) {
+            return $min;
+        }
+
+        // Legacy quirk kept for compatibility
+        if ($min == 0 && $max == 0) {
+            return 0;
+        }
+
+        return ($min < $max)
+            ? random_int($min, $max)
+            : random_int($max, $min);
+    }
+
+    /**
+     * Random float helper with three decimal precision.
+     *
+     * Mirrors the behaviour of legacy r_rand().
+     */
+    public function r_rand(?float $min = null, ?float $max = null): float
+    {
+        if ($min === null) {
+            return random_int(0, mt_getrandmax());
+        }
+
+        $min *= 1000;
+
+        if ($max === null) {
+            return random_int(0, (int) $min) / 1000;
+        }
+
+        $max *= 1000;
+
+        if ($min == $max) {
+            return $min / 1000;
+        }
+
+        // Legacy quirk kept for compatibility
+        if ($min == 0 && $max == 0) {
+            return 0;
+        }
+
+        return ($min < $max)
+            ? random_int((int) $min, (int) $max) / 1000
+            : random_int((int) $max, (int) $min) / 1000;
+    }
+}


### PR DESCRIPTION
## Summary
- Switch forest and PVP flows to Navigation and Output services
- Add `Random` utility and refactor calls from legacy `e_rand`/`r_rand`
- Clean up player helpers and newday routines to use service instances

## Testing
- `composer static`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68baaa354aa08329883bdaa15d203777