### PR TITLE
fix: seed default allowed nav for new characters

### DIFF
--- a/create.php
+++ b/create.php
@@ -309,10 +309,11 @@ if (getsetting("allowcreation", 1) == 0) {
                     } else {
                         $dbpass = md5(md5($pass1));
                     }
+                    $allowednavs = addslashes(serialize(['village.php' => true]));
                     $sql = "INSERT INTO " . Database::prefix("accounts") . "
                                                 (playername,name, superuser, title, password, sex, login, laston, uniqueid, lastip, gold, location, emailaddress, emailvalidation, referer, regdate,badguy,allowednavs,restorepage,specialinc,specialmisc,bufflist,dragonpoints,replaceemail,forgottenpassword,prefs,hauntedby,donationconfig,bio,ctitle,companions)
                                                 VALUES
-                                                ('$shortname','$title $shortname', '" . getsetting("defaultsuperuser", 0) . "', '$title', '$dbpass', '$sex', '$shortname', '" . date("Y-m-d H:i:s", strtotime("-1 day")) . "', '" . (Cookies::getLgi() ?? '') . "', '" . $_SERVER['REMOTE_ADDR'] . "', " . getsetting("newplayerstartgold", 50) . ", '" . addslashes(getsetting('villagename', LOCATION_FIELDS)) . "', '$email', '$emailverification', '$referer', NOW(),'','', 'village.php','','','',0,'','','','','','','','')";
+                                                ('$shortname','$title $shortname', '" . getsetting("defaultsuperuser", 0) . "', '$title', '$dbpass', '$sex', '$shortname', '" . date("Y-m-d H:i:s", strtotime("-1 day")) . "', '" . (Cookies::getLgi() ?? '') . "', '" . $_SERVER['REMOTE_ADDR'] . "', " . getsetting("newplayerstartgold", 50) . ", '" . addslashes(getsetting('villagename', LOCATION_FIELDS)) . "', '$email', '$emailverification', '$referer', NOW(),'','" . $allowednavs . "', 'village.php','','','',0,'','','','','','','','')";
                     Database::query($sql);
                     if (Database::affectedRows() <= 0) {
                         output("`\$Error`^: Your account was not created for an unknown reason, please try again. ");

--- a/login.php
+++ b/login.php
@@ -145,8 +145,6 @@ if ($name != "") {
                     $link = "<a href='{$session['user']['restorepage']}'>{$session['user']['restorepage']}</a>";
                     $msg  = Translator::getInstance()->sprintfTranslate('Sending you to %s, have a safe journey', $link);
                     //$session['allowednavs'] = unserialize($session['user']['allowednavs']);
-                    // Ensure the restore page is allowed in the next request
-                    //\Lotgd\Nav::add('', $session['user']['restorepage']);
                     header("Location: {$session['user']['restorepage']}");
                     Accounts::saveUser();
                     echo $msg;


### PR DESCRIPTION
## Summary
- store village page in allowed navigation during character creation
- remove redundant navigation injection in login flow

## Testing
- `php -l login.php`
- `php -l create.php`
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c46b52f608832980d4e156373dd402