### PR TITLE
refactor: replace rawoutput helpers with Output service

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -317,11 +317,6 @@ parameters:
                         path: src/Lotgd/Newday.php
 
                 -
-                        message: "#^Function rawoutput not found\\.$#"
-                        count: 22
-                        path: src/Lotgd/Newday.php
-
-                -
                         message: "#^Function savesetting not found\\.$#"
                         count: 1
                         path: src/Lotgd/Newday.php
@@ -394,11 +389,6 @@ parameters:
                 -
                         message: "#^Function get_player_defense not found\\.$#"
                         count: 1
-                        path: src/Lotgd/Pvp.php
-
-                -
-                        message: "#^Function rawoutput not found\\.$#"
-                        count: 14
                         path: src/Lotgd/Pvp.php
 
                 -

--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -251,35 +251,35 @@ class Newday
             $text .= "}\n";
             $text .= "// -->\n";
             $text .= "</script>\n";
-            rawoutput($text);
+            $output->rawOutput($text);
             Navigation::add('Reset', "newday.php?pdk=0$resline");
             $link = appendcount("newday.php?pdk=1$resline");
-            rawoutput("<form id='dkForm' action='$link' method='POST'>");
+            $output->rawOutput("<form id='dkForm' action='$link' method='POST'>");
             Navigation::add('', $link);
-            rawoutput("<br><table cellpadding='0' cellspacing='0' border='0' width='200'>");
+            $output->rawOutput("<br><table cellpadding='0' cellspacing='0' border='0' width='200'>");
             foreach ($labels as $type => $label) {
                 $head = explode(',', $label);
                 if (count($head) > 1) {
-                    rawoutput("<tr><td colspan='2' nowrap>");
+                    $output->rawOutput("<tr><td colspan='2' nowrap>");
                     $output->output("`b`4%s`0`b`n", Translator::translateInline($head[0]));
-                    rawoutput("</td></tr>");
+                    $output->rawOutput("</td></tr>");
                     continue;
                 }
                 if (isset($canbuy[$type]) && $canbuy[$type]) {
-                    rawoutput("<tr><td nowrap>");
+                    $output->rawOutput("<tr><td nowrap>");
                     $output->output($label);
                     $output->outputNotl(":");
-                    rawoutput("</td><td>");
-                    rawoutput("<input id='$type' name='$type' size='4' maxlength='4' value='{$canbuy[$type]}' onKeyUp='pointsLeft();' onBlur='pointsLeft();' onFocus='pointsLeft();'>");
-                    rawoutput("</td></tr>");
+                    $output->rawOutput("</td><td>");
+                    $output->rawOutput("<input id='$type' name='$type' size='4' maxlength='4' value='{$canbuy[$type]}' onKeyUp='pointsLeft();' onBlur='pointsLeft();' onFocus='pointsLeft();'>");
+                    $output->rawOutput("</td></tr>");
                 }
             }
-            rawoutput("<tr><td colspan='2'>&nbsp;</td></tr><tr><td colspan='2' align='center'>");
+            $output->rawOutput("<tr><td colspan='2'>&nbsp;</td></tr><tr><td colspan='2' align='center'>");
             $click = Translator::translateInline('Spend');
-            rawoutput("<input id='dksub' type='submit' class='button' value='$click'>");
-            rawoutput("</td></tr><tr><td colspan='2'>&nbsp;</td></tr><tr><td colspan='2' align='center'>");
-            rawoutput('<div id="amtLeft"></div>');
-            rawoutput('</td></tr></table></form>');
+            $output->rawOutput("<input id='dksub' type='submit' class='button' value='$click'>");
+            $output->rawOutput("</td></tr><tr><td colspan='2'>&nbsp;</td></tr><tr><td colspan='2' align='center'>");
+            $output->rawOutput('<div id="amtLeft"></div>');
+            $output->rawOutput('</td></tr></table></form>');
             $count = 0;
             foreach ($labels as $type => $label) {
                 $head = explode(',', $label);
@@ -290,7 +290,7 @@ class Newday
                     break;
                 }
                 if (isset($canbuy[$type]) && $canbuy[$type]) {
-                    rawoutput("<script language='JavaScript'>document.getElementById('$type').focus();</script>");
+                    $output->rawOutput("<script language='JavaScript'>document.getElementById('$type').focus();</script>");
                     $count++;
                 }
             }
@@ -322,29 +322,29 @@ class Newday
                 }
             }
             $output->output("`n`nCurrently, the dragon points you have already spent are distributed in the following manner.");
