### PR TITLE
docs: update changelog for equipment editor fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Everything below reflects the path from 1.3.2 → 2.0 RCs.
 - Normalize withdraw log category to lowercase.
 - Show system label for anonymous gamelog entries and record account IDs in maintenance logs.
 - Extend the template preference cookie to one year to prevent theme resets.
+- Cast equipment editor and hidden field values to strings to avoid PHP type errors on listings.
 
 
 ### Refactor


### PR DESCRIPTION
## Summary
- document that equipment editors and form hidden fields cast their values to strings to prevent PHP type errors in listings

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68cc6a4e6bd883298078951dc6781f24