### PR TITLE
Handle errors in AI script execution

### DIFF
--- a/src/Lotgd/Battle.php
+++ b/src/Lotgd/Battle.php
@@ -1119,9 +1119,18 @@ class Battle
  */
     public static function executeAiScript($script)
     {
-        global $unsetme;
+        global $unsetme, $badguy;
+
         if (!empty($script)) {
-            eval($script);
+            try {
+                eval($script);
+            } catch (\Throwable $e) {
+                \Lotgd\GameLog::log('AI script error: ' . $e->getMessage(), 'battle');
+
+                if (isset($badguy)) {
+                    $badguy['creatureaiscript'] = '';
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- guard AI scripts with try/catch and log failures to gamelog
- skip running AI scripts again after an error

## Testing
- `php -l src/Lotgd/Battle.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bfe855b2c08329a9a0017dcc687c0e