### PR TITLE
Refactor forest hooks and logging

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,25 +1,5 @@
 parameters:
         ignoreErrors:
-                -
-                        message: "#^Function module_display_events not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/Forest.php
-
-                -
-                        message: "#^Function debuglog not found\\.$#"
-                        count: 3
-                        path: src/Lotgd/Forest/Outcomes.php
-
-                -
-                        message: "#^Function get_player_dragonkillmod not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/Forest/Outcomes.php
-
-                -
-                        message: "#^Function page_footer not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/Forest/Outcomes.php
-
 
                 -
                         message: "#^Function addnav not found\\.$#"

--- a/src/Lotgd/Forest.php
+++ b/src/Lotgd/Forest.php
@@ -26,7 +26,8 @@ class Forest
 
         $settings = Settings::getInstance();
 
-        Translator::getInstance()->setSchema('forest');
+        $translator = Translator::getInstance();
+        $translator->setSchema('forest');
 
         $output = Output::getInstance();
 
@@ -68,7 +69,7 @@ class Forest
             HookHandler::hook('forest-desc');
         }
         HookHandler::hook('forest', []);
-        module_display_events('forest', 'forest.php');
-        Translator::getInstance()->setSchema();
+        HookHandler::displayEvents('forest', 'forest.php');
+        $translator->setSchema();
     }
 }

--- a/src/Lotgd/Forest/Outcomes.php
+++ b/src/Lotgd/Forest/Outcomes.php
@@ -11,13 +11,16 @@ namespace Lotgd\Forest;
 use Lotgd\AddNews;
 use Lotgd\Battle;
 use Lotgd\DeathMessage;
-use Lotgd\PageParts;
-use Lotgd\Translator;
-use Lotgd\Settings;
+use Lotgd\DebugLog;
+use Lotgd\Page\Footer;
+use Lotgd\Modules\HookHandler;
 use Lotgd\Nav as Navigation;
 use Lotgd\Output;
+use Lotgd\PageParts;
+use Lotgd\PlayerFunctions;
 use Lotgd\Random;
-use Lotgd\Modules\HookHandler;
+use Lotgd\Settings;
+use Lotgd\Translator;
 
 class Outcomes
 {
@@ -73,7 +76,7 @@ class Outcomes
 
         if ($gold) {
             $output->output("`#You receive `^%s`# gold!`n", $gold);
-            debuglog('received gold for slaying a monster.', false, false, 'forestwin', $gold);
+            DebugLog::add('received gold for slaying a monster.', false, false, 'forestwin', $gold);
         }
         $gemChance = $settings->getSetting('forestgemchance', 25);
         $args = HookHandler::hook('alter-gemchance', ['chance' => $gemChance]);
@@ -82,7 +85,7 @@ class Outcomes
         if ($session['user']['level'] < $maxLevel && $random->e_rand(1, $gemchances) == 1) {
             $output->output("`&You find A GEM!`n`#");
             $session['user']['gems']++;
-            debuglog('found gem when slaying a monster.', false, false, 'forestwingem', 1);
+            DebugLog::add('found gem when slaying a monster.', false, false, 'forestwingem', 1);
         }
         $instantExp = $settings->getSetting('instantexp', false);
         if ($instantExp == true) {
@@ -183,14 +186,14 @@ class Outcomes
             AddNews::add("%s", $deathmessage['deathmessage']);
         }
         $session['user']['alive'] = 0;
-        debuglog("lost gold when they were slain $where", false, false, 'forestlose', -$session['user']['gold']);
+        DebugLog::add("lost gold when they were slain $where", false, false, 'forestlose', -$session['user']['gold']);
         $session['user']['gold'] = 0;
         $session['user']['hitpoints'] = 0;
         $session['user']['experience'] = round($session['user']['experience'] * (1 - ($percent / 100)), 0);
         $output->output("`4All gold on hand has been lost!`n");
         $output->output("`4%s %% of experience has been lost!`b`n", $percent);
         $output->output('You may begin fighting again tomorrow.');
-        page_footer();
+        Footer::pageFooter();
     }
 
     /**
@@ -205,7 +208,7 @@ class Outcomes
         $settings = Settings::getInstance();
         static $dk = false;
         if ($dk === false) {
-            $dk = get_player_dragonkillmod(true);
+            $dk = PlayerFunctions::getPlayerDragonKillMod(true);
             $add = ($session['user']['dragonkills'] / 100) * .10;
             $dk = round($dk * (.25 + $add));
         }


### PR DESCRIPTION
## Summary
- Replace legacy `module_display_events` call with `HookHandler::displayEvents` and cache translator instance
- Use `DebugLog`, `PlayerFunctions`, and `Footer` in forest outcomes
- Drop forest-related ignores from PHPStan baseline

## Testing
- `php -l src/Lotgd/Forest.php`
- `php -l src/Lotgd/Forest/Outcomes.php`
- `composer static`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bb00f15f20832993fdacc5288d4230