### PR TITLE
fix: load dbconnect from project root in migrations config

### DIFF
--- a/src/Lotgd/Config/migrations-db.php
+++ b/src/Lotgd/Config/migrations-db.php
@@ -2,7 +2,7 @@
 
 use Lotgd\MySQL\Database;
 
-$db = require dirname(__DIR__, 2) . '/dbconnect.php';
+$db = require dirname(__DIR__, 3) . '/dbconnect.php';
 
 return [
     'driver' => $db['DB_DRIVER'] ?? 'pdo_mysql',


### PR DESCRIPTION
## Summary
- Adjust migrations db config to require dbconnect from project root

## Testing
- `php -l src/Lotgd/Config/migrations-db.php`
- `composer test`
- `composer static`


------
https://chatgpt.com/codex/tasks/task_e_68c72fca11708329bdc06d058ce5b074