### PR TITLE
Extend template cookie lifetime

### DIFF
--- a/src/Lotgd/Cookies.php
+++ b/src/Lotgd/Cookies.php
@@ -92,7 +92,7 @@ class Cookies
             return;
         }
 
-        $expires = strtotime('+45 days');
+        $expires = strtotime('+1 year');
         self::set('template', $template, $expires, ServerFunctions::isSecureConnection());
     }
 


### PR DESCRIPTION
## Summary
- extend the template cookie expiration interval to one year so the UI selection persists longer

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68ca6c3b6828832993a64f588aece074