### PR TITLE
Refactor Nav to encapsulate global state

### DIFF
--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -382,10 +382,10 @@ class Modules
      */
     public static function hook(string $hookName, array $args = [], bool $allowInactive = false, $only = false)
     {
-        global $navsection;
         global $session;
         $settings = Settings::getInstance();
         $output   = Output::getInstance();
+        $nav      = Navigation::getInstance();
 
         if (defined('IS_INSTALLER') && IS_INSTALLER) {
             return $args;
@@ -470,7 +470,7 @@ class Modules
             }
 
             if (self::inject($row['modulename'], $allowInactive)) {
-                $oldnavsection = $navsection;
+                $oldnavsection = $nav->getNavSection();
                 Translator::getInstance()->setSchema('module-' . $row['modulename']);
 
                 if (!array_key_exists('whenactive', $row)) {
@@ -502,8 +502,8 @@ class Modules
                         $res = $args;
                     }
 
-                    $args       = $res;
-                    $navsection = $oldnavsection;
+                    $args = $res;
+                    $nav->setNavSection($oldnavsection);
                     Translator::getInstance()->setSchema();
                 }
             }
@@ -1257,23 +1257,22 @@ class Modules
      */
     public static function doEvent(string $type, string $module, bool $allowinactive = false, ?string $baseLink = null): void
     {
-        global $navsection;
-
         if ($baseLink === null) {
             $baseLink = ScriptName::current() . '.php?';
         }
 
         $mod = ModuleManager::getMostRecentModule();
+        $nav = Navigation::getInstance();
 
         $_POST['i_am_a_hack'] = 'true';
         if (self::inject($module, $allowinactive)) {
-            $oldnavsection = $navsection;
+            $oldnavsection = $nav->getNavSection();
             Translator::getInstance()->setSchema("module-$module");
             $fname = $module . '_runevent';
             $fname($type, $baseLink);
             Translator::getInstance()->setSchema();
             HookHandler::hook("runevent_$module", ['type' => $type, 'baselink' => $baseLink, 'get' => Http::allGet(), 'post' => Http::allPost()]);
-            $navsection = $oldnavsection;
+            $nav->setNavSection($oldnavsection);
         }
 
         ModuleManager::setMostRecentModule($mod);

--- a/src/Lotgd/Page/Footer.php
+++ b/src/Lotgd/Page/Footer.php
@@ -23,9 +23,12 @@ class Footer
 {
     public static function pageFooter(bool $saveuser = true): void
     {
-        global $header, $nav, $session, $REMOTE_ADDR, $REQUEST_URI, $pagestarttime,
+        global $session, $REMOTE_ADDR, $REQUEST_URI, $pagestarttime,
             $template, $y2, $z2, $logd_version, $copyright, $SCRIPT_NAME, $footer,
             $settings;
+
+        $navInstance = Nav::getInstance();
+        $header = $navInstance->getHeader();
 
         $z = isset($y2, $z2) ? $y2 ^ $z2 : 'copyright';
         if (TwigTemplate::isActive()) {
@@ -188,6 +191,7 @@ class Footer
             $header = PageParts::stripAdPlaceholders($header);
             $browser_output = $header . ($output->getOutput()) . $footer;
         }
+        $navInstance->setHeader($header);
         if (!isset($session['user']['gensize'])) {
             $session['user']['gensize'] = 0;
         }
@@ -204,7 +208,9 @@ class Footer
 
     public static function popupFooter(): void
     {
-        global $header, $session, $y2, $z2, $copyright, $template;
+        global $session, $y2, $z2, $copyright, $template;
+        $navInstance = Nav::getInstance();
+        $header = $navInstance->getHeader();
 
         $settings = Settings::getInstance();
         $headscript = '';
@@ -214,8 +220,8 @@ class Footer
         } else {
             $footer = $template['popupfoot'];
         }
-                $pre_headscript   = PageParts::canonicalLink();
-                $maillink_add_after = '';
+        $pre_headscript   = PageParts::canonicalLink();
+        $maillink_add_after = '';
         if ($settings->getSetting('ajax', 1) == 1 && isset($session['user']['prefs']['ajax']) && $session['user']['prefs']['ajax']) {
             if (file_exists('async/setup.php')) {
                 require 'async/setup.php';
@@ -254,6 +260,7 @@ class Footer
                 'template_path' => TwigTemplate::getPath(),
             ]);
             $browser_output = TwigTemplate::render('popup.twig', PageParts::$twigVars);
+            $navInstance->setHeader($header);
             Accounts::saveUser();
             session_write_close();
             echo $browser_output;
@@ -264,6 +271,7 @@ class Footer
         $header = PageParts::stripAdPlaceholders($header);
 
         $browser_output = $header . $maillink_add_after . ($output->getOutput()) . $footer;
+        $navInstance->setHeader($header);
         Accounts::saveUser();
         session_write_close();
         echo $browser_output;

--- a/src/Lotgd/Page/Header.php
+++ b/src/Lotgd/Page/Header.php
@@ -14,13 +14,15 @@ use Lotgd\Buffs;
 use Lotgd\Util\ScriptName;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Settings;
+use Lotgd\Nav;
 
 class Header
 {
     public static function pageHeader(...$args): void
     {
-        global $header, $SCRIPT_NAME, $session, $template;
+        global $SCRIPT_NAME, $session, $template;
         $settings = Settings::getInstance();
+        $nav = Nav::getInstance();
 
         PageParts::$noPopups['login.php'] = true;
         PageParts::$noPopups['motd.php'] = true;
@@ -69,8 +71,9 @@ class Header
             $header = str_replace('{title}', $title, $header);
             $header = str_replace('{lang}', $lang, $header);
             $header = str_replace('{meta_description}', $metaDesc, $header);
+            $nav->setHeader($header);
         }
-        $header .= Translator::tlbuttonPop();
+        $nav->setHeader($nav->getHeader() . Translator::tlbuttonPop());
         if ($settings->getSetting('debug', 0)) {
             $session['debugstart'] = microtime();
         }
@@ -78,7 +81,8 @@ class Header
 
     public static function popupHeader(...$args): void
     {
-        global $header, $template;
+        global $template;
+        $nav = Nav::getInstance();
 
         Translator::translatorSetup();
         Template::prepareTemplate();
@@ -107,5 +111,6 @@ class Header
         $header = str_replace('{title}', $title, $header);
         $header = str_replace('{lang}', $lang, $header);
         $header = str_replace('{meta_description}', $metaDesc, $header);
+        $nav->setHeader($header);
     }
 }

--- a/tests/NavColoredHeadlineTest.php
+++ b/tests/NavColoredHeadlineTest.php
@@ -17,6 +17,7 @@ final class NavColoredHeadlineTest extends TestCase
         $session = ['user' => ['prefs' => []], 'allowednavs' => [], 'loggedin' => false];
         $nav = '';
         $output = new Output();
+        Nav::clearNav();
         Template::getInstance()->setTemplate([
             'navhead' => '<span class="navhead">{title}</span>',
             'navitem' => '<a href="{link}">{text}</a>'

--- a/tests/NavColoredSubHeaderTest.php
+++ b/tests/NavColoredSubHeaderTest.php
@@ -17,6 +17,7 @@ final class NavColoredSubHeaderTest extends TestCase
         $session = ['user' => ['prefs' => []], 'allowednavs' => [], 'loggedin' => false];
         $nav = '';
         $output = new Output();
+        Nav::clearNav();
         Template::getInstance()->setTemplate([
             'navhead' => '<span class="navhead">{title}</span>',
             'navheadsub' => '<span class="navheadsub">{title}</span>',

--- a/tests/NavFontResetTest.php
+++ b/tests/NavFontResetTest.php
@@ -17,6 +17,7 @@ final class NavFontResetTest extends TestCase
         $session = ['user' => ['prefs' => []], 'allowednavs' => [], 'loggedin' => false];
         $nav = '';
         $output = new Output();
+        Nav::clearNav();
         $template = [
             'navitem' => '<a href="{link}">{text}</a>'
         ];

--- a/tests/NavNullLinkTest.php
+++ b/tests/NavNullLinkTest.php
@@ -17,6 +17,7 @@ final class NavNullLinkTest extends TestCase
         $session = ['user' => ['prefs' => []], 'allowednavs' => [], 'loggedin' => false];
         $nav = '';
         $output = new Output();
+        Nav::clearNav();
         $template = [
             'navitem' => '<a href="{link}"{accesskey}{popup}>{text}</a>',
             'navhelp' => '<span class="navhelp">{text}</span>',

--- a/tests/NavSortTest.php
+++ b/tests/NavSortTest.php
@@ -17,6 +17,7 @@ final class NavSortTest extends TestCase
         $session = ['user' => ['prefs' => []], 'allowednavs' => [], 'loggedin' => false];
         $nav = '';
         $output = new Output();
+        Nav::clearNav();
         Template::getInstance()->setTemplate([
             'navhead' => '<span class="navhead">{title}</span>',
             'navheadsub' => '<span class="navheadsub">{title}</span>',

--- a/tests/NavigationItemTest.php
+++ b/tests/NavigationItemTest.php
@@ -18,6 +18,7 @@ final class NavigationItemTest extends TestCase
         $session = ['user' => ['prefs' => []], 'allowednavs' => [], 'loggedin' => false];
         $nav = '';
         $output = new Output();
+        Nav::clearNav();
         Template::getInstance()->setTemplate([
             'navitem' => '<a href="{link}"{accesskey}{popup}>{text}</a>'
         ]);

--- a/tests/NavigationSubSectionTest.php
+++ b/tests/NavigationSubSectionTest.php
@@ -17,6 +17,7 @@ final class NavigationSubSectionTest extends TestCase
         $session = ['user' => ['prefs' => []], 'allowednavs' => [], 'loggedin' => false];
         $nav = '';
         $output = new Output();
+        Nav::clearNav();
         Template::getInstance()->setTemplate([
             'navhead' => '<span class="navhead">{title}</span>',
             'navheadsub' => '<span class="navheadsub">{title}</span>',


### PR DESCRIPTION
## Summary
- encapsulate navigation state in `Nav` singleton with private properties and accessors
- update modules and page rendering to rely on `Nav::getInstance()` instead of globals
- clean up tests to reset Nav between runs

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bb383a52608329b8b335de5947df65