### PR TITLE
Handle missing city parameter in cities module

### DIFF
--- a/modules/cities/run.php
+++ b/modules/cities/run.php
@@ -11,7 +11,9 @@ use Lotgd\Forest\Outcomes;
 use Lotgd\MySQL\Database;
 
         $op = httpget("op");
-    $city = urldecode(httpget("city"));
+    $cityParam = httpget('city');
+    // Default to an empty string when the parameter is missing
+    $city      = urldecode($cityParam === false ? '' : $cityParam);
     $continue = httpget("continue");
     $danger = httpget("d");
     $su = httpget("su");


### PR DESCRIPTION
## Summary
- Guard against missing `city` parameter by defaulting to an empty string
- Note in code comment that missing parameters default to empty string

## Testing
- `php -l modules/cities/run.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bd2e76329c8329ab0d3d965da4c39e