### PR TITLE
Use safe array access in getPlayerBasename

### DIFF
--- a/src/Lotgd/Names.php
+++ b/src/Lotgd/Names.php
@@ -46,8 +46,8 @@ class Names
             $name = $session['user']['name'];
             $pname = $session['user']['playername'];
         } else {
-            $name = $old['name'];
-            $pname = $old['playername'];
+            $name = $old['name'] ?? '';
+            $pname = $old['playername'] ?? '';
         }
         if ($pname != '') {
             return str_replace('`0', '', $pname);


### PR DESCRIPTION
## Summary
- avoid undefined index errors in getPlayerBasename by using null-coalescing for `name` and `playername`

## Testing
- `composer install`
- `composer test`
- `php -l src/Lotgd/Names.php`


------
https://chatgpt.com/codex/tasks/task_e_68bcb41ffe408329ada9f5413537acf8