### PR TITLE
Avoid Settings calls when DB_NODB is active

### DIFF
--- a/src/Lotgd/DataCache.php
+++ b/src/Lotgd/DataCache.php
@@ -37,6 +37,10 @@ class DataCache
      */
     public function datacache(string $name, int $duration = 60): mixed
     {
+        if (defined('DB_NODB') && DB_NODB) {
+            return false;
+        }
+
         if (! Settings::hasInstance()) {
             return false;
         }
@@ -67,6 +71,10 @@ class DataCache
      */
     public function updatedatacache(string $name, mixed $data): bool
     {
+        if (defined('DB_NODB') && DB_NODB) {
+            return false;
+        }
+
         if (! Settings::hasInstance()) {
             return false;
         }
@@ -114,6 +122,10 @@ class DataCache
      */
     public function invalidatedatacache(string $name, bool $withpath = true): void
     {
+        if (defined('DB_NODB') && DB_NODB) {
+            return;
+        }
+
         if (! Settings::hasInstance()) {
             return;
         }
@@ -134,6 +146,10 @@ class DataCache
      */
     public function massinvalidate(string $name = ''): void
     {
+        if (defined('DB_NODB') && DB_NODB) {
+            return;
+        }
+
         if (! Settings::hasInstance()) {
             return;
         }
@@ -160,6 +176,10 @@ class DataCache
      */
     public function makecachetempname(string $name): string
     {
+        if (defined('DB_NODB') && DB_NODB) {
+            return '';
+        }
+
         if (! Settings::hasInstance()) {
             return '';
         }


### PR DESCRIPTION
## Summary
- Skip DataCache operations when database is disabled by `DB_NODB`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bca3b7d48c83299119f539fb4d1940