### PR TITLE
docs: record __DIR__ require refactor in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Everything below reflects the path from 1.3.2 → 2.0 RCs.
 - Guard against missing city and theme parameters and ensure `diddamage` defaults to zero.
 - Use safe array access for player name lookup and tighten module migration checks.
 
+### Refactor
+- Standardize top-level scripts to use `__DIR__` in `require` statements for safer path resolution.
+
 ### Docs
 - Clarify newday cron configuration and cron job setup instructions.
 - Add module hook reference documentation.


### PR DESCRIPTION
## Summary
- document refactor standardizing top-level script requires to use `__DIR__`

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bd59663e78832998ae345aa643277c