### PR TITLE
Encapsulate commentary post flags

### DIFF
--- a/src/Lotgd/Moderate.php
+++ b/src/Lotgd/Moderate.php
@@ -170,7 +170,7 @@ class Moderate
      */
     public static function viewmoderatedcommentary(string $section, string $message = 'Interject your own commentary?', int $limit = 10, string $talkline = 'says', ?string $schema = null, bool $viewall = false): void
     {
-        global $session, $REQUEST_URI, $doublepost, $emptypost;
+        global $session, $REQUEST_URI;
 
         $output = Output::getInstance();
         $translator = Translator::getInstance();
@@ -220,10 +220,10 @@ class Moderate
         }
 
         // Inform the player about posting issues
-        if ($doublepost) {
+        if (Commentary::isDoublePost()) {
             $output->output("`$`bDouble post?`b`0`n");
         }
-        if ($emptypost) {
+        if (Commentary::isEmptyPost()) {
             // Player attempted to submit an empty line
             $output->output("`$`bWell, they say silence is a virtue.`b`0`n");
         }


### PR DESCRIPTION
## Summary
- encapsulate double-post and empty-post checks behind private Commentary flags
- update posting and moderation flows to use new flags

## Testing
- `php -l src/Lotgd/Commentary.php`
- `php -l src/Lotgd/Moderate.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3fd7a20c8329999edf9486018411