### PR TITLE
fix: handle deleted mail senders

### DIFF
--- a/pages/mail/case_read.php
+++ b/pages/mail/case_read.php
@@ -61,6 +61,8 @@ function mailRead(): void
 
     // Determine sender status
     $statusImage = '';
+    $senderId = $message['acctid'] ?? null;
+
     if ((int) $message['msgfrom'] === 0) {
         $message['name'] = Translator::translateInline('`i`^System`0`i');
 
@@ -79,12 +81,16 @@ function mailRead(): void
         } else {
             $message['body'] = $message['body'];
         }
-    } elseif ($message['name'] === '') {
-        $message['name'] = Translator::translateInline('`^Deleted User');
     } else {
-        $online = (int) PlayerFunctions::isPlayerOnline($message['acctid']);
-        $status = $online ? 'online' : 'offline';
-        $statusImage = "<img src='images/$status.gif' alt='$status'>";
+        $hasSenderRecord = is_numeric($senderId) && (int) $senderId > 0 && ! empty($message['name']);
+
+        if (! $hasSenderRecord) {
+            $message['name'] = Translator::translateInline('`^Deleted User');
+        } else {
+            $online = (int) PlayerFunctions::isPlayerOnline((int) $senderId);
+            $status = $online ? 'online' : 'offline';
+            $statusImage = "<img src='images/$status.gif' alt='$status'>";
+        }
     }
 
     // Show NEW marker if message is unread


### PR DESCRIPTION
## Summary
- treat messages with missing sender records as deleted users before rendering the status icon
- only call `PlayerFunctions::isPlayerOnline()` when a numeric sender id exists so the status icon is blank for deleted accounts

## Testing
- php -l pages/mail/case_read.php
- composer test
- composer static
- php <<'PHP' ... (manual verification script)


------
https://chatgpt.com/codex/tasks/task_e_68cc13cf8d7883299f432787b114bec8