### PR TITLE
docs: note template cookie duration fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Everything below reflects the path from 1.3.2 → 2.0 RCs.
 - Add unsuspend buff wrappers and seed default navigation for new characters.
 - Normalize withdraw log category to lowercase.
 - Show system label for anonymous gamelog entries and record account IDs in maintenance logs.
+- Extend the template preference cookie to one year to prevent theme resets.
 
 
 ### Refactor


### PR DESCRIPTION
## Summary
- record the template preference cookie retention fix in the unreleased bug fixes changelog section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca7192d8bc832983f0dc846c4fd155