### PR TITLE
fix: adjust installer affected rows check

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -248,7 +248,7 @@ class Installer
                     Database::query($sql);
                     $sql = "INSERT INTO " . Database::prefix("accounts") . " (login,password,superuser,name,playername,ctitle,title,regdate,badguy,companions, allowednavs, restorepage, bufflist, dragonpoints, prefs, donationconfig,specialinc,specialmisc,emailaddress,replaceemail,emailvalidation,hauntedby,bio) VALUES('$name','$pass',$su,'`%Admin `&$name`0','`%Admin `&$name`0','`%Admin','', NOW(),'','','','village.php','','','','','','','','','')";
                     $result = Database::query($sql);
-                    if (Database::affectedRows($result) == 0) {
+                    if (Database::affectedRows() == 0) {
                         print_r($sql);
                         die("Failed to create Admin account. Your first check should be to make sure that MYSQL (if that is your type) is not in strict mode.");
                     }


### PR DESCRIPTION
## Summary
- update stage 10 admin creation to call Database::affectedRows() without passing the query result

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d01a295d308329bd660b8146da801f