### PR TITLE
Handle charrestore snapshot failures

### DIFF
--- a/modules/charrestore.php
+++ b/modules/charrestore.php
@@ -215,8 +215,10 @@ function charrestore_dohook(string $hookname, array $args): array
                     $errfile = "charrestore.php";
                     $errline = 169;
                     ErrorHandler::Register($errno, $errstr, $errfile, $errline);
-                    //quit now, which is should anyways, this is a precaution, so we don't delete the data of the char
-                    exit(0);
+                    // Prevent cleanup if the snapshot could not be written
+                    $args['prevent_cleanup'] = true;
+
+                    return $args;
                 }
                 $targetid = $user['account']['acctid'];
                 $targetmail = $user_email;


### PR DESCRIPTION
## Summary
- Flag snapshot write failures to prevent cleanup and return control to caller

## Testing
- `php -l modules/charrestore.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c0807802608329833f4d06351bbc37