### PR TITLE
refactor: relocate migration configs

### DIFF
--- a/config/migrations.php
+++ b/config/migrations.php
@@ -1,7 +1,0 @@
-<?php
-
-return [
-    'migrations_paths' => [
-        'Lotgd\\Migrations' => dirname(__DIR__) . '/migrations',
-    ],
-];

--- a/docs/Doctrine.md
+++ b/docs/Doctrine.md
@@ -29,32 +29,32 @@ $repo = $entityManager->getRepository(Lotgd\Entity\Account::class);
 ## Running Migrations
 
 Schema migrations reside in the `migrations/` directory and are configured
-through two files stored in `config/`:
+through two files stored in `src/Lotgd/Config/`:
 
-* `config/migrations.php` – defines migration paths. When using a single
+* `src/Lotgd/Config/migrations.php` – defines migration paths. When using a single
   connection no additional options are required. For multiple connections you
   may specify a `connection` key to select which database configuration to use.
-* `config/migrations-db.php` – provides the database credentials. With one
+* `src/Lotgd/Config/migrations-db.php` – provides the database credentials. With one
   connection it returns the parameters directly. To support multiple connections
   return an array keyed by connection name.
 
-In a single connection setup `config/migrations.php` only lists
-`migrations_paths` and `config/migrations-db.php` contains the connection
+In a single connection setup `src/Lotgd/Config/migrations.php` only lists
+`migrations_paths` and `src/Lotgd/Config/migrations-db.php` contains the connection
 details:
 
 ```php
 <?php
-// config/migrations.php
+// src/Lotgd/Config/migrations.php
 return [
     'migrations_paths' => [
-        'Lotgd\\Migrations' => dirname(__DIR__) . '/migrations',
+        'Lotgd\\Migrations' => dirname(__DIR__, 2) . '/migrations',
     ],
 ];
 ```
 
 ```php
 <?php
-// config/migrations-db.php
+// src/Lotgd/Config/migrations-db.php
 return [
     'driver' => 'pdo_mysql',
     'host' => 'localhost',
@@ -66,8 +66,8 @@ return [
 ```
 
 If you need more than one connection, add a `connection` key in
-`config/migrations.php` and return an array of credentials keyed by name from
-`config/migrations-db.php`.
+`src/Lotgd/Config/migrations.php` and return an array of credentials keyed by name from
+`src/Lotgd/Config/migrations-db.php`.
 
 Run pending migrations:
 
@@ -76,14 +76,14 @@ Run pending migrations:
 php vendor/bin/doctrine-migrations migrate
 ```
 
-The command automatically reads `config/migrations.php` and
-`config/migrations-db.php`. If you store them elsewhere, pass the paths
+The command automatically reads `src/Lotgd/Config/migrations.php` and
+`src/Lotgd/Config/migrations-db.php`. If you store them elsewhere, pass the paths
 explicitly:
 
 ```bash
 php vendor/bin/doctrine-migrations \
-    --configuration=config/migrations.php \
-    --db-configuration=config/migrations-db.php migrate
+    --configuration=src/Lotgd/Config/migrations.php \
+    --db-configuration=src/Lotgd/Config/migrations-db.php migrate
 ```
 
 ### Upgrade Notes

--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -144,9 +144,9 @@ try {
 
 ## Database Migrations
 
-The project uses [Doctrine Migrations](https://www.doctrine-project.org/projects/migrations.html) to manage schema changes. The migration classes live in the `migrations/` directory and are configured through `config/migrations.php` and `config/migrations-db.php`.
+The project uses [Doctrine Migrations](https://www.doctrine-project.org/projects/migrations.html) to manage schema changes. The migration classes live in the `migrations/` directory and are configured through `src/Lotgd/Config/migrations.php` and `src/Lotgd/Config/migrations-db.php`.
 
-`config/migrations.php` defines the migration paths. With a single database connection it contains only `migrations_paths` and all connection parameters reside in `config/migrations-db.php`. If multiple connections are required, add a `connection` key in `config/migrations.php` and return an array of credentials keyed by name from `config/migrations-db.php`.
+`src/Lotgd/Config/migrations.php` defines the migration paths. With a single database connection it contains only `migrations_paths` and all connection parameters reside in `src/Lotgd/Config/migrations-db.php`. If multiple connections are required, add a `connection` key in `src/Lotgd/Config/migrations.php` and return an array of credentials keyed by name from `src/Lotgd/Config/migrations-db.php`.
 
 ### Running Migrations
 
@@ -156,12 +156,12 @@ Execute pending migrations with the Doctrine command line tool:
 php vendor/bin/doctrine-migrations migrate
 ```
 
-The command uses the default `config/migrations.php` and `config/migrations-db.php` files. If your configuration lives elsewhere, provide their paths explicitly:
+The command uses the default `src/Lotgd/Config/migrations.php` and `src/Lotgd/Config/migrations-db.php` files. If your configuration lives elsewhere, provide their paths explicitly:
 
 ```bash
 php vendor/bin/doctrine-migrations \
-    --configuration=config/migrations.php \
-    --db-configuration=config/migrations-db.php migrate
+    --configuration=src/Lotgd/Config/migrations.php \
+    --db-configuration=src/Lotgd/Config/migrations-db.php migrate
 ```
 
 This will apply all new migrations to the configured database. During development you can generate additional migrations using `migrations:diff` or `migrations:generate`.

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1465,7 +1465,7 @@ class Installer
         $DB_PREFIX = $db['DB_PREFIX'] ?? '';
         InstallerLogger::log('DB_PREFIX set to ' . $DB_PREFIX);
 
-        $config = require dirname(__DIR__, 2) . '/config/migrations.php';
+        $config = require dirname(__DIR__, 2) . '/src/Lotgd/Config/migrations.php';
 
         $em = Bootstrap::getEntityManager();
 

--- a/src/Lotgd/Config/migrations-db.php
+++ b/src/Lotgd/Config/migrations-db.php
@@ -2,7 +2,7 @@
 
 use Lotgd\MySQL\Database;
 
-$db = require dirname(__DIR__) . '/dbconnect.php';
+$db = require dirname(__DIR__, 2) . '/dbconnect.php';
 
 return [
     'driver' => $db['DB_DRIVER'] ?? 'pdo_mysql',

--- a/src/Lotgd/Config/migrations.php
+++ b/src/Lotgd/Config/migrations.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'migrations_paths' => [
+        'Lotgd\\Migrations' => dirname(__DIR__, 2) . '/migrations',
+    ],
+];


### PR DESCRIPTION
## Summary
- move migrations.php and migrations-db.php into src/Lotgd/Config
- update installer and docs for new migration config paths

## Testing
- `composer install`
- `composer static`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c7271737e4832984373fde568bed56