### PR TITLE
fix: renew template cookie on login

### DIFF
--- a/login.php
+++ b/login.php
@@ -10,6 +10,7 @@ use Lotgd\Mail;
 use Lotgd\Serialization;
 use Lotgd\Cookies;
 use Lotgd\DataCache;
+use Lotgd\Template;
 
 define("ALLOW_ANONYMOUS", true);
 require_once __DIR__ . "/common.php";
@@ -112,6 +113,11 @@ if ($name != "") {
                 // like the stafflist which need to invalidate the cache
                 // when someone logs in or off can do so.
                 modulehook("player-login");
+
+                $cookieTemplate = Template::getTemplateCookie();
+                if ($cookieTemplate !== '') {
+                    Template::setTemplateCookie($cookieTemplate);
+                }
 
                 if ($session['user']['loggedin']) {
                     $link = "<a href='" . $session['user']['restorepage'] . "'>" . $session['user']['restorepage'] . "</a>";


### PR DESCRIPTION
## Summary
- import the template helper in the login entry point
- reissue the template cookie after a successful login to preserve the chosen skin

## Testing
- php -l login.php
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68ca6eeae3a483299f80c7e52ddd59f9