### PR TITLE
fix: include player context in maintenance logs

### DIFF
--- a/src/Lotgd/DataCache.php
+++ b/src/Lotgd/DataCache.php
@@ -122,6 +122,8 @@ class DataCache
      */
     public function invalidatedatacache(string $name, bool $withpath = true): void
     {
+        global $session;
+
         if (defined('DB_NODB') && DB_NODB) {
             return;
         }
@@ -133,7 +135,12 @@ class DataCache
         if ($settings->getSetting('usedatacache', 0)) {
             $fullname = $withpath ? $this->makecachetempname($name) : $name;
             if (is_file($fullname) && ! @unlink($fullname)) {
-                GameLog::log('Failed to remove cache file ' . $fullname, 'cache');
+                GameLog::log(
+                    'Failed to remove cache file ' . $fullname,
+                    'cache',
+                    false,
+                    $session['user']['acctid'] ?? 0
+                );
             }
             if (! $withpath) {
                 unset(self::$cache[$name]);

--- a/src/Lotgd/ExpireChars.php
+++ b/src/Lotgd/ExpireChars.php
@@ -56,6 +56,7 @@ class ExpireChars
      */
     private static function cleanupExpiredAccounts(): void
     {
+        global $session;
         $settings = Settings::getInstance();
         $old = (int) $settings->getSetting('expireoldacct', 45);
         $new = (int) $settings->getSetting('expirenewacct', 10);
@@ -95,19 +96,23 @@ class ExpireChars
             if ($error) {
                 GameLog::log(
                     'Failed to delete account ' . $row['acctid'] . ': ' . $error->getMessage(),
-                    'char deletion failure'
+                    'char deletion failure',
+                    false,
+                    $session['user']['acctid'] ?? 0
                 );
             } elseif ($cleanupPerformed) {
                 GameLog::log(
                     sprintf('Deleted account %d (%s)', $row['acctid'], $row['login']),
                     'char expiration',
                     false,
-                    0
+                    $session['user']['acctid'] ?? 0
                 );
             } else {
                 GameLog::log(
                     'Cleanup skipped for account ' . (int) $row['acctid'] . ' (prevented by hook)',
-                    'char expiration'
+                    'char expiration',
+                    false,
+                    $session['user']['acctid'] ?? 0
                 );
             }
         }
@@ -160,6 +165,7 @@ class ExpireChars
      */
     private static function logExpiredAccountStats(array $deletedRows): void
     {
+        global $session;
         $acctCount = count($deletedRows);
         if ($acctCount === 0) {
             return;
@@ -184,7 +190,12 @@ class ExpireChars
         $msg .= 'Avg DK: [' . round($dks / max(1, $acctCount), 2) . "]\n";
         $msg .= 'Accounts: ' . implode(', ', $info);
 
-        GameLog::log('Deleted ' . $acctCount . " accounts:\n$msg", 'char expiration');
+        GameLog::log(
+            'Deleted ' . $acctCount . " accounts:\n$msg",
+            'char expiration',
+            false,
+            $session['user']['acctid'] ?? 0
+        );
     }
 
 

--- a/src/Lotgd/ModuleManager.php
+++ b/src/Lotgd/ModuleManager.php
@@ -67,10 +67,16 @@ class ModuleManager
      */
     public static function install(string $module): bool
     {
+        global $session;
         if (Installer::install($module)) {
             DataCache::getInstance()->massinvalidate('hook');
             DataCache::getInstance()->massinvalidate('module-prepare');
-            GameLog::log("Module {$module} installed", 'modules');
+            GameLog::log(
+                "Module {$module} installed",
+                'modules',
+                false,
+                $session['user']['acctid'] ?? 0
+            );
 
             return true;
         }
@@ -85,11 +91,17 @@ class ModuleManager
      */
     public static function uninstall(string $module): bool
     {
+        global $session;
         if (Installer::uninstall($module)) {
             DataCache::getInstance()->massinvalidate('hook');
             DataCache::getInstance()->massinvalidate('module-prepare');
             DataCache::getInstance()->invalidatedatacache("inject-$module");
-            GameLog::log("Module {$module} uninstalled", 'modules');
+            GameLog::log(
+                "Module {$module} uninstalled",
+                'modules',
+                false,
+                $session['user']['acctid'] ?? 0
+            );
 
             return true;
         }
@@ -102,6 +114,7 @@ class ModuleManager
      */
     public static function activate(string $module): bool
     {
+        global $session;
         $res = Installer::activate($module);
         DataCache::getInstance()->invalidatedatacache("inject-$module");
         DataCache::getInstance()->massinvalidate('hook');
@@ -109,7 +122,12 @@ class ModuleManager
         Modules::inject($module, true);
 
         if ($res) {
-            GameLog::log("Module {$module} activated", 'modules');
+            GameLog::log(
+                "Module {$module} activated",
+                'modules',
+                false,
+                $session['user']['acctid'] ?? 0
+            );
         }
 
         return $res;
@@ -120,12 +138,18 @@ class ModuleManager
      */
     public static function deactivate(string $module): bool
     {
+        global $session;
         $res = Installer::deactivate($module);
         DataCache::getInstance()->invalidatedatacache("inject-$module");
         DataCache::getInstance()->massinvalidate('module-prepare');
 
         if ($res) {
-            GameLog::log("Module {$module} deactivated", 'modules');
+            GameLog::log(
+                "Module {$module} deactivated",
+                'modules',
+                false,
+                $session['user']['acctid'] ?? 0
+            );
         }
 
         return $res;
@@ -136,13 +160,19 @@ class ModuleManager
      */
     public static function reinstall(string $module): bool
     {
+        global $session;
         $sql = 'UPDATE ' . Database::prefix('modules') . " SET filemoddate='" . DATETIME_DATEMIN . "' WHERE modulename='" . $module . "'";
         Database::query($sql);
         DataCache::getInstance()->invalidatedatacache("inject-$module");
         DataCache::getInstance()->massinvalidate('hook');
         DataCache::getInstance()->massinvalidate('module-prepare');
         Modules::inject($module, true);
-        GameLog::log("Module {$module} reinstalled", 'modules');
+        GameLog::log(
+            "Module {$module} reinstalled",
+            'modules',
+            false,
+            $session['user']['acctid'] ?? 0
+        );
 
         return true;
     }
@@ -152,11 +182,17 @@ class ModuleManager
      */
     public static function forceUninstall(string $module): bool
     {
+        global $session;
         if (Installer::forceUninstall($module)) {
             DataCache::getInstance()->massinvalidate('hook');
             DataCache::getInstance()->massinvalidate('module-prepare');
             DataCache::getInstance()->invalidatedatacache("inject-$module");
-            GameLog::log("Module {$module} force-uninstalled", 'modules');
+            GameLog::log(
+                "Module {$module} force-uninstalled",
+                'modules',
+                false,
+                $session['user']['acctid'] ?? 0
+            );
 
             return true;
         }

--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -20,6 +20,7 @@ class Newday
 {
     public static function dbCleanup(): void
     {
+        global $session;
         Settings::getInstance()->saveSetting("lastdboptimize", date("Y-m-d H:i:s"));
         // Fetch all table names at once to avoid leaving an unbuffered
         // result active which can cause "Cannot execute queries while other
@@ -36,16 +37,27 @@ class Newday
             }
         }
         $time = round(microtime(true) - $start, 2);
-        GameLog::log('Optimized tables: ' . join(', ', $tables) . " in $time seconds.", 'maintenance');
+        GameLog::log(
+            'Optimized tables: ' . join(', ', $tables) . " in $time seconds.",
+            'maintenance',
+            false,
+            $session['user']['acctid'] ?? 0
+        );
     }
 
     public static function commentCleanup(): void
     {
+        global $session;
         $settings = Settings::getInstance();
 
         $timestamp = self::calculateExpirationTimestamp('2 month');
         Database::query('DELETE FROM ' . Database::prefix('referers') . " WHERE last < '$timestamp'");
-        GameLog::log('Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('referers') . " older than $timestamp.", 'maintenance');
+        GameLog::log(
+            'Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('referers') . " older than $timestamp.",
+            'maintenance',
+            false,
+            $session['user']['acctid'] ?? 0
+        );
 
         $timestamp = date('Y-m-d H:i:s', strtotime('now'));
         $sql = 'INSERT IGNORE INTO ' . Database::prefix('debuglog_archive') .
@@ -54,26 +66,48 @@ class Newday
         if ($ok) {
             $sql = 'DELETE FROM ' . Database::prefix('debuglog') . " WHERE date <'$timestamp'";
             Database::query($sql);
-        $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expiredebuglog', 18) . ' days');
+
+            $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expiredebuglog', 18) . ' days');
             $sql = 'DELETE FROM ' . Database::prefix('debuglog_archive') . " WHERE date <'$timestamp'";
             if ($settings->getSetting('expiredebuglog', 18) > 0) {
                 Database::query($sql);
             }
-            GameLog::log('Moved ' . Database::affectedRows() . ' from ' . Database::prefix('debuglog') . ' to ' . Database::prefix('debuglog_archive') . " older than $timestamp.", 'maintenance');
+
+            GameLog::log(
+                'Moved ' . Database::affectedRows() . ' from ' . Database::prefix('debuglog') . ' to ' . Database::prefix('debuglog_archive') . " older than $timestamp.",
+                'maintenance',
+                false,
+                $session['user']['acctid'] ?? 0
+            );
         } else {
-            GameLog::log('ERROR, problems with moving the debuglog to the archive', 'maintenance');
+            GameLog::log(
+                'ERROR, problems with moving the debuglog to the archive',
+                'maintenance',
+                false,
+                $session['user']['acctid'] ?? 0
+            );
         }
 
         $timestamp = self::calculateExpirationTimestamp($settings->getSetting('oldmail', 14) . ' days');
         $sql = 'DELETE FROM ' . Database::prefix('mail') . " WHERE sent<'$timestamp'";
         Database::query($sql);
-        GameLog::log('Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('mail') . " older than $timestamp.", 'maintenance');
+        GameLog::log(
+            'Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('mail') . " older than $timestamp.",
+            'maintenance',
+            false,
+            $session['user']['acctid'] ?? 0
+        );
         DataCache::getInstance()->massinvalidate('mail');
 
         if ((int) $settings->getSetting('expirecontent', 180) > 0) {
             $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expirecontent', 180) . ' days');
             $sql = 'DELETE FROM ' . Database::prefix('news') . " WHERE newsdate<'$timestamp'";
-            GameLog::log('Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('news') . " older than $timestamp.", 'comment expiration');
+            GameLog::log(
+                'Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('news') . " older than $timestamp.",
+                'comment expiration',
+                false,
+                $session['user']['acctid'] ?? 0
+            );
             Database::query($sql);
         }
 
@@ -81,28 +115,48 @@ class Newday
         $sql = 'DELETE FROM ' . Database::prefix('gamelog') . " WHERE date < '$timestamp' ";
         if ($settings->getSetting('expiregamelog', 30) > 0) {
             Database::query($sql);
-            GameLog::log('Cleaned up ' . Database::prefix('gamelog') . ' table removing ' . Database::affectedRows() . " older than $timestamp.", 'maintenance');
+            GameLog::log(
+                'Cleaned up ' . Database::prefix('gamelog') . ' table removing ' . Database::affectedRows() . " older than $timestamp.",
+                'maintenance',
+                false,
+                $session['user']['acctid'] ?? 0
+            );
         }
 
         $sql = 'DELETE FROM ' . Database::prefix('commentary') . " WHERE postdate<'" . self::calculateExpirationTimestamp($settings->getSetting('expirecontent', 180) . ' days') . "'";
         if ($settings->getSetting('expirecontent', 180) > 0) {
             $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expirecontent', 180) . ' days');
             Database::query($sql);
-            GameLog::log('Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('commentary') . " older than $timestamp.", 'comment expiration');
+            GameLog::log(
+                'Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('commentary') . " older than $timestamp.",
+                'comment expiration',
+                false,
+                $session['user']['acctid'] ?? 0
+            );
         }
 
         $sql = 'DELETE FROM ' . Database::prefix('moderatedcomments') . " WHERE moddate<'" . self::calculateExpirationTimestamp($settings->getSetting('expirecontent', 180) . ' days') . "'";
         if ($settings->getSetting('expirecontent', 180) > 0) {
             $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expirecontent', 180) . ' days');
             Database::query($sql);
-            GameLog::log('Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('moderatedcomments') . " older than $timestamp.", 'comment expiration');
+            GameLog::log(
+                'Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('moderatedcomments') . " older than $timestamp.",
+                'comment expiration',
+                false,
+                $session['user']['acctid'] ?? 0
+            );
         }
 
         $sql = 'DELETE FROM ' . Database::prefix('faillog') . " WHERE date<'" . self::calculateExpirationTimestamp($settings->getSetting('expirefaillog', 1) . ' days') . "'";
         if ($settings->getSetting('expirefaillog', 1) > 0) {
             Database::query($sql);
             $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expirecontent', 180) . ' days');
-            GameLog::log('Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('faillog') . " older than $timestamp.", 'maintenance');
+            GameLog::log(
+                'Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('faillog') . " older than $timestamp.",
+                'maintenance',
+                false,
+                $session['user']['acctid'] ?? 0
+            );
         }
     }
 

--- a/src/Lotgd/PlayerFunctions.php
+++ b/src/Lotgd/PlayerFunctions.php
@@ -27,6 +27,7 @@ class PlayerFunctions
      */
     public static function charCleanup(int $id, int $type): bool
     {
+        global $session;
         // Run module hooks for character deletion
         $args = HookHandler::hook('delete_character', ['acctid' => $id, 'deltype' => $type]);
 
@@ -62,11 +63,21 @@ class PlayerFunctions
                         $sql = 'UPDATE ' . Database::prefix('accounts') . ' SET clanrank=' . CLAN_LEADER . " WHERE acctid=$id1";
                         Database::query($sql);
                     }
-                    GameLog::log('Clan ' . $cid . ' has a new leader ' . $row['name'] . ' as there were no others left', 'clan');
+                    GameLog::log(
+                        'Clan ' . $cid . ' has a new leader ' . $row['name'] . ' as there were no others left',
+                        'clan',
+                        false,
+                        $session['user']['acctid'] ?? 0
+                    );
                 } else {
                     $sql = 'DELETE FROM ' . Database::prefix('clans') . " WHERE clanid=$cid";
                     Database::query($sql);
-                    GameLog::log('Clan ' . $cid . ' has been disbanded as the last member left', 'clan');
+                    GameLog::log(
+                        'Clan ' . $cid . ' has been disbanded as the last member left',
+                        'clan',
+                        false,
+                        $session['user']['acctid'] ?? 0
+                    );
                     $sql = 'UPDATE ' . Database::prefix('accounts') . " SET clanid=0,clanrank=0,clanjoindate='" . DATETIME_DATEMIN . "' WHERE clanid=$cid";
                     Database::query($sql);
                 }


### PR DESCRIPTION
## Summary
- append current account ID when maintenance scripts write to the game log
- cover module and clan maintenance paths as well

## Testing
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c53a3e42bc8329904c9277a4a9b475