### PR TITLE
refactor: use doctrine connection in cities uninstall

### DIFF
--- a/modules/cities.php
+++ b/modules/cities.php
@@ -70,14 +70,26 @@ function cities_install(): bool
 
 function cities_uninstall(): bool
 {
+    global $session;
+
     // This is semi-unsafe -- If a player is in the process of a page
     // load it could get the location, uninstall the cities and then
     // save their location from their session back into the database
     // I think I have a patch however :)
     $city = getsetting("villagename", LOCATION_FIELDS);
     $inn = getsetting("innname", LOCATION_INN);
-    $sql = "UPDATE " . Database::prefix("accounts") . " SET location='" . addslashes($city) . "' WHERE location!='" . addslashes($inn) . "'";
-    Database::query($sql);
+
+    $conn = Database::getDoctrineConnection();
+    $accounts = Database::prefix("accounts");
+
+    $conn->executeStatement(
+        "UPDATE {$accounts} SET location = :city WHERE location <> :inn",
+        [
+            'city' => $city,
+            'inn' => $inn,
+        ]
+    );
+
     $session['user']['location'] = $city;
     return true;
 }


### PR DESCRIPTION
## Summary
- replace the legacy raw SQL update in `cities_uninstall()` with a Doctrine connection using bound parameters
- ensure the function references the global session before updating the player's location

## Testing
- composer test
- composer static
- php -l modules/cities.php

------
https://chatgpt.com/codex/tasks/task_e_68cab1ef3e808329b9f5a1b089febba3