### PR TITLE
Use __DIR__ for includes in top-level scripts

### DIFF
--- a/about.php
+++ b/about.php
@@ -17,7 +17,7 @@ use Lotgd\Translator;
 */
 
 define("ALLOW_ANONYMOUS", true);
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 use Lotgd\Http;
 use Lotgd\Page\Header;
@@ -37,10 +37,10 @@ switch ($op) {
     case "setup":
     case "listmodules":
     case "license":
-            require("pages/about/about_$op.php");
+            require __DIR__ . "/pages/about/about_$op.php";
         break;
     default:
-            require("pages/about/about_default.php");
+            require __DIR__ . "/pages/about/about_default.php";
         break;
 }
 if ($session['user']['loggedin']) {

--- a/account.php
+++ b/account.php
@@ -13,7 +13,7 @@ use Lotgd\Translator;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 
 Translator::getInstance()->setSchema("account");

--- a/armor.php
+++ b/armor.php
@@ -14,7 +14,7 @@ use Lotgd\Translator;
 * @see village.php
 * @see armoreditor.php
 */
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 use Lotgd\Http;
 use Lotgd\Page\Header;

--- a/armoreditor.php
+++ b/armoreditor.php
@@ -18,7 +18,7 @@ use Lotgd\Forms;
 
 // addnews ready
 // mail ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 use Lotgd\Http;
 use Lotgd\Page\Header;

--- a/badnav.php
+++ b/badnav.php
@@ -22,7 +22,7 @@ use Lotgd\Redirect;
 // addnews ready
 // mail ready
 define("OVERRIDE_FORCED_NAV", true);
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 Translator::getInstance()->setSchema("badnav");
 

--- a/badword.php
+++ b/badword.php
@@ -21,7 +21,7 @@ use Lotgd\DataCache;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 SuAccess::check(SU_EDIT_COMMENTS);
 

--- a/bank.php
+++ b/bank.php
@@ -18,7 +18,7 @@ use Lotgd\Nav\SuperuserNav;
 // mail ready
 use Lotgd\Mail;
 
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 use Lotgd\Sanitize;
 use Lotgd\Http;

--- a/bans.php
+++ b/bans.php
@@ -14,7 +14,7 @@ use Lotgd\Translator;
 
 //addnews ready
 // mail ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 use Lotgd\Names;
 
 Translator::getInstance()->setSchema("bans");
@@ -77,22 +77,22 @@ Nav::add("Search for banned user", "bans.php?op=searchban");
 
 switch ($op) {
     case "setupban":
-            require("pages/bans/case_setupban.php");
+            require __DIR__ . "/pages/bans/case_setupban.php";
         break;
     case "saveban":
-            require("pages/bans/case_saveban.php");
+            require __DIR__ . "/pages/bans/case_saveban.php";
         break;
     case "delban":
-            require("pages/bans/case_delban.php");
+            require __DIR__ . "/pages/bans/case_delban.php";
         break;
     case "removeban":
-            require("pages/bans/case_removeban.php");
+            require __DIR__ . "/pages/bans/case_removeban.php";
         break;
     case "searchban":
-            require("pages/bans/case_searchban.php");
+            require __DIR__ . "/pages/bans/case_searchban.php";
         break;
     default:
             output("From here, you can issue bans for players from being able to play.`n`nBased on the ID = cookie on the machine AND/OR on the IP they accessed the char last the ban takes effect.`n`nNote: Locked chars stay locked, even after they delete their cookie / change their IP.`n`nHowever, they can make new chars and login in that case. You cannot control this.");
-            require("pages/bans/case_.php");
+            require __DIR__ . "/pages/bans/case_.php";
 }
 Footer::pageFooter();

--- a/battle.php
+++ b/battle.php
@@ -18,9 +18,9 @@ use Lotgd\Substitute;
 // translator ready
 // addnews ready
 // mail ready
-require_once("lib/bell_rand.php");
-require_once("common.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/lib/bell_rand.php";
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
 
 
 //just in case we're called from within a function.Yuck is this ugly.

--- a/bio.php
+++ b/bio.php
@@ -24,7 +24,7 @@ use Lotgd\DateTime;
 use Lotgd\Nltoappon;
 use Lotgd\Output;
 
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 $output = Output::getInstance();
 
 $translator = Translator::getInstance();

--- a/bios.php
+++ b/bios.php
@@ -22,7 +22,7 @@ use Lotgd\Nav;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 Translator::getInstance()->setSchema("bio");
 SuAccess::check(SU_EDIT_COMMENTS);

--- a/clan.php
+++ b/clan.php
@@ -15,11 +15,11 @@ use Lotgd\Commentary;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
-require_once("lib/nltoappon.php");
-require_once("lib/sanitize.php");
-require_once("lib/http.php");
-require_once("lib/villagenav.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/nltoappon.php";
+require_once __DIR__ . "/lib/sanitize.php";
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/villagenav.php";
 
 Translator::getInstance()->setSchema("clans");
 
@@ -42,15 +42,15 @@ $op = httpget('op');
 
 $detail = httpget('detail');
 if ($detail > 0) {
-        require_once("pages/clan/detail.php");
+        require_once __DIR__ . "/pages/clan/detail.php";
 } elseif ($op == "list") {
-        require_once("pages/clan/list.php");
+        require_once __DIR__ . "/pages/clan/list.php";
 } elseif ($op == "waiting") {
-        require_once("pages/clan/waiting.php");
+        require_once __DIR__ . "/pages/clan/waiting.php";
 } elseif ($session['user']['clanrank'] == CLAN_APPLICANT) {
-        require_once("pages/clan/applicant.php");
+        require_once __DIR__ . "/pages/clan/applicant.php";
 } else {
-        require_once("pages/clan/clan_start.php");
+        require_once __DIR__ . "/pages/clan/clan_start.php";
 }
 
 

--- a/common.php
+++ b/common.php
@@ -71,39 +71,39 @@ $logd_version = "2.0.0-rc +nb Edition";
 Page::getInstance()->setLogdVersion($logd_version);
 
 // Include some commonly needed and useful routines
-require_once("lib/output.php");
+require_once __DIR__ . "/lib/output.php";
 LocalConfig::apply();
-require_once("src/Lotgd/Config/constants.php");
+require_once __DIR__ . "/src/Lotgd/Config/constants.php";
 
 // Legacy, because modules may rely on that, but those files are already migrated to namespace structure
-require_once("lib/dbwrapper.php");
-require_once("lib/modules.php");
-require_once("lib/translator.php");
-require_once("lib/sanitize.php");
-require_once("lib/holiday_texts.php");
-require_once("lib/nav.php");
-require_once("lib/http.php");
-require_once("lib/e_rand.php");
-require_once("lib/pageparts.php");
-require_once("lib/tempstat.php");
-require_once("lib/su_access.php");
-require_once("lib/datetime.php");
-require_once("lib/translator.php");
-require_once("lib/playerfunctions.php");
-require_once("lib/serialization.php");
-require_once("lib/settings.php");
-require_once("lib/buffs.php");
-require_once("lib/addnews.php");
-require_once("lib/template.php");
-require_once("lib/redirect.php");
-require_once("lib/censor.php");
-require_once("lib/saveuser.php");
-require_once("lib/arrayutil.php");
-require_once("lib/sql.php");
-require_once("lib/mounts.php");
-require_once("lib/debuglog.php");
-require_once("lib/datacache.php");
-require_once("lib/fightnav.php");
+require_once __DIR__ . "/lib/dbwrapper.php";
+require_once __DIR__ . "/lib/modules.php";
+require_once __DIR__ . "/lib/translator.php";
+require_once __DIR__ . "/lib/sanitize.php";
+require_once __DIR__ . "/lib/holiday_texts.php";
+require_once __DIR__ . "/lib/nav.php";
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/e_rand.php";
+require_once __DIR__ . "/lib/pageparts.php";
+require_once __DIR__ . "/lib/tempstat.php";
+require_once __DIR__ . "/lib/su_access.php";
+require_once __DIR__ . "/lib/datetime.php";
+require_once __DIR__ . "/lib/translator.php";
+require_once __DIR__ . "/lib/playerfunctions.php";
+require_once __DIR__ . "/lib/serialization.php";
+require_once __DIR__ . "/lib/settings.php";
+require_once __DIR__ . "/lib/buffs.php";
+require_once __DIR__ . "/lib/addnews.php";
+require_once __DIR__ . "/lib/template.php";
+require_once __DIR__ . "/lib/redirect.php";
+require_once __DIR__ . "/lib/censor.php";
+require_once __DIR__ . "/lib/saveuser.php";
+require_once __DIR__ . "/lib/arrayutil.php";
+require_once __DIR__ . "/lib/sql.php";
+require_once __DIR__ . "/lib/mounts.php";
+require_once __DIR__ . "/lib/debuglog.php";
+require_once __DIR__ . "/lib/datacache.php";
+require_once __DIR__ . "/lib/fightnav.php";
 
 ErrorHandler::register();
 
@@ -243,7 +243,7 @@ if ($link === false) {
                 $notified = false;
         if (file_exists("lib/smsnotify.php")) {
                 $smsmessage = "No DB Server: " . Database::error();
-                require_once("lib/smsnotify.php");
+                require_once __DIR__ . "/lib/smsnotify.php";
                 $notified = true;
         }
                 // And tell the user it died.  No translation here, we need the DB for
@@ -282,7 +282,7 @@ if (!defined("DB_NODB")) {
             // Ignore this bit.  It's only really for Eric's server or people that want to trigger something when the database is jerky
             if (file_exists("lib/smsnotify.php")) {
                                 $smsmessage = "Cant Attach to DB: " . Database::error();
-                require_once("lib/smsnotify.php");
+                require_once __DIR__ . "/lib/smsnotify.php";
                 $notified = true;
             }
             // And tell the user it died.  No translation here, we need the DB for

--- a/companions.php
+++ b/companions.php
@@ -20,7 +20,7 @@ use Lotgd\Translator;
 // translator ready
 
 // hilarious copy of mounts.php
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 SuAccess::check(SU_EDIT_MOUNTS);
 

--- a/configuration.php
+++ b/configuration.php
@@ -17,7 +17,7 @@ use Lotgd\PhpGenericEnvironment;
 // mail ready
 
 
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 $output = Output::getInstance();
 // legacy wrapper removed, instantiate settings directly
 $settings_extended = new Settings('settings_extended');
@@ -272,8 +272,8 @@ addnav("Extended settings", "configuration.php?settings=extended");
 addnav("", PhpGenericEnvironment::getRequestUri());
 
 //get arrays
-require("src/Lotgd/Config/configuration.php");
-require("src/Lotgd/Config/configuration_extended.php");
+require __DIR__ . "/src/Lotgd/Config/configuration.php";
+require __DIR__ . "/src/Lotgd/Config/configuration_extended.php";
 
 
 module_editor_navs('settings', 'configuration.php?op=modulesettings&module=');

--- a/corenews.php
+++ b/corenews.php
@@ -5,7 +5,7 @@ use Lotgd\Nav\SuperuserNav;
 use Lotgd\DataCache;
 use Lotgd\Translator;
 
-require("common.php");
+require __DIR__ . "/common.php";
 
 Translator::getInstance()->setSchema("corenews");
 SuAccess::check(SU_MEGAUSER);

--- a/create.php
+++ b/create.php
@@ -15,8 +15,8 @@ use Lotgd\Settings;
 use Lotgd\Sanitize;
 use Lotgd\DebugLog;
 use Lotgd\Cookies;
-require_once("common.php");
-require_once("lib/is_email.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/is_email.php";
 // legacy wrapper removed, instantiate settings directly
 $settings_extended = new Settings('settings_extended');
 use Lotgd\ServerFunctions;
@@ -280,7 +280,7 @@ if (getsetting("allowcreation", 1) == 0) {
                     if ($sex <> SEX_MALE) {
                         $sex = SEX_FEMALE;
                     }
-                    require_once("lib/titles.php");
+                    require_once __DIR__ . "/lib/titles.php";
                     $title = get_dk_title(0, $sex);
                     if (getsetting("requirevalidemail", 0)) {
                         $emailverification = md5(date("Y-m-d H:i:s") . $email);

--- a/creatures.php
+++ b/creatures.php
@@ -9,8 +9,8 @@ use Lotgd\Forms;
 
 // addnews ready
 // mail ready
-require_once("common.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
 
 SuAccess::check(SU_EDIT_CREATURES);
 

--- a/deathmessages.php
+++ b/deathmessages.php
@@ -15,7 +15,7 @@ use Lotgd\Translator;
 // addnews ready
 // mail ready
 // translator ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 Translator::getInstance()->setSchema("deathmessage");
 

--- a/debug.php
+++ b/debug.php
@@ -8,8 +8,8 @@ use Lotgd\Nav\SuperuserNav;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
 
 Translator::getInstance()->setSchema("debug");
 

--- a/donators.php
+++ b/donators.php
@@ -8,9 +8,9 @@ use Lotgd\Nav\SuperuserNav;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 use Lotgd\Mail;
-require_once("lib/http.php");
+require_once __DIR__ . "/lib/http.php";
 
 SuAccess::check(SU_EDIT_DONATIONS);
 

--- a/dragon.php
+++ b/dragon.php
@@ -7,7 +7,7 @@ use Lotgd\Buffs;
 // addnews ready
 // translator ready
 // mail ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 use Lotgd\FightNav;
 use Lotgd\PlayerFunctions;
 use Lotgd\Http;
@@ -298,7 +298,7 @@ if ($op == "fight" || $op == "run") {
     $battle = true;
 }
 if ($battle) {
-    require_once("battle.php");
+    require_once __DIR__ . "/battle.php";
 
     if ($victory) {
         $flawless = 0;

--- a/forest.php
+++ b/forest.php
@@ -5,12 +5,12 @@ use Lotgd\Translator;
 // addnews ready
 // translator ready
 // mail ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 use Lotgd\Forest;
 use Lotgd\Buffs;
 use Lotgd\Forest\Outcomes;
-require_once("lib/http.php");
-require_once("lib/events.php");
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/events.php";
 use Lotgd\Battle;
 
 Translator::getInstance()->setSchema("forest");
@@ -40,7 +40,7 @@ if ($op == "run") {
 }
 
 if ($op == "dragon") {
-    require_once("lib/partner.php");
+    require_once __DIR__ . "/lib/partner.php";
     addnav("Enter the cave", "dragon.php");
     addnav("Run away like a baby", "inn.php?op=fleedragon");
     output("`\$You approach the blackened entrance of a cave deep in the forest, though the trees are scorched to stumps for a hundred yards all around.");
@@ -306,7 +306,7 @@ if ($op == "fight" || $op == "run" || $op == "newtarget") {
 }
 
 if ($battle) {
-        require_once("battle.php");
+        require_once __DIR__ . "/battle.php";
 
     if ($victory) {
             $op = "";

--- a/gamelog.php
+++ b/gamelog.php
@@ -11,8 +11,8 @@ use Lotgd\Nav\SuperuserNav;
 
 // Written by Christian Rutsch
 
-require_once("common.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
 
 SuAccess::check(SU_EDIT_CONFIG);
 

--- a/gardens.php
+++ b/gardens.php
@@ -6,10 +6,10 @@ use Lotgd\Translator;
 // addnews ready
 // translator ready
 // mail ready
-require_once("common.php");
-require_once("lib/villagenav.php");
-require_once("lib/events.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/villagenav.php";
+require_once __DIR__ . "/lib/events.php";
+require_once __DIR__ . "/lib/http.php";
 
 Translator::getInstance()->setSchema("gardens");
 

--- a/graveyard.php
+++ b/graveyard.php
@@ -9,9 +9,9 @@ use Lotgd\Translator;
 // addnews ready.
 // translator ready
 // mail ready
-require_once("common.php");
-require_once("lib/http.php");
-require_once("lib/events.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/events.php";
 
 Translator::getInstance()->setSchema("graveyard");
 
@@ -35,7 +35,7 @@ $favortoheal = (int)$favortoheal['favor'];
 $op = httpget('op');
 switch ($op) {
     case "search":
-            require_once("pages/graveyard/case_battle_search.php");
+            require_once __DIR__ . "/pages/graveyard/case_battle_search.php";
 
         break;
     case "run":
@@ -73,7 +73,7 @@ if ($battle) {
 //  $session['user']['defense'] =
 //      10 + round(($session['user']['level'] - 1) * 1.5);
 
-    require_once("battle.php");
+    require_once __DIR__ . "/battle.php";
 
     //reverse those adjustments, battle calculations are over.
     $session['user']['attack'] = $originalattack;
@@ -122,28 +122,28 @@ switch ($op) {
     case "fight":
         break;
     case "enter":
-            require_once("pages/graveyard/case_enter.php");
+            require_once __DIR__ . "/pages/graveyard/case_enter.php";
         break;
     case "restore":
-            require_once("pages/graveyard/case_restore.php");
+            require_once __DIR__ . "/pages/graveyard/case_restore.php";
         break;
     case "resurrection":
-            require_once("pages/graveyard/case_resurrection.php");
+            require_once __DIR__ . "/pages/graveyard/case_resurrection.php";
         break;
     case "question":
-            require_once("pages/graveyard/case_question.php");
+            require_once __DIR__ . "/pages/graveyard/case_question.php";
         break;
     case "haunt":
-            require_once("pages/graveyard/case_haunt.php");
+            require_once __DIR__ . "/pages/graveyard/case_haunt.php";
         break;
     case "haunt2":
-            require_once("pages/graveyard/case_haunt2.php");
+            require_once __DIR__ . "/pages/graveyard/case_haunt2.php";
         break;
     case "haunt3":
-            require_once("pages/graveyard/case_haunt3.php");
+            require_once __DIR__ . "/pages/graveyard/case_haunt3.php";
         break;
     default:
-            require_once("pages/graveyard/case_default.php");
+            require_once __DIR__ . "/pages/graveyard/case_default.php";
         break;
 }
 

--- a/gypsy.php
+++ b/gypsy.php
@@ -6,9 +6,9 @@ use Lotgd\Translator;
 // addnews ready
 // translator ready
 // mail ready
-require_once("common.php");
-require_once("lib/http.php");
-require_once("lib/villagenav.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/villagenav.php";
 
 Translator::getInstance()->setSchema("gypsy");
 

--- a/healer.php
+++ b/healer.php
@@ -4,10 +4,10 @@ use Lotgd\Translator;
 // addnews ready
 // translator ready
 // mail ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 use Lotgd\Forest;
-require_once("lib/http.php");
-require_once("lib/villagenav.php");
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/villagenav.php";
 
 Translator::getInstance()->setSchema("healer");
 

--- a/hof.php
+++ b/hof.php
@@ -19,7 +19,7 @@ use Lotgd\Nav\VillageNav;
 use Lotgd\Nav;
 use Lotgd\DateTime;
 
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 Translator::getInstance()->setSchema("hof");
 

--- a/home.php
+++ b/home.php
@@ -22,7 +22,7 @@ if (! isset($_SERVER['REQUEST_URI'])) {
     $_SERVER['REQUEST_URI'] = '/home.php';
 }
 
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 use Lotgd\Page\Header;
 use Lotgd\Page\Footer;

--- a/inn.php
+++ b/inn.php
@@ -13,7 +13,7 @@ use Lotgd\Translator;
 // addnews ready
 // translator ready
 // mail ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 use Lotgd\Pvp;
 
 Translator::getInstance()->setSchema("inn");
@@ -46,7 +46,7 @@ $subop = Http::get('subop');
 $com = Http::get('comscroll');
 $comment = Http::post('insertcommentary');
 
-require_once("lib/partner.php");
+require_once __DIR__ . "/lib/partner.php";
 $partner = get_partner();
 addnav("Other");
 VillageNav::render();
@@ -56,17 +56,17 @@ switch ($op) {
     case "":
     case "strolldown":
     case "fleedragon":
-            require("pages/inn/inn_default.php");
+            require __DIR__ . "/pages/inn/inn_default.php";
             blocknav("inn.php");
         break;
     case "converse":
             Commentary::commentDisplay("You stroll over to a table, place your foot up on the bench and listen in on the conversation:`n", "inn", "Add to the conversation?", 20);
         break;
     case "bartender":
-            require("pages/inn/inn_bartender.php");
+            require __DIR__ . "/pages/inn/inn_bartender.php";
         break;
     case "room":
-            require("pages/inn/inn_room.php");
+            require __DIR__ . "/pages/inn/inn_room.php";
         break;
 }
 

--- a/installer.php
+++ b/installer.php
@@ -54,9 +54,9 @@ if (!file_exists("dbconnect.php")) {
 }
 chdir(__DIR__);
 
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 if (file_exists("dbconnect.php")) {
-    require_once("dbconnect.php");
+    require_once __DIR__ . "/dbconnect.php";
 }
 
 // Load settings only when a database connection is available

--- a/list.php
+++ b/list.php
@@ -17,7 +17,7 @@ use Lotgd\Nav;
 use Lotgd\DateTime;
 use Lotgd\Output;
 
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 $output = Output::getInstance();
 
 Translator::getInstance()->setSchema("list");

--- a/lodge.php
+++ b/lodge.php
@@ -6,10 +6,10 @@ use Lotgd\Translator;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
-require_once("lib/sanitize.php");
-require_once("lib/http.php");
-require_once("lib/villagenav.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/sanitize.php";
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/villagenav.php";
 use Lotgd\Names;
 
 Translator::getInstance()->setSchema("lodge");

--- a/logdnet.php
+++ b/logdnet.php
@@ -21,8 +21,8 @@ use Lotgd\Nav;
 use Lotgd\ErrorHandler;
 use Lotgd\Backtrace;
 
-require_once("common.php");
-require_once("lib/sanitize.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/sanitize.php";
 
 Translator::getInstance()->setSchema("logdnet");
 
@@ -246,7 +246,7 @@ if ($op == "") {
     rawoutput("</td><td>");
     output("Version");
     rawoutput("</td>");
-    require_once("lib/pullurl.php");
+    require_once __DIR__ . "/lib/pullurl.php";
     $servers = array();
     $u = getsetting("logdnetserver", "http://logdnet.logd.com/");
     $logdnet = getsetting('logdnet', 0);

--- a/login.php
+++ b/login.php
@@ -12,8 +12,8 @@ use Lotgd\Cookies;
 use Lotgd\DataCache;
 
 define("ALLOW_ANONYMOUS", true);
-require_once("common.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
 // This must be after common.php for now
 use Lotgd\ServerFunctions;
 

--- a/mail.php
+++ b/mail.php
@@ -5,7 +5,7 @@ use Lotgd\Translator;
 // addnews ready
 // mail ready
 define("OVERRIDE_FORCED_NAV", true);
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 use Lotgd\Mail;
 
 Translator::getInstance()->setSchema("mail");
@@ -72,17 +72,17 @@ switch (httpget('even')) {
 
 if ($op == "send") {
         //needs to be handled first.
-        require("pages/mail/case_send.php");
+        require __DIR__ . "/pages/mail/case_send.php";
 }
 
 switch ($op) {
     case "read":
     case "address":
     case "write":
-        require("pages/mail/case_" . $op . ".php");
+        require __DIR__ . "/pages/mail/case_" . $op . ".php";
         break;
     default:
-        require("pages/mail/case_default.php");
+        require __DIR__ . "/pages/mail/case_default.php";
         break;
 }
 popup_footer();

--- a/masters.php
+++ b/masters.php
@@ -8,8 +8,8 @@ use Lotgd\Nav\SuperuserNav;
 // Initially written as a module by Chris Vorndran.
 // Moved into core by JT Traub
 
-require_once("common.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
 
 SuAccess::check(SU_EDIT_CREATURES);
 

--- a/mercenarycamp.php
+++ b/mercenarycamp.php
@@ -7,9 +7,9 @@ use Lotgd\Buffs;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
-require_once("lib/http.php");
-require_once("lib/villagenav.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/villagenav.php";
 
 $translator = Translator::getInstance();
 

--- a/moderate.php
+++ b/moderate.php
@@ -9,9 +9,9 @@ use Lotgd\Commentary;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
-require_once("lib/sanitize.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/sanitize.php";
+require_once __DIR__ . "/lib/http.php";
 use Lotgd\Moderate;
 
 $translator = Translator::getInstance();

--- a/modules.php
+++ b/modules.php
@@ -8,9 +8,9 @@ use Lotgd\PhpGenericEnvironment;
 // addnews ready
 // translator ready
 // mail ready
-require_once("common.php");
-require_once("lib/http.php");
-require_once("lib/sanitize.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/sanitize.php";
 use Lotgd\ModuleManager;
 SuAccess::check(SU_MANAGE_MODULES);
 Translator::getInstance()->setSchema("modulemanage");
@@ -203,7 +203,7 @@ if ($op == "") {
 
             rawoutput(" ]</td><td valign='top'>");
             output_notl($row['active'] ? $active : $inactive);
-            require_once("lib/sanitize.php");
+            require_once __DIR__ . "/lib/sanitize.php";
             rawoutput("</td><td nowrap valign='top'><span title=\"" .
             (isset($row['description']) && $row['description'] ?
              $row['description'] : sanitize($row['formalname'])) . "\">");

--- a/motd.php
+++ b/motd.php
@@ -12,10 +12,10 @@ use Lotgd\DataCache;
 // mail ready
 define("ALLOW_ANONYMOUS", true);
 define("OVERRIDE_FORCED_NAV", true);
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 $output = Output::getInstance();
-require_once("lib/nltoappon.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/lib/nltoappon.php";
+require_once __DIR__ . "/lib/http.php";
 use Lotgd\Motd;
 
 Translator::getInstance()->setSchema("motd");

--- a/mounts.php
+++ b/mounts.php
@@ -8,8 +8,8 @@ use Lotgd\Nav\SuperuserNav;
 // addnews ready
 // mail ready
 // translator ready
-require_once("common.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
 
 $op = httpget('op');
 $id = httpget('id');

--- a/newday.php
+++ b/newday.php
@@ -15,9 +15,9 @@ use Lotgd\DataCache;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
-require_once("lib/http.php");
-require_once("lib/sanitize.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/sanitize.php";
 
 Translator::getInstance()->setSchema("newday");
 //mass_module_prepare(array("newday-intercept", "newday"));

--- a/news.php
+++ b/news.php
@@ -10,10 +10,10 @@ use Lotgd\Output;
 // addnews ready
 // mail ready
 define("ALLOW_ANONYMOUS", true);
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 $output = Output::getInstance();
-require_once("lib/http.php");
-require_once("lib/villagenav.php");
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/villagenav.php";
 
 $translator = Translator::getInstance();
 
@@ -60,7 +60,7 @@ if ($totaltoday > $newsperpage) {
 $sql2 = "SELECT " . Database::prefix("motd") . ".*,name AS motdauthorname FROM " . Database::prefix("motd") . " LEFT JOIN " . Database::prefix("accounts") . " ON " . Database::prefix("accounts") . ".acctid = " . Database::prefix("motd") . ".motdauthor ORDER BY motddate DESC LIMIT 1";
 $result2 = Database::queryCached($sql2, "lastmotd");
 while ($row = Database::fetchAssoc($result2)) {
-        require_once("lib/nltoappon.php");
+        require_once __DIR__ . "/lib/nltoappon.php";
     if ($row['motdauthorname'] == "") {
         $row['motdauthorname'] = translate_inline("`@Green Dragon Staff`0");
     }

--- a/payment.php
+++ b/payment.php
@@ -14,7 +14,7 @@ define("ALLOW_ANONYMOUS", true);
 use Lotgd\Http;
 use Lotgd\Page\Footer;
 
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 Translator::getInstance()->setSchema("payment");
 

--- a/petition.php
+++ b/petition.php
@@ -13,7 +13,7 @@ use Lotgd\Page\Footer;
 // mail ready
 define("ALLOW_ANONYMOUS", true);
 define("OVERRIDE_FORCED_NAV", true);
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 $op = Http::get('op');
 
@@ -23,10 +23,10 @@ switch ($op) {
     case "faq1":
     case "faq2":
     case "faq3":
-                    require("pages/petition/petition_$op.php");
+                    require __DIR__ . "/pages/petition/petition_$op.php";
         break;
     default:
-            require("pages/petition/petition_default.php");
+            require __DIR__ . "/pages/petition/petition_default.php";
         break;
 }
 Footer::popupFooter();

--- a/prefs.php
+++ b/prefs.php
@@ -9,8 +9,8 @@ use Lotgd\Template;
 // mail ready
 // translator ready
 
-require_once("common.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
 
 $skin = httppost('template');
 if ($skin !== '' && Template::isValidTemplate($skin)) {
@@ -18,12 +18,12 @@ if ($skin !== '' && Template::isValidTemplate($skin)) {
         Template::prepareTemplate(true);
 }
 
-require_once("lib/villagenav.php");
+require_once __DIR__ . "/lib/villagenav.php";
 
 Translator::getInstance()->setSchema("prefs");
 
-require_once("lib/is_email.php");
-require_once("lib/sanitize.php");
+require_once __DIR__ . "/lib/is_email.php";
+require_once __DIR__ . "/lib/sanitize.php";
 
 page_header("Preferences");
 
@@ -32,7 +32,7 @@ $op = httpget('op');
 addnav("Navigation");
 if ($op == "suicide" && getsetting("selfdelete", 0) != 0) {
        $userid = (int)httpget('userid');
-    require_once("lib/charcleanup.php");
+    require_once __DIR__ . "/lib/charcleanup.php";
     char_cleanup($userid, CHAR_DELETE_SUICIDE);
        $sql = "DELETE FROM " . Database::prefix("accounts") . " WHERE acctid=$userid";
     Database::query($sql);

--- a/pvp.php
+++ b/pvp.php
@@ -6,7 +6,7 @@ use Lotgd\Translator;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 use Lotgd\FightNav;
 use Lotgd\Pvp;
 use Lotgd\Battle;
@@ -85,7 +85,7 @@ if ($op == "fight" || $op == "run") {
     $battle = true;
 }
 if ($battle) {
-    require_once("battle.php");
+    require_once __DIR__ . "/battle.php";
     if ($victory) {
         $killedin = $badguy['location'];
                 $handled = Pvp::victory($badguy, $killedin, $options);

--- a/referers.php
+++ b/referers.php
@@ -9,8 +9,8 @@ use Lotgd\Nav\SuperuserNav;
 // mail ready
 use Lotgd\Dhms;
 
-require_once("common.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
 
 Translator::getInstance()->setSchema("referers");
 

--- a/referral.php
+++ b/referral.php
@@ -8,7 +8,7 @@ use Lotgd\Http;
 // addnews ready
 // mail ready
 define("ALLOW_ANONYMOUS", true);
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 global $session;
 
@@ -21,7 +21,7 @@ if ($session['user']['loggedin']) {
     if (file_exists("lodge.php")) {
         addnav("L?Return to the Lodge", "lodge.php");
     } else {
-        require_once("lib/villagenav.php");
+        require_once __DIR__ . "/lib/villagenav.php";
         villagenav();
     }
     output("You will automatically receive %s points for each person that you refer to this website who makes it to level %s.`n`n", $settings->getSetting("refereraward", 25), $settings->getSetting("referminlevel", 4));

--- a/runmodule.php
+++ b/runmodule.php
@@ -18,13 +18,13 @@ use Lotgd\ForcedNavigation;
 use Lotgd\DateTime;
 use Lotgd\Output;
 
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 $output = Output::getInstance();
 
 // Legacy Wrappers for Modules
-require_once("lib/http.php");
-require_once("lib/modules.php");
-require_once("lib/villagenav.php");
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/modules.php";
+require_once __DIR__ . "/lib/villagenav.php";
 
 DateTime::getMicroTime();
 

--- a/shades.php
+++ b/shades.php
@@ -9,7 +9,7 @@ use Lotgd\Redirect;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 $output = Output::getInstance();
 
 Translator::getInstance()->setSchema("shades");

--- a/source.php
+++ b/source.php
@@ -6,9 +6,9 @@ use Lotgd\Translator;
 // mail ready
 define("ALLOW_ANONYMOUS", true);
 define("OVERRIDE_FORCED_NAV", true);
-require_once("common.php");
-require_once("lib/errorhandling.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/errorhandling.php";
+require_once __DIR__ . "/lib/http.php";
 
 Translator::getInstance()->setSchema("source");
 

--- a/stables.php
+++ b/stables.php
@@ -9,10 +9,10 @@ use Lotgd\Mounts;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
-require_once("lib/http.php");
-require_once("lib/sanitize.php");
-require_once("lib/villagenav.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/sanitize.php";
+require_once __DIR__ . "/lib/villagenav.php";
 
 $translator = Translator::getInstance();
 

--- a/superuser.php
+++ b/superuser.php
@@ -10,9 +10,9 @@ use Lotgd\PhpGenericEnvironment;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
-require_once("lib/sanitize.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/sanitize.php";
+require_once __DIR__ . "/lib/http.php";
 
 SuAccess::check(0xFFFFFFFF & ~ SU_DOESNT_GIVE_GROTTO);
 Commentary::addCommentary();

--- a/taunt.php
+++ b/taunt.php
@@ -16,7 +16,7 @@ use Lotgd\Translator;
 // addnews ready
 // mail ready
 // translator ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 Translator::getInstance()->setSchema("taunt");
 

--- a/titleedit.php
+++ b/titleedit.php
@@ -9,8 +9,8 @@ use Lotgd\Forms;
 
 //Author: Lonny Luberts - 3/18/2005
 //Heavily modified by JT Traub
-require_once("common.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
 
 SuAccess::check(SU_EDIT_USERS);
 
@@ -68,7 +68,7 @@ switch ($op) {
 
 switch ($op) {
     case "reset":
-                require_once("lib/titles.php");
+                require_once __DIR__ . "/lib/titles.php";
 
         output("`^Rebuilding all titles for all players.`0`n`n");
         $sql = "SELECT name,title,dragonkills,acctid,sex,ctitle FROM " . Database::prefix("accounts");

--- a/train.php
+++ b/train.php
@@ -13,12 +13,12 @@ use Lotgd\DataCache;
 //addnews ready
 // mail ready
 // translator ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 $output = Output::getInstance();
-require_once("lib/increment_specialty.php");
-require_once("lib/http.php");
-require_once("lib/villagenav.php");
-require_once("lib/experience.php");
+require_once __DIR__ . "/lib/increment_specialty.php";
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/villagenav.php";
+require_once __DIR__ . "/lib/experience.php";
 
 Translator::getInstance()->setSchema("train");
 
@@ -182,7 +182,7 @@ if (Database::numRows($result) > 0 && $session['user']['level'] < getsetting('ma
         Battle::suspendBuffs('allowintrain', "`&Your pride prevents you from using extra abilities during the fight!`0`n");
         Battle::suspendCompanions("allowintrain");
         if (!$victory) {
-            require_once("battle.php");
+            require_once __DIR__ . "/battle.php";
         }
         if ($victory) {
             if (httpget('sugain') == 1) {

--- a/translatorlounge.php
+++ b/translatorlounge.php
@@ -14,7 +14,7 @@ use Lotgd\Translator;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 SuAccess::check(SU_IS_TRANSLATOR);
 Commentary::addCommentary();

--- a/translatortool.php
+++ b/translatortool.php
@@ -9,7 +9,7 @@ use Lotgd\Nav\SuperuserNav;
 // translator ready
 // mail ready
 define("OVERRIDE_FORCED_NAV", true);
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 Translator::getInstance()->setSchema("translatortool");
 
 SuAccess::check(SU_IS_TRANSLATOR);

--- a/untranslated.php
+++ b/untranslated.php
@@ -21,7 +21,7 @@ define("OVERRIDE_FORCED_NAV", true);
 // Translate Untranslated Strings
 // Originally Written by Christian Rutsch
 // Slightly modified by JT Traub
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 SuAccess::check(SU_IS_TRANSLATOR);
 

--- a/user.php
+++ b/user.php
@@ -8,9 +8,9 @@ use Lotgd\DateTime;
 
 //addnews ready
 // mail ready
-require_once("common.php");
-require_once("lib/http.php");
-require_once("lib/sanitize.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/sanitize.php";
 use Lotgd\Names;
 
 Translator::getInstance()->setSchema("user");
@@ -49,7 +49,7 @@ if (!$query && $sort) {
 }
 
 if ($op == "search" || $op == "") {
-    require_once("lib/lookup_user.php");
+    require_once __DIR__ . "/lib/lookup_user.php";
     list($searchresult, $err) = lookup_user($query, $order);
     $op = "";
     if ($err) {
@@ -139,7 +139,7 @@ if ($op == 'edit' || $op == 'save') {
     $racesenum = substr($racesenum, 0, strlen($racesenum) - 1);
     //later on: enumpretrans, because races are already translated in a way...
 }
-require("src/Lotgd/Config/user_account.php");
+require __DIR__ . "/src/Lotgd/Config/user_account.php";
 $sql = "SELECT clanid,clanname,clanshort FROM " . Database::prefix("clans") . " ORDER BY clanshort";
 $result = Database::query($sql);
 while ($row = Database::fetchAssoc($result)) {
@@ -149,46 +149,46 @@ while ($row = Database::fetchAssoc($result)) {
 
 switch ($op) {
     case "lasthit":
-            require("pages/user/user_lasthit.php");
+            require __DIR__ . "/pages/user/user_lasthit.php";
         break;
     case "savemodule":
-            require("pages/user/user_savemodule.php");
+            require __DIR__ . "/pages/user/user_savemodule.php";
         break;
     case "special":
-            require("pages/user/user_special.php");
+            require __DIR__ . "/pages/user/user_special.php";
         break;
     case "save":
-            require("pages/user/user_save.php");
+            require __DIR__ . "/pages/user/user_save.php";
         break;
 }
 
 switch ($op) {
     case "edit":
-            require("pages/user/user_edit.php");
+            require __DIR__ . "/pages/user/user_edit.php";
         break;
     case "setupban":
-            require("pages/user/user_setupban.php");
+            require __DIR__ . "/pages/user/user_setupban.php";
         break;
     case "del":
-            require("pages/user/user_del.php");
+            require __DIR__ . "/pages/user/user_del.php";
         break;
     case "saveban":
-            require("pages/user/user_saveban.php");
+            require __DIR__ . "/pages/user/user_saveban.php";
         break;
     case "delban":
-            require("pages/user/user_delban.php");
+            require __DIR__ . "/pages/user/user_delban.php";
         break;
     case "removeban":
-            require("pages/user/user_removeban.php");
+            require __DIR__ . "/pages/user/user_removeban.php";
         break;
     case "searchban":
-            require("pages/user/user_searchban.php");
+            require __DIR__ . "/pages/user/user_searchban.php";
         break;
     case "debuglog":
-            require("pages/user/user_debuglog.php");
+            require __DIR__ . "/pages/user/user_debuglog.php";
         break;
     case "":
-            require("pages/user/user_.php");
+            require __DIR__ . "/pages/user/user_.php";
         break;
 }
 page_footer();

--- a/viewpetition.php
+++ b/viewpetition.php
@@ -18,7 +18,7 @@ use Lotgd\Modules\HookHandler;
 // addnews ready
 // mail ready
 
-require_once("common.php");
+require_once __DIR__ . "/common.php";
 
 Translator::getInstance()->setSchema('petition');
 

--- a/village.php
+++ b/village.php
@@ -7,10 +7,10 @@ use Lotgd\Commentary;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
-require_once("lib/http.php");
-require_once("lib/events.php");
-require_once("lib/experience.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/events.php";
+require_once __DIR__ . "/lib/experience.php";
 
 $translator = Translator::getInstance();
 

--- a/weaponeditor.php
+++ b/weaponeditor.php
@@ -9,8 +9,8 @@ use Lotgd\Forms;
 
 // addnews ready
 // mail ready
-require_once("common.php");
-require_once("lib/http.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
 
 SuAccess::check(SU_EDIT_EQUIPMENT);
 

--- a/weapons.php
+++ b/weapons.php
@@ -5,9 +5,9 @@ use Lotgd\Translator;
 // translator ready
 // addnews ready
 // mail ready
-require_once("common.php");
-require_once("lib/http.php");
-require_once("lib/villagenav.php");
+require_once __DIR__ . "/common.php";
+require_once __DIR__ . "/lib/http.php";
+require_once __DIR__ . "/lib/villagenav.php";
 
 $translator = Translator::getInstance();
 


### PR DESCRIPTION
## Summary
- replace relative require paths with `__DIR__` in top-level PHP scripts

## Testing
- `composer install`
- `php -l <modified files>`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bd548c67f48329b131fb048b7c18b7