### PR TITLE
fix: cast travel special chance setting

### DIFF
--- a/modules/cities/run.php
+++ b/modules/cities/run.php
@@ -96,7 +96,9 @@ if ($op == "travel") {
         if (e_rand(0, 100) < $dlevel && $su != '1') {
             //they've been waylaid.
 
-            if (module_events("travel", get_module_setting("travelspecialchance"), "runmodule.php?module=cities&city=" . urlencode($city) . "&d=$danger&continue=1&") != 0) {
+            $chance = (int) get_module_setting('travelspecialchance');
+
+            if (module_events("travel", $chance, "runmodule.php?module=cities&city=" . urlencode($city) . "&d=$danger&continue=1&") != 0) {
                 page_header("Something Special!");
                 if (checknavs()) {
                     page_footer();


### PR DESCRIPTION
## Summary
- cast the cities travel special chance setting to an integer before invoking module events

## Testing
- php -l modules/cities/run.php
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68caebec67ac832995f4f5647837aa1b