### PR TITLE
fix: stabilise account expiration thresholds

### DIFF
--- a/src/Lotgd/ExpireChars.php
+++ b/src/Lotgd/ExpireChars.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use DateTimeImmutable;
 use Lotgd\Translator;
 use Lotgd\MySQL\Database;
 use Lotgd\Settings;
@@ -134,17 +135,18 @@ class ExpireChars
      *
      * @return array<int,array{acctid:int,login:string,dragonkills:int,level:int}>
      */
-    private static function fetchAccountsToExpire(int $old, int $new, int $trash): array
+    private static function fetchAccountsToExpire(int $old, int $new, int $trash, ?DateTimeImmutable $now = null): array
     {
+        $base = $now ?? new DateTimeImmutable('now');
         $conditions = [];
         if ($old > 0) {
-            $conditions[] = "(laston < '" . date('Y-m-d H:i:s', strtotime("-$old days")) . "')";
+            $conditions[] = "(laston < '" . $base->modify("-$old days")->format('Y-m-d H:i:s') . "')";
         }
         if ($new > 0) {
-            $conditions[] = "(laston < '" . date('Y-m-d H:i:s', strtotime("-$new days")) . "' AND level=1 AND dragonkills=0)";
+            $conditions[] = "(laston < '" . $base->modify("-$new days")->format('Y-m-d H:i:s') . "' AND level=1 AND dragonkills=0)";
         }
         if ($trash > 0) {
-            $conditions[] = "(laston < '" . date('Y-m-d H:i:s', strtotime('-' . ($trash + 1) . ' days')) . "' AND level=1 AND experience < 10 AND dragonkills=0)";
+            $conditions[] = "(laston < '" . $base->modify('-' . ($trash + 1) . ' days')->format('Y-m-d H:i:s') . "' AND level=1 AND experience < 10 AND dragonkills=0)";
         }
 
         if (empty($conditions)) {

--- a/tests/FetchAccountsToExpireQueryTest.php
+++ b/tests/FetchAccountsToExpireQueryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lotgd\Tests;
 
+use DateTimeImmutable;
 use Lotgd\ExpireChars;
 use Lotgd\Tests\Stubs\Database;
 use PHPUnit\Framework\TestCase;
@@ -30,15 +31,16 @@ final class FetchAccountsToExpireQueryTest extends TestCase
             Database::$mockResults = [];
         }
 
+        $now = new DateTimeImmutable('now');
         $conditions = [];
         if ($old > 0) {
-            $conditions[] = "(laston < '" . date('Y-m-d H:i:s', strtotime("-$old days")) . "')";
+            $conditions[] = "(laston < '" . $now->modify("-$old days")->format('Y-m-d H:i:s') . "')";
         }
         if ($new > 0) {
-            $conditions[] = "(laston < '" . date('Y-m-d H:i:s', strtotime("-$new days")) . "' AND level=1 AND dragonkills=0)";
+            $conditions[] = "(laston < '" . $now->modify("-$new days")->format('Y-m-d H:i:s') . "' AND level=1 AND dragonkills=0)";
         }
         if ($trash > 0) {
-            $conditions[] = "(laston < '" . date('Y-m-d H:i:s', strtotime('-' . ($trash + 1) . ' days')) . "' AND level=1 AND experience < 10 AND dragonkills=0)";
+            $conditions[] = "(laston < '" . $now->modify('-' . ($trash + 1) . ' days')->format('Y-m-d H:i:s') . "' AND level=1 AND experience < 10 AND dragonkills=0)";
         }
 
         $expected = null;
@@ -50,7 +52,7 @@ final class FetchAccountsToExpireQueryTest extends TestCase
         $ref = new \ReflectionClass(ExpireChars::class);
         $method = $ref->getMethod('fetchAccountsToExpire');
         $method->setAccessible(true);
-        $method->invoke(null, $old, $new, $trash);
+        $method->invoke(null, $old, $new, $trash, $now);
 
         if ($expected === null) {
             $this->assertSame([], Database::$queries);


### PR DESCRIPTION
## Summary
- use a shared DateTimeImmutable reference when computing inactivity thresholds in `ExpireChars`
- update the fetch accounts to expire test to reuse the same reference instant when building expectations

## Testing
- composer test


------
https://chatgpt.com/codex/tasks/task_e_68cc744af30c832980cd00a9667ccfec