### PR TITLE
refactor: centralize timeout flags in singleton

### DIFF
--- a/async/common/jaxon.php
+++ b/async/common/jaxon.php
@@ -19,7 +19,7 @@ use function Jaxon\jaxon;
 // Load asynchronous configuration settings
 require_once __DIR__ . '/settings.php';
 
-global $jaxon, $s_js;
+global $jaxon;
 // Get the Jaxon singleton object
 $jaxon = jaxon();
 
@@ -41,7 +41,4 @@ $jaxon->setOption('core.debug.verbose', false);
 $jaxon->register(Jaxon::CALLABLE_CLASS, Mail::class);
 $jaxon->register(Jaxon::CALLABLE_CLASS, Commentary::class);
 $jaxon->register(Jaxon::CALLABLE_CLASS, Timeout::class);
-
-// Generate the script tag for Jaxon Javascript and make it available
-$s_js = $jaxon->getJs();
 

--- a/async/common/settings.php
+++ b/async/common/settings.php
@@ -44,9 +44,28 @@ if (is_readable($customFile)) {
 
 extract($asyncSettings, EXTR_SKIP);
 
+$timeout = \Lotgd\Async\Handler\Timeout::getInstance();
+
+$neverTimeoutIfBrowserOpen = (int) ($never_timeout_if_browser_open ?? 0);
+$startTimeoutShowSeconds = (int) ($start_timeout_show_seconds ?? 300);
+$checkMailTimeoutSeconds = (int) ($check_mail_timeout_seconds ?? 10);
+$clearScriptExecutionSeconds = (int) ($clear_script_execution_seconds ?? -1);
+
 if ($mail_debug == 1) {
-    $check_mail_timeout_seconds = 500;   // how often check for new mail
+    $checkMailTimeoutSeconds = 500;   // how often check for new mail
     $check_timeout_seconds = 5;          // how often checking for timeout
-    $start_timeout_show_seconds = 999;   // when should the counter start to display (time left)
-    $clear_script_execution_seconds = -1; // when javascript should stop checking (ddos)
+    $startTimeoutShowSeconds = 999;   // when should the counter start to display (time left)
+    $clearScriptExecutionSeconds = -1; // when javascript should stop checking (ddos)
 }
+
+$timeout->setNeverTimeoutIfBrowserOpen($neverTimeoutIfBrowserOpen === 1);
+$timeout->setStartTimeoutShowSeconds($startTimeoutShowSeconds);
+$timeout->setCheckMailTimeoutSeconds($checkMailTimeoutSeconds);
+$timeout->setClearScriptExecutionSeconds($clearScriptExecutionSeconds);
+
+unset(
+    $never_timeout_if_browser_open,
+    $start_timeout_show_seconds,
+    $check_mail_timeout_seconds,
+    $clear_script_execution_seconds
+);

--- a/async/maillink.php
+++ b/async/maillink.php
@@ -13,26 +13,20 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     require_once __DIR__ . '/common/bootstrap.php';
 }
 
-// Ensure asynchronous settings are loaded so polling timeouts are defined.
-if (!isset($check_mail_timeout_seconds)) {
-    require_once __DIR__ . '/common/settings.php';
-}
+require_once __DIR__ . '/common/settings.php';
 
-global $session,
-    $check_mail_timeout_seconds,
-    $start_timeout_show_seconds,
-    $clear_script_execution_seconds,
-    $s_js;
+global $session;
 
-$check_mail_timeout_seconds ??= 60;
-$start_timeout_show_seconds ??= 1;
-$clear_script_execution_seconds ??= 86400;
+$timeout = \Lotgd\Async\Handler\Timeout::getInstance();
+$checkMailTimeoutSeconds = $timeout->getCheckMailTimeoutSeconds();
+$clearScriptExecutionSeconds = $timeout->getClearScriptExecutionSeconds();
+$startTimeoutShowSeconds = $timeout->getStartTimeoutShowSeconds();
 
 $maillink_add_after = "<script>";
 $maillink_add_after .= "var lotgd_comment_section = " . json_encode($session['last_comment_section'] ?? '') . ";";
 $maillink_add_after .= "var lotgd_lastCommentId = " . (int)($session['lastcommentid'] ?? 0) . ";";
-$maillink_add_after .= "var lotgd_poll_interval_ms = " . ($check_mail_timeout_seconds * 1000) . ";";
-$maillink_add_after .= "var lotgd_timeout_delay_ms = " . ((getsetting('LOGINTIMEOUT', 900) - $start_timeout_show_seconds) * 1000) . ";";
-$maillink_add_after .= "var lotgd_clear_delay_ms = " . ((getsetting('LOGINTIMEOUT', 900) - $clear_script_execution_seconds) * 1000) . ";";
+$maillink_add_after .= "var lotgd_poll_interval_ms = " . ($checkMailTimeoutSeconds * 1000) . ";";
+$maillink_add_after .= "var lotgd_timeout_delay_ms = " . ((getsetting('LOGINTIMEOUT', 900) - $startTimeoutShowSeconds) * 1000) . ";";
+$maillink_add_after .= "var lotgd_clear_delay_ms = " . ((getsetting('LOGINTIMEOUT', 900) - $clearScriptExecutionSeconds) * 1000) . ";";
 $maillink_add_after .= "</script>";
 $maillink_add_after .= "<div id='notify'></div>";

