### PR TITLE
fix: update city travel battle nav call

### DIFF
--- a/modules/cities/run.php
+++ b/modules/cities/run.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  */
 
 use Doctrine\DBAL\ParameterType;
-use Lotgd\FightNav;
+use Lotgd\Battle;
 use Lotgd\Forest\Outcomes;
 use Lotgd\MySQL\Database;
 
@@ -219,7 +219,7 @@ if ($battle) {
         require_once 'lib/forestoutcomes.php';
         forestdefeat($newenemies, ['travelling to %s', $city]);
     } else {
-        FightNav::fightnav(true, true, "runmodule.php?module=cities&city=" . urlencode($city) . "&d=$danger");
+        Battle::fightnav(true, true, "runmodule.php?module=cities&city=" . urlencode($city) . "&d=$danger");
     }
     page_footer();
 }


### PR DESCRIPTION
## Summary
- switch the cities travel module to import `Lotgd\Battle` instead of the legacy fight navigation wrapper
- call the updated `Battle::fightnav()` helper when presenting travel battle navigation

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68cd0a220c74832990178f2048ac7762