### PR TITLE
refactor: harden graveyard haunt queries

### DIFF
--- a/modules/graveyard_haunt.php
+++ b/modules/graveyard_haunt.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * Allows deceased players to haunt the living.
  */
 
+use Doctrine\DBAL\ParameterType;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
 use Lotgd\Mail;
@@ -52,12 +53,14 @@ function graveyard_haunt_dohook(string $hookname, array $args): array
         case "newday":
             $by = (int)get_module_pref('hauntedby');
             if ($by != 0) {
-                $sql = "SELECT name from " . Database::prefix('accounts') . " WHERE acctid=" . $by;
-                $result = Database::query($sql);
-                if (Database::numRows($result) == 0) {
+                $connection = Database::getDoctrineConnection();
+                $sql = 'SELECT name FROM ' . Database::prefix('accounts') . ' WHERE acctid = :acctid';
+                $result = $connection->executeQuery($sql, ['acctid' => $by], ['acctid' => ParameterType::INTEGER]);
+                $row = $result->fetchAssociative();
+
+                if ($row === false || $row === null) {
                     $haunter = translate_inline("The Evil Reaper");
                 } else {
-                    $row = Database::fetchAssoc($result);
                     $haunter = $row['name'];
                 }
                 output("`n`n`)You have been haunted by %s`); as a result, you lose a forest fight!", $haunter);
@@ -97,11 +100,17 @@ function graveyard_haunt_run(): void
             for ($x = 0; $x < strlen($name); $x++) {
                 $string .= substr($name, $x, 1) . "%";
             }
-            $sql = "SELECT login,name,level FROM " . Database::prefix("accounts") . " WHERE name LIKE '" . addslashes($string) . "' AND locked=0 ORDER BY level,login";
-            $result = Database::query($sql);
-            if (Database::numRows($result) <= 0) {
+
+            $connection = Database::getDoctrineConnection();
+            $sql = 'SELECT login, name, level FROM ' . Database::prefix('accounts') . ' WHERE name LIKE :pattern AND locked = 0 ORDER BY level, login';
+            $statement = $connection->prepare($sql);
+            $result = $statement->executeQuery(['pattern' => $string]);
+            $rows = $result->fetchAllAssociative();
+            $rowCount = count($rows);
+
+            if ($rowCount <= 0) {
                 output("`\$%s`) could find no one who matched the name you gave him.", $deathoverlord);
-            } elseif (Database::numRows($result) > 100) {
+            } elseif ($rowCount > 100) {
                 output("`\$%s`) thinks you should narrow down the number of people you wish to haunt.", $deathoverlord);
                 $search = translate_inline("Search");
                 rawoutput("<form action='runmodule.php?module=graveyard_haunt&op=stage2' method='POST'>");
@@ -117,9 +126,8 @@ function graveyard_haunt_run(): void
                 $lev = translate_inline("Level");
                 rawoutput("<table cellpadding='3' cellspacing='0' border='0'>");
                 rawoutput("<tr class='trhead'><td>$name</td><td>$lev</td></tr>");
-                for ($i = 0; $i < Database::numRows($result); $i++) {
-                    $row = Database::fetchAssoc($result);
-                    rawoutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'><td><a href='runmodule.php?module=graveyard_haunt&op=stage3&name=" . HTMLEntities($row['login'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "'>");
+                foreach ($rows as $index => $row) {
+                    rawoutput("<tr class='" . ($index % 2 ? "trlight" : "trdark") . "'><td><a href='runmodule.php?module=graveyard_haunt&op=stage3&name=" . HTMLEntities($row['login'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "'>");
                     output_notl("%s", $row['name']);
                     rawoutput("</a></td><td>");
                     output_notl("%s", $row['level']);
@@ -132,10 +140,12 @@ function graveyard_haunt_run(): void
         case "stage3":
             output("`)`c`bThe Mausoleum`b`c");
             $name = httpget('name');
-            $sql = "SELECT name,level,acctid FROM " . Database::prefix("accounts") . " WHERE login='$name'";
-            $result = Database::query($sql);
-            if (Database::numRows($result) > 0) {
-                $row = Database::fetchAssoc($result);
+            $connection = Database::getDoctrineConnection();
+            $sql = 'SELECT name, level, acctid FROM ' . Database::prefix('accounts') . ' WHERE login = :login';
+            $result = $connection->executeQuery($sql, ['login' => $name]);
+            $row = $result->fetchAssociative();
+
+            if ($row !== false && $row !== null) {
                 $already_haunted = (int)get_module_pref('hauntedby', 'graveyard_haunt', $row['acctid']);
                 if ($row['hauntedby'] != 0) {
                     output("That person has already been haunted, please select another target");


### PR DESCRIPTION
## Summary
- replace raw account lookups in the graveyard haunt module with Doctrine prepared statements
- parameterize the LIKE search pattern and fetch candidate rows via Doctrine helpers while keeping the UI the same
- continue haunt resolution logic using Doctrine result helpers instead of the legacy Database fetch utilities

## Testing
- php -l modules/graveyard_haunt.php
- composer test
- composer static *(fails: phpstan not found)*

------
https://chatgpt.com/codex/tasks/task_e_68caabc54948832983b1403a2bb789e8