-            rawoutput('<blockquote><table>');
+            $output->rawOutput('<blockquote><table>');
             foreach ($labels as $type => $label) {
                 $head = explode(',', $label);
                 if (isset($type) && $type > 0 && (!isset($dist[$type]) || $dist[$type] == 0)) {
                     continue;
                 }
                 if (count($head) > 1) {
-                    rawoutput("<tr><td colspan='2' nowrap>");
+                    $output->rawOutput("<tr><td colspan='2' nowrap>");
                     $output->output("`b`4%s`0`b`n", Translator::translateInline($head[0]));
-                    rawoutput('</td></tr>');
+                    $output->rawOutput('</td></tr>');
                     continue;
                 }
                 if ($type == 'unknown' && $dist[$type] == 0) {
                     continue;
                 }
-                rawoutput('<tr><td nowrap>');
+                $output->rawOutput('<tr><td nowrap>');
                 $output->output($label);
                 $output->outputNotl(':');
-                rawoutput('</td><td>&nbsp;&nbsp;</td><td>');
+                $output->rawOutput('</td><td>&nbsp;&nbsp;</td><td>');
                 $output->outputNotl("`@%s", $dist[$type]);
-                rawoutput('</td></tr>');
+                $output->rawOutput('</td></tr>');
             }
-            rawoutput('</table></blockquote>');
+            $output->rawOutput('</table></blockquote>');
         }
     }
 

--- a/src/Lotgd/Pvp.php
+++ b/src/Lotgd/Pvp.php
@@ -338,8 +338,8 @@ class Pvp
         $bio = Translator::translateInline('Bio');
         $att = Translator::translateInline('Attack');
 
-        rawoutput("<table border='0' cellpadding='3' cellspacing='0'>");
-        rawoutput("<tr class='trhead'><td>$n</td><td>$l</td><td>$loc</td><td>$ops</td></tr>");
+        $output->rawOutput("<table border='0' cellpadding='3' cellspacing='0'>");
+        $output->rawOutput("<tr class='trhead'><td>$n</td><td>$l</td><td>$loc</td><td>$ops</td></tr>");
         $j = 0;
         $num = count($pvp);
         for ($i = 0; $i < $num; $i++) {
@@ -350,8 +350,8 @@ class Pvp
             $j++;
             $biolink = "bio.php?char=" . $row['acctid'] . "&ret=" . urlencode($_SERVER['REQUEST_URI']);
             Navigation::add('', $biolink);
-            rawoutput("<tr class='" . ($j % 2 ? 'trlight' : 'trdark') . "'>");
-            rawoutput('<td>');
+            $output->rawOutput("<tr class='" . ($j % 2 ? 'trlight' : 'trdark') . "'>");
+            $output->rawOutput('<td>');
             if ($row['clanshort'] > '' && $row['clanrank'] > CLAN_APPLICANT) {
                 $output->outputNotl(
                     '%s&lt;`2%s%s&gt;`0 ',
@@ -362,14 +362,14 @@ class Pvp
                 );
             }
             $output->outputNotl('`@%s`0', $row['name']);
-            rawoutput('</td>');
-            rawoutput('<td>');
+            $output->rawOutput('</td>');
+            $output->rawOutput('<td>');
             $output->outputNotl('%s', $row['level']);
-            rawoutput('</td>');
-            rawoutput('<td>');
+            $output->rawOutput('</td>');
+            $output->rawOutput('<td>');
             $output->outputNotl('%s', $row['location']);
-            rawoutput('</td>');
-            rawoutput("<td>[ <a href='$biolink'>$bio</a> | ");
+            $output->rawOutput('</td>');
+            $output->rawOutput("<td>[ <a href='$biolink'>$bio</a> | ");
             if ($row['pvpflag'] > $pvptimeout) {
                 $output->output("`i(Attacked too recently)`i");
             } elseif ($location != $row['location'] && (!isset($row['anylocation']) || !$row['anylocation'])) {
@@ -380,11 +380,11 @@ class Pvp
                 }
                 $output->output('`i`4(%s`4)`i', $row['invalid']);
             } else {
-                rawoutput("<a href='$link$extra&name=" . $row['acctid'] . "'>$att</a>");
+                $output->rawOutput("<a href='$link$extra&name=" . $row['acctid'] . "'>$att</a>");
                 Navigation::add('', "$link$extra&name=" . $row['acctid']);
             }
-            rawoutput(' ]</td>');
-            rawoutput('</tr>');
+            $output->rawOutput(' ]</td>');
+            $output->rawOutput('</tr>');
         }
 
         $sql = "SELECT count(location) as counter, location FROM " . Database::prefix('accounts') .
@@ -401,7 +401,7 @@ class Pvp
             $noone = Translator::translateInline('`iThere are no available targets.`i');
             $output->outputNotl("<tr><td align='center' colspan='4'>$noone</td></tr>", true);
         }
-        rawoutput('</table>', true);
+        $output->rawOutput('</table>', true);
 
         if (Database::numRows($result) != 0) {
             $output->output('`n`n`&As you listen to different people around you talking, you glean the following additional information:`n');


### PR DESCRIPTION
## Summary
- replace direct `rawoutput` calls with `Output` service in new day and PvP flows
- drop obsolete phpstan baseline entries

## Testing
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68badf3b6d1c8329894952dbc45f0a57