### PR TITLE
Initialize template global and streamline translator

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10,27 +10,3 @@ parameters:
 
 
 
-                -
-                        message: "#^Variable \\$template might not be defined\\.$#"
-                        count: 1
-                        path: src/Lotgd/Template.php
-
-                -
-                        message: "#^Function popup not found\\.$#"
-                        count: 1
-                        path: src/Lotgd/Translator.php
-
-                -
-                        message: "#^Undefined variable\\: \\$settings$#"
-                        count: 1
-                        path: src/Lotgd/Translator.php
-
-                -
-                        message: "#^Variable \\$namespace in isset\\(\\) always exists and is not nullable\\.$#"
-                        count: 1
-                        path: src/Lotgd/Translator.php
-
-                -
-                        message: "#^Variable \\$settings in isset\\(\\) is never defined\\.$#"
-                        count: 1
-                        path: src/Lotgd/Translator.php

--- a/src/Lotgd/Template.php
+++ b/src/Lotgd/Template.php
@@ -34,6 +34,7 @@ class Template
         }
 
         global $template;
+        $template = $template ?? [];
         if (!isset($template[$itemname])) {
             // If the template part is not found, it's usually not a bad thing. So comment in if you have issues with missing template parts.
             // output("`bWarning:`b The `i%s`i template part was not found!`n", $itemname);
@@ -256,6 +257,7 @@ class Template
         }
         $fulltemplate = file_get_contents("templates/$templatename");
         $fulltemplate = explode("<!--!", $fulltemplate);
+        $template = [];
         foreach ($fulltemplate as $val) {
             if ($val == "") {
                 continue; // Skip empty sections

--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -9,6 +9,7 @@ use Lotgd\MySQL\Database;
 use Lotgd\Sanitize;
 use Lotgd\Cookies;
 use Lotgd\Output;
+use Lotgd\PageParts;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 
 
@@ -102,7 +103,7 @@ class Translator
             $namespace = self::$translation_namespace;
         }
         $outdata = $indata;
-        if (!isset($namespace) || $namespace == "") {
+        if ($namespace === "") {
             self::tlschema();
         }
 
@@ -379,6 +380,7 @@ class Translator
      */
     public static function translateLoadNamespace(string $namespace, string|false $language = false)
     {
+        $settings = Settings::hasInstance() ? Settings::getInstance() : null;
         if (!defined('DB_CHOSEN') || !DB_CHOSEN) {
             return [];
         }
@@ -410,7 +412,7 @@ class Translator
                         WHERE language='$language'
                                 AND $where";
             /*  debug(nl2br(htmlentities($sql, ENT_COMPAT, Settings::getInstance()->getSetting("charset", "UTF-8")))); */
-            if (isset($settings) && !$settings->getSetting("cachetranslations", 0)) {
+            if ($settings instanceof Settings && !$settings->getSetting("cachetranslations", 1)) {
                 $result = Database::query($sql);
             } else {
                 $cacheNamespace = $namespace;
@@ -469,7 +471,7 @@ class Translator
                     $link = "translatortool.php?u=" .
                         rawurlencode($uri) . "&t=" . rawurlencode($indata);
                     $link = "<a href='$link' target='_blank' onClick=\"" .
-                        popup($link) . ";return false;\" class='t" .
+                        PageParts::popup($link) . ";return false;\" class='t" .
                         ($hot ? "hot" : "") .
                         "' title='" .
                         ($hot ? $hotText : $nothotText) .


### PR DESCRIPTION
## Summary
- Initialize global template array before access
- Use PageParts::popup and ensure Translator settings init
- Drop outdated PHPStan baseline entries

## Testing
- `php -l src/Lotgd/Template.php`
- `php -l src/Lotgd/Translator.php`
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bb1e6ff04c83298add0510f4911dea