### PR TITLE
refactor: encapsulate language schema

### DIFF
--- a/src/Lotgd/Forms.php
+++ b/src/Lotgd/Forms.php
@@ -24,10 +24,10 @@ class Forms
         array|bool $info = false,
         bool $scriptOutput = true
     ): string {
-        global $schema, $session;
+        global $session;
         $output = Output::getInstance();
 
-        $talkline = Translator::translateInline($talkline, $schema);
+        $talkline = Translator::translateInline($talkline, Translator::getInstance()->getSchema());
         $youhave = Translator::translateInline('You have ');
         $charsleft = Translator::translateInline(' characters left.');
         $startdiv = $startdiv === false ? '' : $startdiv;


### PR DESCRIPTION
## Summary
- encapsulate translator language and schema state with new getters and setters
- rely on Translator instance instead of global $schema in Forms

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bb4eda34bc8329993f7f339fd7056d