### PR TITLE
chore: exclude md5.js from PHPCS

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,4 +4,5 @@
 		<exclude name="Generic.Files.LineLength"/>
 	</rule>
 	<exclude-pattern>vendor/*</exclude-pattern>
+        <exclude-pattern>lib/md5.js</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
## Summary
- ignore lib/md5.js in PHPCS ruleset to keep legacy JS out of linting

## Testing
- `composer lint` (fails: Script phpcs . handling the lint event returned with error code 2)
- `composer lint:fix` (fails: Script phpcbf . handling the lint:fix event returned with error code 1)
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c6eec61aac8329b2148ecf307ab1bc