### PR TITLE
fix: ensure doctrine wrapper loads default migration configs

### DIFF
--- a/bin/doctrine
+++ b/bin/doctrine
@@ -29,6 +29,25 @@ if ($fromVersion !== null && $fromVersion !== '') {
     }
 }
 
+// Ensure default configuration paths are included unless already provided
+$hasConfiguration = false;
+$hasDbConfiguration = false;
+foreach ($filtered as $arg) {
+    if ($arg === '--configuration' || str_starts_with($arg, '--configuration=')) {
+        $hasConfiguration = true;
+    }
+    if ($arg === '--db-configuration' || str_starts_with($arg, '--db-configuration=')) {
+        $hasDbConfiguration = true;
+    }
+}
+
+if (! $hasConfiguration) {
+    $filtered[] = '--configuration=src/Lotgd/Config/migrations.php';
+}
+if (! $hasDbConfiguration) {
+    $filtered[] = '--db-configuration=src/Lotgd/Config/migrations-db.php';
+}
+
 $vendor = __DIR__ . '/../vendor/bin/doctrine-migrations';
 $command = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($vendor);
 if ($filtered) {

--- a/tests/DoctrineWrapperTest.php
+++ b/tests/DoctrineWrapperTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+final class DoctrineWrapperTest extends TestCase
+{
+    private string $vendor;
+    private string $backup;
+
+    protected function setUp(): void
+    {
+        $this->vendor = __DIR__ . '/../vendor/bin/doctrine-migrations';
+        $this->backup = $this->vendor . '.bak';
+        rename($this->vendor, $this->backup);
+
+        $stub = "#!/usr/bin/env php\n<?php echo json_encode(\$_SERVER['argv']);";
+        file_put_contents($this->vendor, $stub);
+        chmod($this->vendor, 0755);
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->backup)) {
+            rename($this->backup, $this->vendor);
+        }
+    }
+
+    public function testDefaultConfigArgsAreAppended(): void
+    {
+        $cmd = escapeshellcmd(PHP_BINARY) . ' ' . escapeshellarg(__DIR__ . '/../bin/doctrine') . ' status';
+        $output = shell_exec($cmd);
+        $args = json_decode((string) $output, true);
+
+        $this->assertContains('--configuration=src/Lotgd/Config/migrations.php', $args);
+        $this->assertContains('--db-configuration=src/Lotgd/Config/migrations-db.php', $args);
+    }
+
+    public function testProvidedConfigArgsAreNotDuplicated(): void
+    {
+        $cmd = escapeshellcmd(PHP_BINARY) . ' ' . escapeshellarg(__DIR__ . '/../bin/doctrine') .
+            ' status --configuration=foo.php --db-configuration=bar.php';
+        $output = shell_exec($cmd);
+        $args = json_decode((string) $output, true);
+
+        $this->assertContains('--configuration=foo.php', $args);
+        $this->assertContains('--db-configuration=bar.php', $args);
+        $this->assertNotContains('--configuration=src/Lotgd/Config/migrations.php', $args);
+        $this->assertNotContains('--db-configuration=src/Lotgd/Config/migrations-db.php', $args);
+    }
+}


### PR DESCRIPTION
## Summary
- append default migration configuration and db configuration flags unless provided
- add tests validating wrapper behavior with and without explicit config flags

## Testing
- `composer static`
- `composer test`
- `php bin/doctrine status`

------
https://chatgpt.com/codex/tasks/task_e_68c72fd11e6c8329a6000cc7f008872c