### PR TITLE
Use upsert for settings to prevent duplicate key errors

### DIFF
--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -141,15 +141,13 @@ class Database
             $affected = self::getInstance()->affectedRows();
         }
 
-        $charset  = 'UTF-8';
-        $settings = null;
+        $charset = 'UTF-8';
 
         if (!$r && $die === true) {
             if (defined('IS_INSTALLER') && IS_INSTALLER) {
                 return [];
             }
-            $settings ??= Settings::getInstance();
-            $charset = $settings->getSetting('charset', 'UTF-8');
+            $charset = Settings::getInstance()->getSetting('charset', 'UTF-8');
             if (isset($session['user']['superuser']) && ($session['user']['superuser'] & SU_DEVELOPER)) {
                 die("<pre>" . HTMLEntities($sql, ENT_COMPAT, $charset) . '</pre>' . self::error() . Backtrace::show());
             }
@@ -161,8 +159,7 @@ class Database
             if (strlen($s) > 800) {
                 $s = substr($s, 0, 400) . ' ... ' . substr($s, strlen($s) - 400);
             }
-            $settings ??= Settings::getInstance();
-            $charset = $settings->getSetting('charset', 'UTF-8');
+            $charset = Settings::getInstance()->getSetting('charset', 'UTF-8');
             Output::getInstance()->debug('Slow Query (' . round($endtime - $starttime, 2) . 's): ' . HTMLEntities($s, ENT_COMPAT, $charset) . '`n');
         }
         unset(self::$dbinfo['affected_rows']);

--- a/src/Lotgd/Settings.php
+++ b/src/Lotgd/Settings.php
@@ -75,17 +75,14 @@ class Settings
         }
 
         $this->loadSettings();
-        if (!isset($this->settings[$settingname]) && $value) {
-            $settingValue = is_string($value) ? '"' . addslashes($value) . '"' : $value;
-            $settingName = is_string($settingname) ? '"' . addslashes($settingname) . '"' : $settingname;
-            $sql = "INSERT INTO " . $this->tablename . " (setting,value) VALUES ($settingName,$settingValue)";
-        } elseif (isset($this->settings[$settingname])) {
-            $settingValue = is_string($value) ? '"' . addslashes($value) . '"' : $value;
-            $settingName = is_string($settingname) ? '"' . addslashes($settingname) . '"' : $settingname;
-            $sql = "UPDATE " . $this->tablename . " SET value=$settingValue WHERE setting=$settingName";
-        } else {
-            return false;
-        }
+
+        $settingValue = is_string($value) ? '"' . addslashes($value) . '"' : $value;
+        $settingName = is_string($settingname) ? '"' . addslashes($settingname) . '"' : $settingname;
+
+        $sql = "INSERT INTO " . $this->tablename .
+            " (setting,value) VALUES ($settingName,$settingValue) " .
+            "ON DUPLICATE KEY UPDATE value=VALUES(value)";
+
         Database::query($sql);
         $this->settings[$settingname] = $value;
         DataCache::invalidatedatacache('game' . $this->tablename);
@@ -160,9 +157,7 @@ class Settings
             $this->loadSettings();
             if (!isset($this->settings[$settingname])) {
                 if ($settingname === 'charset') {
-                    if (Database::tableExists($this->tablename)) {
-                        $this->saveSetting('charset', 'UTF-8');
-                    }
+                    $this->saveSetting('charset', 'UTF-8');
 
                     return 'UTF-8';
                 }
@@ -174,9 +169,7 @@ class Settings
                 } else {
                     $value = $default;
                 }
-                if (Database::tableExists($this->tablename)) {
-                    $this->saveSetting($settingname, $value);
-                }
+                $this->saveSetting($settingname, $value);
             } else {
                 $value = $this->settings[$settingname];
             }
@@ -185,9 +178,7 @@ class Settings
         }
 
         if ($settingname === 'charset' && $value !== 'UTF-8') {
-            if (Database::tableExists($this->tablename)) {
-                $this->saveSetting('charset', 'UTF-8');
-            }
+            $this->saveSetting('charset', 'UTF-8');
 
             return 'UTF-8';
         }

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -80,7 +80,25 @@ final class SettingsTest extends TestCase
         \Lotgd\MySQL\Database::$affected_rows = 0;
         \Lotgd\MySQL\Database::$lastSql = '';
         $this->assertSame('UTF-8', $settings->getSetting('charset', 'ISO-8859-1'));
-        $this->assertStringContainsString('INSERT INTO settings', \Lotgd\MySQL\Database::$lastSql);
+        $this->assertStringContainsString('ON DUPLICATE KEY UPDATE', \Lotgd\MySQL\Database::$lastSql);
+        $this->assertSame(1, \Lotgd\MySQL\Database::$affected_rows);
+
+        \Lotgd\MySQL\Database::$affected_rows = 0;
+        \Lotgd\MySQL\Database::$lastSql = '';
+        $this->assertSame('UTF-8', $settings->getSetting('charset'));
+        $this->assertSame('', \Lotgd\MySQL\Database::$lastSql);
+        $this->assertSame(0, \Lotgd\MySQL\Database::$affected_rows);
+    }
+
+    public function testRepeatedCharsetCallsDoNotDuplicateInsert(): void
+    {
+        \Lotgd\MySQL\Database::$settings_table = [];
+        $settings = new Settings('settings');
+
+        \Lotgd\MySQL\Database::$affected_rows = 0;
+        \Lotgd\MySQL\Database::$lastSql = '';
+        $this->assertSame('UTF-8', $settings->getSetting('charset'));
+        $this->assertStringContainsString('ON DUPLICATE KEY UPDATE', \Lotgd\MySQL\Database::$lastSql);
         $this->assertSame(1, \Lotgd\MySQL\Database::$affected_rows);
 
         \Lotgd\MySQL\Database::$affected_rows = 0;


### PR DESCRIPTION
## Summary
- Upsert settings rows to avoid duplicate key errors
- Simplify charset handling to rely on upsert
- Test repeated charset fetches and new upsert behavior

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bad7dd3dec8329925db3e01b56302e