### PR TITLE
fix: simplify expiration notice query

### DIFF
--- a/src/Lotgd/ExpireChars.php
+++ b/src/Lotgd/ExpireChars.php
@@ -180,9 +180,11 @@ class ExpireChars
     {
         $settings = Settings::getInstance();
         $old = max(1, ((int) $settings->getSetting('expireoldacct', 45)) - ((int) $settings->getSetting('notifydaysbeforedeletion', 5)));
-        $sql = 'SELECT login,acctid,emailaddress FROM ' . Database::prefix('accounts') .
-            " WHERE 1=0 " . ($old > 0 ? "OR (laston < '" . date('Y-m-d H:i:s', strtotime("-$old days")) . "')" : '') .
-            " AND emailaddress!='' AND sentnotice=0 AND (superuser&" . NO_ACCOUNT_EXPIRATION . ')=0';
+
+        $threshold = date('Y-m-d H:i:s', strtotime("-$old days"));
+        $sql = 'SELECT login,acctid,emailaddress FROM ' . Database::prefix('accounts')
+            . " WHERE (laston < '$threshold')"
+            . " AND emailaddress!='' AND sentnotice=0 AND (superuser&" . NO_ACCOUNT_EXPIRATION . ')=0';
         $result = Database::query($sql);
 
         $subject = Translator::translateInline(self::$settingsExtended->getSetting('expirationnoticesubject'));

--- a/tests/NotifyUpcomingExpirationsQueryTest.php
+++ b/tests/NotifyUpcomingExpirationsQueryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\ExpireChars;
+use Lotgd\Settings;
+use Lotgd\Tests\Stubs\DbMysqli;
+use Lotgd\Tests\Stubs\Database;
+use Lotgd\Tests\Stubs\DummySettings;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class NotifyUpcomingExpirationsQueryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        class_exists(DbMysqli::class);
+        class_exists(Database::class);
+        if (!class_exists('Lotgd\\Doctrine\\Bootstrap', false)) {
+            require __DIR__ . '/Stubs/DoctrineBootstrap.php';
+        }
+        \Lotgd\MySQL\Database::$doctrineConnection = null;
+        \Lotgd\MySQL\Database::$instance = null;
+        \Lotgd\Tests\Stubs\DoctrineBootstrap::$conn = null;
+        Database::$queries = [];
+        Database::$mockResults = [];
+        Database::$affected_rows = 0;
+
+        Settings::setInstance(new DummySettings([
+            'expireoldacct' => 45,
+            'notifydaysbeforedeletion' => 5,
+            'gameadminemail' => 'admin@example.com',
+            'serverurl' => 'http://example.com',
+        ]));
+
+        $ref = new \ReflectionClass(ExpireChars::class);
+        $prop = $ref->getProperty('settingsExtended');
+        $prop->setAccessible(true);
+        $prop->setValue(null, new DummySettings([
+            'expirationnoticesubject' => 'Subject',
+            'expirationnoticetext' => 'Body',
+        ]));
+
+        class_exists(\Lotgd\Tests\Stubs\PHPMailer::class);
+        $GLOBALS['mail_sent_count'] = 0;
+    }
+
+    public function testQueryTargetsPendingAccounts(): void
+    {
+        Database::$mockResults = [
+            [
+                ['login' => 'tester', 'acctid' => 1, 'emailaddress' => 'tester@example.com'],
+            ],
+            true,
+        ];
+
+        $method = new \ReflectionMethod(ExpireChars::class, 'notifyUpcomingExpirations');
+        $method->setAccessible(true);
+        $method->invoke(null);
+
+        $expectedDate = date('Y-m-d H:i:s', strtotime('-40 days'));
+        $expected = 'SELECT login,acctid,emailaddress FROM accounts'
+            . " WHERE (laston < '$expectedDate')"
+            . " AND emailaddress!='' AND sentnotice=0 AND (superuser&" . NO_ACCOUNT_EXPIRATION . ')=0';
+
+        $this->assertSame($expected, Database::$queries[0]);
+        $this->assertSame(1, $GLOBALS['mail_sent_count']);
+        $this->assertStringContainsString('sentnotice=1', Database::$queries[1]);
+    }
+}


### PR DESCRIPTION
## Summary
- streamline impending-deletion notice query
- add regression test for upcoming expiration query

## Testing
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c471dc87148329a8fde7b96fcea002