### PR TITLE
refactor: remove redundant buff wrappers

### DIFF
--- a/lib/battle-skills.php
+++ b/lib/battle-skills.php
@@ -12,29 +12,9 @@ function report_power_move($crit, $dmg)
     return Battle::reportPowerMove($crit, $dmg);
 }
 
-function suspend_buffs($susp = false, $msg = false)
-{
-    Battle::suspendBuffs($susp, $msg);
-}
-
-function suspend_buff_by_name($name, $msg = false)
-{
-    Battle::suspendBuffByName($name, $msg);
-}
-
-function unsuspend_buff_by_name($name, $msg = false)
-{
-    Battle::unsuspendBuffByName($name, $msg);
-}
-
 function is_buff_active($name)
 {
     return Battle::isBuffActive($name);
-}
-
-function unsuspend_buffs($susp = false, $msg = false)
-{
-    Battle::unsuspendBuffs($susp, $msg);
 }
 
 function apply_bodyguard($level)


### PR DESCRIPTION
## Summary
- remove suspend buff wrappers from `lib/battle-skills.php`
- rely on `lib/buffs.php` for buff suspension helpers

## Testing
- `php -l lib/battle-skills.php`
- `composer test`
- `composer static`


------
https://chatgpt.com/codex/tasks/task_e_68c52b70ac548329b4480a1f3f8c498b