### PR TITLE
docs: favor bin/doctrine for migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,9 +263,14 @@ Doctrine migrations.
 
 2. **Step 2**:
 
-   ```bash
-   php vendor/bin/doctrine-migrations migrate
-   ```
+    ```bash
+    php bin/doctrine migrations:migrate
+    ```
+
+    The command reads `src/Lotgd/Config/migrations.php` and
+    `src/Lotgd/Config/migrations-db.php` by default. If your configuration lives
+    elsewhere, pass `--configuration` and `--db-configuration` with the
+    appropriate paths.
 
 Omitting `--from-version` bypasses legacy SQL entirely.
 - [Installation](#installation)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -54,11 +54,15 @@ If you are coming directly from **1.3.2** (or earlier 1.x):
 Once the legacy upgrade is complete:
 
 1. In your project root, run:
-   ```bash
-   vendor/bin/doctrine-migrations migrate
-   ```
-2. This will apply all new **2.x schema changes**.  
-3. Watch for any DB prefix issues — these are now supported and should migrate correctly.
+    ```bash
+    php bin/doctrine migrations:migrate
+    ```
+2. The command reads `src/Lotgd/Config/migrations.php` and
+   `src/Lotgd/Config/migrations-db.php` by default. If you use custom paths,
+   supply `--configuration` and `--db-configuration` flags with the appropriate
+   locations.
+3. This will apply all new **2.x schema changes**.
+4. Watch for any DB prefix issues — these are now supported and should migrate correctly.
 
 ---
 

--- a/docs/Doctrine.md
+++ b/docs/Doctrine.md
@@ -47,7 +47,7 @@ details:
 // src/Lotgd/Config/migrations.php
 return [
     'migrations_paths' => [
-        'Lotgd\\Migrations' => dirname(__DIR__, 2) . '/migrations',
+        'Lotgd\\Migrations' => dirname(__DIR__, 3) . '/migrations',
     ],
 ];
 ```
@@ -72,8 +72,7 @@ If you need more than one connection, add a `connection` key in
 Run pending migrations:
 
 ```bash
-
-php vendor/bin/doctrine-migrations migrate
+php bin/doctrine migrations:migrate
 ```
 
 The command automatically reads `src/Lotgd/Config/migrations.php` and
@@ -81,15 +80,15 @@ The command automatically reads `src/Lotgd/Config/migrations.php` and
 explicitly:
 
 ```bash
-php vendor/bin/doctrine-migrations \
+php bin/doctrine \
     --configuration=src/Lotgd/Config/migrations.php \
-    --db-configuration=src/Lotgd/Config/migrations-db.php migrate
+    --db-configuration=src/Lotgd/Config/migrations-db.php migrations:migrate
 ```
 
 ### Upgrade Notes
 
 Earlier versions used a single `config/doctrine.php`. Replace it with the split
-configuration above and run `php vendor/bin/doctrine-migrations migrate` when
+configuration above and run `php bin/doctrine migrations:migrate` when
 upgrading.
 
 ## Persisting an Account

--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -153,15 +153,15 @@ The project uses [Doctrine Migrations](https://www.doctrine-project.org/projects
 Execute pending migrations with the Doctrine command line tool:
 
 ```bash
-php vendor/bin/doctrine-migrations migrate
+php bin/doctrine migrations:migrate
 ```
 
 The command uses the default `src/Lotgd/Config/migrations.php` and `src/Lotgd/Config/migrations-db.php` files. If your configuration lives elsewhere, provide their paths explicitly:
 
 ```bash
-php vendor/bin/doctrine-migrations \
+php bin/doctrine \
     --configuration=src/Lotgd/Config/migrations.php \
-    --db-configuration=src/Lotgd/Config/migrations-db.php migrate
+    --db-configuration=src/Lotgd/Config/migrations-db.php migrations:migrate
 ```
 
 This will apply all new migrations to the configured database. During development you can generate additional migrations using `migrations:diff` or `migrations:generate`.


### PR DESCRIPTION
## Summary
- document `dirname(__DIR__, 3)` for `migrations.php`
- prefer `php bin/doctrine` over vendor binary and show config flags

## Testing
- `composer test`
- `composer static`

------
https://chatgpt.com/codex/tasks/task_e_68c72fd371508329bd69283d929146c1