### PR TITLE
Introduce query count tracking and remove global

### DIFF
--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -22,7 +22,7 @@ Important methods include:
 - `affectedRows()` – number of rows changed by the last query.
 - `prefix()` – prepend the configured table prefix.
 
-The wrapper also stores various counters in the static `$dbinfo` property, such as `queriesthishit` and the total query time.
+The wrapper also stores various counters in the static `$dbinfo` property, such as the total query time. The number of executed queries for the current request can be retrieved via `Database::getQueryCount()`.
 
 ## DbMysqli
 

--- a/src/Lotgd/Accounts.php
+++ b/src/Lotgd/Accounts.php
@@ -68,7 +68,7 @@ class Accounts
      */
     public static function saveUser(): void
     {
-        global $session, $dbqueriesthishit, $baseaccount, $companions;
+        global $session, $baseaccount, $companions;
 
         if (defined('NO_SAVE_USER')) {
             return;

--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -26,17 +26,20 @@ class Database
     /**
      * Runtime statistics collected during query execution.
      *
-     *  - 'queriesthishit'   Number of queries executed for the current request.
      *  - 'querytime'        Cumulative time spent running SQL queries.
      *  - 'DB_DATACACHEPATH' Optional path for datacache files.
      *
      * @var array<string,int|string>
      */
     protected static array $dbinfo = [
-        'queriesthishit'   => 0,
         'querytime'        => 0,
         'DB_DATACACHEPATH' => '',
     ];
+
+    /**
+     * Number of queries executed for the current request.
+     */
+    private static int $queryCount = 0;
 
     /**
      * Default table prefix for prefixed database tables.
@@ -57,6 +60,14 @@ class Database
     public static function getInfo(string $key, mixed $default = null): mixed
     {
         return self::$dbinfo[$key] ?? $default;
+    }
+
+    /**
+     * Get the number of queries executed during the current request.
+     */
+    public static function getQueryCount(): int
+    {
+        return self::$queryCount;
     }
 
     /**
@@ -110,10 +121,7 @@ class Database
             return [];
         }
         global $session;
-        if (!isset(self::$dbinfo['queriesthishit'])) {
-            self::$dbinfo['queriesthishit'] = 0;
-        }
-        self::$dbinfo['queriesthishit']++;
+        self::$queryCount++;
         $starttime = DateTime::getMicroTime();
         static $configExists = null;
         if ($configExists === null) {

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -958,10 +958,10 @@ class PageParts
             $sql = "INSERT INTO " . Database::prefix('debug') . " VALUES (0,'pagegentime','dbtime','$SCRIPT_NAME','" . (round(Database::getInfo('querytime', 0), 3)) . "');";
             Database::query($sql);
         }
-        $queriesthishit = Database::getInfo('queriesthishit', 0);
+        $queryCount = Database::getQueryCount();
         $querytime = Database::getInfo('querytime', 0);
 
-        return "Page gen: " . round($gentime, 3) . "s / " . $queriesthishit . " queries (" . round($querytime, 3) . "s), Ave: " . round($session['user']['gentime'] / $session['user']['gentimecount'], 3) . "s - " . round($session['user']['gentime'], 3) . "/" . round($session['user']['gentimecount'], 3);
+        return "Page gen: " . round($gentime, 3) . "s / " . $queryCount . " queries (" . round($querytime, 3) . "s), Ave: " . round($session['user']['gentime'] / $session['user']['gentimecount'], 3) . "s - " . round($session['user']['gentime'], 3) . "/" . round($session['user']['gentimecount'], 3);
     }
 
 


### PR DESCRIPTION
## Summary
- track executed queries with a private counter in Database
- expose `getQueryCount()` and use it in PageParts
- drop obsolete `$dbqueriesthishit` global

## Testing
- `php -l src/Lotgd/MySQL/Database.php`
- `php -l src/Lotgd/PageParts.php`
- `php -l src/Lotgd/Accounts.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3fe060488329a7d539790da8602a