### PR TITLE
fix: show system label for anonymous gamelog entries

### DIFF
--- a/gamelog.php
+++ b/gamelog.php
@@ -1,7 +1,5 @@
 <?php
 use Lotgd\MySQL\Database;
-use Lotgd\Translator;
-
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
 
@@ -11,12 +9,13 @@ use Lotgd\Nav\SuperuserNav;
 
 // Written by Christian Rutsch
 
-require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/http.php";
+if (!defined('GAMELOG_TEST')) {
+    require_once __DIR__ . "/common.php";
+    require_once __DIR__ . "/lib/http.php";
+}
 
 SuAccess::check(SU_EDIT_CONFIG);
 
-Translator::getInstance()->setSchema("gamelog");
 
 page_header("Game Log");
 addnav("Navigation");
@@ -75,10 +74,16 @@ while ($row = Database::fetchAssoc($result)) {
         $odate = $dom;
     }
     $time = date("H:i:s", strtotime($row['date'])) . " (" . reltime(strtotime($row['date'])) . ")";
-    if ($row['name'] != '') {
+    if ($row['name'] != '' && (int) ($row['who'] ?? 0) !== 0) {
         output_notl("`7(`\$%s`7) %s `7(`&%s`7) (`v%s`7)", $row['category'], $row['message'], $row['name'], $time);
     } else {
-        output_notl("`7(`\$%s`7) %s `7(`v%s`7)", $row['category'], $row['message'], $time);
+        output_notl(
+            "`7(`\$%s`7) %s: %s `7(`v%s`7)",
+            $row['category'],
+            'System',
+            $row['message'],
+            $time
+        );
     }
     if (!isset($categories[$row['category']]) && $category == "") {
         addnav("Operations");

--- a/tests/GameLogSystemLabelTest.php
+++ b/tests/GameLogSystemLabelTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class GameLogSystemLabelTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $forms_output;
+        $forms_output = '';
+
+        if (!class_exists('\\Lotgd\\SuAccess', false)) {
+            eval('namespace Lotgd; class SuAccess { public static function check(int $level): void {} }');
+        }
+        if (!class_exists('\\Lotgd\\Nav\\SuperuserNav', false)) {
+            eval('namespace Lotgd\\Nav; class SuperuserNav { public static function render(): void {} }');
+        }
+        if (!function_exists('page_header')) {
+            eval('function page_header($title): void {}');
+        }
+        if (!function_exists('page_footer')) {
+            eval('function page_footer(): void {}');
+        }
+        if (!function_exists('httpget')) {
+            eval('function httpget(string $name) { return $_GET[$name] ?? ""; }');
+        }
+        if (!function_exists('reltime')) {
+            eval('function reltime(int $timestamp): string { return "ago"; }');
+        }
+
+        Database::$mockResults = [
+            [['c' => 1]],
+            [[
+                'date' => '2024-01-01 00:00:00',
+                'category' => 'general',
+                'message' => 'Something happened',
+                'name' => '',
+                'who' => 0,
+            ]],
+        ];
+        if (!defined('DB_CHOSEN')) {
+            define('DB_CHOSEN', false);
+        }
+        $_GET = [];
+    }
+
+    public function testSystemLabelShownForWhoZero(): void
+    {
+        if (!defined('GAMELOG_TEST')) {
+            define('GAMELOG_TEST', true);
+        }
+        require __DIR__ . '/../gamelog.php';
+        global $forms_output;
+        $this->assertStringContainsString('System: Something happened', $forms_output);
+    }
+}
+


### PR DESCRIPTION
## Summary
- display a fixed "System" label for gamelog entries without an associated user
- remove unused translation file
- test display of the "System" label for who=0 entries

## Testing
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c53a55de00832990e5792f931c80b4