### PR TITLE
fix: trim legacy newline tokens from login message

### DIFF
--- a/home.php
+++ b/home.php
@@ -144,11 +144,15 @@ if ($onlinecount < getsetting("maxonline", 0) || getsetting("maxonline", 0) == 0
     $uname = translate_inline("<u>U</u>sername");
     $pass = translate_inline("<u>P</u>assword");
     $butt = translate_inline("Log in");
+        $message = (string) ($session['message'] ?? '');
+        $message = preg_replace('/(?:\A(?:`n|\s)+|(?:`n|\s)+\z)/', '', $message) ?? '';
+        $message = trim($message);
+
         $templateVars = [
             "username" => $uname,
             "password" => $pass,
             "button" => $butt,
-            "message" => appoencode($session['message'])
+            "message" => appoencode($message)
         ];
     if (TwigTemplate::isActive()) {
         $templateVars['template_path'] = TwigTemplate::getPath();


### PR DESCRIPTION
## Summary
- strip leading and trailing `n` display tokens and whitespace from the session login message before encoding so the templates do not render extra `<br>` elements
- reuse the sanitized message when passing context into the login view

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68c9347a81e88329a1553169bef77f5d