### PR TITLE
docs: add translation system guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ For details on key components:
 
 - [docs/Nav.md](docs/Nav.md)
 - [docs/Doctrine.md](docs/Doctrine.md)
+- [docs/TranslationGuide.md](docs/TranslationGuide.md)
 
 ## Twig Templates
 

--- a/docs/Lotgd.md
+++ b/docs/Lotgd.md
@@ -38,7 +38,7 @@ The `MySQL` sub-namespace (see `MySQL.md`) implements the actual database wrappe
 
 ## Miscellaneous Utilities
 
-Many other files provide focused helpers: `AddNews` writes stories to the news feed, `Http` performs simple HTTP requests, `Mail` implements the in-game mail system and `Substitute` offers a very small template engine used by buffs.  The complete list is available in `docs/Namespaces.md`.
+Many other files provide focused helpers: `AddNews` writes stories to the news feed, `Http` performs simple HTTP requests, `Mail` implements the in-game mail system and `Substitute` offers a very small template engine used by buffs.  The complete list is available in [Namespaces.md](Namespaces.md). For translation tools and conventions see [TranslationGuide.md](TranslationGuide.md).
 
 ### Usage Example
 

--- a/docs/TranslationGuide.md
+++ b/docs/TranslationGuide.md
@@ -1,0 +1,51 @@
+# Translation System Guide
+
+## Introduction
+The Legend of the Green Dragon (LotGD) engine ships with an extensible translation system.  Text is stored in the database and retrieved at runtime so the game can be fully localised.  Namespaces isolate groups of phrases and the engine automatically falls back to the English source when a translation is missing.
+
+## Quickstart for New Translators
+1. **Collect new strings** – enable translation collection in the superuser settings and browse the game.  Untranslated phrases are written to the `untranslated` table.
+2. **translatorlounge.php** – visit `translatorlounge.php` to see the overview of languages and grant yourself translator access.
+3. **translatortool.php** – open `translatortool.php` to translate strings in the selected namespace.
+4. **untranslated.php** – use `untranslated.php` to review and prune entries that were collected but should not be translated.
+
+Example workflow:
+```bash
+# Log in as a translator and browse the game to collect text
+# Then open the translation tool in your browser
+https://example.com/translatortool.php
+```
+
+## Administrator Guide
+- **Configuration** – adjust translation options in `config/configuration.php` such as the default language and whether untranslated phrases are collected.
+- **Permissions** – assign the "Translator" flag on user accounts via the superuser editor or through `translatorlounge.php`.
+- **Database backups** – regularly export the `translations` table:
+  ```bash
+  mysqldump -u lotgd -p lotgd translations > translations.sql
+  ```
+
+## Developer Guide
+Use the helper functions to integrate translations into code:
+
+```php
+$greeting = translate('hello', 'my-module');
+output("`@%s`0", $greeting);
+
+tlschema('my-module');
+output("A namespaced line");
+tlschema();
+```
+
+Namespaces should match the module or page name.  The optional `translationwizard` module can be installed to aid module developers by scaffolding namespace files and simplifying string exports.
+
+Sample setup steps:
+```bash
+# From the modules repository
+cp modules/translationwizard.php modules/
+# Enable the module in the game
+```
+
+## Best Practices
+- **Naming conventions** – use lowercase namespaces separated by hyphens (e.g. `cities-market`).
+- **Collaboration** – coordinate via version control or the translator lounge before editing shared strings.
+- **Database maintenance** – periodically remove unused namespaces and back up the `translations` and `untranslated` tables.


### PR DESCRIPTION
## Summary
- document translation workflow, admin/developer usage, and best practices
- cross-link translation docs from README and Lotgd namespace guide

## Testing
- `php -l docs/TranslationGuide.md`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bf0ea0ca28832998e46706adf34160