### PR TITLE
Initialize session message before timeout notice

### DIFF
--- a/common.php
+++ b/common.php
@@ -340,7 +340,10 @@ if (isset($session['lasthit']) && isset($session['loggedin']) && strtotime("-" .
     // ignore it.
     // 1.1.1 now should be a good time to get it on with it, added tl-inline
     Translator::translatorSetup();
-        $session['message'] .= Translator::translateInline("`nYour session has expired!`n", "common");
+    if (!isset($session['message'])) {
+        $session['message'] = '';
+    }
+    $session['message'] .= Translator::translateInline("`nYour session has expired!`n", "common");
 }
 $session['lasthit'] = strtotime("now");
 


### PR DESCRIPTION
## Summary
- Safely initialize session message before appending timeout warning to avoid undefined index errors

## Testing
- `php -l common.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bee91fbf8c8329b37a3f15a28e2949