### PR TITLE
Centralize environment state to replace global variables

### DIFF
--- a/common.php
+++ b/common.php
@@ -342,7 +342,7 @@ $session['lasthit'] = strtotime("now");
 $cp = $copyright;
 $l = $license;
 
-PhpGenericEnvironment::setup();
+PhpGenericEnvironment::setup($session);
 if (!AJAX_MODE) {
     ForcedNavigation::doForcedNav(ALLOW_ANONYMOUS, OVERRIDE_FORCED_NAV);
 }

--- a/src/Lotgd/Nav/SuperuserNav.php
+++ b/src/Lotgd/Nav/SuperuserNav.php
@@ -8,6 +8,7 @@ use Lotgd\Util\ScriptName;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Translator;
 use Lotgd\Nav as Navigation;
+use Lotgd\PhpGenericEnvironment;
 
 /**
  * Navigation helpers for superuser areas.
@@ -19,7 +20,7 @@ class SuperuserNav
      */
     public static function render(): void
     {
-        global $SCRIPT_NAME, $session;
+        $session = &PhpGenericEnvironment::getSession();
         Translator::getInstance()->setSchema('nav');
         Navigation::add('Navigation');
         if ($session['user']['superuser'] & ~ SU_DOESNT_GIVE_GROTTO) {

--- a/src/Lotgd/PhpGenericEnvironment.php
+++ b/src/Lotgd/PhpGenericEnvironment.php
@@ -12,48 +12,166 @@ use Lotgd\Http;
 class PhpGenericEnvironment
 {
     /**
+     * Current PATH_INFO value.
+     */
+    private static string $pathInfo = '';
+
+    /**
+     * Current SCRIPT_NAME value.
+     */
+    private static string $scriptName = '';
+
+    /**
+     * Current REQUEST_URI value.
+     */
+    private static string $requestUri = '';
+
+    /**
+     * Reference to the $_SERVER superglobal.
+     *
+     * @var array<string,mixed>
+     */
+    private static array $server = [];
+
+    /**
+     * Reference to the session array.
+     *
+     * @var array<string,mixed>
+     */
+    private static array $session = [];
+
+    /**
+     * Set the current PATH_INFO value.
+     */
+    public static function setPathInfo(string $pathInfo): void
+    {
+        self::$pathInfo = $pathInfo;
+    }
+
+    /**
+     * Get the current PATH_INFO value.
+     */
+    public static function getPathInfo(): string
+    {
+        return self::$pathInfo;
+    }
+
+    /**
+     * Set the current SCRIPT_NAME value.
+     */
+    public static function setScriptName(string $scriptName): void
+    {
+        self::$scriptName = $scriptName;
+    }
+
+    /**
+     * Get the current SCRIPT_NAME value.
+     */
+    public static function getScriptName(): string
+    {
+        return self::$scriptName;
+    }
+
+    /**
+     * Set the current REQUEST_URI value.
+     */
+    public static function setRequestUri(string $requestUri): void
+    {
+        self::$requestUri = $requestUri;
+    }
+
+    /**
+     * Get the current REQUEST_URI value.
+     */
+    public static function getRequestUri(): string
+    {
+        return self::$requestUri;
+    }
+
+    /**
+     * Retrieve a value from the server superglobal.
+     */
+    public static function getServer(string $key, mixed $default = null): mixed
+    {
+        return self::$server[$key] ?? $default;
+    }
+
+    /**
+     * Set a value in the server superglobal.
+     */
+    public static function setServer(string $key, mixed $value): void
+    {
+        self::$server[$key] = $value;
+    }
+
+    /**
+     * Access the session array by reference.
+     *
+     * @return array<string,mixed>
+     */
+    public static function &getSession(): array
+    {
+        return self::$session;
+    }
+
+    /**
      * Normalise REQUEST_URI and SCRIPT_NAME when running under unusual setups.
      */
     public static function sanitizeUri(): void
     {
-        global $PATH_INFO, $SCRIPT_NAME, $REQUEST_URI;
-        if (isset($PATH_INFO) && $PATH_INFO != '') {
-            $SCRIPT_NAME = $PATH_INFO;
-            $REQUEST_URI = '';
+        if (self::$pathInfo !== '') {
+            self::$scriptName = self::$pathInfo;
+            self::$requestUri = '';
         }
-        if ($REQUEST_URI == '') {
+
+        if (self::$requestUri === '') {
             // necessary for some IIS installations
             $get = Http::allGet();
             if (count($get) > 0) {
-                $REQUEST_URI = $SCRIPT_NAME . '?';
+                self::$requestUri = self::$scriptName . '?';
                 $i = 0;
                 foreach ($get as $key => $val) {
                     if ($i > 0) {
-                        $REQUEST_URI .= '&';
+                        self::$requestUri .= '&';
                     }
-                    $REQUEST_URI .= "$key=" . URLEncode($val);
+                    self::$requestUri .= "$key=" . URLEncode($val);
                     $i++;
                 }
             } else {
-                $REQUEST_URI = $SCRIPT_NAME;
+                self::$requestUri = self::$scriptName;
             }
-            $_SERVER['REQUEST_URI'] = $REQUEST_URI;
+            self::$server['REQUEST_URI'] = self::$requestUri;
         }
-        $SCRIPT_NAME = basename($SCRIPT_NAME);
-        if (strpos($REQUEST_URI, '?')) {
-            $REQUEST_URI = $SCRIPT_NAME . substr($REQUEST_URI, strpos($REQUEST_URI, '?'));
+
+        self::$scriptName = basename(self::$scriptName);
+        if (strpos(self::$requestUri, '?')) {
+            self::$requestUri = self::$scriptName . substr(self::$requestUri, strpos(self::$requestUri, '?'));
         } else {
-            $REQUEST_URI = $SCRIPT_NAME;
+            self::$requestUri = self::$scriptName;
         }
-        $_SERVER['REQUEST_URI'] = $REQUEST_URI;
+
+        self::$server['REQUEST_URI'] = self::$requestUri;
+        $GLOBALS['SCRIPT_NAME'] = self::$scriptName;
+        $GLOBALS['REQUEST_URI'] = self::$requestUri;
     }
 
     /**
      * Register global variables and sanitise the URI.
      */
-    public static function setup(): void
+    public static function setup(?array &$session = null): void
     {
-        RegisterGlobal::register($_SERVER);
+        self::$server = &$_SERVER;
+        if ($session === null && isset($GLOBALS['session']) && is_array($GLOBALS['session'])) {
+            self::$session = &$GLOBALS['session'];
+        } elseif ($session !== null) {
+            self::$session = &$session;
+        }
+
+        self::$pathInfo = $GLOBALS['PATH_INFO'] ?? '';
+        self::$scriptName = $GLOBALS['SCRIPT_NAME'] ?? ($_SERVER['SCRIPT_NAME'] ?? '');
+        self::$requestUri = $GLOBALS['REQUEST_URI'] ?? ($_SERVER['REQUEST_URI'] ?? '');
+
+        RegisterGlobal::register(self::$server);
         self::sanitizeUri();
     }
 }

--- a/src/Lotgd/Redirect.php
+++ b/src/Lotgd/Redirect.php
@@ -8,6 +8,7 @@ use Lotgd\Accounts;
 use Lotgd\Output;
 use Lotgd\Nav;
 use Lotgd\Translator;
+use Lotgd\PhpGenericEnvironment;
 
 class Redirect
 {
@@ -21,7 +22,8 @@ class Redirect
      */
     public static function redirect(string $location, string|bool $reason = false): void
     {
-        global $session, $REQUEST_URI;
+        $session = &PhpGenericEnvironment::getSession();
+        $requestUri = PhpGenericEnvironment::getRequestUri();
         $settings = Settings::getInstance();
         if (strpos($location, 'badnav.php') === false) {
             $session['allowednavs'] = [];
@@ -41,13 +43,13 @@ class Redirect
         }
 
         Accounts::saveUser();
-        $host = $_SERVER['HTTP_HOST'];
-        $http = $_SERVER['SERVER_PORT'] == 443 ? 'https' : 'http';
-        $uri = rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
+        $host = PhpGenericEnvironment::getServer('HTTP_HOST');
+        $http = PhpGenericEnvironment::getServer('SERVER_PORT') == 443 ? 'https' : 'http';
+        $uri = rtrim(dirname(PhpGenericEnvironment::getServer('PHP_SELF')), '/\\');
         header("Location: $http://$host$uri/$location");
 
     //fall through if this does not work!
-        $session['debug'] .= "Redirected on '$host' with protocol '$http' to uri '$uri' to location '$location' from location '$REQUEST_URI'.<br/><br/>Reasion if given:<br/>  $reason<br>";
+        $session['debug'] .= "Redirected on '$host' with protocol '$http' to uri '$uri' to location '$location' from location '$requestUri'.<br/><br/>Reasion if given:<br/>  $reason<br>";
         $text = Translator::translateInline('Whoops. There has been an error concering redirecting your to your new page. Please inform the admins about this. More Information for your petition down below:<br/><br/>');
         echo "<html><head><link href=\"templates/common/colors.css\" rel=\"stylesheet\" type=\"text/css\"></head><body style='background-color: #000000; color: #fff;'>$text</body></html>";
         echo $session['debug'];

--- a/tests/PhpGenericEnvironmentTest.php
+++ b/tests/PhpGenericEnvironmentTest.php
@@ -42,31 +42,33 @@ final class PhpGenericEnvironmentTest extends TestCase
 
     public function testSanitizeUriWithDirectorySeparator(): void
     {
-        global $PATH_INFO, $SCRIPT_NAME, $REQUEST_URI;
-        $PATH_INFO = '';
-        $SCRIPT_NAME = '/dir/index.php';
-        $REQUEST_URI = '/dir/index.php?foo=bar';
-        $_SERVER['REQUEST_URI'] = $REQUEST_URI;
+        $_SERVER['PATH_INFO'] = '';
+        $_SERVER['SCRIPT_NAME'] = '/dir/index.php';
+        $_SERVER['REQUEST_URI'] = '/dir/index.php?foo=bar';
 
-        PhpGenericEnvironment::sanitizeUri();
+        $session = [];
+        PhpGenericEnvironment::setup($session);
 
-        $this->assertSame('index.php', $SCRIPT_NAME);
-        $this->assertSame('index.php?foo=bar', $REQUEST_URI);
-        $this->assertSame('index.php?foo=bar', $_SERVER['REQUEST_URI']);
+        $this->assertSame('index.php', PhpGenericEnvironment::getScriptName());
+        $this->assertSame('index.php?foo=bar', PhpGenericEnvironment::getRequestUri());
+        $this->assertSame('index.php?foo=bar', PhpGenericEnvironment::getServer('REQUEST_URI'));
+        $this->assertSame('index.php', $GLOBALS['SCRIPT_NAME']);
+        $this->assertSame('index.php?foo=bar', $GLOBALS['REQUEST_URI']);
     }
 
     public function testSanitizeUriWithoutDirectorySeparator(): void
     {
-        global $PATH_INFO, $SCRIPT_NAME, $REQUEST_URI;
-        $PATH_INFO = '';
-        $SCRIPT_NAME = 'index.php';
-        $REQUEST_URI = 'index.php?foo=bar';
-        $_SERVER['REQUEST_URI'] = $REQUEST_URI;
+        $_SERVER['PATH_INFO'] = '';
+        $_SERVER['SCRIPT_NAME'] = 'index.php';
+        $_SERVER['REQUEST_URI'] = 'index.php?foo=bar';
 
-        PhpGenericEnvironment::sanitizeUri();
+        $session = [];
+        PhpGenericEnvironment::setup($session);
 
-        $this->assertSame('index.php', $SCRIPT_NAME);
-        $this->assertSame('index.php?foo=bar', $REQUEST_URI);
-        $this->assertSame('index.php?foo=bar', $_SERVER['REQUEST_URI']);
+        $this->assertSame('index.php', PhpGenericEnvironment::getScriptName());
+        $this->assertSame('index.php?foo=bar', PhpGenericEnvironment::getRequestUri());
+        $this->assertSame('index.php?foo=bar', PhpGenericEnvironment::getServer('REQUEST_URI'));
+        $this->assertSame('index.php', $GLOBALS['SCRIPT_NAME']);
+        $this->assertSame('index.php?foo=bar', $GLOBALS['REQUEST_URI']);
     }
 }


### PR DESCRIPTION
## Summary
- store PATH_INFO, SCRIPT_NAME, REQUEST_URI, server and session data inside `PhpGenericEnvironment`
- populate environment during bootstrap and expose helpers for session and server values
- use the environment in `Redirect` and `SuperuserNav` instead of touching globals directly

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bb449b9e588329b6122ffe71eb1925