### PR TITLE
Default missing diddamage flags

### DIFF
--- a/deathmessages.php
+++ b/deathmessages.php
@@ -35,7 +35,11 @@ switch ($op) {
             $sql = "SELECT * FROM " . Database::prefix("deathmessages") . " WHERE deathmessageid=\"$deathmessageid\"";
             $result = Database::query($sql);
             $row = Database::fetchAssoc($result);
-            $badguy = array('creaturename' => '`2The Nasty Rabbit', 'creatureweapon' => 'Rabbit Ears');
+            $badguy = array(
+                'creaturename' => '`2The Nasty Rabbit',
+                'creatureweapon' => 'Rabbit Ears',
+                'diddamage' => 0,
+            );
             $deathmessage = Substitute::applyArray($row['deathmessage'], array("{where}"), array("in the fields"));
             $deathmessage = Translator::sprintfTranslate(...$deathmessage);
             $output->output("Preview: %s`0`n`n", $deathmessage);

--- a/dragon.php
+++ b/dragon.php
@@ -262,7 +262,10 @@ if ($op == "") {
     $regname = Names::getPlayerBasename();
     //get the dragons name
     $badguys = @unserialize($badguys);
-    $badguy = array("creaturename" => translate_inline("`@The Green Dragon`0"));
+    $badguy = array(
+        "creaturename" => translate_inline("`@The Green Dragon`0"),
+        "diddamage" => 0,
+    );
     foreach ($badguys['enemies'] as $opponent) {
         if ($opponent['type'] == 'dragon') {
             //hit

--- a/forest.php
+++ b/forest.php
@@ -184,7 +184,7 @@ if ($op == "search") {
             if (Database::numRows($result) == 0) {
                 // There is nothing in the database to challenge you, let's
                 // give you a doppleganger.
-                $badguy = array();
+                $badguy = ['diddamage' => 0];
                 $badguy['creaturename'] =
                     "An evil doppleganger of " . $session['user']['name'];
                 $badguy['creatureweapon'] = $session['user']['weapon'];

--- a/modules/cities/run.php
+++ b/modules/cities/run.php
@@ -122,7 +122,7 @@ if ($op == "travel") {
             if (Database::numRows($result) == 0) {
                 // There is nothing in the database to challenge you,
                 // let's give you a doppleganger.
-                $badguy = array();
+                $badguy = ['diddamage' => 0];
                 $badguy['creaturename'] =
                     "An evil doppleganger of " . $session['user']['name'];
                 $badguy['creatureweapon'] = $session['user']['weapon'];

--- a/src/Lotgd/Forest/Outcomes.php
+++ b/src/Lotgd/Forest/Outcomes.php
@@ -42,7 +42,10 @@ class Outcomes
         $exp = 0;
         $expbonus = 0;
         $count = 0;
-        $badguy = ['creaturelevel' => 0];
+        $badguy = [
+            'creaturelevel' => 0,
+            'diddamage' => 0,
+        ];
         foreach ($enemies as $badguy) {
             $dropMinGold = $settings->getSetting('dropmingold', 0);
             if ($dropMinGold) {
@@ -57,7 +60,7 @@ class Outcomes
             }
             $output->output("`b`\$You have slain %s!`0`b`n", $badguy['creaturename']);
             $count++;
-            if ($badguy['diddamage'] == 1) {
+            if (($badguy['diddamage'] ?? 0) == 1) {
                 $diddamage = true;
             }
             $creaturelevel = max($creaturelevel, (int)$badguy['creaturelevel']);

--- a/src/Lotgd/Substitute.php
+++ b/src/Lotgd/Substitute.php
@@ -77,7 +77,11 @@ class Substitute
         $string = str_replace($search, $replace, $string);
         $search = ['{goodguyweapon}', '{badguyweapon}', '{goodguyarmor}', '{badguyname}', '{goodguyname}', '{badguy}', '{goodguy}', '{weapon}', '{armor}', '{creatureweapon}'];
         if (!isset($badguy)) {
-            $badguy = ['creatureweapon' => '', 'creaturename' => ''];
+            $badguy = [
+                'creatureweapon' => '',
+                'creaturename' => '',
+                'diddamage' => 0,
+            ];
         }
         $replace = [
             $session['user']['weapon'],

--- a/taunt.php
+++ b/taunt.php
@@ -35,7 +35,11 @@ if ($op == "edit") {
         $sql = "SELECT * FROM " . Database::prefix("taunts") . " WHERE tauntid=\"$tauntid\"";
         $result = Database::query($sql);
         $row = Database::fetchAssoc($result);
-        $badguy = array('creaturename' => 'Baron Munchausen', 'creatureweapon' => 'Bad Puns');
+        $badguy = array(
+            'creaturename' => 'Baron Munchausen',
+            'creatureweapon' => 'Bad Puns',
+            'diddamage' => 0,
+        );
         $taunt = Substitute::applyArray($row['taunt']);
         $taunt = Translator::sprintfTranslate(...$taunt);
         $output->output("Preview: %s`0`n`n", $taunt);

--- a/tests/SubstituteTest.php
+++ b/tests/SubstituteTest.php
@@ -21,6 +21,7 @@ final class SubstituteTest extends TestCase
         $badguy = [
             'creaturename'  => 'Goblin',
             'creatureweapon' => 'Club',
+            'diddamage' => 0,
         ];
     }
 


### PR DESCRIPTION
## Summary
- avoid undefined diddamage checks during victory processing
- initialize `diddamage` flag on enemy arrays for consistent combat data

## Testing
- `php -l src/Lotgd/Forest/Outcomes.php forest.php modules/cities/run.php dragon.php deathmessages.php taunt.php src/Lotgd/Substitute.php tests/SubstituteTest.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bd2e737eb0832980eabe7c3327f54a