### PR TITLE
Use unread mail count for mail notifications

### DIFF
--- a/async/js/ajax_polling.js
+++ b/async/js/ajax_polling.js
@@ -15,7 +15,8 @@ var active_mail_interval;     // ID of the mail polling interval (unused)
 var active_comment_interval;  // ID of the commentary polling interval (unused)
 var active_timeout_interval;  // ID of the timeout polling interval (unused)
 var active_poll_interval;     // ID of the combined polling interval
-var lotgd_lastUnreadMailId = 0;  // Track last unread mail count
+var lotgd_lastUnreadMailId = 0;      // Track last mail ID
+var lotgd_lastUnreadMailCount = 0;   // Track last unread mail count
 
 /**
  * Display a Web Notification with the given title and message.
@@ -39,21 +40,22 @@ function lotgdShowNotification(title, message)
 }
 
 /**
- * Handle updated unread mail count from the server.
+ * Handle updated mail status from the server.
  */
-function lotgdMailNotify(count)
+function lotgdMailNotify(lastId, count)
 {
     if (lotgd_lastUnreadMailId === 0) {
-        // First time we get the count, just store it
-        lotgd_lastUnreadMailId = count;
+        lotgd_lastUnreadMailId = lastId;
+        lotgd_lastUnreadMailCount = count;
         return;
     }
-    if (count > lotgd_lastUnreadMailId && !document.hasFocus()) {
+    if (lastId > lotgd_lastUnreadMailId && !document.hasFocus()) {
         var msg = count === 1 ? 'You have 1 unread message' :
             'You have ' + count + ' unread messages';
         lotgdShowNotification('Unread game messages', msg);
     }
-    lotgd_lastUnreadMailId = count;
+    lotgd_lastUnreadMailId = lastId;
+    lotgd_lastUnreadMailCount = count;
 }
 
 /**

--- a/async/setup.php
+++ b/async/setup.php
@@ -70,8 +70,9 @@ $polling_script .= "console.log('AJAX polling initialized:', {interval: lotgd_po
 
 // Add missing notification functions and clean AJAX polling implementation
 $polling_script .= "
-// Global mail counter for notifications
+// Global mail status for notifications
 var lotgd_lastUnreadMailId = 0;
+var lotgd_lastUnreadMailCount = 0;
 
 // Notification functions (previously in ajax_polling.js)
 function lotgdShowNotification(title, message) {
@@ -89,18 +90,19 @@ function lotgdShowNotification(title, message) {
     }
 }
 
-function lotgdMailNotify(count) {
+function lotgdMailNotify(lastId, count) {
     if (lotgd_lastUnreadMailId === 0) {
-        // First time we get the count, just store it
-        lotgd_lastUnreadMailId = count;
+        lotgd_lastUnreadMailId = lastId;
+        lotgd_lastUnreadMailCount = count;
         return;
     }
-    if (count > lotgd_lastUnreadMailId && !document.hasFocus()) {
+    if (lastId > lotgd_lastUnreadMailId && !document.hasFocus()) {
         var msg = count === 1 ? 'You have 1 unread message' :
             'You have ' + count + ' unread messages';
         lotgdShowNotification('Unread game messages', msg);
     }
-    lotgd_lastUnreadMailId = count;
+    lotgd_lastUnreadMailId = lastId;
+    lotgd_lastUnreadMailCount = count;
 }
 
 function lotgdCommentNotify(count) {

--- a/src/Lotgd/Async/Handler/Mail.php
+++ b/src/Lotgd/Async/Handler/Mail.php
@@ -32,16 +32,18 @@ class Mail
         $new = PageParts::mailLink();
         $tabtext = PageParts::mailLinkTabText();
 
-        // Get the highest message ID for the current user there is
-        $sql = 'SELECT MAX(messageid) AS lastid FROM ' . Database::prefix('mail')
+        // Get the highest message ID and unread mail count for the current user
+        $sql = 'SELECT MAX(messageid) AS lastid, SUM(seen=0) AS unread FROM '
+            . Database::prefix('mail')
             . ' WHERE msgto=\'' . $session['user']['acctid'] . '\'';
         $result = Database::query($sql);
         $row = Database::fetchAssoc($result);
         if ($row === false) {
-            $row = ['lastid' => 0];
+            $row = ['lastid' => 0, 'unread' => 0];
         }
         Database::freeResult($result);
         $lastMailId = (int) ($row['lastid'] ?? 0);
+        $unreadCount = (int) ($row['unread'] ?? 0);
 
         $objResponse = jaxon()->newResponse();
         $objResponse->assign('maillink', 'innerHTML', $new);
@@ -54,7 +56,7 @@ class Mail
         $tabtext = Translator::translateInline('Legend of the Green Dragon', 'home')
             . ' - ' . $tabtext;
         $objResponse->script('document.title="' . $tabtext . '";');
-        $objResponse->script('lotgdMailNotify(' . $lastMailId . ');');
+        $objResponse->script('lotgdMailNotify(' . $lastMailId . ', ' . $unreadCount . ');');
 
         return $objResponse;
     }

--- a/tests/Ajax/MailStatusTest.php
+++ b/tests/Ajax/MailStatusTest.php
@@ -32,7 +32,7 @@ namespace Lotgd\Tests\Ajax {
                 'mail-1' => [['seencount' => 0, 'notseen' => 1]],
             ];
             Database::$mockResults = [
-                [['lastid' => 7]],
+                [['lastid' => 7, 'unread' => 1]],
             ];
 
             $response = (new Mail())->mailStatus(true);
@@ -43,7 +43,7 @@ namespace Lotgd\Tests\Ajax {
             $this->assertStringContainsString('mail.php', $assign[0]['data']);
 
             $scripts = array_filter($commands, fn($c) => ($c['cmd'] ?? '') === 'js');
-            $notify = array_values(array_filter($scripts, fn($c) => str_contains($c['data'] ?? '', 'lotgdMailNotify(7)')));
+            $notify = array_values(array_filter($scripts, fn($c) => str_contains($c['data'] ?? '', 'lotgdMailNotify(7, 1)')));
             $this->assertNotEmpty($notify);
             $title = array_values(array_filter($scripts, fn($c) => str_contains($c['data'] ?? '', 'Legend of the Green Dragon - 1 new mail(s)')));
             $this->assertNotEmpty($title);
@@ -56,7 +56,7 @@ namespace Lotgd\Tests\Ajax {
                 'mail-1' => [['seencount' => 0, 'notseen' => 0]],
             ];
             Database::$mockResults = [
-                [['lastid' => 5]],
+                [['lastid' => 5, 'unread' => 0]],
             ];
 
             $response = (new Mail())->mailStatus(true);


### PR DESCRIPTION
## Summary
- Track highest mail ID and unread count
- Trigger notifications only when new ID arrives
- Adapt tests and async scripts for `lotgdMailNotify(lastId, count)`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c134bb5f58832986a05dc93eabe26b