### PR TITLE
refactor: use Doctrine parameter binding in race modules

### DIFF
--- a/modules/racecat.php
+++ b/modules/racecat.php
@@ -56,8 +56,15 @@ function racecat_uninstall()
 {
     global $session;
     // Force anyone who was a Felyne to rechoose race
-    $sql = "UPDATE  " . Database::prefix("accounts") . " SET race='" . RACE_UNKNOWN . "' WHERE race='Felyne'";
-    Database::query($sql);
+    $conn = Database::getDoctrineConnection();
+    $accounts = Database::prefix("accounts");
+    $conn->executeStatement(
+        "UPDATE {$accounts} SET race = :unknown WHERE race = :race",
+        [
+            'unknown' => RACE_UNKNOWN,
+            'race' => 'Felyne',
+        ]
+    );
     if ($session['user']['race'] == 'Felyne') {
         $session['user']['race'] = RACE_UNKNOWN;
     }

--- a/modules/racedwarf.php
+++ b/modules/racedwarf.php
@@ -1,5 +1,6 @@
 <?php
 
+use Lotgd\DataCache;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 
@@ -53,14 +54,26 @@ function racedwarf_uninstall()
     global $session;
     $vname = getsetting("villagename", LOCATION_FIELDS);
     $gname = get_module_setting("villagename");
-    $sql = "UPDATE " . Database::prefix("accounts") . " SET location='$vname' WHERE location = '$gname'";
-    Database::query($sql);
+    $conn = Database::getDoctrineConnection();
+    $accounts = Database::prefix("accounts");
+    $conn->executeStatement(
+        "UPDATE {$accounts} SET location = :newCity WHERE location = :oldCity",
+        [
+            'newCity' => $vname,
+            'oldCity' => $gname,
+        ]
+    );
     if ($session['user']['location'] == $gname) {
         $session['user']['location'] = $vname;
     }
     // Force anyone who was a Dwarf to rechoose race
-    $sql = "UPDATE  " . Database::prefix("accounts") . " SET race='" . RACE_UNKNOWN . "' WHERE race='Dwarf'";
-    Database::query($sql);
+    $conn->executeStatement(
+        "UPDATE {$accounts} SET race = :unknown WHERE race = :race",
+        [
+            'unknown' => RACE_UNKNOWN,
+            'race' => 'Dwarf',
+        ]
+    );
     if ($session['user']['race'] == 'Dwarf') {
         $session['user']['race'] = RACE_UNKNOWN;
     }
@@ -93,16 +106,26 @@ function racedwarf_dohook($hookname, $args)
                 if ($session['user']['location'] == $args['old']) {
                     $session['user']['location'] = $args['new'];
                 }
-                $sql = "UPDATE " . Database::prefix("accounts") .
-                " SET location='" . addslashes($args['new']) .
-                "' WHERE location='" . addslashes($args['old']) . "'";
-                Database::query($sql);
+                $conn = Database::getDoctrineConnection();
+                $accounts = Database::prefix("accounts");
+                $conn->executeStatement(
+                    "UPDATE {$accounts} SET location = :newCity WHERE location = :oldCity",
+                    [
+                        'newCity' => $args['new'],
+                        'oldCity' => $args['old'],
+                    ]
+                );
                 if (is_module_active("cities")) {
-                    $sql = "UPDATE " . Database::prefix("module_userprefs") .
-                    " SET value='" . addslashes($args['new']) .
-                    "' WHERE modulename='cities' AND setting='homecity'" .
-                    "AND value='" . addslashes($args['old']) . "'";
-                    Database::query($sql);
+                    $userPrefs = Database::prefix("module_userprefs");
+                    $conn->executeStatement(
+                        "UPDATE {$userPrefs} SET value = :newCity"
+                        . " WHERE modulename = 'cities' AND setting = 'homecity'"
+                        . " AND value = :oldCity",
+                        [
+                            'newCity' => $args['new'],
+                            'oldCity' => $args['old'],
+                        ]
+                    );
                 }
             }
             break;
