### PR TITLE
Include creature info in AI script error logs

### DIFF
--- a/src/Lotgd/Battle.php
+++ b/src/Lotgd/Battle.php
@@ -1125,7 +1125,11 @@ class Battle
             try {
                 eval($script);
             } catch (\Throwable $e) {
-                \Lotgd\GameLog::log('AI script error: ' . $e->getMessage(), 'battle');
+                \Lotgd\GameLog::log(
+                    "AI script error for {$badguy['creaturename']} ({$badguy['creatureid']}): "
+                    . $e->getMessage() . ' Script: ' . $script,
+                    'battle'
+                );
 
                 if (isset($badguy)) {
                     $badguy['creatureaiscript'] = '';


### PR DESCRIPTION
## Summary
- expand AI script error logs to include creature name, ID, and failing script

## Testing
- `composer install`
- `php -l src/Lotgd/Battle.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c07d83a04c8329a03f319cabaf805a