### PR TITLE
feat: show excluded moderation sections

### DIFF
--- a/src/Lotgd/Moderate.php
+++ b/src/Lotgd/Moderate.php
@@ -195,9 +195,12 @@ class Moderate
             foreach ($array as $entry) {
                 $sectselect .= "section NOT LIKE '$entry' AND ";
             }
-        }
 
-        $output->debug('Select: ' . $sectselect);
+            $excludedList = implode(', ', $array);
+            if ($session['user']['superuser'] & SU_EDIT_COMMENTS) {
+                $output->output('Excluded sections: %s`n', $excludedList);
+            }
+        }
 
         // Determine which translation schema to use for output
         if ($schema === null) {


### PR DESCRIPTION
## Summary
- show human-readable list of excluded sections to moderators
- remove debug output in moderation view

## Testing
- `php -l src/Lotgd/Moderate.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c18faaa21c8329a34d25a93751a567