@@ -197,12 +220,27 @@ function racedwarf_dohook($hookname, $args)
                 $args['schemas']['talk'] = "module-racedwarf";
                 $new = get_module_setting("newest-$city", "cities");
                 if ($new != 0) {
-                    $sql =  "SELECT name FROM " . Database::prefix("accounts") .
-                    " WHERE acctid='$new'";
-                    $result = Database::queryCached($sql, "newest-$city");
-                    $row = Database::fetchAssoc($result);
-                    $args['newestplayer'] = $row['name'];
-                    $args['newestid'] = $new;
+                    $cacheKey = "newest-$city";
+                    $dataCache = DataCache::getInstance();
+                    $row = $dataCache->datacache($cacheKey, 900);
+                    if (! is_array($row)) {
+                        $conn = Database::getDoctrineConnection();
+                        $accounts = Database::prefix("accounts");
+                        $row = $conn->fetchAssociative(
+                            "SELECT name FROM {$accounts} WHERE acctid = :acctid",
+                            [
+                                'acctid' => $new,
+                            ]
+                        ) ?: [];
+                        $dataCache->updatedatacache($cacheKey, $row);
+                    }
+                    if ($row !== []) {
+                        $args['newestplayer'] = $row['name'];
+                        $args['newestid'] = $new;
+                    } else {
+                        $args['newestplayer'] = $new;
+                        $args['newestid'] = "";
+                    }
                 } else {
                     $args['newestplayer'] = $new;
                     $args['newestid'] = "";

--- a/modules/raceelf.php
+++ b/modules/raceelf.php
@@ -1,5 +1,6 @@
 <?php
 
+use Lotgd\DataCache;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 
@@ -48,14 +49,26 @@ function raceelf_uninstall()
     global $session;
     $vname = getsetting("villagename", LOCATION_FIELDS);
     $gname = get_module_setting("villagename");
-    $sql = "UPDATE " . Database::prefix("accounts") . " SET location='$vname' WHERE location = '$gname'";
-    Database::query($sql);
+    $conn = Database::getDoctrineConnection();
+    $accounts = Database::prefix("accounts");
+    $conn->executeStatement(
+        "UPDATE {$accounts} SET location = :newCity WHERE location = :oldCity",
+        [
+            'newCity' => $vname,
+            'oldCity' => $gname,
+        ]
+    );
     if ($session['user']['location'] == $gname) {
         $session['user']['location'] = $vname;
     }
     // Force anyone who was a Elf to rechoose race
-    $sql = "UPDATE  " . Database::prefix("accounts") . " SET race='" . RACE_UNKNOWN . "' WHERE race='Elf'";
-    Database::query($sql);
+    $conn->executeStatement(
+        "UPDATE {$accounts} SET race = :unknown WHERE race = :race",
+        [
+            'unknown' => RACE_UNKNOWN,
+            'race' => 'Elf',
+        ]
+    );
     if ($session['user']['race'] == 'Elf') {
         $session['user']['race'] = RACE_UNKNOWN;
     }
@@ -95,16 +108,26 @@ function raceelf_dohook($hookname, $args)
                 if ($session['user']['location'] == $args['old']) {
                     $session['user']['location'] = $args['new'];
                 }
-                $sql = "UPDATE " . Database::prefix("accounts") .
-                " SET location='" . addslashes($args['new']) .
-                "' WHERE location='" . addslashes($args['old']) . "'";
-                Database::query($sql);
+                $conn = Database::getDoctrineConnection();
+                $accounts = Database::prefix("accounts");
+                $conn->executeStatement(
+                    "UPDATE {$accounts} SET location = :newCity WHERE location = :oldCity",
+                    [
+                        'newCity' => $args['new'],
+                        'oldCity' => $args['old'],
+                    ]
+                );
                 if (is_module_active("cities")) {
-                    $sql = "UPDATE " . Database::prefix("module_userprefs") .
-                    " SET value='" . addslashes($args['new']) .
-                    "' WHERE modulename='cities' AND setting='homecity'" .
-                    "AND value='" . addslashes($args['old']) . "'";
-                    Database::query($sql);
+                    $userPrefs = Database::prefix("module_userprefs");
+                    $conn->executeStatement(
+                        "UPDATE {$userPrefs} SET value = :newCity"
+                        . " WHERE modulename = 'cities' AND setting = 'homecity'"
+                        . " AND value = :oldCity",
+                        [
+                            'newCity' => $args['new'],
+                            'oldCity' => $args['old'],
+                        ]
+                    );
                 }
             }
             break;
