### PR TITLE
Report reassigned IDs when restoring accounts

### DIFF
--- a/modules/charrestore.php
+++ b/modules/charrestore.php
@@ -564,6 +564,8 @@ function charrestore_run(): void
             $em->flush();
 
             $id = (int) Database::insertId();
+            $idReassigned = false;
+            $originalId   = (int) $desiredId;
             if (is_numeric($desiredId) && (int) $desiredId !== $id) {
                 $conn = Database::getDoctrineConnection();
                 try {
@@ -571,6 +573,9 @@ function charrestore_run(): void
                     $id = (int) $desiredId;
                 } catch (UniqueConstraintViolationException $e) {
                     // old ID already taken; keep $id
+                }
+                if ((int) $desiredId !== $id) {
+                    $idReassigned = true;
                 }
             }
 
@@ -591,6 +596,11 @@ function charrestore_run(): void
                     }
                 }
                 output("`#The preferences were restored.`n");
+                if ($idReassigned) {
+                    output("`#The original account ID `^%s`# could not be used.`n", $originalId);
+                    output("`#A new account ID `^%s`# has been assigned.`n", $id);
+                    output("`#Preferences have been applied to the new ID.`n");
+                }
                 // sadly not possible anymore. we do not know the emailaddress (data privacy regulation)
                 /*                  $targetid=$user['account']['acctid'];
                                     $targetmail=$user['account']['emailaddress'];


### PR DESCRIPTION
## Summary
- Flag when a restored account can't reuse its original ID
- Notify admins of the reassigned ID and confirm prefs were applied

## Testing
- `composer install`
- `php -l modules/charrestore.php`
- `composer test` *(fails: process hangs during database migration)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdee4fc908329a42569038eda3cea