### PR TITLE
fix: use lowercase clan category in withdraw log

### DIFF
--- a/pages/clan/clan_withdraw.php
+++ b/pages/clan/clan_withdraw.php
@@ -37,7 +37,7 @@ if ($session['user']['clanrank'] >= CLAN_LEADER) {
             $sql = "UPDATE " . Database::prefix("accounts") . " SET clanid=0,clanrank=" . CLAN_APPLICANT . ",clanjoindate='" . DATETIME_DATEMIN . "' WHERE clanid={$session['user']['clanid']}";
             Database::query($sql);
             $output->output("`^As you were the last member of this clan, it has been deleted.");
-            GameLog::log("Clan " . $session['user']['clanid'] . " has been deleted, last member gone", "Clan");
+            GameLog::log("Clan " . $session['user']['clanid'] . " has been deleted, last member gone", "clan");
         }
     } else {
         //we don't have to do anything special with this clan as


### PR DESCRIPTION
## Summary
- use lowercase `clan` category when logging a clan deletion during withdrawal

## Testing
- `php -l pages/clan/clan_withdraw.php`
- `composer install`
- `composer test`
- `composer static`


------
https://chatgpt.com/codex/tasks/task_e_68c4987cee948329928a75cb3e848639