### PR TITLE
fix: restore settings instance after extended init

### DIFF
--- a/src/Lotgd/ExpireChars.php
+++ b/src/Lotgd/ExpireChars.php
@@ -24,9 +24,13 @@ class ExpireChars
     /** Execute the full expiration routine. */
     public static function expire(): void
     {
-        self::$settingsExtended = new Settings('settings_extended');
+        $original = Settings::getInstance();
 
-        if (!self::needsExpiration()) {
+        self::$settingsExtended = new Settings('settings_extended');
+        Settings::setInstance($original);
+        $GLOBALS['settings'] = $original;
+
+        if (! self::needsExpiration()) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- preserve original Settings singleton when ExpireChars initializes extended settings

## Testing
- `composer test`
- `composer static`


------
https://chatgpt.com/codex/tasks/task_e_68c5b22abf948329b2cf46298fe06553