### PR TITLE
Guard user_save indices

### DIFF
--- a/pages/user/user_save.php
+++ b/pages/user/user_save.php
@@ -74,7 +74,7 @@ foreach ($post as $key => $val) {
                 debuglog($session['user']['name'] . "`0 changed superuser to " . show_bitfield($value), $userid) . "`n";
                 debug("superuser has changed to $value");
             }
-        } elseif ($key == "name33" && isset($oldvalues[$key]) && stripslashes($val) != $oldvalues[$key]) {
+        } elseif ($key == "name33" && stripslashes($val) != ($oldvalues[$key] ?? '')) {
             $updates++;
             $tmp = sanitize_colorname(
                 getsetting("spaceinname", 0),
@@ -99,7 +99,7 @@ foreach ($post as $key => $val) {
             if ($session['user']['acctid'] == $userid) {
                 $session['user']['name'] = $newname;
             }
-        } elseif ($key == "title" && isset($oldvalues[$key]) && stripslashes($val) != $oldvalues[$key]) {
+        } elseif ($key == "title" && stripslashes($val) != ($oldvalues[$key] ?? '')) {
             $updates++;
             $tmp = sanitize_colorname(true, stripslashes($val), true);
             $tmp = preg_replace("/[`][cHw]/", "", $tmp);
@@ -114,7 +114,7 @@ foreach ($post as $key => $val) {
             $sql .= "$key = \"$val\",";
             $output->output("Changed player title from %s`0 to %s`0`n", $oldvalues['title'] ?? '', $tmp);
             $oldvalues[$key] = $tmp;
-            if (isset($oldvalues['name']) && $newname != $oldvalues['name']) {
+            if (!isset($oldvalues['name']) || $newname != $oldvalues['name']) {
                 $sql .= "name = \"" . addslashes($newname) . "\",";
                 $output->output("`2Changed player name to %s`2 due to changed dragonkill title`n", $newname);
                 debuglog($session['user']['name'] . "`0 changed player name to $newname`0 due to changed dragonkill title", $userid);
@@ -126,7 +126,7 @@ foreach ($post as $key => $val) {
             if ($session['user']['acctid'] == $userid) {
                 $session['user']['title'] = $tmp;
             }
-        } elseif ($key == "ctitle" && isset($oldvalues[$key]) && stripslashes($val) != $oldvalues[$key]) {
+        } elseif ($key == "ctitle" && stripslashes($val) != ($oldvalues[$key] ?? '')) {
             $updates++;
             $tmp = sanitize_colorname(true, stripslashes($val), true);
             $tmp = preg_replace("/[`][cHw]/", "", $tmp);
@@ -141,7 +141,7 @@ foreach ($post as $key => $val) {
             $sql .= "$key = \"$val\",";
             $output->output("`2Changed player ctitle from `\$%s`2 to `\$%s`2`n", $oldvalues['ctitle'] ?? '', $tmp);
             $oldvalues[$key] = $tmp;
-            if (isset($oldvalues['name']) && $newname != $oldvalues['name']) {
+            if (!isset($oldvalues['name']) || $newname != $oldvalues['name']) {
                 $sql .= "name = \"" . addslashes($newname) . "\",";
                 if ((!isset($oldvalues['playername']) || $oldvalues['playername'] == '') && !isset($post['playername'])) {
                     //no valid title currently, add update
@@ -157,7 +157,7 @@ foreach ($post as $key => $val) {
             if ($session['user']['acctid'] == $userid) {
                 $session['user']['ctitle'] = $tmp;
             }
-        } elseif (($key == "playername") && isset($oldvalues[$key]) && stripslashes($val) != $oldvalues[$key]) {
+        } elseif (($key == "playername") && stripslashes($val) != ($oldvalues[$key] ?? '')) {
             $updates++;
             $tmp = sanitize_colorname(true, stripslashes($val), true);
             $tmp = preg_replace("/[`][cHw]/", "", $tmp);
@@ -174,7 +174,7 @@ foreach ($post as $key => $val) {
             $sql .= "$key = \"$val\",";
             $output->output("`2Changed player name from `\$%s`2 to `\$%s`2`n", $oldvalues['playername'] ?? '', $tmp);
             $oldvalues[$key] = $tmp;
-            if (isset($oldvalues['name']) && $newname != $oldvalues['name']) {
+            if (!isset($oldvalues['name']) || $newname != $oldvalues['name']) {
                 $sql .= "name = \"" . addslashes($newname) . "\",";
                 debuglog($session['user']['name'] . "`0 changed player name to $newname`0 due to changed custom title", $userid);
                 $oldvalues['name'] = $newname;
@@ -187,14 +187,14 @@ foreach ($post as $key => $val) {
             }
         } elseif ($key == "oldvalues") {
             //donothing.
-        } elseif (isset($oldvalues[$key]) && $oldvalues[$key] != stripslashes($val)) {
+        } elseif (!array_key_exists($key, $oldvalues) || $oldvalues[$key] != stripslashes($val)) {
             if ($key == 'name') {
                 continue; //well, name is composed now
             }
             $sql .= "$key = \"$val\",";
             $updates++;
             $output->output("`2 Value `\$'%s`2' has changed to '`\$%s`2'.`n", $key, stripslashes($val));
-            debuglog($session['user']['name'] . "`0 changed $key from {$oldvalues[$key]} to $val", $userid);
+            debuglog($session['user']['name'] . "`0 changed $key from " . ($oldvalues[$key] ?? '') . " to $val", $userid);
             if ($session['user']['acctid'] == $userid) {
                 $session['user'][$key] = stripslashes($val);
             }

--- a/tests/UserSaveNoOldvaluesTest.php
+++ b/tests/UserSaveNoOldvaluesTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (!function_exists('httpallpost')) {
+        function httpallpost(): array
+        {
+            return $_POST ?? [];
+        }
+    }
+    if (!function_exists('httppost')) {
+        function httppost(string $name): string
+        {
+            return $_POST[$name] ?? '';
+        }
+    }
+    if (!function_exists('httpget')) {
+        function httpget(string $name): string
+        {
+            return $_GET[$name] ?? '';
+        }
+    }
+    if (!function_exists('getsetting')) {
+        function getsetting(string $setting, string $default = ''): string
+        {
+            return $default;
+        }
+    }
+    if (!function_exists('httpset')) {
+        function httpset(mixed ...$args): void
+        {
+        }
+    }
+    if (!function_exists('debuglog')) {
+        function debuglog(string $message, mixed $userid = null): void
+        {
+        }
+    }
+    if (!function_exists('debug')) {
+        function debug(mixed ...$args): void
+        {
+        }
+    }
+    if (!function_exists('sanitize_colorname')) {
+        function sanitize_colorname(mixed ...$args): string
+        {
+            return $args[1] ?? '';
+        }
+    }
+    if (!function_exists('sanitize_html')) {
+        function sanitize_html(string $str): string
+        {
+            return $str;
+        }
+    }
+    if (!function_exists('soap')) {
+        function soap(string $str): string
+        {
+            return $str;
+        }
+    }
+    if (!function_exists('show_bitfield')) {
+        function show_bitfield(mixed $value): string
+        {
+            return (string) $value;
+        }
+    }
+}
+
+
+namespace Lotgd\Tests {
+    use PHPUnit\Framework\TestCase;
+
+    final class UserSaveNoOldvaluesTest extends TestCase
+    {
+        public function testPostWithoutOldvaluesDoesNotTriggerNotices(): void
+        {
+            $errors = [];
+            set_error_handler(function (int $errno, string $errstr) use (&$errors): bool {
+                if ($errno === E_NOTICE || $errno === E_WARNING) {
+                    $errors[] = $errstr;
+                }
+                return true;
+            });
+
+            $include = function (): void {
+                global $_POST, $_GET, $output, $session, $userid, $userinfo;
+                $_POST = ['playername' => 'Foo'];
+                $_GET = [];
+                $session = ['user' => ['acctid' => 1, 'superuser' => 0, 'name' => 'Admin']];
+                $userid = 1;
+                $userinfo = [];
+                $output = new class {
+                    public function outputNotl(string $format, mixed ...$args): void {}
+                    public function output(string $format, mixed ...$args): void {}
+                };
+                require __DIR__ . '/../pages/user/user_save.php';
+            };
+
+            \Closure::bind($include, null, null)();
+
+            restore_error_handler();
+            $this->assertSame([], $errors);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- prevent notices in user_save when oldvalues is missing
- add regression coverage for missing oldvalues

## Testing
- `php -l pages/user/user_save.php`
- `php -l tests/UserSaveNoOldvaluesTest.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c057b514a08329aae3bab4f5bb45f7