### PR TITLE
fix: restore settings after using extended templates

### DIFF
--- a/src/Lotgd/Mail.php
+++ b/src/Lotgd/Mail.php
@@ -103,9 +103,13 @@ class Mail
             $body = preg_replace("'[`]n'", "\n", $body);
             $body = Sanitize::fullSanitize($body);
             $subject = htmlentities(Sanitize::fullSanitize($subject), ENT_COMPAT, $settings->getSetting('charset', 'UTF-8'));
+            $original = Settings::getInstance();
             $settings_extended = new Settings('settings_extended');
             $subj = Translator::translateMail($settings_extended->getSetting('notificationmailsubject'), $to);
             $msg = Translator::translateMail($settings_extended->getSetting('notificationmailtext'), $to);
+            Settings::setInstance($original);
+            $GLOBALS['settings'] = $original;
+            $settings = $original;
             $replace = [
                 '{subject}' => stripslashes($subject),
                 '{sendername}' => $fromline,


### PR DESCRIPTION
## Summary
- restore Settings singleton after accessing extended template settings in systemMail

## Testing
- `composer test`
- `composer static`


------
https://chatgpt.com/codex/tasks/task_e_68c5bcc5d65483299633cd5f8ae90a21