### PR TITLE
Fix installer stage6 success flag initialisation

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -800,6 +800,7 @@ class Installer
     public function stage6(): void
     {
         global $session, $logd_version, $recommended_modules, $noinstallnavs, $stage, $DB_USEDATACACHE;
+        $success = false;
         if (file_exists("dbconnect.php")) {
             $success = true;
             $initial = false;
@@ -862,7 +863,8 @@ class Installer
                 $this->output->output("`2Create a new file, past the entire contents from above into it (everything from and including `3<?php`2 up to and including `3?>`2 ).");
                 $this->output->output("When you have that done, save the file as 'dbconnect.php' and upload this to the location you have LoGD at.");
                 $this->output->output("You can refresh this page to see if you were successful.");
-            } else {
+            }
+            if (! $failure) {
                 $success = true;
             }
         }

--- a/tests/Installer/Stage6Test.php
+++ b/tests/Installer/Stage6Test.php
@@ -144,8 +144,6 @@ final class Stage6Test extends TestCase
         try {
             $installer = new Installer();
             $installer->stage6();
-        } catch (\Throwable $error) {
-            $this->assertStringContainsString('Undefined variable $success', $error->getMessage());
         } finally {
             self::$simulateWriteFailure = false;
         }


### PR DESCRIPTION
## Summary
- ensure the stage 6 installer step initialises the $success flag before attempting to write dbconnect.php and only marks success after a successful write
- update the stage 6 installer test to expect the method to complete without an undefined variable warning when file writes fail

## Testing
- composer test -- tests/Installer/Stage6Test.php

------
https://chatgpt.com/codex/tasks/task_e_68d01f66bc2c83298b0b21519f5cbd60