### PR TITLE
Skip settings load when DB disabled

### DIFF
--- a/src/Lotgd/Settings.php
+++ b/src/Lotgd/Settings.php
@@ -32,6 +32,10 @@ class Settings
         self::$instance = $this;
         $GLOBALS['settings'] = $this;
 
+        if (defined('DB_NODB') && DB_NODB) {
+            return;
+        }
+
         $this->loadSettings();
     }
 


### PR DESCRIPTION
## Summary
- Avoid loading settings when DB_NODB is defined and true

## Testing
- `php -l src/Lotgd/Settings.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bca1dfe1b483298734b56c8b70951a