### PR TITLE
Refactor HTTP utilities and settings access

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -66,25 +66,6 @@ parameters:
                         count: 2
                         path: src/Lotgd/Modules.php
 
-                -
-                        message: "#^Function httpallget not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/Modules.php
-
-                -
-                        message: "#^Function httpallpost not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/Modules.php
-
-                -
-                        message: "#^Function httpget not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/Modules.php
-
-                -
-                        message: "#^Function httpset not found\\.$#"
-                        count: 2
-                        path: src/Lotgd/Modules.php
 
                 -
                         message: "#^Function module_compare_versions not found\\.$#"
@@ -274,11 +255,6 @@ parameters:
                         path: src/Lotgd/PageParts.php
 
                 -
-                        message: "#^Function httpallget not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/PhpGenericEnvironment.php
-
-                -
                         message: "#^Function debuglog not found\\.$#"
                         count: 4
                         path: src/Lotgd/Pvp.php
@@ -297,11 +273,6 @@ parameters:
                         message: "#^Function reltime not found\\.$#"
                         count: 1
                         path: src/Lotgd/Pvp.php
-
-                -
-                        message: "#^Variable \\$defaults on left side of \\?\\? is never defined\\.$#"
-                        count: 1
-                        path: src/Lotgd/Settings.php
 
                 -
                         message: "#^Function output not found\\.$#"

--- a/referral.php
+++ b/referral.php
@@ -1,15 +1,20 @@
 <?php
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
+use Lotgd\Settings;
+use Lotgd\Http;
 
 // translator ready
 // addnews ready
 // mail ready
 define("ALLOW_ANONYMOUS", true);
 require_once("common.php");
-require_once("lib/http.php");
 
