### PR TITLE
Fix improper escape sequences in character restore module

### DIFF
--- a/modules/charrestore.php
+++ b/modules/charrestore.php
@@ -255,9 +255,9 @@ function charrestore_create_snapshot(int $acctid): bool
     $body = str_replace("`n", "</br>", $body);
     $result = charrestore_sendmail($targetmail, $body, $subject, get_module_setting('adminmail', 'charrestore'), get_module_setting('adminname', 'charrestore'));
     if ($result) {
-        output("`\\$The notification message has been sent!`n");
+        output("`\$The notification message has been sent!`n");
     } else {
-        output("`\\$There has been an error! The notification message was NOT sent!`n");
+        output("`\$There has been an error! The notification message was NOT sent!`n");
     }
 
     return true;


### PR DESCRIPTION
## Summary
- Correct escaping for notification messages in charrestore module

## Testing
- `php -l modules/charrestore.php`
- `composer test`
- `php runmodule.php module=charrestore op=backup userid=1`

------
https://chatgpt.com/codex/tasks/task_e_68c08b98423c8329b02574877440b434