### PR TITLE
feat: log user management actions

### DIFF
--- a/pages/user/user_del.php
+++ b/pages/user/user_del.php
@@ -6,11 +6,13 @@ use Lotgd\PlayerFunctions;
 use Lotgd\Translator;
 use Lotgd\MySQL\Database;
 use Lotgd\AddNews;
+use Lotgd\GameLog;
 
 $sql = "SELECT name,superuser from " . Database::prefix("accounts") . " WHERE acctid='$userid'";
 $res = Database::query($sql);
 $cleanup = PlayerFunctions::charCleanup($userid, CHAR_DELETE_MANUAL);
 $fail = ! $cleanup;
+$username = '';
 while (! $fail && ($row = Database::fetchAssoc($res))) {
     if ($row['superuser'] > 0 && ($session['user']['superuser'] & SU_MEGAUSER) != SU_MEGAUSER) {
         $output->output("`\$You are trying to delete a user with superuser powers. Regardless of the type, ONLY a megauser can do so due to security reasons.");
@@ -19,9 +21,14 @@ while (! $fail && ($row = Database::fetchAssoc($res))) {
     }
     AddNews::add("`#%s was unmade by the gods.", $row['name'], true);
     debuglog("deleted user" . $row['name'] . "'0");
+    $username = $row['name'];
 }
 if ($fail !== true) {
     $sql = "DELETE FROM " . Database::prefix("accounts") . " WHERE acctid='$userid'";
     Database::query($sql);
     $output->output(Database::affectedRows() . " user deleted.");
+    GameLog::log(
+        'User ' . $userid . ' (' . $username . ') deleted by ' . $session['user']['acctid'],
+        'user management'
+    );
 }

--- a/pages/user/user_save.php
+++ b/pages/user/user_save.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Lotgd\Names;
 use Lotgd\Nav;
 use Lotgd\MySQL\Database;
+use Lotgd\GameLog;
 
 $sql = "";
 $updates = 0;
@@ -212,6 +213,10 @@ if ($updates > 0) {
     Database::query($sql);
     debug("Updated $updates fields in the user record with:\n$sql");
     $output->output("%s fields in the user's record were updated.", $updates);
+    GameLog::log(
+        'User ' . $session['user']['acctid'] . ' edited ' . $updates . ' fields for user ' . $userid,
+        'user management'
+    );
 } else {
     $output->output("No fields were changed in the user's record.");
 }


### PR DESCRIPTION
## Summary
- log manual user deletions
- log admin user field edits

## Testing
- `php -l pages/user/user_del.php`
- `php -l pages/user/user_save.php`
- `composer install --no-interaction --no-progress`
- `composer test`
- `composer static`


------
https://chatgpt.com/codex/tasks/task_e_68c498846e0883299724a10e73ceea33