### PR TITLE
Handle mysqli exceptions in tableExists

### DIFF
--- a/src/Lotgd/MySQL/DbMysqli.php
+++ b/src/Lotgd/MySQL/DbMysqli.php
@@ -137,7 +137,16 @@ class DbMysqli
      */
     public function tableExists(string $tablename): bool
     {
-        $result = $this->query("SHOW TABLES LIKE '$tablename'");
+        try {
+            $result = $this->query("SHOW TABLES LIKE '$tablename'");
+        } catch (\mysqli_sql_exception $exception) {
+            if (defined('IS_INSTALLER') && IS_INSTALLER && class_exists('Lotgd\\Installer\\InstallerLogger')) {
+                \Lotgd\Installer\InstallerLogger::log($exception->getMessage());
+            }
+
+            return false;
+        }
+
         return ($result && mysqli_num_rows($result) > 0);
     }
 


### PR DESCRIPTION
## Summary
- Wrap DbMysqli::tableExists query in try/catch for `mysqli_sql_exception`
- Log installer exceptions and return `false` on failure

## Testing
- `php -l src/Lotgd/MySQL/DbMysqli.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bca19e5ad08329894235e2ebdaa2f4