### PR TITLE
Ensure module manager respects install status

### DIFF
--- a/src/Lotgd/ModuleManager.php
+++ b/src/Lotgd/ModuleManager.php
@@ -44,11 +44,7 @@ class ModuleManager
      */
     public static function listUninstalled(): array
     {
-        if (function_exists('get_module_install_status')) {
-            $status = get_module_install_status(false);
-        } else {
-            $status = Installer::getInstallStatus(false);
-        }
+        $status = Installer::getInstallStatus(true);
         return $status['uninstalledmodules'] ?? [];
     }
 
@@ -59,11 +55,7 @@ class ModuleManager
      */
     public static function getInstalledCategories(): array
     {
-        if (function_exists('get_module_install_status')) {
-            $status = get_module_install_status(false);
-        } else {
-            $status = Installer::getInstallStatus(false);
-        }
+        $status = Installer::getInstallStatus(true);
         return $status['installedcategories'] ?? [];
     }
 

--- a/tests/Stubs/Database.php
+++ b/tests/Stubs/Database.php
@@ -33,6 +33,12 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
         public static array $mockResults = [];
         public static string $last_error = '';
         public static bool $alterFail = false;
+        /**
+         * Log of executed SQL queries.
+         *
+         * @var array<int,string>
+         */
+        public static array $queries = [];
 
         public static function connect(string $host, string $user, string $pass): bool
         {
@@ -74,6 +80,7 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
         {
             global $accounts_table, $mail_table, $last_query_result;
             self::$lastSql = $sql;
+            self::$queries[] = $sql;
 
             if (self::$mockResults) {
                 $last_query_result = array_shift(self::$mockResults);


### PR DESCRIPTION
## Summary
- Replace legacy module status wrapper with direct `Installer::getInstallStatus` calls
- Log executed SQL in test database stub and adjust tests

## Testing
- `php -l src/Lotgd/ModuleManager.php`
- `php -l tests/ModuleManagerTest.php`
- `php -l tests/Stubs/Database.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bef1f0eb84832999bbc1f77d97b5d7