### PR TITLE
Honor TTL for charStats cache

### DIFF
--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -411,8 +411,9 @@ class PageParts
             $loginTimeout = $settings->getSetting("LOGINTIMEOUT", 900);
             $cacheMinutes = $mode === 2 ? $minutesSetting : (int) ceil($loginTimeout / 60);
             $cacheKey = "charlisthomepage-$mode-$cacheMinutes";
+            $ttl = $cacheMinutes * 60;
             $minutes = 0;
-            if ($ret = DataCache::getInstance()->datacache($cacheKey)) {
+            if ($ret = DataCache::getInstance()->datacache($cacheKey, $ttl)) {
             } else {
                 $onlinecount = 0;
                 $list = HookHandler::hook("onlinecharlist", array("count" => 0, "list" => ""));

--- a/tests/DataCacheTest.php
+++ b/tests/DataCacheTest.php
@@ -106,4 +106,28 @@ final class DataCacheTest extends TestCase
         fclose($resource);
         $this->assertFileDoesNotExist(DataCache::getInstance()->makecachetempname('failjson'));
     }
+
+    public function testCachePersistsForSpecifiedMinutes(): void
+    {
+        $name = 'persisted';
+        $data = ['value' => 99];
+
+        $minutes = 2;
+        $seconds = $minutes * 60;
+
+        $this->assertTrue(DataCache::getInstance()->updatedatacache($name, $data));
+
+        $file = DataCache::getInstance()->makecachetempname($name);
+
+        touch($file, time() - $seconds + 1);
+        $this->assertSame($data, DataCache::getInstance()->datacache($name, $seconds));
+
+        $ref = new \ReflectionClass(DataCache::class);
+        $prop = $ref->getProperty('cache');
+        $prop->setAccessible(true);
+        $prop->setValue(null, []);
+
+        touch($file, time() - $seconds - 1);
+        $this->assertFalse(DataCache::getInstance()->datacache($name, $seconds));
+    }
 }


### PR DESCRIPTION
## Summary
- compute cache TTL in `charStats` and apply it when retrieving from `DataCache`
- remove unused TTL parameter from `updatedatacache`
- test that `DataCache` respects minute-based TTLs

## Testing
- `php -l lib/datacache.php`
- `php -l src/Lotgd/DataCache.php`
- `php -l src/Lotgd/PageParts.php`
- `php -l tests/DataCacheTest.php`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c30859f07483298e75a15d74a767bd