### PR TITLE
 zlib default, cache checks, deprecations + upgrade docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Regular upkeep tasks:
 - Async/Ajax (Jaxon) UX improvements
 - PHP 8.4 baseline
  
+Performance defaults:
+- zlib output compression enabled when available.
+- Data cache and Twig cache use the `datacachepath` directory; the game warns admins if the path is missing or not writable.
+ 
 👉 See [UPGRADING.md](UPGRADING.md) if you’re moving from 1.3.x
 
 ## Further Reading
@@ -111,6 +115,8 @@ For details on key components:
 - [docs/Nav.md](docs/Nav.md)
 - [docs/Doctrine.md](docs/Doctrine.md)
 - [docs/TranslationsGuide.md](docs/TranslationsGuide.md)
+ - [UPGRADING.md](UPGRADING.md) — 1.3.x → 2.0 changes, performance defaults
+ - [docs/Deprecations.md](docs/Deprecations.md) — deprecations and migration timelines
 
 ## Twig Templates
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -80,6 +80,11 @@ Once the legacy upgrade is complete:
   - Each skin requires a `config.json` and core files (`page.twig`, `popup.twig`).  
   - Old `.htm` templates still work but are deprecated.
 
+- **Performance Defaults**  
+  - Output compression via zlib is enabled by default when the `zlib` extension is present. Disable at the PHP level if undesired.  
+  - Data cache requires a writable directory: set `DB_USEDATACACHE=1` and `DB_DATACACHEPATH=/path/to/cache`. The app will warn admins if the path is missing or not writable.  
+  - Twig will cache compiled templates under `<datacachepath>/twig` when writable; otherwise it runs without caching.
+
 ---
 
 ## 7. Breaking Changes

--- a/docs/Deprecations.md
+++ b/docs/Deprecations.md
@@ -1,0 +1,42 @@
+## Deprecations Policy (2.x)
+
+This project aims to preserve legacy compatibility while moving to a modern stack. Deprecations are communicated here and via `CHANGELOG.md`.
+
+### Policy
+- Deprecated APIs remain available for at least one minor release after deprecation is announced.
+- Calls to deprecated APIs may trigger PHP notices in debug mode or be logged.
+- Removal occurs in the next major release (e.g., deprecated in 2.1 → removed in 3.0), unless a critical security or maintenance constraint requires earlier removal.
+
+### Current Deprecations
+
+- Legacy template system (`templates/*.htm`)  
+  - Status: Deprecated, still supported in 2.x  
+  - Replacement: Twig templates under `templates_twig/<skin>/`  
+  - Migration: Port HTML chunks to Twig views; see skin structure in README and sample template config.
+
+- Global helper includes under `lib/*.php`  
+  - Status: Deprecated shims  
+  - Replacement: Namespaced classes under `Lotgd\...`  
+  - Migration: Replace direct `require` usage with Composer autoloaded classes.
+
+- Raw SQL access patterns  
+  - Status: Deprecated where Doctrine is available  
+  - Replacement: Doctrine ORM/DBAL repositories and migrations  
+  - Migration: Move writes/reads into services or repositories; create migrations instead of ad‑hoc SQL.
+
+- Custom Ajax endpoints not using Jaxon  
+  - Status: Deprecated  
+  - Replacement: Jaxon-based async calls under `async/`  
+  - Migration: Wrap Ajax actions with Jaxon controllers; adhere to rate limiting.
+
+### Upgrade Guidance (1.3.x → 2.0)
+
+See `UPGRADING.md` for the full process. Key points:
+- Require PHP 8.4+, install via Composer, run legacy upgrade then Doctrine migrations.
+- Enable data cache with a writable `DB_DATACACHEPATH`; Twig caches to `<path>/twig` when writable.
+- zlib output compression defaults on when the extension is present.
+
+### Contact
+Open an issue if you need a longer grace period or migration examples for a specific API.
+
+

--- a/src/Lotgd/TwigTemplate.php
+++ b/src/Lotgd/TwigTemplate.php
@@ -28,8 +28,10 @@ class TwigTemplate extends Template
         if ($datacachePath !== null && $datacachePath !== '') {
             self::$cacheDir = $datacachePath;
             $cacheDir = rtrim($datacachePath, '/\\') . '/' . self::CACHE_SUBDIR;
-            if ((is_dir($cacheDir) || mkdir($cacheDir, 0755, true)) && is_writable($cacheDir)) {
+            if ((is_dir($cacheDir) || @mkdir($cacheDir, 0755, true)) && is_writable($cacheDir)) {
                 $options['cache'] = $cacheDir;
+            } else {
+                // Leave cache disabled; optionally, could log in future
             }
         }
 


### PR DESCRIPTION
- perf: enable zlib output compression when the extension is present
- perf/ux: early cache path validation; admin-only warning when DB_USEDATACACHE=1 but path is missing/unwritable
- twig: gracefully skip cache if <datacachepath>/twig cannot be created/written
- docs: add docs/Deprecations.md (policy + items), expand UPGRADING.md with performance defaults, and note defaults/links in README.md
- Risk: Low. Behavior is additive and warnings show only to admins. Twig caches continue to work when path is writable; otherwise fallback is non-cached render.