### PR TITLE
Cast insert ID to integer during character restore

### DIFF
--- a/modules/charrestore.php
+++ b/modules/charrestore.php
@@ -555,7 +555,7 @@ function charrestore_run(): void
 
             $conn = Database::getDoctrineConnection();
             $conn->insert(Database::prefix('accounts'), $accountData, $types);
-            $id = Database::insertId();
+            $id = (int) Database::insertId();
             if ($id > 0) {
                 if ($session['user']['superuser'] & SU_EDIT_USERS == SU_EDIT_USERS) {
                     addnav("Edit the restored user", "user.php?op=edit&userid=$id" . $retnav);


### PR DESCRIPTION
## Summary
- cast Database::insertId() to integer before setting module preferences during character restores

## Testing
- `php -l modules/charrestore.php`
- `composer test`
- `php modules/charrestore.php` *(no output; restore not fully executed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf410d59b083299846bfd621629ecc