--- a/async/setup.php
+++ b/async/setup.php
@@ -32,12 +32,17 @@ require_once __DIR__ . '/common/settings.php';
 $polling_script = "<script>";
 $polling_script .= "var lotgd_comment_section = " . json_encode($session['last_comment_section'] ?? '') . ";";
 $polling_script .= "var lotgd_lastCommentId = " . (int)($session['lastcommentid'] ?? 0) . ";";
-$polling_script .= "var lotgd_poll_interval_ms = " . ($check_mail_timeout_seconds * 1000) . ";";
+
+$timeout = \Lotgd\Async\Handler\Timeout::getInstance();
+$checkMailTimeoutSeconds = $timeout->getCheckMailTimeoutSeconds();
+$clearScriptExecutionSeconds = $timeout->getClearScriptExecutionSeconds();
+$start_timeout_show = max(1, $timeout->getStartTimeoutShowSeconds());
+
+$polling_script .= "var lotgd_poll_interval_ms = " . ($checkMailTimeoutSeconds * 1000) . ";";
 
 // Fix timeout calculations to prevent negative values
 $login_timeout = getsetting('LOGINTIMEOUT', 900);
-$start_timeout_show = max(1, $start_timeout_show_seconds ?? 300);
-$clear_script_execution = max($login_timeout, $clear_script_execution_seconds ?? -1);
+$clear_script_execution = max($login_timeout, $clearScriptExecutionSeconds);
 
 $polling_script .= "var lotgd_timeout_delay_ms = " . (($login_timeout - $start_timeout_show) * 1000) . ";";
 // Only set clear delay if it's positive and reasonable

--- a/src/Lotgd/Async/Handler/Commentary.php
+++ b/src/Lotgd/Async/Handler/Commentary.php
@@ -126,7 +126,7 @@ class Commentary
         }
 
         try {
-            $response->appendResponse((new Timeout())->timeoutStatus(true));
+            $response->appendResponse(Timeout::getInstance()->timeoutStatus(true));
         } catch (\Throwable $e) {
             throw new Exception('AJAX polling: Timeout handler error', 0, $e);
         }

