### PR TITLE
Ensure color codes are string before formatting in darkhorse bartender

### DIFF
--- a/modules/darkhorse.php
+++ b/modules/darkhorse.php
@@ -151,6 +151,7 @@ function darkhorse_bartender($from)
         rawoutput("</td></tr>");
         $i = 0;
         foreach ($colors as $code) {
+            $code = (string) $code;
             if ($i == 0) {
                 rawoutput("<tr>");
             }


### PR DESCRIPTION
## Summary
- Cast color codes to string before applying `stripslashes`

## Testing
- `php -l modules/darkhorse.php`
- `composer install --no-progress`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bfcf8f36a883299413a67fe745bf74