### PR TITLE
Skip Settings::getSetting DB calls when DB_NODB

### DIFF
--- a/src/Lotgd/Settings.php
+++ b/src/Lotgd/Settings.php
@@ -159,6 +159,10 @@ class Settings
     {
         global $config;
         $defaults = [];
+
+        if (defined('DB_NODB') && DB_NODB) {
+            return $default === false ? ($defaults[$settingname] ?? '') : $default;
+        }
         if (!is_array($config)) {
             $root = dirname(__DIR__, 2);
             $path = realpath($root . '/dbconnect.php');


### PR DESCRIPTION
## Summary
- avoid database access in `Settings::getSetting` when database is disabled via `DB_NODB`

## Testing
- `php -l src/Lotgd/Settings.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bca6463c848329b59da2a72c47cd48