### PR TITLE
Expose PHPMailer error details to callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Everything below reflects the path from 1.3.2 → 2.0 RCs.
 - Remove legacy settings stub and streamline cron handling.
 - Expanded logging: game log entries can include account IDs, user management and module lifecycle actions, and anonymous entries show a system label.
 - Account cleanup now runs inside a database transaction for safer deletions.
+- Mail delivery helpers expose PHPMailer error details so admin tools can surface actionable diagnostics.
 
 
 ### Bug Fixes

--- a/cron.php
+++ b/cron.php
@@ -43,7 +43,13 @@ if (!defined('CRON_TEST')) {
                 $settings->getSetting('serverurl', ''),
                 $e->getMessage()
             );
-            Mail::send([$email => $email], $body, 'Cronjob Error', [$email => $email]);
+            $mailResult = Mail::send([$email => $email], $body, 'Cronjob Error', [$email => $email], false, 'text/plain', true);
+
+            if (is_array($mailResult) && ! $mailResult['success']) {
+                error_log('Cron notification mail failed: ' . $mailResult['error']);
+            } elseif ($mailResult === false) {
+                error_log('Cron notification mail failed to send.');
+            }
         }
 
         exit(1);
@@ -75,7 +81,13 @@ if (!$result) {
         "Sorry, but the gamedir is not set for your cronjob setup at your game at %s.\n\nPlease correct the error or you will have *NO* server newdays.",
         $settings->getSetting('serverurl', '')
     );
-    Mail::send([$email => $email], $body, 'Cronjob Setup Screwed', [$email => $email]);
+    $mailResult = Mail::send([$email => $email], $body, 'Cronjob Setup Screwed', [$email => $email], false, 'text/plain', true);
+
+    if (is_array($mailResult) && ! $mailResult['success']) {
+        error_log('Cron setup warning mail failed: ' . $mailResult['error']);
+    } elseif ($mailResult === false) {
+        error_log('Cron setup warning mail failed to send.');
+    }
     if (!defined('CRON_TEST')) {
         exit(0); //that's it.
     }

--- a/docs/AdminGuide.md
+++ b/docs/AdminGuide.md
@@ -39,7 +39,8 @@ email. Run `cron.php` regularly via your system's scheduler:
 
 Configure SMTP credentials in `config/configuration.php` or your environment to send reliable
 email. Use authenticated TLS connections and monitor logs for delivery failures. Avoid running an
-open relay.
+open relay. The SMTP test in the configuration panel now surfaces the underlying PHPMailer error
+message whenever delivery fails, making troubleshooting significantly easier.
 
 For translation details, consult the [Translations guide](TranslationsGuide.md).
 

--- a/lib/mail.php
+++ b/lib/mail.php
@@ -32,9 +32,9 @@ function mail_is_inbox_full(int $userId, bool $onlyUnread = false): bool
     return Mail::isInboxFull($userId, $onlyUnread);
 }
 
-function send_email(array $to, string $body, string $subject, array $from, $cc = false, string $contenttype = 'text/plain')
+function send_email(array $to, string $body, string $subject, array $from, $cc = false, string $contenttype = 'text/plain', bool $withErrorInfo = false)
 {
-    return Mail::send($to, $body, $subject, $from, $cc, $contenttype);
+    return Mail::send($to, $body, $subject, $from, $cc, $contenttype, $withErrorInfo);
 }
 
 function systemmail(int $to, string $subject, string $body, int $from = 0, bool $noemail = false)

--- a/lib/sendmail.php
+++ b/lib/sendmail.php
@@ -2,7 +2,7 @@
 
 use Lotgd\Mail;
 
-function send_email($to, $body, $subject, $from, $cc = false, $contenttype = 'text/plain')
+function send_email($to, $body, $subject, $from, $cc = false, $contenttype = 'text/plain', $withErrorInfo = false)
 {
-    return Mail::send($to, $body, $subject, $from, $cc, $contenttype);
+    return Mail::send($to, $body, $subject, $from, $cc, $contenttype, (bool) $withErrorInfo);
 }

--- a/src/Lotgd/ErrorHandler.php
+++ b/src/Lotgd/ErrorHandler.php
@@ -196,7 +196,13 @@ class ErrorHandler
                     $output->debug("Notifying $email of this error.", true);
                     $admin = $settings->getSetting('gameadminemail', 'postmaster@localhost');
                     $from = [$admin => $admin];
-                    \Lotgd\Mail::send([$email => $email], $body, $subject, $from, false, 'text/html');
+                    $mailResult = \Lotgd\Mail::send([$email => $email], $body, $subject, $from, false, 'text/html', true);
+
+                    if (is_array($mailResult) && ! $mailResult['success']) {
+                        $output->debug('Mail notification failed: ' . $mailResult['error'], true);
+                    } elseif ($mailResult === false) {
+                        $output->debug('Mail notification failed: delivery returned false.', true);
+                    }
                 }
                 $data['errors'][$msg] = strtotime('now');
             } else {

--- a/src/Lotgd/ExpireChars.php
+++ b/src/Lotgd/ExpireChars.php
@@ -227,7 +227,18 @@ class ExpireChars
         while ($row = Database::fetchAssoc($result)) {
             $to = [$row['emailaddress'] => $row['emailaddress']];
             $body = str_replace('{charname}', $row['login'], $message);
-            Mail::send($to, $body, $subject, $from, $cc, 'text/html');
+            $mailResult = Mail::send($to, $body, $subject, $from, $cc, 'text/html', true);
+
+            if (is_array($mailResult) && ! $mailResult['success']) {
+                error_log(sprintf('Failed to send expiration notice to %s: %s', $row['emailaddress'], $mailResult['error']));
+                continue;
+            }
+
+            if ($mailResult === false) {
+                error_log(sprintf('Failed to send expiration notice to %s.', $row['emailaddress']));
+                continue;
+            }
+
             $collector[] = $row['acctid'];
         }
 

--- a/tests/Stubs/PHPMailer.php
+++ b/tests/Stubs/PHPMailer.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Lotgd\Tests\Stubs;
 
+class PHPMailerException extends \Exception
+{
+}
+
 #[\AllowDynamicProperties]
 class PHPMailer
 {
@@ -62,9 +66,18 @@ class PHPMailer
 
     public function Send()
     {
+        if (!empty($GLOBALS['mail_force_error'])) {
+            $message = $GLOBALS['mail_force_error_message'] ?? 'Forced mail failure.';
+            $this->ErrorInfo = $message;
+            $GLOBALS['mail_force_error'] = false;
+
+            throw new PHPMailerException($message);
+        }
+
         $GLOBALS['mail_sent_count'] = ($GLOBALS['mail_sent_count'] ?? 0) + 1;
         $GLOBALS['last_subject'] = $this->Subject;
     }
 }
 
 class_alias(PHPMailer::class, 'PHPMailer\\PHPMailer\\PHPMailer');
+class_alias(PHPMailerException::class, 'PHPMailer\\PHPMailer\\Exception');


### PR DESCRIPTION
## Summary
- extend `Lotgd\Mail::send` (and wrappers) with an optional detailed result that returns PHPMailer errors without breaking existing boolean callers
- surface delivery failures to admins by capturing the detailed result in cron, error notifications, and account expiration warnings
- expand the mail test suite and documentation to cover the new diagnostics and keep the changelog up to date

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68ca5a87c0f88329bea13bc141d4459e