### PR TITLE
Drop obsolete gzip handler logic

### DIFF
--- a/common.php
+++ b/common.php
@@ -107,13 +107,13 @@ require_once("lib/fightnav.php");
 
 ErrorHandler::register();
 
-//start the gzip compression
-$gz_handler_on = get_gz_handler_setting();
-if ($gz_handler_on) {
-    ob_start('ob_gzhandler');
-} else {
-    ob_start();
+// Enable zlib output compression when available.
+if (function_exists('ini_set') && extension_loaded('zlib')) {
+    ini_set('zlib.output_compression', '1');
 }
+
+// Start output buffering (compression occurs automatically when enabled).
+ob_start();
 
 $pagestarttime = DateTime::getMicroTime();
 PhpGenericEnvironment::setPageStartTime($pagestarttime);

--- a/configuration.php
+++ b/configuration.php
@@ -323,14 +323,12 @@ switch ($type_setting) {
                 $output->rawOutput(Translator::clearButton());
 
                 $secstonewday = secondstonextgameday($details);
-                $gz_handler_on = get_gz_handler_setting();
                 $useful_vals = array(
                     "datacachepath" => $DB_DATACACHEPATH,
                     "usedatacache" => $DB_USEDATACACHE,
                     "charset" => getsetting('charset', 'UTF-8'),
                     "defaultsuperuser" => getsetting('defaultsuperuser', 0), // this needs to be there as the showform loads from the database; so a value has to be present if it's not set, and this is a technical field
                     "dayduration" => round(($details['dayduration'] / 60 / 60), 0) . " hours",
-                    "gziphandler" => $gz_handler_on,
                     "databasetype" => "MySQLi",
                     "curgametime" => getgametime(),
                     "curservertime" => date("Y-m-d h:i:s a"),

--- a/lib/settings.php
+++ b/lib/settings.php
@@ -28,11 +28,6 @@ function getsetting($settingname, $default)
     return Settings::getInstance()->getSetting($settingname, $default);
 }
 
-function get_gz_handler_setting()
-{
-    return (bool) getsetting('gziphandler', (bool) ini_get('zlib.output_compression'));
-}
-
 function get_admin_email($default = 'postmaster@localhost')
 {
     return (string) Settings::getInstance()->getSetting('gameadminemail', $default);

--- a/settings.php
+++ b/settings.php
@@ -10,14 +10,6 @@
 $GAME_DIR = '/PATH/TO/GAME';
 // enter here the directory of your datacache, this cannot be done elsewhere
 
-$gz_handler_on = 0;
-/* set to 1 if you want to enable gzip compression to save bandwidth (~30-50%), but it costs slightly more processor power for PHP to get it done. z_lib in apache is favoured if you have direct access to your machine.
-Actually, if you can set this to 0 and add these lines in i.e. /etc/php5/apache2/conf.d into a randomly named .ini file:
-zlib.output_compression = 1
-zlib.output_compression_level = 7
-for instance. And then do an "apache2 -k graceful" and check with phpinfo() to see if it worked.
-*/
-
 /* The bundled **aurora** template is used when no skin is configured or the
 database is unavailable. Change the template by adjusting the `defaultskin`
 setting in your game configuration.

--- a/src/Lotgd/Config/configuration.php
+++ b/src/Lotgd/Config/configuration.php
@@ -274,7 +274,6 @@ $setup = array(
     "usedatacache" => "Use Data Caching,viewonly",
     "datacachepath" => "Path to store data cache information`n`iNote`i when using in an environment where Safe Mode is enabled; this needs to be a path that has the same UID as the web server runs.,viewonly",
     "This is in settings.php,note",
-    "gziphandler" => "Is the GzHandler turned on,viewonly",
     "databasetype" => "Type of database,viewonly",
 
 

--- a/src/Lotgd/LocalConfig.php
+++ b/src/Lotgd/LocalConfig.php
@@ -10,5 +10,6 @@ class LocalConfig
     {
         ini_set('memory_limit', '128M');
         ini_set('max_execution_time', '90');
+
     }
 }


### PR DESCRIPTION
## Summary
- remove `get_gz_handler_setting` helper and any calls to it
- simplify request initialization to rely on `zlib.output_compression` instead of `ob_gzhandler`
- eliminate `$gz_handler_on` configuration option and template entries
- enable zlib compression automatically when the extension is available, removing the `LOTGD_ENABLE_OUTPUT_COMPRESSION` toggle

## Testing
- `php -l common.php`
- `php -l src/Lotgd/LocalConfig.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bd3955dfa48329bb74f6c1eebfc2d8