### PR TITLE
Fix undefined blockaccount key in account creation

### DIFF
--- a/create.php
+++ b/create.php
@@ -253,6 +253,9 @@ if (getsetting("allowcreation", 1) == 0) {
                 $blockaccount = true;
             }
             $args = modulehook("check-create", httpallpost());
+            $args['blockaccount'] = $args['blockaccount'] ?? false;
+            $args['msg'] = $args['msg'] ?? '';
+
             if ($args['blockaccount']) {
                 $msg .= $args['msg'];
                 $blockaccount = true;


### PR DESCRIPTION
## Summary
- Initialize `blockaccount` and `msg` keys after `modulehook` call to prevent undefined array key warnings during account creation

## Testing
- `php -l create.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c1d7895b308329b62e274f818ccbea