### PR TITLE
Ensure moderation reads live comments

### DIFF
--- a/src/Lotgd/Moderate.php
+++ b/src/Lotgd/Moderate.php
@@ -57,11 +57,7 @@ class Moderate
                 . Database::prefix('accounts') . ' ON ' . Database::prefix('accounts') . '.acctid = ' . Database::prefix('commentary') . '.author LEFT JOIN '
                 . Database::prefix('clans') . ' ON ' . Database::prefix('clans') . '.clanid=' . Database::prefix('accounts') . '.clanid WHERE '
                 . "$sectselect (" . Database::prefix('accounts') . ".locked=0 OR " . Database::prefix('accounts') . ".locked is null ) ORDER BY commentid DESC LIMIT " . ($com * $limit) . ",$limit";
-            if ($com == 0 && strstr($_SERVER['REQUEST_URI'], '/moderate.php') != $_SERVER['REQUEST_URI']) {
-                $result = Database::queryCached($sql, "comments-{$section}");
-            } else {
-                $result = Database::query($sql);
-            }
+            $result = Database::query($sql);
         } else {
             $sql = 'SELECT ' . Database::prefix('commentary') . '.*, '
                 . Database::prefix('accounts') . '.name, '


### PR DESCRIPTION
## Summary
- Always run comment queries directly in moderation to bypass cache

## Testing
- `php -l src/Lotgd/Moderate.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c1650501d08329a44b23923926a4d8