@@ -204,12 +227,27 @@ function raceelf_dohook($hookname, $args)
                 $args['schemas']['talk'] = "module-raceelf";
                 $new = get_module_setting("newest-$city", "cities");
                 if ($new != 0) {
-                    $sql =  "SELECT name FROM " . Database::prefix("accounts") .
-                    " WHERE acctid='$new'";
-                    $result = Database::queryCached($sql, "newest-$city");
-                    $row = Database::fetchAssoc($result);
-                    $args['newestplayer'] = $row['name'];
-                    $args['newestid'] = $new;
+                    $cacheKey = "newest-$city";
+                    $dataCache = DataCache::getInstance();
+                    $row = $dataCache->datacache($cacheKey, 900);
+                    if (! is_array($row)) {
+                        $conn = Database::getDoctrineConnection();
+                        $accounts = Database::prefix("accounts");
+                        $row = $conn->fetchAssociative(
+                            "SELECT name FROM {$accounts} WHERE acctid = :acctid",
+                            [
+                                'acctid' => $new,
+                            ]
+                        ) ?: [];
+                        $dataCache->updatedatacache($cacheKey, $row);
+                    }
+                    if ($row !== []) {
+                        $args['newestplayer'] = $row['name'];
+                        $args['newestid'] = $new;
+                    } else {
+                        $args['newestplayer'] = $new;
+                        $args['newestid'] = "";
+                    }
                 } else {
                     $args['newestplayer'] = $new;
                     $args['newestid'] = "";

--- a/modules/racehuman.php
+++ b/modules/racehuman.php
@@ -1,5 +1,6 @@
 <?php
 
+use Lotgd\DataCache;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 
@@ -48,14 +49,26 @@ function racehuman_uninstall()
     global $session;
     $vname = getsetting("villagename", LOCATION_FIELDS);
     $gname = get_module_setting("villagename");
-    $sql = "UPDATE " . Database::prefix("accounts") . " SET location='$vname' WHERE location = '$gname'";
-    Database::query($sql);
+    $conn = Database::getDoctrineConnection();
+    $accounts = Database::prefix("accounts");
+    $conn->executeStatement(
+        "UPDATE {$accounts} SET location = :newCity WHERE location = :oldCity",
+        [
+            'newCity' => $vname,
+            'oldCity' => $gname,
+        ]
+    );
     if ($session['user']['location'] == $gname) {
         $session['user']['location'] = $vname;
     }
     // Force anyone who was a Human to rechoose race
-    $sql = "UPDATE  " . Database::prefix("accounts") . " SET race='" . RACE_UNKNOWN . "' WHERE race='Human'";
-    Database::query($sql);
+    $conn->executeStatement(
+        "UPDATE {$accounts} SET race = :unknown WHERE race = :race",
+        [
+            'unknown' => RACE_UNKNOWN,
+            'race' => 'Human',
+        ]
+    );
     if ($session['user']['race'] == 'Human') {
         $session['user']['race'] = RACE_UNKNOWN;
     }
@@ -85,16 +98,26 @@ function racehuman_dohook($hookname, $args)
                 if ($session['user']['location'] == $args['old']) {
                     $session['user']['location'] = $args['new'];
                 }
-                $sql = "UPDATE " . Database::prefix("accounts") .
-                " SET location='" . addslashes($args['new']) .
-                "' WHERE location='" . addslashes($args['old']) . "'";
-                Database::query($sql);
+                $conn = Database::getDoctrineConnection();
+                $accounts = Database::prefix("accounts");
+                $conn->executeStatement(
+                    "UPDATE {$accounts} SET location = :newCity WHERE location = :oldCity",
+                    [
+                        'newCity' => $args['new'],
+                        'oldCity' => $args['old'],
+                    ]
+                );
                 if (is_module_active("cities")) {
-                    $sql = "UPDATE " . Database::prefix("module_userprefs") .
-                    " SET value='" . addslashes($args['new']) .
-                    "' WHERE modulename='cities' AND setting='homecity'" .
-                    "AND value='" . addslashes($args['old']) . "'";
-                    Database::query($sql);
+                    $userPrefs = Database::prefix("module_userprefs");
+                    $conn->executeStatement(
+                        "UPDATE {$userPrefs} SET value = :newCity"
+                        . " WHERE modulename = 'cities' AND setting = 'homecity'"
+                        . " AND value = :oldCity",
+                        [
+                            'newCity' => $args['new'],
+                            'oldCity' => $args['old'],
+                        ]
+                    );
                 }
             }
             break;
