### PR TITLE
Honor prevent_cleanup flag in charCleanup

### DIFF
--- a/src/Lotgd/PlayerFunctions.php
+++ b/src/Lotgd/PlayerFunctions.php
@@ -22,11 +22,18 @@ class PlayerFunctions
      *
      * @param int $id   Account id of the player to clean up
      * @param int $type Type of deletion (see constants)
+     *
+     * @return bool True if cleanup was performed, false if prevented
      */
-    public static function charCleanup(int $id, int $type): void
+    public static function charCleanup(int $id, int $type): bool
     {
         // Run module hooks for character deletion
-        HookHandler::hook('delete_character', ['acctid' => $id, 'deltype' => $type]);
+        $args = HookHandler::hook('delete_character', ['acctid' => $id, 'deltype' => $type]);
+
+        // Allow modules to prevent cleanup
+        if ($args['prevent_cleanup'] ?? false) {
+            return false;
+        }
 
         // Remove output cache records for this player
         Database::query('DELETE FROM ' . Database::prefix('accounts_output') . " WHERE acctid=$id;");
@@ -68,6 +75,8 @@ class PlayerFunctions
 
         // Remove module user preferences
         HookHandler::deleteUserPrefs($id);
+
+        return true;
     }
 
     /**

--- a/tests/PlayerFunctionsCharCleanupTest.php
+++ b/tests/PlayerFunctionsCharCleanupTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\PlayerFunctions;
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class PlayerFunctionsCharCleanupTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $modulehook_returns;
+        $modulehook_returns = [];
+        if (! class_exists('Lotgd\\Modules\\HookHandler', false)) {
+            eval('namespace Lotgd\\Modules; class HookHandler { public static array $deleted = []; public static function hook($name, $data = [], $allowinactive = false, $only = false) { global $modulehook_returns; return $modulehook_returns[$name] ?? $data; } public static function deleteUserPrefs(int $id): void { self::$deleted[] = $id; }}');
+        }
+        class_exists(Database::class);
+        Database::$queries = [];
+        Database::$mockResults = [];
+        if (! defined('CLAN_LEADER')) {
+            define('CLAN_LEADER', 1);
+        }
+        if (! defined('CLAN_FOUNDER')) {
+            define('CLAN_FOUNDER', 2);
+        }
+        if (! defined('CLAN_APPLICANT')) {
+            define('CLAN_APPLICANT', 3);
+        }
+    }
+
+    public function testCleanupPreventedByHook(): void
+    {
+        global $modulehook_returns;
+        $modulehook_returns['delete_character'] = ['prevent_cleanup' => true];
+        $result = PlayerFunctions::charCleanup(1, 0);
+        $this->assertFalse($result);
+        $this->assertSame([], \Lotgd\Modules\HookHandler::$deleted);
+        $this->assertSame([], Database::$queries);
+    }
+
+    public function testCleanupRunsWhenNotPrevented(): void
+    {
+        global $modulehook_returns;
+        $modulehook_returns['delete_character'] = [];
+        Database::$mockResults = [true, true, [['clanrank' => 0, 'clanid' => 0]]];
+        $result = PlayerFunctions::charCleanup(1, 0);
+        $this->assertTrue($result);
+        $this->assertSame([1], \Lotgd\Modules\HookHandler::$deleted);
+        $this->assertCount(3, Database::$queries);
+    }
+}


### PR DESCRIPTION
## Summary
- Capture `HookHandler::hook` result in `charCleanup` and bail out when `prevent_cleanup` is set
- Return a boolean from `charCleanup` and update PHPDoc
- Test `charCleanup` behavior with and without `prevent_cleanup`

## Testing
- `php -l src/Lotgd/PlayerFunctions.php`
- `php -l tests/PlayerFunctionsCharCleanupTest.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c080ba7e388329b130ad3f61171e41