--- a/src/Lotgd/Async/Handler/Timeout.php
+++ b/src/Lotgd/Async/Handler/Timeout.php
@@ -16,12 +16,75 @@ use function Jaxon\jaxon;
  */
 class Timeout
 {
+    private static ?self $instance = null;
+
+    private int $startTimeoutShowSeconds = 300;
+
+    private bool $neverTimeoutIfBrowserOpen = false;
+
+    private int $checkMailTimeoutSeconds = 10;
+
+    private int $clearScriptExecutionSeconds = -1;
+
+    private function __construct()
+    {
+    }
+
+    public static function getInstance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function setStartTimeoutShowSeconds(int $seconds): void
+    {
+        $this->startTimeoutShowSeconds = $seconds;
+    }
+
+    public function getStartTimeoutShowSeconds(): int
+    {
+        return $this->startTimeoutShowSeconds;
+    }
+
+    public function setNeverTimeoutIfBrowserOpen(bool $never): void
+    {
+        $this->neverTimeoutIfBrowserOpen = $never;
+    }
+
+    public function isNeverTimeoutIfBrowserOpen(): bool
+    {
+        return $this->neverTimeoutIfBrowserOpen;
+    }
+
+    public function setCheckMailTimeoutSeconds(int $seconds): void
+    {
+        $this->checkMailTimeoutSeconds = $seconds;
+    }
+
+    public function getCheckMailTimeoutSeconds(): int
+    {
+        return $this->checkMailTimeoutSeconds;
+    }
+
+    public function setClearScriptExecutionSeconds(int $seconds): void
+    {
+        $this->clearScriptExecutionSeconds = $seconds;
+    }
+
+    public function getClearScriptExecutionSeconds(): int
+    {
+        return $this->clearScriptExecutionSeconds;
+    }
+
     /**
      * Update last activity time and report remaining session timeout.
      */
     public function timeoutStatus(bool $args = false): Response
     {
-        global $session, $start_timeout_show_seconds, $never_timeout_if_browser_open;
+        global $session;
         $output = Output::getInstance();
         $settings = Settings::getInstance();
 
@@ -35,7 +98,7 @@ class Timeout
 
         $warning = '';
 
-        if ($never_timeout_if_browser_open == 1) {
+        if ($this->isNeverTimeoutIfBrowserOpen()) {
             $session['user']['laston'] = date('Y-m-d H:i:s'); // set to now
             // manual db update
             $sql = 'UPDATE ' . Database::prefix('accounts') . " set laston='" . $session['user']['laston']
@@ -49,7 +112,7 @@ class Timeout
         if ($timeout <= 1) {
             // Preserve legacy behaviour by including the TIMEOUT keyword
             $warning = $output->appoencode('`$`b') . 'TIMEOUT: Your session has timed out!' . $output->appoencode('`b');
-        } elseif ($timeout < $start_timeout_show_seconds) {
+        } elseif ($timeout < $this->getStartTimeoutShowSeconds()) {
             if ($timeout > 60) {
                 $min = floor($timeout / 60);
                 $sec = $timeout % 60;

--- a/tests/Ajax/PollUpdatesTest.php
+++ b/tests/Ajax/PollUpdatesTest.php
@@ -4,6 +4,7 @@ namespace Tests\Ajax;
 
 use Jaxon\Response\Response;
 use Lotgd\Async\Handler\Commentary;
+use Lotgd\Async\Handler\Timeout;
 use Lotgd\Tests\Stubs\Database;
 use Lotgd\Tests\Stubs\MailDummySettings;
 use Lotgd\Settings;
@@ -27,12 +28,14 @@ class PollUpdatesTest extends TestCase
 {
     protected function setUp(): void
     {
-        global $session, $start_timeout_show_seconds, $never_timeout_if_browser_open, $output;
+        global $session, $output;
 
         $session = [];
         $_SERVER['SCRIPT_NAME'] = 'test.php';
-        $start_timeout_show_seconds = 300;
-        $never_timeout_if_browser_open = 0;
+
+        Timeout::getInstance()->setStartTimeoutShowSeconds(300);
+        Timeout::getInstance()->setNeverTimeoutIfBrowserOpen(false);
+
         Settings::setInstance(new MailDummySettings(['LOGINTIMEOUT' => 360]));
         $output = new class {
             public function appoencode($data, bool $priv = false)

--- a/tests/Ajax/TimeoutStatusTest.php
+++ b/tests/Ajax/TimeoutStatusTest.php
@@ -40,11 +40,13 @@ namespace Lotgd\Tests\Ajax {
     {
         protected function setUp(): void
         {
-            global $session, $start_timeout_show_seconds, $never_timeout_if_browser_open, $settings, $output;
+            global $session, $settings, $output;
 
             $session = ['user' => ['acctid' => 1, 'laston' => date('Y-m-d H:i:s', strtotime('-700 seconds'))]];
-            $start_timeout_show_seconds = 300;
-            $never_timeout_if_browser_open = 0;
+
+            Timeout::getInstance()->setStartTimeoutShowSeconds(300);
+            Timeout::getInstance()->setNeverTimeoutIfBrowserOpen(false);
+
             $settings = new class {
                 private array $values = ['LOGINTIMEOUT' => 900];
                 public function getSetting(string $name, mixed $default = null): mixed
@@ -58,14 +60,14 @@ namespace Lotgd\Tests\Ajax {
                     return $data;
                 }
             };
-          
+
             require_once __DIR__ . '/../bootstrap.php';
 
         }
 
         public function testTimeoutWarningIsReturned(): void
         {
-            $response = (new Timeout())->timeoutStatus(true);
+            $response = Timeout::getInstance()->timeoutStatus(true);
             $commands = $response->getCommands();
 
             $this->assertNotEmpty($commands);
@@ -78,7 +80,7 @@ namespace Lotgd\Tests\Ajax {
             global $session;
             $session = [];
 
-            $response = (new Timeout())->timeoutStatus(true);
+            $response = Timeout::getInstance()->timeoutStatus(true);
             $this->assertEmpty($response->getCommands());
         }
     }

--- a/tests/Async/HandlerResponseTest.php
+++ b/tests/Async/HandlerResponseTest.php
@@ -33,6 +33,9 @@ final class HandlerResponseTest extends TestCase
         require_once __DIR__ . '/../bootstrap.php';
         Settings::setInstance(new MailDummySettings(['LOGINTIMEOUT' => 360]));
         Database::$mockResults = [];
+
+        Timeout::getInstance()->setStartTimeoutShowSeconds(300);
+        Timeout::getInstance()->setNeverTimeoutIfBrowserOpen(false);
     }
 
     public function testMailStatusReturnsResponse(): void
@@ -52,7 +55,7 @@ final class HandlerResponseTest extends TestCase
     public function testTimeoutStatusReturnsResponse(): void
     {
         Database::$mockResults = [];
-        $response = (new Timeout())->timeoutStatus(false);
+        $response = Timeout::getInstance()->timeoutStatus(false);
         $this->assertInstanceOf(Response::class, $response);
     }
 }


### PR DESCRIPTION
## Summary
- encapsulate mail polling and clear-execution settings in `Timeout` singleton
- load async settings into singleton and drop remaining globals
- use singleton in maillink and setup scripts; remove unused Jaxon JS global

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bb449f380c8329af51877037bca113