-Translator::getInstance()->setSchema("referral");
+global $session;
+
+$settings   = Settings::getInstance();
+$translator = Translator::getInstance();
+$translator->setSchema("referral");
 
 if ($session['user']['loggedin']) {
     page_header("Referral Page");
@@ -19,9 +24,9 @@ if ($session['user']['loggedin']) {
         require_once("lib/villagenav.php");
         villagenav();
     }
-    output("You will automatically receive %s points for each person that you refer to this website who makes it to level %s.`n`n", getsetting("refereraward", 25), getsetting("referminlevel", 4));
+    output("You will automatically receive %s points for each person that you refer to this website who makes it to level %s.`n`n", $settings->getSetting("refereraward", 25), $settings->getSetting("referminlevel", 4));
 
-    $url = getsetting(
+    $url = $settings->getSetting(
         "serverurl",
         "http://" . $_SERVER['SERVER_NAME'] .
             ($_SERVER['SERVER_PORT'] == 80 ? "" : ":" . $_SERVER['SERVER_PORT']) .
@@ -29,23 +34,23 @@ if ($session['user']['loggedin']) {
     );
     if (!preg_match("/\/$/", $url)) {
         $url = $url . "/";
-        savesetting("serverurl", $url);
+        $settings->saveSetting("serverurl", $url);
     }
 
     output("How does the site know that I referred a person?`n");
     output("Easy!  When you tell your friends about this site, give out the following link:`n`n");
     output_notl("%sreferral.php?r=%s`n`n", $url, rawurlencode($session['user']['login']));
     output("If you do, the site will know that you were the one who sent them here.");
-    output("When they reach level %s for the first time, you'll get your points!", getsetting("referminlevel", 4));
+    output("When they reach level %s for the first time, you'll get your points!", $settings->getSetting("referminlevel", 4));
 
     $sql = "SELECT name,level,refererawarded FROM " . Database::prefix("accounts") . " WHERE referer={$session['user']['acctid']} ORDER BY dragonkills,level";
     $result = Database::query($sql);
-    $name = translate_inline("Name");
-    $level = translate_inline("Level");
-    $awarded = translate_inline("Awarded?");
-    $yes = translate_inline("`@Yes!`0");
-    $no = translate_inline("`\$No!`0");
-    $none = translate_inline("`iNone`i");
+    $name = $translator->translateInline("Name");
+    $level = $translator->translateInline("Level");
+    $awarded = $translator->translateInline("Awarded?");
+    $yes = $translator->translateInline("`@Yes!`0");
+    $no = $translator->translateInline("`\$No!`0");
+    $none = $translator->translateInline("`iNone`i");
     output("`n`nAccounts which you referred:`n");
     rawoutput("<table border='0' cellpadding='3' cellspacing='0'><tr><td>$name</td><td>$level</td><td>$awarded</td></tr>");
     $number = Database::numRows($result);
@@ -70,7 +75,7 @@ if ($session['user']['loggedin']) {
     page_header("Welcome to Legend of the Green Dragon");
     output("`@Legend of the Green Dragon is a remake of the classic BBS Door Game Legend of the Red Dragon.");
     output("Adventure into the classic realm that was one of the world's very first multiplayer roleplaying games!");
-    addnav("Create a character", "create.php?r=" . HTMLEntities(httpget('r'), ENT_COMPAT, getsetting("charset", "UTF-8")));
+    addnav("Create a character", "create.php?r=" . HTMLEntities(Http::get('r'), ENT_COMPAT, $settings->getSetting("charset", "UTF-8")));
     addnav("Login Page", "index.php");
     page_footer();
 }

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
  */
 
 namespace Lotgd;
-use Lotgd\Settings;
 
+use Lotgd\Settings;
 use Lotgd\MySQL\Database;
 use Lotgd\Backtrace;
 use Lotgd\Forms;
@@ -19,6 +19,7 @@ use Lotgd\Modules\HookHandler;
 use Lotgd\Translator;
 use Lotgd\DataCache;
 use Lotgd\Output;
+use Lotgd\Http;
 
 class Modules
 {
@@ -1234,10 +1235,10 @@ class Modules
                     Translator::getInstance()->setSchema('events');
                     output('`^`c`bSomething Special!`c`b`0');
                     Translator::getInstance()->setSchema();
-                    $op = httpget('op');
-                    httpset('op', '');
+                    $op = Http::get('op');
+                    Http::set('op', '');
                     self::doEvent($eventtype, $event['modulename'], false, $baseLink);
-                    httpset('op', $op);
+                    Http::set('op', $op);
                     return 1;
                 }
                 $sum += $event['normchance'];
@@ -1270,7 +1271,7 @@ class Modules
             $fname = $module . '_runevent';
             $fname($type, $baseLink);
             Translator::getInstance()->setSchema();
-            HookHandler::hook("runevent_$module", ['type' => $type, 'baselink' => $baseLink, 'get' => httpallget(), 'post' => httpallpost()]);
+            HookHandler::hook("runevent_$module", ['type' => $type, 'baselink' => $baseLink, 'get' => Http::allGet(), 'post' => Http::allPost()]);
             $navsection = $oldnavsection;
         }
 

--- a/src/Lotgd/PhpGenericEnvironment.php
+++ b/src/Lotgd/PhpGenericEnvironment.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use Lotgd\Http;
+
 /**
  * Provide functions for setting up PHP globals when running under various web servers.
  */
@@ -21,7 +23,7 @@ class PhpGenericEnvironment
         }
         if ($REQUEST_URI == '') {
             // necessary for some IIS installations
-            $get = httpallget();
+            $get = Http::allGet();
             if (count($get) > 0) {
                 $REQUEST_URI = $SCRIPT_NAME . '?';
                 $i = 0;

--- a/src/Lotgd/Settings.php
+++ b/src/Lotgd/Settings.php
@@ -143,6 +143,7 @@ class Settings
     public function getSetting(string|int $settingname, mixed $default = false): mixed
     {
         global $config;
+        $defaults = [];
         if (!is_array($config)) {
             $root = dirname(__DIR__, 2);
             $path = realpath($root . '/dbconnect.php');


### PR DESCRIPTION
## Summary
- remove Http singleton and rely on static helpers in core utilities
- replace legacy setting and translation helpers in referral page
- initialise settings defaults to avoid undefined variable
- drop obsolete phpstan baseline entries

## Testing
- `php -l referral.php`
- `php -l src/Lotgd/Http.php`
- `php -l src/Lotgd/Modules.php`
- `php -l src/Lotgd/PhpGenericEnvironment.php`
- `composer test`
- `composer static`


------
https://chatgpt.com/codex/tasks/task_e_68baf0f3c6d4832981c62bcd58cc69de