### PR TITLE
Refactor mount handling to avoid global player mount

### DIFF
--- a/common.php
+++ b/common.php
@@ -519,7 +519,10 @@ if (
     if (!isset($session['user']['hashorse'])) {
         $session['user']['hashorse'] = 0;
     }
-        $playermount = Mounts::getmount($session['user']['hashorse']);
+    Mounts::getInstance()->loadPlayerMount($session['user']['hashorse']);
+
+    global $playermount; // Legacy setting for modules
+    $playermount = Mounts::getInstance()->getPlayerMount();
     $temp_comp = @unserialize($session['user']['companions']);
     $companions = array();
     if (is_array($temp_comp)) {

--- a/modules/cities.php
+++ b/modules/cities.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Lotgd\Translator;
+use Lotgd\Mounts;
 /**
  * Core module handling multiple cities and travel events.
  */
@@ -103,10 +104,10 @@ function cities_dohook(string $hookname, array $args): array
             }
             break;
         case "count-travels":
-            global $playermount;
             $args['available'] += get_module_setting("allowance");
-            if ($playermount && isset($playermount['mountid'])) {
-                $id = $playermount['mountid'];
+            $mount = Mounts::getInstance()->getPlayerMount();
+            if ($mount && isset($mount['mountid'])) {
+                $id    = $mount['mountid'];
                 $extra = get_module_objpref("mounts", $id, "extratravel");
                 $args['available'] += $extra;
             }

--- a/modules/darkhorse.php
+++ b/modules/darkhorse.php
@@ -10,6 +10,7 @@ use Lotgd\Commentary;
 use Lotgd\MountName;
 use Lotgd\MySQL\Database;
 use Lotgd\Output;
+use Lotgd\Mounts;
 
 // translator ready
 // addnews ready
@@ -37,9 +38,9 @@ function darkhorse_getmoduleinfo(): array
 
 function darkhorse_tavernmount()
 {
-    global $playermount;
-    if (isset($playermount) && is_array($playermount) && array_key_exists("mountid", $playermount)) {
-        $id = $playermount['mountid'];
+    $mount = Mounts::getInstance()->getPlayerMount();
+    if (isset($mount['mountid'])) {
+        $id = $mount['mountid'];
     } else {
         $id = 0;
     }

--- a/newday.php
+++ b/newday.php
@@ -5,6 +5,7 @@ use Lotgd\Translator;
 use Lotgd\Buffs;
 use Lotgd\Newday;
 use Lotgd\MountName;
+use Lotgd\Mounts;
 use Lotgd\Names;
 use Lotgd\Battle;
 use Lotgd\Substitute;
@@ -197,7 +198,8 @@ if ($dp < $dkills) {
         }
     }
     if ($session['user']['hashorse']) {
-        $buff = unserialize($playermount['mountbuff']);
+        $mount = Mounts::getInstance()->getPlayerMount();
+        $buff  = unserialize($mount['mountbuff']);
         if (!isset($buff['schema']) || $buff['schema'] == "") {
             $buff['schema'] = "mounts";
         }
@@ -295,12 +297,13 @@ if ($dp < $dkills) {
     $session['user']['recentcomments'] = $session['user']['lasthit'];
     $session['user']['lasthit'] = gmdate("Y-m-d H:i:s");
     if ($session['user']['hashorse']) {
-        $msg = $playermount['newday'];
-        $msg = Substitute::applyArray("`n`&" . $msg . "`0`n");
+        $mount = Mounts::getInstance()->getPlayerMount();
+        $msg   = $mount['newday'];
+        $msg   = Substitute::applyArray("`n`&" . $msg . "`0`n");
         output($msg);
                 list($name, $lcname) = MountName::getmountname();
 
-        $mff = (int)$playermount['mountforestfights'];
+        $mff = (int) $mount['mountforestfights'];
         $session['user']['turns'] += $mff;
         $turnstoday .= ", Mount: $mff";
         if ($mff > 0) {

--- a/src/Lotgd/Events.php
+++ b/src/Lotgd/Events.php
@@ -40,7 +40,7 @@ class Events
                 //debug("Base link was specified as $baseLink");
                 //debug(debug_backtrace());
         }
-        global $session, $playermount, $badguy;
+        global $session, $badguy;
         $output = Output::getInstance();
         $skipdesc = false;
 

--- a/src/Lotgd/Forest.php
+++ b/src/Lotgd/Forest.php
@@ -22,7 +22,7 @@ class Forest
      */
     public static function forest(bool $noshowmessage = false): void
     {
-        global $session, $playermount;
+        global $session;
 
         $settings = Settings::getInstance();
 

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -1165,7 +1165,7 @@ class Modules
      */
     public static function collectEvents(string $type, bool $allowinactive = false): array
     {
-        global $session, $playermount;
+        global $session;
 
         $active = '';
         $events = [];

--- a/src/Lotgd/MountName.php
+++ b/src/Lotgd/MountName.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\Translator;
+use Lotgd\Mounts;
 /**
  * Helper for retrieving the player mount names.
  */
@@ -17,18 +18,18 @@ class MountName
      */
     public static function getmountname(): array
     {
-        global $playermount;
+        $mount = Mounts::getInstance()->getPlayerMount();
         Translator::getInstance()->setSchema('mountname');
         $name = '';
         $lcname = '';
-        if (isset($playermount['mountname'])) {
-            $name = Translator::getInstance()->sprintfTranslate('Your %s', $playermount['mountname']);
-            $lcname = Translator::getInstance()->sprintfTranslate('your %s', $playermount['mountname']);
+        if (isset($mount['mountname'])) {
+            $name = Translator::getInstance()->sprintfTranslate('Your %s', $mount['mountname']);
+            $lcname = Translator::getInstance()->sprintfTranslate('your %s', $mount['mountname']);
         }
         Translator::getInstance()->setSchema();
-        if (isset($playermount['newname']) && $playermount['newname'] != '') {
-            $name = $playermount['newname'];
-            $lcname = $playermount['newname'];
+        if (isset($mount['newname']) && $mount['newname'] != '') {
+            $name = $mount['newname'];
+            $lcname = $mount['newname'];
         }
         return [$name, $lcname];
     }

--- a/src/Lotgd/Mounts.php
+++ b/src/Lotgd/Mounts.php
@@ -13,6 +13,18 @@ use Lotgd\MySQL\Database;
 class Mounts
 {
     /**
+     * Instance for singleton pattern.
+     */
+    private static ?self $instance = null;
+
+    /**
+     * Current player mount data.
+     *
+     * @var array<string,mixed>
+     */
+    private array $playerMount = [];
+
+    /**
      * Retrieve mount information from the database.
      *
      * @param int $horse Mount id
@@ -26,6 +38,53 @@ class Mounts
         if (Database::numRows($result) > 0) {
             return Database::fetchAssoc($result);
         }
+
         return [];
+    }
+
+    /**
+     * Get the Mounts singleton instance.
+     */
+    public static function getInstance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Set the current player mount.
+     *
+     * @param array<string,mixed> $mount Mount data
+     */
+    public function setPlayerMount(array $mount): void
+    {
+        $this->playerMount = $mount;
+    }
+
+    /**
+     * Retrieve the current player mount.
+     *
+     * @return array<string,mixed>
+     */
+    public function getPlayerMount(): array
+    {
+        return $this->playerMount;
+    }
+
+    /**
+     * Load a mount from the database and set it as the current player mount.
+     *
+     * @param int $horse Mount id
+     *
+     * @return array<string,mixed>
+     */
+    public function loadPlayerMount(int $horse): array
+    {
+        $this->playerMount = self::getmount($horse);
+
+        return $this->playerMount;
     }
 }

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -30,6 +30,7 @@ use Lotgd\Modules\HookHandler;
 use Lotgd\Translator;
 use Lotgd\DataCache;
 use Lotgd\Http;
+use Lotgd\Mounts;
 
 class PageParts
 {
@@ -213,7 +214,8 @@ class PageParts
  */
     public static function charStats(): string
     {
-        global $session, $playermount, $companions;
+        global $session, $companions;
+        $mount = Mounts::getInstance()->getPlayerMount();
         $output = Output::getInstance();
 
         $settings = Settings::getInstance();
@@ -389,8 +391,8 @@ class PageParts
             self::addCharStat("Equipment Info");
             self::addCharStat("Weapon", $u['weapon']);
             self::addCharStat("Armor", $u['armor']);
-            if ($u['hashorse'] && isset($playermount['mountname'])) {
-                self::addCharStat("Creature", $playermount['mountname'] . "`0");
+            if ($u['hashorse'] && isset($mount['mountname'])) {
+                self::addCharStat("Creature", $mount['mountname'] . "`0");
             }
 
             HookHandler::hook("charstats");

--- a/tests/MountsTest.php
+++ b/tests/MountsTest.php
@@ -31,4 +31,11 @@ final class MountsTest extends TestCase
         $row = Mounts::getmount(2);
         $this->assertSame([], $row);
     }
+
+    public function testPlayerMountAccessors(): void
+    {
+        $mounts = Mounts::getInstance();
+        $mounts->setPlayerMount(['mountid' => 5]);
+        $this->assertSame(['mountid' => 5], $mounts->getPlayerMount());
+    }
 }


### PR DESCRIPTION
## Summary
- manage player mount via `Lotgd\Mounts` singleton instead of global
- replace `$playermount` usages with `Mounts::getInstance()` accessors
- expose `$playermount` global for legacy module compatibility
- add tests for new mount accessors

## Testing
- `composer install`
- `php -l src/Lotgd/Mounts.php common.php newday.php stables.php modules/cities.php modules/darkhorse.php src/Lotgd/MountName.php src/Lotgd/Forest.php src/Lotgd/Events.php src/Lotgd/PageParts.php src/Lotgd/Modules.php tests/MountsTest.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bb450d3bf48329873d7ad85f9a6789