### PR TITLE
refactor: use Doctrine prepared statement in darkhorse enemies lookup

### DIFF
--- a/modules/darkhorse.php
+++ b/modules/darkhorse.php
@@ -224,12 +224,15 @@ function darkhorse_bartender($from)
             }
         } else {
             if ($session['user']['gold'] >= 100) {
-                $sql = "SELECT name,acctid,alive,location,maxhitpoints,gold,sex,level,weapon,armor,attack,race,defense,charm,strength,dexterity,wisdom,intelligence,constitution FROM " . Database::prefix("accounts") . " WHERE login='$who'";
-                $result = Database::query($sql);
+                $conn = Database::getDoctrineConnection();
+                $sql = 'SELECT name,acctid,alive,location,maxhitpoints,gold,sex,level,weapon,armor,attack,race,defense,charm,strength,dexterity,wisdom,intelligence,constitution FROM ' . Database::prefix('accounts') . ' WHERE login = :login';
+                $stmt = $conn->prepare($sql);
+                $stmt->bindValue('login', $who);
+                $result = $stmt->executeQuery();
                 require_once("lib/playerfunctions.php");
 
                 if (Database::numRows($result) > 0) {
-                    $row = Database::fetchAssoc($result);
+                    $row = $result->fetchAssociative();
                     $row = modulehook("adjuststats", $row);
                     $name = str_replace("s", "sh", $row['name']);
                     $name = str_replace("S", "Sh", $name);


### PR DESCRIPTION
## Summary
- replace the raw enemies lookup query in Dark Horse with a Doctrine prepared statement that binds the player login
- switch the account fetch to use Doctrine's `fetchAssociative()` while preserving the displayed data

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68caabd6827c8329bf159d8ec32721f5