### PR TITLE
fix: avoid undefined acctid warning in MOTD polls

### DIFF
--- a/src/Lotgd/Motd.php
+++ b/src/Lotgd/Motd.php
@@ -85,7 +85,9 @@ class Motd
     {
         global $session;
 
-        $sql = 'SELECT count(resultid) AS c, MAX(choice) AS choice FROM ' . Database::prefix('pollresults') . " WHERE motditem='$id' AND account='{$session['user']['acctid']}'";
+        $acctid = isset($session['user']['acctid']) ? (int)$session['user']['acctid'] : 0;
+
+        $sql = 'SELECT count(resultid) AS c, MAX(choice) AS choice FROM ' . Database::prefix('pollresults') . " WHERE motditem='$id' AND account='$acctid'";
         $result = Database::query($sql);
         $row = Database::numRows($result) > 0 ? Database::fetchAssoc($result) : [];
         $choice = $row['choice'] ?? null;


### PR DESCRIPTION
## Summary
- handle missing `acctid` in MOTD poll queries to prevent warnings for logged-out users
- explicitly check for `acctid` before fetching poll results

## Testing
- `php -l src/Lotgd/Motd.php`
- `composer test --no-interaction --no-progress`


------
https://chatgpt.com/codex/tasks/task_e_68baf788d65c83298c68f8ab017f4b91