### PR TITLE
Fix mail cleanup log message

### DIFF
--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -67,7 +67,7 @@ class Newday
         $timestamp = self::calculateExpirationTimestamp($settings->getSetting('oldmail', 14) . ' days');
         $sql = 'DELETE FROM ' . Database::prefix('mail') . " WHERE sent<'$timestamp'";
         Database::query($sql);
-        GameLog::log('Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('mails') . " older than $timestamp.", 'maintenance');
+        GameLog::log('Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('mail') . " older than $timestamp.", 'maintenance');
         DataCache::getInstance()->massinvalidate('mail');
 
         if ((int) $settings->getSetting('expirecontent', 180) > 0) {


### PR DESCRIPTION
## Summary
- ensure mail cleanup log references correct table

## Testing
- `php -l src/Lotgd/Newday.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bde3c29744832993ab70d1373133e1