### PR TITLE
Respect LOTGD_DATA_DIR for installer logs

### DIFF
--- a/install/lib/InstallerLogger.php
+++ b/install/lib/InstallerLogger.php
@@ -11,21 +11,18 @@ class InstallerLogger
      */
     public static function getLogFilePath(): string
     {
-        $defaultDir = __DIR__ . '/../errors';
+        $customDir = getenv('LOTGD_DATA_DIR');
+        if ($customDir) {
+            return rtrim($customDir, '/') . '/install.log';
+        }
 
-        // Use the default install directory when it is writable
+        $defaultDir = __DIR__ . '/../errors';
         if ((is_dir($defaultDir) && is_writable($defaultDir))
             || (!is_dir($defaultDir) && is_writable(dirname($defaultDir)))) {
             return $defaultDir . '/install.log';
         }
 
-        // Fall back to a configurable data directory or the system temp dir
-        $fallback = getenv('LOTGD_DATA_DIR');
-        if (!$fallback) {
-            $fallback = sys_get_temp_dir() . '/lotgd_install';
-        }
-
-        return rtrim($fallback, '/') . '/install.log';
+        return sys_get_temp_dir() . '/lotgd_install/install.log';
     }
 
     /**

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,4 +7,7 @@
             <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <env name="LOTGD_DATA_DIR" value="/tmp/lotgd_install_test"/>
+    </php>
 </phpunit>


### PR DESCRIPTION
## Summary
- Respect `LOTGD_DATA_DIR` when determining installer log path
- Configure phpunit to write installer logs to `/tmp/lotgd_install_test`

## Testing
- `php -l install/lib/InstallerLogger.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bb36ba67508329980e442e2550dacb