### PR TITLE
fix: guard sender status lookup for deleted accounts

### DIFF
--- a/pages/mail/case_read.php
+++ b/pages/mail/case_read.php
@@ -61,7 +61,14 @@ function mailRead(): void
 
     // Determine sender status
     $statusImage = '';
-    $senderId = $message['acctid'] ?? null;
+    $senderIdRaw = $message['acctid'] ?? null;
+    $senderId = null;
+
+    if (is_int($senderIdRaw)) {
+        $senderId = $senderIdRaw;
+    } elseif (is_string($senderIdRaw) && ctype_digit($senderIdRaw)) {
+        $senderId = (int) $senderIdRaw;
+    }
 
     if ((int) $message['msgfrom'] === 0) {
         $message['name'] = Translator::translateInline('`i`^System`0`i');
@@ -82,12 +89,12 @@ function mailRead(): void
             $message['body'] = $message['body'];
         }
     } else {
-        $hasSenderRecord = is_numeric($senderId) && (int) $senderId > 0 && ! empty($message['name']);
+        $hasSenderRecord = $senderId !== null && $senderId > 0 && ! empty($message['name']);
 
         if (! $hasSenderRecord) {
             $message['name'] = Translator::translateInline('`^Deleted User');
         } else {
-            $online = (int) PlayerFunctions::isPlayerOnline((int) $senderId);
+            $online = PlayerFunctions::isPlayerOnline($senderId);
             $status = $online ? 'online' : 'offline';
             $statusImage = "<img src='images/$status.gif' alt='$status'>";
         }


### PR DESCRIPTION
## Summary
- skip status lookup when a mail sender record lacks an acctid from the join
- ensure online/offline indicator only renders for numeric account ids

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68ced016901c8329ae9b662d3b8e4ba3