### PR TITLE
Handle inverted buff damage ranges

### DIFF
--- a/src/Lotgd/Buffs.php
+++ b/src/Lotgd/Buffs.php
@@ -517,6 +517,10 @@ class Buffs
                 }
                 $min = (int) $min;
                 $max = (int) $max;
+                if ($min > $max) {
+                    error_log(sprintf('Buff "%s" has min damage (%d) greater than max damage (%d); swapping values.', $key, $min, $max));
+                    [$min, $max] = [$max, $min];
+                }
                 $minioncounter = 1;
                 while ($minioncounter <= ((int)$buff['minioncount']) && $who >= 0) {
                     $damage = random_int($min, $max);

--- a/tests/BuffsInvertedDamageTest.php
+++ b/tests/BuffsInvertedDamageTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Buffs;
+use PHPUnit\Framework\TestCase;
+
+final class BuffsInvertedDamageTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $session, $badguy, $count;
+        $session = [];
+        $badguy = [];
+        $count = 0;
+    }
+
+    public function testInvertedDamageRangeDoesNotThrow(): void
+    {
+        global $session, $badguy, $count;
+
+        $session['bufflist'] = [
+            'test' => [
+                'schema' => '',
+                'minioncount' => 1,
+                'maxbadguydamage' => 10,
+                'minbadguydamage' => 20,
+            ],
+        ];
+
+        $badguy = [
+            'creaturehealth' => 100,
+            'istarget' => true,
+            'dead' => false,
+        ];
+        $count = 0;
+
+        Buffs::activateBuffs('roundstart');
+
+        $this->assertGreaterThanOrEqual(80, $badguy['creaturehealth']);
+        $this->assertLessThanOrEqual(90, $badguy['creaturehealth']);
+    }
+}


### PR DESCRIPTION
## Summary
- Swap buff damage bounds when min exceeds max to prevent `random_int` errors
- Add test ensuring inverted damage range no longer throws

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c3054d1aac8329ba1cd4f8379ff206