### PR TITLE
Add defer attribute to logdnet registration script

### DIFF
--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -601,7 +601,7 @@ class PageParts
             $e = rawurlencode($e);
             $v = rawurlencode($v);
             $u = rawurlencode($u);
-            $paypalstr .= "<script type='text/javascript' charset='UTF-8' src='images/logdnet.php?op=register&c=$c&l=$l&v=$v&a=$a&d=$d&e=$e&u=$u'></script>";
+            $paypalstr .= "<script defer type='text/javascript' charset='UTF-8' src='images/logdnet.php?op=register&c=$c&l=$l&v=$v&a=$a&d=$d&e=$e&u=$u'></script>";
         } else {
             $paypalstr .= "<form action=\"https://www.paypal.com/cgi-bin/webscr\" method=\"post\" target=\"_blank\" onsubmit=\"return confirm('You are donating to the author of Lotgd. Donation points can not be credited unless you petition. Press Ok to make a donation, or press Cancel.');\">" .
                 "<input type='hidden' name='cmd' value='_xclick'>" .


### PR DESCRIPTION
## Summary
- Avoid blocking page rendering by loading the logdnet registration script with the `defer` attribute

## Testing
- `php -l src/Lotgd/PageParts.php`
- `composer install`
- `composer test`
- `php -S 127.0.0.1:8000` then `curl http://127.0.0.1:8000/test_page.html`
- `curl http://127.0.0.1:8000/images/logdnet.php?op=register&a=a&c=0&l=en&v=1&d=desc&e=admin@localhost&u=http://lotgd.net/`


------
https://chatgpt.com/codex/tasks/task_e_68bfd31c4b3c83299ec4dab5e392422d