### PR TITLE
fix: surface login message in templates

### DIFF
--- a/home.php
+++ b/home.php
@@ -126,7 +126,7 @@ if ($onlinecount < getsetting("maxonline", 0) || getsetting("maxonline", 0) == 0
             $session['message'] .= translate_inline("It appears that you may be blocking cookies from this site.  At least session cookies must be enabled in order to use this site.`n");
             $session['message'] .= translate_inline("`b`#If you are not sure what cookies are, please <a href='http://en.wikipedia.org/wiki/WWW_browser_cookie'>read this article</a> about them, and how to enable them.`b`n");
     }
-    if (isset($session['message']) && $session['message'] > "") {
+    if (!TwigTemplate::isActive() && $session['message'] > '') {
         output_notl("`b`\$%s`b`n", $session['message'], true);
     }
     rawoutput("<script src='src/Lotgd/md5.js' defer></script>");
@@ -144,7 +144,12 @@ if ($onlinecount < getsetting("maxonline", 0) || getsetting("maxonline", 0) == 0
     $uname = translate_inline("<u>U</u>sername");
     $pass = translate_inline("<u>P</u>assword");
     $butt = translate_inline("Log in");
-        $templateVars = ["username" => $uname, "password" => $pass, "button" => $butt];
+        $templateVars = [
+            "username" => $uname,
+            "password" => $pass,
+            "button" => $butt,
+            "message" => $session['message']
+        ];
     if (TwigTemplate::isActive()) {
         $templateVars['template_path'] = TwigTemplate::getPath();
     }

--- a/templates_twig/aurora/assets/style.css
+++ b/templates_twig/aurora/assets/style.css
@@ -263,6 +263,15 @@ td[class*="page-bottom"] {
     text-align: center;
 }
 
+.login-message {
+    border: 2px solid #ff7043;
+    background-color: rgba(255, 112, 67, 0.15);
+    padding: 0.75rem 1rem;
+    margin-bottom: 0.75rem;
+    font-size: 1.1em;
+    border-radius: 4px;
+}
+
 /* Other Styles */
 .select {
     background-color: #000000;

--- a/templates_twig/aurora/login.twig
+++ b/templates_twig/aurora/login.twig
@@ -10,11 +10,14 @@
                     </tr>
                     <tr>
                         <td>
-                                                        <input name='name' id='name' autocomplete='username' accesskey='u' size='10'></input>
-                                                </td>
+                            <input name='name' id='name' autocomplete='username' accesskey='u' size='10'></input>
+                        </td>
                         <td>
-                                                        <input name='password' autocomplete='current-password' id='password' accesskey='p' type='password' size='10'></input>
-                                                </td>
+                            {% if message %}
+                                <div class="login-message">{{ message|raw }}</div>
+                            {% endif %}
+                            <input name='password' autocomplete='current-password' id='password' accesskey='p' type='password' size='10'></input>
+                        </td>
                     </tr>
                     <tr>
                         <td colspan='2' class="login-submit">

--- a/templates_twig/aurora_test/assets/style.css
+++ b/templates_twig/aurora_test/assets/style.css
@@ -269,6 +269,15 @@ td[class*="page-bottom"] {
     text-align: center;
 }
 
+.login-message {
+    border: 2px solid #ff7043;
+    background-color: rgba(255, 112, 67, 0.15);
+    padding: 0.75rem 1rem;
+    margin-bottom: 0.75rem;
+    font-size: 1.1em;
+    border-radius: 4px;
+}
+
 /* Other Styles */
 .select {
     background-color: #000000;

--- a/templates_twig/aurora_test/login.twig
+++ b/templates_twig/aurora_test/login.twig
@@ -9,11 +9,14 @@
                     </tr>
                     <tr>
                         <td>
-                                                        <input name='name' id='name' autocomplete='username' accesskey='u' size='10'></input>
-                                                </td>
+                            <input name='name' id='name' autocomplete='username' accesskey='u' size='10'></input>
+                        </td>
                         <td>
-                                                        <input name='password' autocomplete='current-password' id='password' accesskey='p' type='password' size='10'></input>
-                                                </td>
+                            {% if message %}
+                                <div class="login-message">{{ message|raw }}</div>
+                            {% endif %}
+                            <input name='password' autocomplete='current-password' id='password' accesskey='p' type='password' size='10'></input>
+                        </td>
                     </tr>
                     <tr>
                         <td colspan='2' class="login-submit">

--- a/templates_twig/modern/assets/style.css
+++ b/templates_twig/modern/assets/style.css
@@ -148,6 +148,15 @@ font-family: verdana,arial,helvetica,sans-serif;
      border-right: 1px solid #403225;
      border-bottom: 1px solid #403225;
 }
+
+.login-message {
+    border: 2px solid #F8DB83;
+    background-color: rgba(107, 86, 63, 0.35);
+    padding: 0.75rem 1rem;
+    margin-bottom: 0.75rem;
+    font-size: 1.1em;
+    border-radius: 4px;
+}
 .input {
     background-color: #433828;
     border: 1px solid #806B4D;

--- a/templates_twig/modern/login.twig
+++ b/templates_twig/modern/login.twig
@@ -10,8 +10,15 @@
                     <td align='center'><label for='password'><font color='#ffff00'>{{ password|raw }}:</font></label></td>
                 </tr>
                 <tr>
-                    <td><input name='name' id="name" accesskey='u' size='10' autocomplete='username'></td>
-                    <td><input name='password' id="password" accesskey='p' type='password' size='10' autocomplete='current-password'></td>
+                    <td>
+                        <input name='name' id="name" accesskey='u' size='10' autocomplete='username'>
+                    </td>
+                    <td>
+                        {% if message %}
+                            <div class="login-message">{{ message|raw }}</div>
+                        {% endif %}
+                        <input name='password' id="password" accesskey='p' type='password' size='10' autocomplete='current-password'>
+                    </td>
                 </tr>
                 <tr>
                     <td colspan='2' align='center'><input type='submit' value='{{ button|raw }}' class='button'><br></td>

--- a/templates_twig/puritanic/assets/style.css
+++ b/templates_twig/puritanic/assets/style.css
@@ -234,6 +234,15 @@ td[class*="page-bottom"] {
     text-align: center;
 }
 
+.login-message {
+    border: 2px solid #ff4d4d;
+    background-color: rgba(68, 0, 0, 0.45);
+    padding: 0.75rem 1rem;
+    margin-bottom: 0.75rem;
+    font-size: 1.1em;
+    border-radius: 4px;
+}
+
 /* Other Styles */
 .select {
     background-color: #000000;

--- a/templates_twig/puritanic/login.twig
+++ b/templates_twig/puritanic/login.twig
@@ -8,7 +8,12 @@
                 </tr>
                 <tr>
                     <td><input name='name' id='name' accesskey='u' size='10' autocomplete='username'></td>
-                    <td><input name='password' id='password' accesskey='p' type='password' size='10' autocomplete='current-password'></td>
+                    <td>
+                        {% if message %}
+                            <div class="login-message">{{ message|raw }}</div>
+                        {% endif %}
+                        <input name='password' id='password' accesskey='p' type='password' size='10' autocomplete='current-password'>
+                    </td>
                 </tr>
                 <tr>
                     <td colspan='2' class="login-submit"><input type='submit' value='{{ button|raw }}' class='button'></td>

--- a/templates_twig/puritanic_ai/assets/style.css
+++ b/templates_twig/puritanic_ai/assets/style.css
@@ -225,6 +225,15 @@ td[class*="page-bottom"] {
     color: #CCCCCC;
 }
 
+.login-message {
+    border: 2px solid #dc3545;
+    background-color: rgba(220, 53, 69, 0.2);
+    padding: 0.75rem 1rem;
+    margin-bottom: 0.75rem;
+    font-size: 1.1em;
+    border-radius: 0.5rem;
+}
+
 .btn {
     background-color: #222222;
     color: #CCCCCC;

--- a/templates_twig/puritanic_ai/login.twig
+++ b/templates_twig/puritanic_ai/login.twig
@@ -5,6 +5,9 @@
     </div>
     <div class="col-12 col-sm">
     <label for="password" class="visually-hidden">{{ password|raw }}</label>
+    {% if message %}
+    <div class="login-message">{{ message|raw }}</div>
+    {% endif %}
     <input name="password" id="password" accesskey="p" type="password" size="10" class="form-control" placeholder="{{ password|striptags }}" autocomplete="password" />
     </div>
     <div class="col-12 text-center">


### PR DESCRIPTION
## Summary
- pass the session message into the login template variables on the home page
- display the login message above the password field in each Twig login form
- style the themed login message box so the notice stands out
- keep legacy PHP templates rendering the login message via output_notl when Twig is inactive

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68c8801b7d048329a15e76e88adb5ed5