### PR TITLE
Use Output singleton in Censor::soap

### DIFF
--- a/src/Lotgd/Censor.php
+++ b/src/Lotgd/Censor.php
@@ -9,6 +9,7 @@ use Lotgd\Sanitize;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Settings;
 use Lotgd\DataCache;
+use Lotgd\Output;
 use const \SU_EDIT_COMMENTS;
 
 class Censor
@@ -24,7 +25,8 @@ class Censor
      */
     public static function soap(string $input, bool $debug = false, bool $skiphook = false): string
     {
-        global $session, $output;
+        global $session;
+        $output = Output::getInstance();
         $final_output = $input;
         $sanitized = Sanitize::fullSanitize($input);
         $mix_mask = str_pad('', strlen($sanitized), 'X');


### PR DESCRIPTION
## Summary
- Import `Lotgd\Output` and use its singleton within `Censor::soap`
- Drop `$output` from the global scope and instantiate locally

## Testing
- `php -l src/Lotgd/Censor.php`
- `composer test`
- `composer static`


------
https://chatgpt.com/codex/tasks/task_e_68bb27c25f6c8329a6aac0f53495843b