### PR TITLE
Fix companion editor null output error

### DIFF
--- a/companions.php
+++ b/companions.php
@@ -14,6 +14,7 @@ use Lotgd\DataCache;
 use Lotgd\Settings;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Translator;
+use Lotgd\Output;
 
 // addnews ready
 // mail ready
@@ -237,6 +238,7 @@ if ($op == "") {
 
 function companionform($companion)
 {
+    $output = Output::getInstance();
     // Let's sanitize the data
     if (!isset($companion['companionactive'])) {
         $companion['companionactive'] = "";


### PR DESCRIPTION
## Summary
- Initialize output instance within `companionform`
- Import `Lotgd\Output` for companion editor

## Testing
- `php -l companions.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bdbc6d9010832996651fb0c3cb8231