### PR TITLE
fix: use new migrations config path

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1465,7 +1465,7 @@ class Installer
         $DB_PREFIX = $db['DB_PREFIX'] ?? '';
         InstallerLogger::log('DB_PREFIX set to ' . $DB_PREFIX);
 
-        $config = require dirname(__DIR__, 2) . '/config/migrations.php';
+        $config = require dirname(__DIR__, 2) . '/src/Lotgd/Config/migrations.php';
 
         $em = Bootstrap::getEntityManager();
 

--- a/src/Lotgd/Config/migrations.php
+++ b/src/Lotgd/Config/migrations.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'migrations_paths' => [
+        'Lotgd\\Migrations' => dirname(__DIR__, 3) . '/migrations',
+    ],
+];


### PR DESCRIPTION
## Summary
- point installer migrations configuration to new location

## Testing
- `composer install`
- `php -l install/lib/Installer.php`
- `composer static`
- `composer test` *(fails: Attempt to read property "migrated" on null)*

------
https://chatgpt.com/codex/tasks/task_e_68c72717a6fc8329bec1136f05104af0