### PR TITLE
Refactor services and remove wrapper calls

### DIFF
--- a/installer.php
+++ b/installer.php
@@ -71,7 +71,7 @@ if (!defined('DB_NODB') || !DB_NODB) {
 
 $noinstallnavs = false;
 
-Datacache::invalidatedatacache("gamesettings");
+DataCache::invalidatedatacache("gamesettings");
 $DB_USEDATACACHE = 0;
 //make sure we do not use the caching during this, else we might need to run  through the installer multiple times. AND we now need to reset the game settings, as these were due to faulty code not cached before.
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,16 +26,6 @@ parameters:
                         path: src/Lotgd/Config/user_account.php
 
                 -
-                        message: "#^Function rawoutput not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/ErrorHandler.php
-
-                -
-                        message: "#^Function redirect not found\\.$#"
-                        count: 4
-                        path: src/Lotgd/ForcedNavigation.php
-
-                -
                         message: "#^Function module_display_events not found\\.$#"
                         count: 1
                         path: src/Lotgd/Forest.php
@@ -54,51 +44,6 @@ parameters:
                         message: "#^Function page_footer not found\\.$#"
                         count: 1
                         path: src/Lotgd/Forest/Outcomes.php
-
-                -
-                        message: "#^Function datacache not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/Forms.php
-
-                -
-                        message: "#^Function httppost not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/Forms.php
-
-                -
-                        message: "#^Function output not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/Forms.php
-
-                -
-                        message: "#^Function output_notl not found\\.$#"
-                        count: 6
-                        path: src/Lotgd/Forms.php
-
-                -
-                        message: "#^Function rawoutput not found\\.$#"
-                        count: 68
-                        path: src/Lotgd/Forms.php
-
-                -
-                        message: "#^Function tlbutton_pop not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/Forms.php
-
-                -
-                        message: "#^Function translate not found\\.$#"
-                        count: 2
-                        path: src/Lotgd/Forms.php
-
-                -
-                        message: "#^Function updatedatacache not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/Forms.php
-
-                -
-                        message: "#^Static method Lotgd\\\\Forms\\:\\:renderField\\(\\) invoked with 8 parameters, 7 required\\.$#"
-                        count: 1
-                        path: src/Lotgd/Forms.php
 
 
                 -
@@ -216,30 +161,6 @@ parameters:
                         count: 9
                         path: src/Lotgd/Modules/Installer.php
 
-                -
-                        message: "#^Function addnav not found\\.$#"
-                        count: 2
-                        path: src/Lotgd/Motd.php
-
-                -
-                        message: "#^Function httppost not found\\.$#"
-                        count: 10
-                        path: src/Lotgd/Motd.php
-
-                -
-                        message: "#^Function output not found\\.$#"
-                        count: 5
-                        path: src/Lotgd/Motd.php
-
-                -
-                        message: "#^Function output_notl not found\\.$#"
-                        count: 7
-                        path: src/Lotgd/Motd.php
-
-                -
-                        message: "#^Function rawoutput not found\\.$#"
-                        count: 26
-                        path: src/Lotgd/Motd.php
 
                 -
                         message: "#^Variable \\$affected on left side of \\?\\? always exists and is not nullable\\.$#"
@@ -332,29 +253,10 @@ parameters:
                         path: src/Lotgd/Output.php
 
                 -
-                        message: "#^Class Lotgd\\\\DataCache referenced with incorrect case\\: Lotgd\\\\Datacache\\.$#"
-                        count: 1
-                        path: src/Lotgd/Page/CharStats.php
-
-                -
-                        message: "#^Class Lotgd\\\\DataCache referenced with incorrect case\\: Lotgd\\\\Datacache\\.$#"
-                        count: 2
-                        path: src/Lotgd/PageParts.php
-
-                -
-                        message: "#^Function addnav not found\\.$#"
-                        count: 3
-                        path: src/Lotgd/PageParts.php
-
-                -
                         message: "#^Function check_temp_stat not found\\.$#"
                         count: 19
                         path: src/Lotgd/PageParts.php
 
-                -
-                        message: "#^Function httpget not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/PageParts.php
 
                 -
                         message: "#^Variable \\$maillink_add_after on left side of \\?\\? always exists and is not nullable\\.$#"

--- a/src/Lotgd/ErrorHandler.php
+++ b/src/Lotgd/ErrorHandler.php
@@ -87,7 +87,7 @@ class ErrorHandler
                 Translator::getInstance()->setSchema();
                 if (isset($session['user']['superuser']) && ($session['user']['superuser'] & SU_DEBUG_OUTPUT) == SU_DEBUG_OUTPUT) {
                     $backtrace = Backtrace::show();
-                    rawoutput($backtrace);
+                    $output->rawOutput($backtrace);
                 } else {
                     $backtrace = '';
                 }

--- a/src/Lotgd/ForcedNavigation.php
+++ b/src/Lotgd/ForcedNavigation.php
@@ -9,6 +9,7 @@ use Lotgd\Translator;
 use Lotgd\MySQL\Database;
 use Lotgd\Serialization;
 use Lotgd\Output;
+use Lotgd\Redirect;
 
 class ForcedNavigation
 {
@@ -53,19 +54,19 @@ class ForcedNavigation
                         $session['loggedin'] = false;
                         return;
                     }
-                    redirect('index.php?op=timeout', 'Account not logged in but session thinks they are.');
+                    Redirect::redirect('index.php?op=timeout', 'Account not logged in but session thinks they are.');
                 }
             } else {
                 $session = [];
                 $session['message'] = Translator::translateInline("`4Error, your login was incorrect`0", "login");
-                redirect('index.php', 'Account Disappeared!');
+                Redirect::redirect('index.php', 'Account Disappeared!');
             }
             Database::freeResult($result);
             if (isset($session['allowednavs'][$REQUEST_URI]) && $session['allowednavs'][$REQUEST_URI] && $overrideforced !== true) {
                 $session['allowednavs'] = [];
             } else {
                 if ($overrideforced !== true) {
-                    redirect('badnav.php', 'Navigation not allowed to ' . $REQUEST_URI);
+                    Redirect::redirect('badnav.php', 'Navigation not allowed to ' . $REQUEST_URI);
                 }
             }
         } else {
@@ -75,7 +76,7 @@ class ForcedNavigation
                     $session = [];
                     return;
                 }
