### PR TITLE
feat: allow specifying account for game log entries

### DIFF
--- a/lib/gamelog.php
+++ b/lib/gamelog.php
@@ -2,7 +2,7 @@
 
 use Lotgd\GameLog;
 
-function gamelog($message, $category = "general", $filed = false)
+function gamelog($message, $category = "general", $filed = false, $acctId = null)
 {
-    GameLog::log($message, $category, $filed);
+    GameLog::log($message, $category, $filed, $acctId);
 }

--- a/src/Lotgd/ExpireChars.php
+++ b/src/Lotgd/ExpireChars.php
@@ -98,7 +98,12 @@ class ExpireChars
                     'char deletion failure'
                 );
             } elseif ($cleanupPerformed) {
-                GameLog::log('Deleted account ' . (int) $row['acctid'], 'char expiration');
+                GameLog::log(
+                    sprintf('Deleted account %d (%s)', $row['acctid'], $row['login']),
+                    'char expiration',
+                    false,
+                    0
+                );
             } else {
                 GameLog::log(
                     'Cleanup skipped for account ' . (int) $row['acctid'] . ' (prevented by hook)',

--- a/src/Lotgd/GameLog.php
+++ b/src/Lotgd/GameLog.php
@@ -15,12 +15,13 @@ class GameLog
     /**
      * Insert a log message into the database.
      */
-    public static function log(string $message, string $category = 'general', bool $filed = false): void
+    public static function log(string $message, string $category = 'general', bool $filed = false, ?int $acctId = null): void
     {
         global $session;
+        $who = $acctId ?? (int) ($session['user']['acctid'] ?? 0);
         $sql = 'INSERT INTO ' . Database::prefix('gamelog') .
             ' (message,category,filed,date,who) VALUES (' .
-            "'" . addslashes($message) . "','" . addslashes($category) . "','" . ($filed ? "1" : "0") . "','" . date('Y-m-d H:i:s') . "','" . ((int)($session['user']['acctid'] ?? 0)) . "')";
+            "'" . addslashes($message) . "','" . addslashes($category) . "','" . ($filed ? "1" : "0") . "','" . date('Y-m-d H:i:s') . "','" . $who . "')";
         Database::query($sql);
     }
 }

--- a/tests/CharCleanupFailurePreventsDeletionTest.php
+++ b/tests/CharCleanupFailurePreventsDeletionTest.php
@@ -28,7 +28,7 @@ final class CharCleanupFailurePreventsDeletionTest extends TestCase
             eval('namespace Lotgd; class PlayerFunctions { public static function charCleanup(int $id, int $type): bool { return false; } }');
         }
         if (! class_exists('Lotgd\\GameLog', false)) {
-            eval('namespace Lotgd; class GameLog { public static function log(string $m, string $c): void {} }');
+            eval('namespace Lotgd; class GameLog { public static function log(string $m, string $c, bool $f = false, ?int $a = null): void {} }');
         }
 
         Database::$mockResults = [

--- a/tests/CleanupExpiredAccountsLogsFailureTest.php
+++ b/tests/CleanupExpiredAccountsLogsFailureTest.php
@@ -29,7 +29,7 @@ final class CleanupExpiredAccountsLogsFailureTest extends TestCase
         }
 
         if (! class_exists('Lotgd\\GameLog', false)) {
-            eval('namespace Lotgd; class GameLog { public static array $entries = []; public static function log(string $m, string $c, bool $f = false): void { self::$entries[] = [$c, $m]; } }');
+            eval('namespace Lotgd; class GameLog { public static array $entries = []; public static function log(string $m, string $c, bool $f = false, ?int $a = null): void { self::$entries[] = [$c, $m]; } }');
         } else {
             \Lotgd\GameLog::$entries = [];
         }
@@ -73,7 +73,7 @@ final class CleanupExpiredAccountsLogsFailureTest extends TestCase
         $method->invoke(null);
 
         $this->assertSame('char expiration', \Lotgd\GameLog::$entries[0][0] ?? null);
-        $this->assertSame('Deleted account 1', \Lotgd\GameLog::$entries[0][1] ?? null);
+        $this->assertSame('Deleted account 1 (test)', \Lotgd\GameLog::$entries[0][1] ?? null);
         $this->assertCount(2, \Lotgd\GameLog::$entries);
 
         $this->assertStringContainsString('COMMIT', Database::$queries[3] ?? '');

--- a/tests/LogExpiredAccountStatsUsesDeletedAccountsTest.php
+++ b/tests/LogExpiredAccountStatsUsesDeletedAccountsTest.php
@@ -29,7 +29,7 @@ final class LogExpiredAccountStatsUsesDeletedAccountsTest extends TestCase
         }
 
         if (! class_exists('Lotgd\\GameLog', false)) {
-            eval('namespace Lotgd; class GameLog { public static array $entries = []; public static function log(string $m, string $c): void { self::$entries[] = [$c, $m]; } }');
+            eval('namespace Lotgd; class GameLog { public static array $entries = []; public static function log(string $m, string $c, bool $f = false, ?int $a = null): void { self::$entries[] = [$c, $m]; } }');
         } else {
             \Lotgd\GameLog::$entries = [];
         }


### PR DESCRIPTION
## Summary
- allow overriding the `who` field in `GameLog::log` with an optional account id
- record deleted accounts with their login name and a neutral `who` value during expiration cleanup
- update tests for new logger signature

## Testing
- `php -l src/Lotgd/GameLog.php`
- `php -l src/Lotgd/ExpireChars.php`
- `php -l lib/gamelog.php`
- `php -l tests/CleanupExpiredAccountsLogsFailureTest.php`
- `php -l tests/LogExpiredAccountStatsUsesDeletedAccountsTest.php`
- `php -l tests/CharCleanupFailurePreventsDeletionTest.php`
- `composer install`
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c52975c4f08329bdb969d04aefd9ed