### PR TITLE
refactor: localize output instance in timeout handler

### DIFF
--- a/src/Lotgd/Async/Handler/Timeout.php
+++ b/src/Lotgd/Async/Handler/Timeout.php
@@ -21,7 +21,8 @@ class Timeout
      */
     public function timeoutStatus(bool $args = false): Response
     {
-        global $session, $start_timeout_show_seconds, $never_timeout_if_browser_open, $output;
+        global $session, $start_timeout_show_seconds, $never_timeout_if_browser_open;
+        $output = Output::getInstance();
         $settings = Settings::getInstance();
 
         if ($args === false) {


### PR DESCRIPTION
## Summary
- avoid using global Output instance inside `timeoutStatus`

## Testing
- `composer test`
- `vendor/bin/phpstan analyse --memory-limit=1G`


------
https://chatgpt.com/codex/tasks/task_e_68bb27cc2a288329be2c05af6501c24f