### PR TITLE
fix: ensure fetchAssoc handles cached associative rows

### DIFF
--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -231,6 +231,9 @@ class Database
     public static function fetchAssoc(array|\mysqli_result|DoctrineResult &$result): array|false|null
     {
         if (is_array($result)) {
+            if (!array_is_list($result)) {
+                $result = [$result];
+            }
             $val = current($result);
             next($result);
             return $val;

--- a/tests/DatabaseDoctrineTest.php
+++ b/tests/DatabaseDoctrineTest.php
@@ -39,6 +39,15 @@ final class DatabaseDoctrineTest extends TestCase
         $this->assertSame(['ok' => true], $row);
     }
 
+    public function testFetchAssocWrapsCachedAssociativeRow(): void
+    {
+        $cachedRow = ['id' => 1, 'name' => 'Shadowfax'];
+
+        $row = Database::fetchAssoc($cachedRow);
+
+        $this->assertSame(['id' => 1, 'name' => 'Shadowfax'], $row);
+    }
+
     public function testInsertIdUsesDoctrine(): void
     {
         $id = Database::insertId();

--- a/tests/Stubs/Database.php
+++ b/tests/Stubs/Database.php
@@ -350,6 +350,10 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
         public static function fetchAssoc(mixed &$result): mixed
         {
             if (is_array($result)) {
+                if (!array_is_list($result)) {
+                    $result = [$result];
+                }
+
                 return array_shift($result);
             }
 


### PR DESCRIPTION
## Summary
- ensure `Database::fetchAssoc` wraps associative cached rows before iterating so it always returns arrays
- add a regression test covering cached associative rows and update the database stub to match the behavior

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68ced0303f5c8329990341631184f1e1