### PR TITLE
Guard cache invalidation unlink

### DIFF
--- a/src/Lotgd/DataCache.php
+++ b/src/Lotgd/DataCache.php
@@ -132,10 +132,10 @@ class DataCache
         $settings = Settings::getInstance();
         if ($settings->getSetting('usedatacache', 0)) {
             $fullname = $withpath ? $this->makecachetempname($name) : $name;
-            if (file_exists($fullname)) {
-                unlink($fullname);
+            if (is_file($fullname) && ! @unlink($fullname)) {
+                GameLog::log('Failed to remove cache file ' . $fullname, 'cache');
             }
-            if (!$withpath) {
+            if (! $withpath) {
                 unset(self::$cache[$name]);
             }
         }


### PR DESCRIPTION
## Summary
- prevent warnings when removing cache entries by checking for files and suppressing unlink errors
- log failures when cache file removal fails

## Testing
- `php -l src/Lotgd/DataCache.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c130f460108329b96a47805f442e76