### PR TITLE
fix: handle skipped character cleanup

### DIFF
--- a/tests/CharCleanupFailurePreventsDeletionTest.php
+++ b/tests/CharCleanupFailurePreventsDeletionTest.php
@@ -43,6 +43,8 @@ final class CharCleanupFailurePreventsDeletionTest extends TestCase
         foreach (Database::$queries as $query) {
             $this->assertStringNotContainsString('DELETE FROM accounts', $query);
         }
+        $this->assertContains('ROLLBACK', Database::$queries);
+        $this->assertNotContains('COMMIT', Database::$queries);
     }
 
     public function testUserDelAbortsOnCleanupFailure(): void


### PR DESCRIPTION
## Summary
- rollback transaction when character cleanup is prevented by a hook
- cover rollback behavior in tests

## Testing
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c480c280e483298de615da84461455