### PR TITLE
docs: note deleted mail user fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Everything below reflects the path from 1.3.2 → 2.0 RCs.
 - Add unsuspend buff wrappers and seed default navigation for new characters.
 - Normalize withdraw log category to lowercase.
 - Show system label for anonymous gamelog entries and record account IDs in maintenance logs.
+- Show "Deleted User" placeholder when reading mail from deleted accounts instead of erroring.
 - Extend the template preference cookie to one year to prevent theme resets.
 
 


### PR DESCRIPTION
## Summary
- document that deleted mail now shows a Deleted User placeholder instead of erroring

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc6a4ae4c4832990da440738597250