### PR TITLE
Handle missing theme selection in Forms

### DIFF
--- a/src/Lotgd/Forms.php
+++ b/src/Lotgd/Forms.php
@@ -340,9 +340,10 @@ JS;
                 }
 
                 asort($skins, SORT_NATURAL | SORT_FLAG_CASE);
-                $current = Template::addTypePrefix($row[$key]);
+                $current = isset($row[$key]) ? Template::addTypePrefix($row[$key]) : '';
 
                 $output->rawOutput("<select id='$entityId' name='" . htmlentities($keyout, ENT_QUOTES, $charset) . "'>");
+                $output->rawOutput("<option value=''" . ($current === '' ? ' selected' : '') . '>---</option>');
                 foreach ($skins as $skin => $display) {
                     $display = htmlentities($display, ENT_COMPAT, $charset);
                     $skinEsc = htmlentities($skin, ENT_QUOTES, $charset);

--- a/tests/FormsTest.php
+++ b/tests/FormsTest.php
@@ -54,4 +54,11 @@ final class FormsTest extends TestCase
         $this->assertStringNotContainsString("value='twig:test_no_config'", $output);
         $this->assertStringNotContainsString("value='twig:.git'", $output);
     }
+
+    public function testThemeFieldHandlesNullValue(): void
+    {
+        Forms::showForm(['skin' => 'Skin,theme'], ['skin' => null]);
+        $output = Output::getInstance()->getRawOutput();
+        $this->assertStringContainsString("<option value='' selected>---</option>", $output);
+    }
 }


### PR DESCRIPTION
## Summary
- guard theme field rendering when no template is set
- render an empty option so theme select works without a value
- add unit test for null theme

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bca728e07c8329acf1b1b2a3c054c9