### PR TITLE
Sanitize translator URI handling

### DIFF
--- a/src/Lotgd/Sanitize.php
+++ b/src/Lotgd/Sanitize.php
@@ -162,6 +162,7 @@ class Sanitize
     {
         $uri = self::comscrollSanitize($in);
         $uri = self::cmdSanitize($uri);
+        $uri = str_replace(["'", '"', '`', ';'], '', $uri);
         if (substr($uri, -1) == '?') {
             $uri = substr($uri, 0, -1);
         }
@@ -184,6 +185,7 @@ class Sanitize
         if (strpos($page, '?') !== false) {
             $page = substr($page, 0, strpos($page, '?'));
         }
+        $page = str_replace(["'", '"', '`', ';'], '', $page);
         return $page;
     }
 

--- a/tests/SanitizeExtraTest.php
+++ b/tests/SanitizeExtraTest.php
@@ -62,6 +62,28 @@ final class SanitizeExtraTest extends TestCase
         $this->assertLessThanOrEqual(Sanitize::URI_MAX_LENGTH, strlen($clean));
     }
 
+    public function testTranslatorUriStripsMaliciousCharacters(): void
+    {
+        $uri = "pa'ge.php\"`;;?op=f'o;o\"`;";
+        $clean = Sanitize::translatorUri($uri);
+        $this->assertSame('page.php?op=foo', $clean);
+        $this->assertStringNotContainsString("'", $clean);
+        $this->assertStringNotContainsString('"', $clean);
+        $this->assertStringNotContainsString('`', $clean);
+        $this->assertStringNotContainsString(';', $clean);
+    }
+
+    public function testTranslatorPageStripsMaliciousCharacters(): void
+    {
+        $uri = "pa'ge.php\"`;;?op=f'o;o\"`;";
+        $page = Sanitize::translatorPage($uri);
+        $this->assertSame('page.php', $page);
+        $this->assertStringNotContainsString("'", $page);
+        $this->assertStringNotContainsString('"', $page);
+        $this->assertStringNotContainsString('`', $page);
+        $this->assertStringNotContainsString(';', $page);
+    }
+
     public function testModulenameSanitize(): void
     {
         $this->assertSame('ModuleName', Sanitize::modulenameSanitize('Module!Name'));


### PR DESCRIPTION
## Summary
- Strip quotes, backticks, and semicolons from translator URIs and page paths
- Add tests ensuring translatorSanitize rejects malicious characters

## Testing
- `php -l src/Lotgd/Sanitize.php`
- `php -l tests/SanitizeExtraTest.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bc55b943c883299f36de7ce0732968