### PR TITLE
fix: restore Settings instance after loading extended settings

### DIFF
--- a/create.php
+++ b/create.php
@@ -15,11 +15,15 @@ use Lotgd\Settings;
 use Lotgd\Sanitize;
 use Lotgd\DebugLog;
 use Lotgd\Cookies;
+use Lotgd\ServerFunctions;
+
 require_once __DIR__ . "/common.php";
 require_once __DIR__ . "/lib/is_email.php";
-// legacy wrapper removed, instantiate settings directly
+
+$original = Settings::getInstance();
 $settings_extended = new Settings('settings_extended');
-use Lotgd\ServerFunctions;
+Settings::setInstance($original);
+$GLOBALS['settings'] = $original;
 
 Translator::getInstance()->setSchema("create");
 


### PR DESCRIPTION
## Summary
- Preserve original `Settings` singleton in create process
- Instantiate extended settings for email templates without altering global state

## Testing
- `php -l create.php`
- `composer install`
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c5bcc435208329b574ef8c763d94ca