### PR TITLE
fix: correct variables in deleteAccounts

### DIFF
--- a/src/Lotgd/ExpireChars.php
+++ b/src/Lotgd/ExpireChars.php
@@ -94,21 +94,23 @@ class ExpireChars
         self::logExpiredAccountStats($rows);
     }
     /**
-     * Delete accounts
-     * @return void
-    **/
-
+     * Delete accounts.
+     *
+     * @param array<int> $acctIds
+     */
     private static function deleteAccounts(array $acctIds): void
     {
         if (empty($acctIds)) {
             return;
         }
-        foreach ($acctIds as $acctid) {
-            $sql = 'DELETE FROM ' . Database::prefix('accounts') . ' WHERE acctid = ' . $acctId ;
+
+        foreach ($acctIds as $acctId) {
+            $sql = 'DELETE FROM ' . Database::prefix('accounts') . ' WHERE acctid = ' . (int) $acctId;
             Database::query($sql);
+
             if (Database::affectedRows() !== 1) {
                 GameLog::log(
-                    sprintf('Failed to delete account %d: %s', (int) $row['acctid'], Database::error()),
+                    sprintf('Failed to delete account %d: %s', (int) $acctId, Database::error()),
                     'char deletion failure'
                 );
             }


### PR DESCRIPTION
## Summary
- fix variable names and logging in `ExpireChars::deleteAccounts`

## Testing
- `php -l src/Lotgd/ExpireChars.php`
- `composer test`
- `composer static`


------
https://chatgpt.com/codex/tasks/task_e_68c46e8349a083299986532e076cebdf