### PR TITLE
Prevent account deletion when char cleanup fails

### DIFF
--- a/lib/charcleanup.php
+++ b/lib/charcleanup.php
@@ -2,7 +2,7 @@
 
 use Lotgd\PlayerFunctions;
 
-function char_cleanup($id, $type)
+function char_cleanup($id, $type): bool
 {
-        PlayerFunctions::charCleanup((int)$id, (int)$type);
+        return PlayerFunctions::charCleanup((int)$id, (int)$type);
 }

--- a/pages/user/user_del.php
+++ b/pages/user/user_del.php
@@ -9,9 +9,9 @@ use Lotgd\AddNews;
 
 $sql = "SELECT name,superuser from " . Database::prefix("accounts") . " WHERE acctid='$userid'";
 $res = Database::query($sql);
-PlayerFunctions::charCleanup($userid, CHAR_DELETE_MANUAL);
-$fail = false;
-while ($row = Database::fetchAssoc($res)) {
+$cleanup = PlayerFunctions::charCleanup($userid, CHAR_DELETE_MANUAL);
+$fail = ! $cleanup;
+while (! $fail && ($row = Database::fetchAssoc($res))) {
     if ($row['superuser'] > 0 && ($session['user']['superuser'] & SU_MEGAUSER) != SU_MEGAUSER) {
         $output->output("`\$You are trying to delete a user with superuser powers. Regardless of the type, ONLY a megauser can do so due to security reasons.");
         $fail = true;

--- a/prefs.php
+++ b/prefs.php
@@ -33,18 +33,19 @@ addnav("Navigation");
 if ($op == "suicide" && getsetting("selfdelete", 0) != 0) {
        $userid = (int)httpget('userid');
     require_once __DIR__ . "/lib/charcleanup.php";
-    char_cleanup($userid, CHAR_DELETE_SUICIDE);
+    if (char_cleanup($userid, CHAR_DELETE_SUICIDE)) {
        $sql = "DELETE FROM " . Database::prefix("accounts") . " WHERE acctid=$userid";
-    Database::query($sql);
-    output("Your character has been deleted!");
-    AddNews::add("`#%s quietly passed from this world.", $session['user']['name']);
-    addnav("Login Page", "index.php");
-    $session = array();
-    $session['user'] = array();
-    $session['loggedin'] = false;
-    $session['user']['loggedin'] = false;
-    massinvalidate('charlisthomepage');
-    invalidatedatacache("list.php-warsonline");
+        Database::query($sql);
+        output("Your character has been deleted!");
+        AddNews::add("`#%s quietly passed from this world.", $session['user']['name']);
+        addnav("Login Page", "index.php");
+        $session = array();
+        $session['user'] = array();
+        $session['loggedin'] = false;
+        $session['user']['loggedin'] = false;
+        massinvalidate('charlisthomepage');
+        invalidatedatacache("list.php-warsonline");
+    }
 } elseif ($op == "forcechangeemail") {
     checkday();
     if ($session['user']['alive']) {

--- a/src/Lotgd/ExpireChars.php
+++ b/src/Lotgd/ExpireChars.php
@@ -68,8 +68,9 @@ class ExpireChars
 
         $acctIds = [];
         foreach ($rows as $row) {
-            PlayerFunctions::charCleanup($row['acctid'], CHAR_DELETE_AUTO);
-            $acctIds[] = $row['acctid'];
+            if (PlayerFunctions::charCleanup($row['acctid'], CHAR_DELETE_AUTO)) {
+                $acctIds[] = $row['acctid'];
+            }
         }
 
         self::logExpiredAccountStats($rows);

--- a/tests/CharCleanupFailurePreventsDeletionTest.php
+++ b/tests/CharCleanupFailurePreventsDeletionTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class CharCleanupFailurePreventsDeletionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Database::$queries = [];
+        Database::$mockResults = [];
+    }
+
+    public function testExpireCharsDoesNotDeleteOnCleanupFailure(): void
+    {
+        if (! class_exists('Lotgd\\Settings', false)) {
+            eval('namespace Lotgd; class Settings { public function __construct(string $t = "settings_extended"){} public static function getInstance(): self { return new self(); } public function getSetting(string $n, mixed $d = null): mixed { return $d; } public function saveSetting(string $n, mixed $v): void {} }');
+        }
+        if (! class_exists('Lotgd\\PlayerFunctions', false)) {
+            eval('namespace Lotgd; class PlayerFunctions { public static function charCleanup(int $id, int $type): bool { return false; } }');
+        }
+        if (! class_exists('Lotgd\\GameLog', false)) {
+            eval('namespace Lotgd; class GameLog { public static function log(string $m, string $c): void {} }');
+        }
+
+        Database::$mockResults = [
+            [["acctid" => 1, "login" => "test", "dragonkills" => 0, "level" => 1]],
+        ];
+
+        $ref = new \ReflectionClass(\Lotgd\ExpireChars::class);
+        $method = $ref->getMethod('cleanupExpiredAccounts');
+        $method->setAccessible(true);
+        $method->invoke(null);
+
+        foreach (Database::$queries as $query) {
+            $this->assertStringNotContainsString('DELETE FROM accounts', $query);
+        }
+    }
+
+    public function testUserDelAbortsOnCleanupFailure(): void
+    {
+        if (! class_exists('Lotgd\\PlayerFunctions', false)) {
+            eval('namespace Lotgd; class PlayerFunctions { public static function charCleanup(int $id, int $type): bool { return false; } }');
+        }
+        if (! class_exists('Lotgd\\AddNews', false)) {
+            eval('namespace Lotgd; class AddNews { public static function add(string $m, string $n, bool $b = true): void {} }');
+        }
+        if (! function_exists('debuglog')) {
+            eval('function debuglog(string $m): void {}');
+        }
+
+        global $session, $userid, $output;
+        $session = ['user' => ['superuser' => 0]];
+        $userid = 1;
+        $output = new class {
+            public array $log = [];
+            public function output(string $m): void { $this->log[] = $m; }
+        };
+
+        Database::$mockResults = [
+            [["name" => "Tester", "superuser" => 0]],
+        ];
+
+        include __DIR__ . '/../pages/user/user_del.php';
+
+        $this->assertCount(1, Database::$queries);
+        $this->assertStringStartsWith('SELECT name,superuser from accounts', Database::$queries[0]);
+    }
+}


### PR DESCRIPTION
## Summary
- Skip deleting expired accounts when `PlayerFunctions::charCleanup` fails
- Abort user deletions if character cleanup does not complete
- Add regression tests ensuring accounts remain after cleanup failures

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c0831ae14883298c6fb6ae3ebc4fd7