### PR TITLE
Use environment singleton for request metadata

### DIFF
--- a/common.php
+++ b/common.php
@@ -112,6 +112,7 @@ if (isset($gz_handler_on) && $gz_handler_on) {
 }
 
 $pagestarttime = DateTime::getMicroTime();
+PhpGenericEnvironment::setPageStartTime($pagestarttime);
 
 // Set some constant defaults in case they weren't set before the inclusion of
 // common.php
@@ -373,12 +374,13 @@ if (!isset($session['counter'])) {
     $session['counter'] = 0;
 }
 $session['counter']++;
-$nokeeprestore = array("newday.php" => 1,"badnav.php" => 1,"motd.php" => 1,"mail.php" => 1,"petition.php" => 1);
+$nokeeprestore = ["newday.php" => 1, "badnav.php" => 1, "motd.php" => 1, "mail.php" => 1, "petition.php" => 1];
+$scriptNameEnv = PhpGenericEnvironment::getScriptName();
 if (OVERRIDE_FORCED_NAV) {
-    $nokeeprestore[$SCRIPT_NAME] = 1;
+    $nokeeprestore[$scriptNameEnv] = 1;
 }
-if (!isset($nokeeprestore[$SCRIPT_NAME]) || !$nokeeprestore[$SCRIPT_NAME]) {
-    $session['user']['restorepage'] = $REQUEST_URI;
+if (!isset($nokeeprestore[$scriptNameEnv]) || !$nokeeprestore[$scriptNameEnv]) {
+    $session['user']['restorepage'] = PhpGenericEnvironment::getRequestUri();
 } else {
 }
 
@@ -422,8 +424,9 @@ if (isset($session['user']['bufflist'])) {
 if (!is_array($session['bufflist'])) {
     $session['bufflist'] = array();
 }
-if (isset($REMOTE_ADDR)) {
-    $session['user']['lastip'] = $REMOTE_ADDR;   //cron i.e. doesn't have an $REMOTE_ADDR
+$remoteAddr = PhpGenericEnvironment::getRemoteAddr();
+if ($remoteAddr !== '') {
+    $session['user']['lastip'] = $remoteAddr;   //cron i.e. doesn't have an $REMOTE_ADDR
 }
 $cookieId = Cookies::getLgi();
 if ($cookieId === null) {
@@ -473,9 +476,9 @@ if (
                 $row = Database::fetchAssoc($result);
                 Database::freeResult($result);
         if (isset($row['refererid']) && $row['refererid'] > "") {
-                $sql = "UPDATE " . Database::prefix("referers") . " SET count=count+1,last='" . date("Y-m-d H:i:s") . "',site='" . addslashes($site) . "',dest='" . addslashes($host) . "/" . addslashes($REQUEST_URI) . "',ip='{$_SERVER['REMOTE_ADDR']}' WHERE refererid='{$row['refererid']}'";
+                $sql = "UPDATE " . Database::prefix("referers") . " SET count=count+1,last='" . date("Y-m-d H:i:s") . "',site='" . addslashes($site) . "',dest='" . addslashes($host) . "/" . addslashes(PhpGenericEnvironment::getRequestUri()) . "',ip='{$_SERVER['REMOTE_ADDR']}' WHERE refererid='{$row['refererid']}'";
         } else {
-                $sql = "INSERT INTO " . Database::prefix("referers") . " (uri,count,last,site,dest,ip) VALUES ('{$_SERVER['HTTP_REFERER']}',1,'" . date("Y-m-d H:i:s") . "','" . addslashes($site) . "','" . addslashes($host) . "/" . addslashes($REQUEST_URI) . "','{$_SERVER['REMOTE_ADDR']}')";
+                $sql = "INSERT INTO " . Database::prefix("referers") . " (uri,count,last,site,dest,ip) VALUES ('{$_SERVER['HTTP_REFERER']}',1,'" . date("Y-m-d H:i:s") . "','" . addslashes($site) . "','" . addslashes($host) . "/" . addslashes(PhpGenericEnvironment::getRequestUri()) . "','{$_SERVER['REMOTE_ADDR']}')";
         }
                 Database::query($sql);
     }

--- a/configuration.php
+++ b/configuration.php
@@ -10,6 +10,7 @@ use Lotgd\Forms;
 use Lotgd\Output;
 use Lotgd\DataCache;
 use Lotgd\Modules\ModuleManager;
+use Lotgd\PhpGenericEnvironment;
 
 // translator ready
 // addnews ready
@@ -268,7 +269,7 @@ if ($module) {
 addnav("Game Settings");
 addnav("Standard settings", "configuration.php");
 addnav("Extended settings", "configuration.php?settings=extended");
-addnav("", $REQUEST_URI);
+addnav("", PhpGenericEnvironment::getRequestUri());
 
 //get arrays
 require("src/Lotgd/Config/configuration.php");

--- a/home.php
+++ b/home.php
@@ -22,10 +22,6 @@ if (! isset($_SERVER['REQUEST_URI'])) {
     $_SERVER['REQUEST_URI'] = '/home.php';
 }
 
-if (! isset($REQUEST_URI)) {
-    $REQUEST_URI = $_SERVER['REQUEST_URI'];
-}
-
 require_once("common.php");
 
 use Lotgd\Page\Header;

--- a/modules.php
+++ b/modules.php
@@ -3,6 +3,7 @@
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
 use Lotgd\Translator;
+use Lotgd\PhpGenericEnvironment;
 
 // addnews ready
 // translator ready
@@ -19,7 +20,7 @@ page_header("Module Manager");
 SuperuserNav::render();
 
 
-addnav("", $REQUEST_URI);
+addnav("", PhpGenericEnvironment::getRequestUri());
 $op = httpget('op');
 $module = httpget('module');
 

--- a/pages/inn/inn_bartender.php
+++ b/pages/inn/inn_bartender.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Lotgd\Http;
 use Lotgd\Nav;
 use Lotgd\Sanitize;
+use Lotgd\PhpGenericEnvironment;
 
 $act = Http::get('act');
 if ($act == "") {
@@ -101,7 +102,7 @@ if ($act == "") {
     $output->outputNotl("`n`1&#0096;1 `2&#0096;2 `3&#0096;3 `4&#0096;4 `5&#0096;5 `6&#0096;6 `7&#0096;7 ", true);
     $output->outputNotl("`n`!&#0096;! `@&#0096;@ `#&#0096;# `\$&#0096;\$ `%&#0096;% `^&#0096;^ `&&#0096;& `n", true);
     $output->output("`% Got it?`0\"  You can practice below:");
-    $output->rawOutput("<form action=\"$REQUEST_URI\" method='POST'>", true);
+    $output->rawOutput("<form action=\"" . PhpGenericEnvironment::getRequestUri() . "\" method='POST'>", true);
     $testtext = Http::post('testtext');
     $output->output("You entered %s`n", prevent_colors(HTMLEntities($testtext, ENT_COMPAT, getsetting("charset", "UTF-8"))), true);
     $output->output("It looks like %s`n", $testtext);
@@ -111,7 +112,7 @@ if ($act == "") {
     $output->rawOutput("</form>");
     $output->rawOutput("<script language='javascript'>document.getElementById('input').focus();</script>");
         $output->output("`0`n`nThese colors can be used in your name, and in any conversations you have.");
-    Nav::add("", $REQUEST_URI);
+    Nav::add("", PhpGenericEnvironment::getRequestUri());
 } elseif ($act == "specialty") {
     $specialty = Http::get('specialty');
     if ($specialty == "") {
@@ -123,7 +124,7 @@ if ($act == "") {
         $output->output("`0\"`3What new specialty did you have in mind?`0\"");
         $specialities = modulehook("specialtynames");
         foreach ($specialities as $key => $name) {
-            Nav::add($name, Sanitize::cmdSanitize($REQUEST_URI) . "&specialty=$key");
+            Nav::add($name, Sanitize::cmdSanitize(PhpGenericEnvironment::getRequestUri()) . "&specialty=$key");
         }
     } else {
         $output->output("\"`3Ok then,`0\" %s`0 says, \"`3You're all set.`0\"`n`n\"`2That's it?`0\" you ask him.`n`n", $barkeep);

--- a/src/Lotgd/Commentary.php
+++ b/src/Lotgd/Commentary.php
@@ -14,6 +14,7 @@ use Lotgd\DataCache;
 use Lotgd\DateTime;
 use Lotgd\Censor;
 use Lotgd\Redirect;
+use Lotgd\PhpGenericEnvironment;
 
 use Lotgd\MySQL\Database;
 use Lotgd\Util\ScriptName;
@@ -535,7 +536,8 @@ SQL;
         bool $returnastext = false,
         $scriptname_pre = false
     ): ?string {
-        global $session, $REQUEST_URI;
+        global $session;
+        $requestUri = PhpGenericEnvironment::getRequestUri();
         
         $output = Output::getInstance();
         $translator = Translator::getInstance();
@@ -719,7 +721,7 @@ SQL;
             $val = Database::fetchAssoc($r);
             $val = round($val['c'] / $limit + 0.5, 0) - 1;
             if ($val > 0) {
-                $first = Sanitize::comscrollSanitize($REQUEST_URI) . '&comscroll=' . ($val);
+                $first = Sanitize::comscrollSanitize($requestUri) . '&comscroll=' . ($val);
                 $first = str_replace('?&', '?', $first);
                 if (!strpos($first, '?')) {
                     $first = str_replace('&', '?', $first);
@@ -733,7 +735,7 @@ SQL;
             } else {
                 $output->outputNotl($firstu, true);
             }
-            $req = Sanitize::comscrollSanitize($REQUEST_URI) . '&comscroll=' . ($com + 1);
+            $req = Sanitize::comscrollSanitize($requestUri) . '&comscroll=' . ($com + 1);
             $req = str_replace('?&', '?', $req);
             if (!strpos($req, '?')) {
                 $req = str_replace('&', '?', $req);
@@ -747,7 +749,7 @@ SQL;
         } else {
             $output->outputNotl("$firstu $prev", true);
         }
-        $last = Navigation::appendLink(Sanitize::comscrollSanitize($REQUEST_URI), 'refresh=1');
+        $last = Navigation::appendLink(Sanitize::comscrollSanitize($requestUri), 'refresh=1');
 
         $last = Navigation::appendCount($last);
 
@@ -758,7 +760,7 @@ SQL;
         $output->outputNotl("&nbsp;<a href=\"$last\">$ref</a>&nbsp;", true);
         Navigation::add('', $last);
         if ($com > 0 || ($cid > 0 && $newadded > $limit)) {
-            $req = Sanitize::comscrollSanitize($REQUEST_URI) . '&comscroll=' . ($com - 1);
+            $req = Sanitize::comscrollSanitize($requestUri) . '&comscroll=' . ($com - 1);
             $req = str_replace('?&', '?', $req);
             if (!strpos($req, '?')) {
                 $req = str_replace('&', '?', $req);
@@ -987,7 +989,8 @@ SQL;
      */
     public static function talkForm(string $section, string $talkline, int $limit = 10, $schema = false)
     {
-        global $REQUEST_URI, $session;
+        global $session;
+        $requestUri = PhpGenericEnvironment::getRequestUri();
 
         $output = Output::getInstance();
         $translator = Translator::getInstance();
@@ -1027,7 +1030,7 @@ SQL;
         } else {
             $tll = 0;
         }
-        $req = Sanitize::comscrollSanitize($REQUEST_URI) . "&comment=1";
+        $req = Sanitize::comscrollSanitize($requestUri) . "&comment=1";
         if (strpos($req, "?") === false) {
             $req = str_replace("&", "?", $req);
         }

--- a/src/Lotgd/DateTime.php
+++ b/src/Lotgd/DateTime.php
@@ -9,6 +9,7 @@ use Lotgd\Output;
 use Lotgd\Redirect;
 use Lotgd\Settings;
 use Lotgd\Translator;
+use Lotgd\PhpGenericEnvironment;
 
 use const \DATETIME_DATEMIN;
 use const \DATETIME_TODAY;
@@ -99,12 +100,13 @@ class DateTime
 
     public static function checkDay(): void
     {
-        global $session, $revertsession, $REQUEST_URI;
+        global $session, $revertsession;
+        $requestUri = PhpGenericEnvironment::getRequestUri();
         if ($session['user']['loggedin']) {
             Output::getInstance()->outputNotl('<!--CheckNewDay()-->', true);
             if (self::isNewDay()) {
                 $session = $revertsession;
-                $session['user']['restorepage'] = $REQUEST_URI;
+                $session['user']['restorepage'] = $requestUri;
                 $session['allowednavs'] = [];
                 Nav::add('', 'newday.php');
                 Redirect::redirect('newday.php');

--- a/src/Lotgd/ForcedNavigation.php
+++ b/src/Lotgd/ForcedNavigation.php
@@ -10,6 +10,7 @@ use Lotgd\MySQL\Database;
 use Lotgd\Serialization;
 use Lotgd\Output;
 use Lotgd\Redirect;
+use Lotgd\PhpGenericEnvironment;
 
 class ForcedNavigation
 {
@@ -20,7 +21,8 @@ class ForcedNavigation
      */
     public static function doForcedNav(bool $anonymous, bool $overrideforced): void
     {
-        global $session, $REQUEST_URI;
+        global $session;
+        $requestUri = PhpGenericEnvironment::getRequestUri();
         Output::getInstance()->rawOutput("<!--\nAllowAnonymous: " . ($anonymous ? "True" : "False") . "\nOverride Forced Nav: " . ($overrideforced ? "True" : "False") . "\n-->");
         if (isset($session['loggedin']) && $session['loggedin']) {
             $sql = "SELECT * FROM " . Database::prefix('accounts') . " WHERE acctid='" . $session['user']['acctid'] . "'";
@@ -62,11 +64,11 @@ class ForcedNavigation
                 Redirect::redirect('index.php', 'Account Disappeared!');
             }
             Database::freeResult($result);
-            if (isset($session['allowednavs'][$REQUEST_URI]) && $session['allowednavs'][$REQUEST_URI] && $overrideforced !== true) {
+            if (isset($session['allowednavs'][$requestUri]) && $session['allowednavs'][$requestUri] && $overrideforced !== true) {
                 $session['allowednavs'] = [];
             } else {
                 if ($overrideforced !== true) {
-                    Redirect::redirect('badnav.php', 'Navigation not allowed to ' . $REQUEST_URI);
+                    Redirect::redirect('badnav.php', 'Navigation not allowed to ' . $requestUri);
                 }
             }
         } else {
@@ -76,7 +78,7 @@ class ForcedNavigation
                     $session = [];
                     return;
                 }
-                Redirect::redirect('index.php?op=timeout', 'Not logged in: ' . $REQUEST_URI);
+                Redirect::redirect('index.php?op=timeout', 'Not logged in: ' . $requestUri);
             }
         }
     }

--- a/src/Lotgd/Moderate.php
+++ b/src/Lotgd/Moderate.php
@@ -15,6 +15,7 @@ use Lotgd\Translator;
 use Lotgd\Sanitize;
 use Lotgd\Http;
 use Lotgd\DateTime;
+use Lotgd\PhpGenericEnvironment;
 
 use Lotgd\MySQL\Database;
 use Lotgd\Forms;
@@ -89,7 +90,7 @@ class Moderate
      * Render pagination and navigation links under the comment block.
      * Encapsulates the old navigation logic for readability.
      */
-    private static function showNavLinks(string $section, int $limit, int $cid, int $rowcount, bool $jump, int $com, string $REQUEST_URI, int $newadded): void
+    private static function showNavLinks(string $section, int $limit, int $cid, int $rowcount, bool $jump, int $com, string $requestUri, int $newadded): void
     {
         global $session;
 
@@ -108,7 +109,7 @@ class Moderate
             Database::freeResult($r);
             $val = round($val['c'] / $limit + 0.5, 0) - 1;
             if ($val > 0) {
-                $first = Sanitize::comscrollSanitize($REQUEST_URI) . '&comscroll=' . $val;
+                $first = Sanitize::comscrollSanitize($requestUri) . '&comscroll=' . $val;
                 $first = str_replace('?&', '?', $first);
                 if (!strpos($first, '?')) {
                     $first = str_replace('&', '?', $first);
@@ -123,7 +124,7 @@ class Moderate
                 $output->outputNotl($firstu, true);
             }
 
-            $req = Sanitize::comscrollSanitize($REQUEST_URI) . '&comscroll=' . ($com + 1);
+            $req = Sanitize::comscrollSanitize($requestUri) . '&comscroll=' . ($com + 1);
             $req = str_replace('?&', '?', $req);
             if (!strpos($req, '?')) {
                 $req = str_replace('&', '?', $req);
@@ -138,7 +139,7 @@ class Moderate
             $output->outputNotl("$firstu $prev", true);
         }
 
-        $last = Navigation::appendLink(Sanitize::comscrollSanitize($REQUEST_URI), 'refresh=1');
+        $last = Navigation::appendLink(Sanitize::comscrollSanitize($requestUri), 'refresh=1');
         $last = Navigation::appendCount($last);
         $last = str_replace('?&', '?', $last);
         if ($jump) {
@@ -148,7 +149,7 @@ class Moderate
         Navigation::add('', $last);
 
         if ($com > 0 || ($cid > 0 && $newadded > $limit)) {
-            $req = Sanitize::comscrollSanitize($REQUEST_URI) . '&comscroll=' . ($com - 1);
+            $req = Sanitize::comscrollSanitize($requestUri) . '&comscroll=' . ($com - 1);
             $req = str_replace('?&', '?', $req);
             if (!strpos($req, '?')) {
                 $req = str_replace('&', '?', $req);
@@ -170,7 +171,8 @@ class Moderate
      */
     public static function viewmoderatedcommentary(string $section, string $message = 'Interject your own commentary?', int $limit = 10, string $talkline = 'says', ?string $schema = null, bool $viewall = false): void
     {
-        global $session, $REQUEST_URI;
+        global $session;
+        $requestUri = PhpGenericEnvironment::getRequestUri();
 
         $output = Output::getInstance();
         $translator = Translator::getInstance();
@@ -499,7 +501,7 @@ class Moderate
         $jump = !isset($session['user']['prefs']['nojump']) || $session['user']['prefs']['nojump'] == false;
 
         // Render pagination navigation for the comment block
-        self::showNavLinks($section, $limit, $cid, $rowcount, $jump, $com, $REQUEST_URI, $newadded);
+        self::showNavLinks($section, $limit, $cid, $rowcount, $jump, $com, $requestUri, $newadded);
         $translator->setSchema();
         if ($needclose) {
             HookHandler::hook('}collapse');

--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -603,7 +603,7 @@ class Nav
      */
     public static function privateAddNav($text, string|false|null $link = false, $priv = false, $pop = false, $popsize = '500x300')
     {
-        global $session, $REQUEST_URI;
+        global $session;
         $output = Output::getInstance();
         $instance = self::getInstance();
 

--- a/src/Lotgd/Page/Footer.php
+++ b/src/Lotgd/Page/Footer.php
@@ -18,14 +18,17 @@ use Lotgd\Util\ScriptName;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Output;
 use Lotgd\Translator;
+use Lotgd\PhpGenericEnvironment;
 
 class Footer
 {
     public static function pageFooter(bool $saveuser = true): void
     {
-        global $session, $REMOTE_ADDR, $REQUEST_URI, $pagestarttime,
-            $template, $y2, $z2, $logd_version, $copyright, $SCRIPT_NAME, $footer,
+        global $session,
+            $template, $y2, $z2, $logd_version, $copyright, $footer,
             $settings;
+
+        $scriptName = PhpGenericEnvironment::getScriptName();
 
         $navInstance = Nav::getInstance();
         $header = $navInstance->getHeader();
@@ -67,7 +70,7 @@ class Footer
             if (
                 Database::numRows($result) > 0 && isset($session['user']['lastmotd']) &&
                 ($row['motddate'] > $session['user']['lastmotd']) &&
-                (!isset(PageParts::$noPopups[$SCRIPT_NAME]) || PageParts::$noPopups[$SCRIPT_NAME] != 1) &&
+                (!isset(PageParts::$noPopups[$scriptName]) || PageParts::$noPopups[$scriptName] != 1) &&
                 $session['user']['loggedin']
             ) {
                 if (isset($settings) && $settings->getSetting('forcedmotdpopup', 0)) {
@@ -156,7 +159,7 @@ class Footer
         list($header, $footer) = PageParts::assembleMailLink($header, $footer);
         list($header, $footer) = PageParts::assemblePetitionLink($header, $footer);
         list($header, $footer) = PageParts::assemblePetitionDisplay($header, $footer);
-        $sourcelink = 'source.php?url=' . preg_replace('/[?].*/', '', ($_SERVER['REQUEST_URI']));
+        $sourcelink = 'source.php?url=' . preg_replace('/[?].*/', '', (PhpGenericEnvironment::getRequestUri()));
 
         $output = Output::getInstance();
 
@@ -166,7 +169,7 @@ class Footer
             'motd'    => $motd_link,
             'source'  => "<a href='$sourcelink' onclick=\"" . PageParts::popup($sourcelink) . ";return false;\" target='_blank'>" . Translator::translateInline('View PHP Source') . '</a>',
             'version' => "Version: $logd_version",
-            'pagegen' => PageParts::computePageGenerationStats($pagestarttime),
+            'pagegen' => PageParts::computePageGenerationStats(PhpGenericEnvironment::getPageStartTime()),
             $z       => $$z,
         ];
         if (TwigTemplate::isActive()) {

--- a/src/Lotgd/Page/Header.php
+++ b/src/Lotgd/Page/Header.php
@@ -15,12 +15,13 @@ use Lotgd\Util\ScriptName;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Settings;
 use Lotgd\Nav;
+use Lotgd\PhpGenericEnvironment;
 
 class Header
 {
     public static function pageHeader(...$args): void
     {
-        global $SCRIPT_NAME, $session, $template;
+        global $session, $template;
         $settings = Settings::getInstance();
         $nav = Nav::getInstance();
 
@@ -33,7 +34,7 @@ class Header
 
         Translator::translatorSetup();
         Template::prepareTemplate();
-        if (isset($SCRIPT_NAME)) {
+        if (PhpGenericEnvironment::getScriptName() !== '') {
             $script = ScriptName::current();
             if ($script) {
                 if (!array_key_exists($script, PageParts::$runHeaders)) {

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -31,6 +31,7 @@ use Lotgd\Translator;
 use Lotgd\DataCache;
 use Lotgd\Http;
 use Lotgd\Mounts;
+use Lotgd\PhpGenericEnvironment;
 
 class PageParts
 {
@@ -839,14 +840,13 @@ class PageParts
      */
     public static function canonicalLink(): string
     {
-        global $REQUEST_URI, $SCRIPT_NAME;
         $settings = Settings::getInstance();
 
         $serverUrl = rtrim($settings->getSetting('serverurl', 'http://' . $_SERVER['HTTP_HOST']), '/');
 
-        $uri = $REQUEST_URI ?? '';
+        $uri = PhpGenericEnvironment::getRequestUri();
         if ($uri === '') {
-            $uri = $SCRIPT_NAME ?? '';
+            $uri = PhpGenericEnvironment::getScriptName();
         }
 
         // Remove the session "c" parameter while keeping the rest intact
@@ -942,7 +942,7 @@ class PageParts
      */
     public static function computePageGenerationStats(float $pagestarttime): string
     {
-        global $session, $SCRIPT_NAME;
+        global $session;
         $settings = Settings::getInstance();
 
         $gentime = DateTime::getMicroTime() - $pagestarttime;
@@ -955,9 +955,9 @@ class PageParts
         }
         $session['user']['gentimecount']++;
         if ($settings->getSetting('debug', 0)) {
-            $sql = "INSERT INTO " . Database::prefix('debug') . " VALUES (0,'pagegentime','runtime','$SCRIPT_NAME','" . ($gentime) . "');";
+            $sql = "INSERT INTO " . Database::prefix('debug') . " VALUES (0,'pagegentime','runtime','" . PhpGenericEnvironment::getScriptName() . "','" . ($gentime) . "');";
             Database::query($sql);
-            $sql = "INSERT INTO " . Database::prefix('debug') . " VALUES (0,'pagegentime','dbtime','$SCRIPT_NAME','" . (round(Database::getInfo('querytime', 0), 3)) . "');";
+            $sql = "INSERT INTO " . Database::prefix('debug') . " VALUES (0,'pagegentime','dbtime','" . PhpGenericEnvironment::getScriptName() . "','" . (round(Database::getInfo('querytime', 0), 3)) . "');";
             Database::query($sql);
         }
         $queryCount = Database::getQueryCount();

--- a/src/Lotgd/PhpGenericEnvironment.php
+++ b/src/Lotgd/PhpGenericEnvironment.php
@@ -27,6 +27,16 @@ class PhpGenericEnvironment
     private static string $requestUri = '';
 
     /**
+     * Current REMOTE_ADDR value.
+     */
+    private static string $remoteAddr = '';
+
+    /**
+     * Page generation start time.
+     */
+    private static float $pageStartTime = 0.0;
+
+    /**
      * Reference to the $_SERVER superglobal.
      *
      * @var array<string,mixed>
@@ -86,6 +96,38 @@ class PhpGenericEnvironment
     public static function getRequestUri(): string
     {
         return self::$requestUri;
+    }
+
+    /**
+     * Set the current REMOTE_ADDR value.
+     */
+    public static function setRemoteAddr(string $remoteAddr): void
+    {
+        self::$remoteAddr = $remoteAddr;
+    }
+
+    /**
+     * Get the current REMOTE_ADDR value.
+     */
+    public static function getRemoteAddr(): string
+    {
+        return self::$remoteAddr;
+    }
+
+    /**
+     * Set the current page start time.
+     */
+    public static function setPageStartTime(float $pageStartTime): void
+    {
+        self::$pageStartTime = $pageStartTime;
+    }
+
+    /**
+     * Get the current page start time.
+     */
+    public static function getPageStartTime(): float
+    {
+        return self::$pageStartTime;
     }
 
     /**
@@ -170,8 +212,15 @@ class PhpGenericEnvironment
         self::$pathInfo = $GLOBALS['PATH_INFO'] ?? '';
         self::$scriptName = $GLOBALS['SCRIPT_NAME'] ?? ($_SERVER['SCRIPT_NAME'] ?? '');
         self::$requestUri = $GLOBALS['REQUEST_URI'] ?? ($_SERVER['REQUEST_URI'] ?? '');
+        self::$remoteAddr = $GLOBALS['REMOTE_ADDR'] ?? ($_SERVER['REMOTE_ADDR'] ?? '');
+        self::$pageStartTime = $GLOBALS['pagestarttime'] ?? self::$pageStartTime;
+
+        self::$server['REMOTE_ADDR'] = self::$remoteAddr;
 
         RegisterGlobal::register(self::$server);
         self::sanitizeUri();
+
+        $GLOBALS['REMOTE_ADDR'] = self::$remoteAddr;
+        $GLOBALS['pagestarttime'] = self::$pageStartTime;
     }
 }

--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -10,6 +10,7 @@ use Lotgd\Sanitize;
 use Lotgd\Cookies;
 use Lotgd\Output;
 use Lotgd\PageParts;
+use Lotgd\PhpGenericEnvironment;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 
 
@@ -570,7 +571,6 @@ class Translator
      */
     public static function tlschema(string|false|null $schema = false): void
     {
-        global $REQUEST_URI;
         $stack =& self::$translation_namespace_stack;
 
         if ($schema === false) {
@@ -579,7 +579,7 @@ class Translator
                 self::$translation_namespace = (string) array_pop($stack);
             } else {
                 // Default to empty string when REQUEST_URI is unavailable
-                self::$translation_namespace = Sanitize::translatorUri($REQUEST_URI ?? '');
+                self::$translation_namespace = Sanitize::translatorUri(PhpGenericEnvironment::getRequestUri());
             }
         } else {
             // Push current namespace to stack, set new one

--- a/superuser.php
+++ b/superuser.php
@@ -5,6 +5,7 @@ use Lotgd\Translator;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
 use Lotgd\Commentary;
+use Lotgd\PhpGenericEnvironment;
 
 // translator ready
 // addnews ready
@@ -24,8 +25,7 @@ $op = httpget('op');
 if ($op == "keepalive") {
     $sql = "UPDATE " . Database::prefix("accounts") . " SET laston='" . date("Y-m-d H:i:s") . "' WHERE acctid='{$session['user']['acctid']}'";
     Database::query($sql);
-    global $REQUEST_URI;
-    echo '<html><meta http-equiv="Refresh" content="30;url=' . $REQUEST_URI . '"></html><body>' . date("Y-m-d H:i:s") . "</body></html>";
+    echo '<html><meta http-equiv="Refresh" content="30;url=' . PhpGenericEnvironment::getRequestUri() . '"></html><body>' . date("Y-m-d H:i:s") . "</body></html>";
     exit();
 } elseif ($op == "newsdelete") {
     $sql = "DELETE FROM " . Database::prefix("news") . " WHERE newsid='" . httpget('newsid') . "'";

--- a/tests/Installer/Stage9Test.php
+++ b/tests/Installer/Stage9Test.php
@@ -104,9 +104,9 @@ class Stage9Test extends TestCase
     protected function setUp(): void
     {
         global $session, $logd_version, $recommended_modules, $noinstallnavs,
-            $DB_USEDATACACHE, $settings, $REQUEST_URI;
+            $DB_USEDATACACHE, $settings;
 
-        $REQUEST_URI        = '/installer.php';
+        \Lotgd\PhpGenericEnvironment::setRequestUri('/installer.php');
         $session            = [
             'dbinfo'            => [
                 'DB_HOST'         => 'localhost',

--- a/tests/PhpGenericEnvironmentTest.php
+++ b/tests/PhpGenericEnvironmentTest.php
@@ -18,6 +18,8 @@ final class PhpGenericEnvironmentTest extends TestCase
             'SCRIPT_NAME' => $GLOBALS['SCRIPT_NAME'] ?? null,
             'REQUEST_URI' => $GLOBALS['REQUEST_URI'] ?? null,
             'SERVER_REQUEST_URI' => $_SERVER['REQUEST_URI'] ?? null,
+            'REMOTE_ADDR' => $GLOBALS['REMOTE_ADDR'] ?? null,
+            'PAGESTART' => $GLOBALS['pagestarttime'] ?? null,
         ];
     }
 
@@ -29,6 +31,14 @@ final class PhpGenericEnvironmentTest extends TestCase
                     unset($_SERVER['REQUEST_URI']);
                 } else {
                     $_SERVER['REQUEST_URI'] = $value;
+                }
+                continue;
+            }
+            if ($key === 'PAGESTART') {
+                if ($value === null) {
+                    unset($GLOBALS['pagestarttime']);
+                } else {
+                    $GLOBALS['pagestarttime'] = $value;
                 }
                 continue;
             }
@@ -70,5 +80,17 @@ final class PhpGenericEnvironmentTest extends TestCase
         $this->assertSame('index.php?foo=bar', PhpGenericEnvironment::getServer('REQUEST_URI'));
         $this->assertSame('index.php', $GLOBALS['SCRIPT_NAME']);
         $this->assertSame('index.php?foo=bar', $GLOBALS['REQUEST_URI']);
+    }
+
+    public function testSetupStoresRemoteAddrAndPageStartTime(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
+        $GLOBALS['pagestarttime'] = 123.45;
+
+        $session = [];
+        PhpGenericEnvironment::setup($session);
+
+        $this->assertSame('8.8.8.8', PhpGenericEnvironment::getRemoteAddr());
+        $this->assertSame(123.45, PhpGenericEnvironment::getPageStartTime());
     }
 }


### PR DESCRIPTION
## Summary
- Track REQUEST_URI, SCRIPT_NAME, REMOTE_ADDR and pagestarttime in `PhpGenericEnvironment`
- Replace direct globals in translator, page parts, headers/footers and navigation logic with environment lookups
- Ensure tests cover new environment fields

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bb565054bc83298e75edb527e10a0e