### PR TITLE
fix: harden travel cost type handling

### DIFF
--- a/modules/cities/run.php
+++ b/modules/cities/run.php
@@ -73,14 +73,18 @@ if ($op == "travel") {
     } else {
         if ($continue != "1" && $su != "1" && !get_module_pref("paidcost")) {
             set_module_pref("paidcost", 1);
-            $httpcost = httpget('cost');
-            $cost = modulehook("travel-cost", array("from" => $session['user']['location'],"to" => $city,"cost" => 0));
-            $cost = max(1, $cost['cost'], $httpcost);
+            $httpCost = (int) httpget('cost');
+            $hookResult = modulehook(
+                "travel-cost",
+                array("from" => $session['user']['location'], "to" => $city, "cost" => 0)
+            );
+            $hookCost = (int) ($hookResult['cost'] ?? 0);
+            $cost = (int) max(1, $hookCost, $httpCost);
             $reallyfree = $free - $cost;
             if ($reallyfree > 0) {
                 // Only increment travel used if they are still within
                 // their allowance.
-                increment_module_pref("traveltoday", $cost);
+                increment_module_pref("traveltoday", (int) $cost);
                 //do nothing, they're within their travel allowance.
             } elseif ($session['user']['turns'] + $free > 0) {
                 $over = abs($reallyfree);


### PR DESCRIPTION
## Summary
- cast travel cost inputs to integers before comparing hook and request values
- ensure the travel counter increment receives an integer

## Testing
- php -l modules/cities/run.php
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68caebeb0ff8832987dc2e58073c5aac