### PR TITLE
Initialize payment error tracking

### DIFF
--- a/payment.php
+++ b/payment.php
@@ -9,7 +9,8 @@ use Lotgd\Translator;
 // addnews ready
 // translator ready
 ob_start();
-set_error_handler("payment_error");
+$payment_errors = '';
+set_error_handler('payment_error');
 define("ALLOW_ANONYMOUS", true);
 use Lotgd\Http;
 use Lotgd\Page\Footer;


### PR DESCRIPTION
## Summary
- define `$payment_errors` before registering `payment_error` handler

## Testing
- `php -l payment.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c130ec35f08329a848b2e381864b48