### PR TITLE
Cast module setting insert values to string

### DIFF
--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -583,7 +583,7 @@ class Modules
         } else {
             $sql = 'INSERT INTO ' . Database::prefix('module_settings')
                 . " (modulename,setting,value) VALUES ('$module','" . addslashes($name)
-                . "','" . addslashes($value) . "')";
+                . "','" . addslashes((string) $value) . "')";
             Database::query($sql);
         }
 

--- a/tests/Modules/Settings/ModuleSettingsTest.php
+++ b/tests/Modules/Settings/ModuleSettingsTest.php
@@ -115,6 +115,15 @@ final class ModuleSettingsTest extends TestCase
             $this->assertSame($increment, get_module_setting('counter'), "increment {$increment}");
         }
     }
+
+    public function testSetModuleSettingAcceptsInteger(): void
+    {
+        ModuleManager::setMostRecentModule('mymodule');
+
+        set_module_setting('number', 42);
+
+        $this->assertSame(42, get_module_setting('number'));
+    }
 }
 
 }


### PR DESCRIPTION
## Summary
- Cast `$value` to string when inserting module settings
- Add regression test to ensure `set_module_setting` accepts integers

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf4898910832990063961009cd5c9