### PR TITLE
Fix healnav translator access

### DIFF
--- a/mercenarycamp.php
+++ b/mercenarycamp.php
@@ -218,7 +218,7 @@ page_footer();
 
 function healnav($companions, $texts, $schemas)
 {
-    global $session;
+    global $session, $translator;
     $translator->setSchema($schemas['healnav']);
     addnav($texts['healnav']);
     $translator->setSchema();


### PR DESCRIPTION
## Summary
- include `$translator` as a global in `healnav`

## Testing
- `php -l mercenarycamp.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c1b2dfdefc8329815d15fc0b9eae34