### PR TITLE
fix: add unsuspend buff wrappers

### DIFF
--- a/lib/buffs.php
+++ b/lib/buffs.php
@@ -4,6 +4,7 @@
 // translator ready
 // mail ready
 
+use Lotgd\Battle;
 use Lotgd\Buffs;
 
 $buffreplacements = [];
@@ -52,4 +53,24 @@ function strip_all_buffs(): void
 function has_buff($name): bool
 {
     return Buffs::hasBuff($name);
+}
+
+function unsuspend_buffs($susp = false, $msg = false)
+{
+    Battle::unsuspendBuffs($susp, $msg);
+}
+
+function suspend_buffs($susp = false, $msg = false)
+{
+    Battle::suspendBuffs($susp, $msg);
+}
+
+function suspend_buff_by_name($name, $msg = false)
+{
+    Battle::suspendBuffByName($name, $msg);
+}
+
+function unsuspend_buff_by_name($name, $msg = false)
+{
+    Battle::unsuspendBuffByName($name, $msg);
 }


### PR DESCRIPTION
## Summary
- allow battle wrappers to unsuspend buffs from legacy lib
- add wrappers for suspending and unsuspending buffs by name for backward compatibility

## Testing
- `php -l lib/buffs.php`
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c529d6f5f4832998fb8e511eca39c4