### PR TITLE
Initialize Settings singleton earlier to avoid recursion

### DIFF
--- a/src/Lotgd/Settings.php
+++ b/src/Lotgd/Settings.php
@@ -28,6 +28,10 @@ class Settings
     {
         $this->tablename = Database::prefix($tablename);
         $this->settings = null;
+
+        self::$instance = $this;
+        $GLOBALS['settings'] = $this;
+
         $this->loadSettings();
     }
 


### PR DESCRIPTION
## Summary
- Ensure Settings constructor registers the instance before loading configuration so DataCache accesses reuse the same object

## Testing
- `composer test`
- `php home.php`


------
https://chatgpt.com/codex/tasks/task_e_68bab1d53ae48329871153aeb209362a