@@ -188,12 +211,27 @@ function racehuman_dohook($hookname, $args)
                 $args['schemas']['talk'] = "module-racehuman";
                 $new = get_module_setting("newest-$city", "cities");
                 if ($new != 0) {
-                    $sql =  "SELECT name FROM " . Database::prefix("accounts") .
-                    " WHERE acctid='$new'";
-                    $result = Database::queryCached($sql, "newest-$city");
-                    $row = Database::fetchAssoc($result);
-                    $args['newestplayer'] = $row['name'];
-                    $args['newestid'] = $new;
+                    $cacheKey = "newest-$city";
+                    $dataCache = DataCache::getInstance();
+                    $row = $dataCache->datacache($cacheKey, 900);
+                    if (! is_array($row)) {
+                        $conn = Database::getDoctrineConnection();
+                        $accounts = Database::prefix("accounts");
+                        $row = $conn->fetchAssociative(
+                            "SELECT name FROM {$accounts} WHERE acctid = :acctid",
+                            [
+                                'acctid' => $new,
+                            ]
+                        ) ?: [];
+                        $dataCache->updatedatacache($cacheKey, $row);
+                    }
+                    if ($row !== []) {
+                        $args['newestplayer'] = $row['name'];
+                        $args['newestid'] = $new;
+                    } else {
+                        $args['newestplayer'] = $new;
+                        $args['newestid'] = "";
+                    }
                 } else {
                     $args['newestplayer'] = $new;
                     $args['newestid'] = "";

--- a/modules/racestorm.php
+++ b/modules/racestorm.php
@@ -53,8 +53,15 @@ function racestorm_install()
 function racestorm_uninstall()
 {
     global $session;
-    $sql = "UPDATE  " . Database::prefix("accounts") . " SET race='" . RACE_UNKNOWN . "' WHERE race='Storm Giant'";
-    Database::query($sql);
+    $conn = Database::getDoctrineConnection();
+    $accounts = Database::prefix("accounts");
+    $conn->executeStatement(
+        "UPDATE {$accounts} SET race = :unknown WHERE race = :race",
+        [
+            'unknown' => RACE_UNKNOWN,
+            'race' => 'Storm Giant',
+        ]
+    );
     if ($session['user']['race'] == 'Storm Giant') {
         $session['user']['race'] = RACE_UNKNOWN;
     }


### PR DESCRIPTION
## Summary
- replace string-concatenated UPDATEs in the race modules with Doctrine executeStatement calls that bind city and race values
- switch newest-resident lookups in the city text hooks to Doctrine fetchAssociative calls wrapped in DataCache helpers instead of queryCached

## Testing
- `composer test`
- `composer static` *(fails: phpstan not found in container PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68caab9e840883299a8089936a92910a