### PR TITLE
Use Translator and initialise config variables

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -166,7 +166,7 @@ switch ($type_setting) {
                         $post = modulehook("validatesettings", $post, true, $module);
                         if (isset($post['validation_error'])) {
                             $post['validation_error'] =
-                                translate_inline($post['validation_error']);
+                                Translator::translateInline($post['validation_error']);
                             output(
                                 "Unable to change settings:`\$%s`0",
                                 $post['validation_error']
@@ -223,14 +223,14 @@ switch ($type_setting) {
                             $msettings = modulehook("mod-dyn-settings", $msettings);
                             if (is_module_active($module)) {
                                 output("This module is currently active: ");
-                                $deactivate = translate_inline("Deactivate");
+                                $deactivate = Translator::translateInline("Deactivate");
                                 rawoutput("<a href='modules.php?op=deactivate&module={$module}&cat={$info['category']}'>");
                                 output_notl($deactivate);
                                 rawoutput("</a>");
                                 addnav("", "modules.php?op=deactivate&module={$module}&cat={$info['category']}");
                             } else {
                                 output("This module is currently deactivated: ");
-                                $deactivate = translate_inline("Activate");
+                                $deactivate = Translator::translateInline("Activate");
                                 rawoutput("<a href='modules.php?op=activate&module={$module}&cat={$info['category']}'>");
                                 output_notl($deactivate);
                                 rawoutput("</a>");
@@ -259,7 +259,7 @@ SuperuserNav::render();
 addnav("Module Manager", "modules.php");
 if ($module) {
     $cat = $info['category'];
-    addnav(array("Module Category - `^%s`0", translate_inline($cat)), "modules.php?cat=$cat");
+    addnav(array("Module Category - `^%s`0", Translator::translateInline($cat)), "modules.php?cat=$cat");
 }
 
 addnav("Game Settings");

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,31 +1,6 @@
 parameters:
         ignoreErrors:
                 -
-                        message: "#^Variable \\$session might not be defined\\.$#"
-                        count: 1
-                        path: src/Lotgd/Config/configuration.php
-
-                -
-                        message: "#^Function translate_inline not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/Config/user_account.php
-
-                -
-                        message: "#^Variable \\$enum might not be defined\\.$#"
-                        count: 1
-                        path: src/Lotgd/Config/user_account.php
-
-                -
-                        message: "#^Variable \\$mounts might not be defined\\.$#"
-                        count: 1
-                        path: src/Lotgd/Config/user_account.php
-
-                -
-                        message: "#^Variable \\$session might not be defined\\.$#"
-                        count: 4
-                        path: src/Lotgd/Config/user_account.php
-
-                -
                         message: "#^Function module_display_events not found\\.$#"
                         count: 1
                         path: src/Lotgd/Forest.php

--- a/src/Lotgd/Config/configuration.php
+++ b/src/Lotgd/Config/configuration.php
@@ -2,6 +2,10 @@
 
 use Lotgd\Settings;
 
+global $session;
+
+$settings = Settings::getInstance();
+
 
 $setup = array(
     "Game Setup,title",
@@ -14,7 +18,7 @@ $setup = array(
     "This is a comma separated list the petitionsender can choose one point from. Use as many as you like - without colors,note",
     "Enter languages here like this: `i(shortname 2 chars) comma (readable name of the language)`i and continue as long as you wish,note",
     "serverlanguages" => "Languages available on this server",
-    "defaultlanguage" => "Default Language,enum," . Settings::getInstance()->getSetting("serverlanguages", "en,English,fr,Français,dk,Danish,de,Deutsch,es,Español,it,Italian"),
+    "defaultlanguage" => "Default Language,enum," . $settings->getSetting("serverlanguages", "en,English,fr,Français,dk,Danish,de,Deutsch,es,Español,it,Italian"),
     "corenewspath" => "Path and file to fetch the Core News for +nb Editions",
     "edittitles" => "Should DK titles be editable in user editor,bool",
     "forcedmotdpopup" => "Force a MOTD popup if an unseen motd is there?,bool",

--- a/src/Lotgd/Config/user_account.php
+++ b/src/Lotgd/Config/user_account.php
@@ -1,8 +1,13 @@
 <?php
 
 use Lotgd\Settings;
+use Lotgd\Translator;
+
+global $session;
 
 $settings = Settings::getInstance();
+$enum = '';
+$mounts = '';
 
 $userinfo = array(
     "Account info,title",
@@ -84,7 +89,7 @@ $userinfo = array(
         (($session['user']['superuser'] & SU_MEGAUSER) ? "int" : "viewonly"),
 
     "Clan Info,title",
-    "clanid" => "Clan,enumpretrans,0," . translate_inline("None"),
+    "clanid" => "Clan,enumpretrans,0," . Translator::translateInline("None"),
     "clanrank" => "Clan Rank,floatrange,0,31,1",
     "clanjoindate" => "Clan Join Date",
 


### PR DESCRIPTION
## Summary
- Declare `$session` as global in configuration helpers
- Replace `translate_inline()` with `Translator::translateInline()`
- Initialise enum-related variables and prune PHPStan baseline

## Testing
- `php -l src/Lotgd/Config/configuration.php src/Lotgd/Config/user_account.php configuration.php`
- `vendor/bin/phpstan analyse --memory-limit=1G`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bafd991d18832996bf56cbcf251465