### PR TITLE
Avoid recursive charset lookup on initial settings insert

### DIFF
--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -141,12 +141,15 @@ class Database
             $affected = self::getInstance()->affectedRows();
         }
 
-        $settings = Settings::getInstance();
-        $charset  = $settings->getSetting('charset', 'UTF-8');
+        $charset  = 'UTF-8';
+        $settings = null;
+
         if (!$r && $die === true) {
             if (defined('IS_INSTALLER') && IS_INSTALLER) {
                 return [];
             }
+            $settings ??= Settings::getInstance();
+            $charset = $settings->getSetting('charset', 'UTF-8');
             if (isset($session['user']['superuser']) && ($session['user']['superuser'] & SU_DEVELOPER)) {
                 die("<pre>" . HTMLEntities($sql, ENT_COMPAT, $charset) . '</pre>' . self::error() . Backtrace::show());
             }
@@ -158,6 +161,8 @@ class Database
             if (strlen($s) > 800) {
                 $s = substr($s, 0, 400) . ' ... ' . substr($s, strlen($s) - 400);
             }
+            $settings ??= Settings::getInstance();
+            $charset = $settings->getSetting('charset', 'UTF-8');
             Output::getInstance()->debug('Slow Query (' . round($endtime - $starttime, 2) . 's): ' . HTMLEntities($s, ENT_COMPAT, $charset) . '`n');
         }
         unset(self::$dbinfo['affected_rows']);


### PR DESCRIPTION
## Summary
- defer charset lookup in `Database::query()` until needed for error/debug output
- prevent recursive `Settings::saveSetting('charset')` calls when initializing settings

## Testing
- `php -l src/Lotgd/MySQL/Database.php`
- `composer install`
- `composer test`
- `php -dauto_prepend_file=db_stub.php home.php` *(no duplicate-key errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bab34bb0788329b89aafd9519083bb