### PR TITLE
Ensure new accounts default to village restorepage

### DIFF
--- a/create.php
+++ b/create.php
@@ -307,9 +307,9 @@ if (getsetting("allowcreation", 1) == 0) {
                         $dbpass = md5(md5($pass1));
                     }
                     $sql = "INSERT INTO " . Database::prefix("accounts") . "
-						(playername,name, superuser, title, password, sex, login, laston, uniqueid, lastip, gold, location, emailaddress, emailvalidation, referer, regdate,badguy,allowednavs,specialinc,specialmisc,bufflist,dragonpoints,replaceemail,forgottenpassword,prefs,hauntedby,donationconfig,bio,ctitle,companions)
-						VALUES
-						('$shortname','$title $shortname', '" . getsetting("defaultsuperuser", 0) . "', '$title', '$dbpass', '$sex', '$shortname', '" . date("Y-m-d H:i:s", strtotime("-1 day")) . "', '" . (Cookies::getLgi() ?? '') . "', '" . $_SERVER['REMOTE_ADDR'] . "', " . getsetting("newplayerstartgold", 50) . ", '" . addslashes(getsetting('villagename', LOCATION_FIELDS)) . "', '$email', '$emailverification', '$referer', NOW(),'','','','','',0,'','','','','','','','')";
+                                                (playername,name, superuser, title, password, sex, login, laston, uniqueid, lastip, gold, location, emailaddress, emailvalidation, referer, regdate,badguy,allowednavs,restorepage,specialinc,specialmisc,bufflist,dragonpoints,replaceemail,forgottenpassword,prefs,hauntedby,donationconfig,bio,ctitle,companions)
+                                                VALUES
+                                                ('$shortname','$title $shortname', '" . getsetting("defaultsuperuser", 0) . "', '$title', '$dbpass', '$sex', '$shortname', '" . date("Y-m-d H:i:s", strtotime("-1 day")) . "', '" . (Cookies::getLgi() ?? '') . "', '" . $_SERVER['REMOTE_ADDR'] . "', " . getsetting("newplayerstartgold", 50) . ", '" . addslashes(getsetting('villagename', LOCATION_FIELDS)) . "', '$email', '$emailverification', '$referer', NOW(),'','', 'village.php','','','',0,'','','','','','','','')";
                     Database::query($sql);
                     if (Database::affectedRows() <= 0) {
                         output("`\$Error`^: Your account was not created for an unknown reason, please try again. ");

--- a/install/data/tables.php
+++ b/install/data/tables.php
@@ -166,7 +166,7 @@ function get_all_tables()
             'name' => 'locked', 'type' => 'tinyint(4) unsigned', 'default' => '0'
             ),
         'restorepage' => array(
-            'name' => 'restorepage', 'type' => 'varchar(255)', 'null' => '1'
+            'name' => 'restorepage', 'type' => 'varchar(255)', 'default' => 'village.php', 'null' => '1'
             ),
         'hashorse' => array(
             'name' => 'hashorse', 'type' => 'tinyint(4) unsigned', 'default' => '0'

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -247,7 +247,7 @@ class Installer
                     $pass = md5(md5(stripslashes(Http::post("pass1"))));
                     $sql = "DELETE FROM " . Database::prefix("accounts") . " WHERE login='$name'";
                     Database::query($sql);
-                    $sql = "INSERT INTO " . Database::prefix("accounts") . " (login,password,superuser,name,playername,ctitle,title,regdate,badguy,companions, allowednavs, bufflist, dragonpoints, prefs, donationconfig,specialinc,specialmisc,emailaddress,replaceemail,emailvalidation,hauntedby,bio) VALUES('$name','$pass',$su,'`%Admin `&$name`0','`%Admin `&$name`0','`%Admin','', NOW(),'','','','','','','','','','','','','','')";
+                    $sql = "INSERT INTO " . Database::prefix("accounts") . " (login,password,superuser,name,playername,ctitle,title,regdate,badguy,companions, allowednavs, restorepage, bufflist, dragonpoints, prefs, donationconfig,specialinc,specialmisc,emailaddress,replaceemail,emailvalidation,hauntedby,bio) VALUES('$name','$pass',$su,'`%Admin `&$name`0','`%Admin `&$name`0','`%Admin','', NOW(),'','','','village.php','','','','','','','','','')";
                     $result = Database::query($sql);
                     if (Database::affectedRows($result) == 0) {
                         print_r($sql);

--- a/tests/AccountRestorepageTest.php
+++ b/tests/AccountRestorepageTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+final class AccountRestorepageTest extends TestCase
+{
+    public function testCreatePhpSetsDefaultRestorepage(): void
+    {
+        $content = file_get_contents(dirname(__DIR__) . '/create.php');
+        $this->assertMatchesRegularExpression('/restorepage.*village\.php/s', $content);
+    }
+
+    public function testInstallerSetsDefaultRestorepage(): void
+    {
+        $content = file_get_contents(dirname(__DIR__) . '/install/lib/Installer.php');
+        $this->assertMatchesRegularExpression('/restorepage.*village\.php/s', $content);
+    }
+
+    public function testTablesDefaultRestorepage(): void
+    {
+        $content = file_get_contents(dirname(__DIR__) . '/install/data/tables.php');
+        $this->assertMatchesRegularExpression("/'restorepage' => array\\(.*'default' => 'village.php'/s", $content);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Give newly created accounts a default `restorepage` of `village.php`
- Apply the same default when creating the initial admin account during installation
- Document default in installation schema and add regression tests

## Testing
- `composer install`
- `php -l create.php`
- `php -l install/lib/Installer.php`
- `php -l install/data/tables.php`
- `php -l tests/AccountRestorepageTest.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bdefe44c3483299182cd1ce5b17b4a