-                redirect('index.php?op=timeout', 'Not logged in: ' . $REQUEST_URI);
+                Redirect::redirect('index.php?op=timeout', 'Not logged in: ' . $REQUEST_URI);
             }
         }
     }

--- a/src/Lotgd/Page/CharStats.php
+++ b/src/Lotgd/Page/CharStats.php
@@ -10,7 +10,6 @@ use Lotgd\Translator;
 use Lotgd\PlayerFunctions;
 use Lotgd\Buffs;
 use Lotgd\DateTime;
-use Lotgd\Datacache;
 
 class CharStats
 {

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -25,10 +25,11 @@ use Lotgd\Sanitize;
 use Lotgd\Nav;
 use Lotgd\DateTime;
 use Lotgd\Settings;
-
 use Lotgd\Output;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Translator;
+use Lotgd\DataCache;
+use Lotgd\Http;
 
 class PageParts
 {
@@ -407,7 +408,7 @@ class PageParts
             $loginTimeout = $settings->getSetting("LOGINTIMEOUT", 900);
             $cacheMinutes = $mode === 2 ? $minutesSetting : (int) ceil($loginTimeout / 60);
             $cacheKey = "charlisthomepage-$mode-$cacheMinutes";
-            if ($ret = Datacache::datacache($cacheKey)) {
+            if ($ret = DataCache::datacache($cacheKey)) {
             } else {
                 $onlinecount = 0;
                 $list = HookHandler::hook("onlinecharlist", array("count" => 0, "list" => ""));
@@ -448,7 +449,7 @@ class PageParts
                 $settings->saveSetting("OnlineCount", $onlinecount);
                 $settings->saveSetting("OnlineCountLast", strtotime("now"));
             }
-                Datacache::updatedatacache($cacheKey, $ret);
+                DataCache::updatedatacache($cacheKey, $ret);
             }
             return $ret;
         }
@@ -728,14 +729,14 @@ class PageParts
             $admin_array = array();
             if ($session['user']['superuser'] & SU_EDIT_USERS) {
                 $admin_array[] = "<a href='user.php'>$ued</a>";
-                addnav('', 'user.php');
+                Nav::add('', 'user.php');
             }
             if ($session['user']['superuser'] & SU_MANAGE_MODULES) {
                 $admin_array[] = "<a href='modules.php'>$mod</a>";
-                addnav('', 'modules.php');
+                Nav::add('', 'modules.php');
             }
             $admin_array[] = "<a href='viewpetition.php'>$pet</a>";
-            addnav('', 'viewpetition.php');
+            Nav::add('', 'viewpetition.php');
             $p = implode('|', $admin_array);
             $pcolors = array('`$','`^','`6','`!','`#','`%','`v');
             $pets = '`n';
@@ -780,7 +781,7 @@ class PageParts
     {
         // Gather module hook results for footer replacements
         $replacementbits = HookHandler::hook("footer-$script", []);
-        if ($script == 'runmodule' && (($module = httpget('module'))) > '') {
+        if ($script == 'runmodule' && (($module = Http::get('module'))) > '') {
             $replacementbits = HookHandler::hook("footer-$module", $replacementbits);
         }
         $replacementbits['__scriptfile__'] = $script;


### PR DESCRIPTION
## Summary
- use service singletons for MOTD output and form rendering
- replace global wrappers with service methods and correct DataCache casing
- update phpstan baseline

## Testing
- `php -l src/Lotgd/Motd.php`
- `php -l src/Lotgd/Forms.php`
- `php -l src/Lotgd/ErrorHandler.php`
- `php -l src/Lotgd/ForcedNavigation.php`
- `php -l src/Lotgd/PageParts.php`
- `php -l src/Lotgd/Page/CharStats.php`
- `php -l installer.php`
- `composer install`
- `composer static`
- `composer test` *(failed: Failed asserting that '' contains "type='radio' name='choice'")*

------
https://chatgpt.com/codex/tasks/task_e_68bae8b58c4c83298552a976c10748de