### PR TITLE
fix: preserve settings singleton after extended instantiation

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -18,9 +18,12 @@ use Lotgd\PhpGenericEnvironment;
 
 
 require_once __DIR__ . "/common.php";
+$previous = Settings::getInstance();
 $output = Output::getInstance();
 // legacy wrapper removed, instantiate settings directly
 $settings_extended = new Settings('settings_extended');
+Settings::setInstance($previous);
+$GLOBALS['settings'] = $settings = $previous;
 
 SuAccess::check(SU_EDIT_CONFIG);
 


### PR DESCRIPTION
## Summary
- Preserve the original `Settings` singleton when creating the extended settings handler
- Ensure extended options operate on their own handler without affecting legacy calls

## Testing
- `php -l configuration.php`
- `composer test`
- `composer static`

------
https://chatgpt.com/codex/tasks/task_e_68c5b235b7d8832988ee45b17dbfe31a