### PR TITLE
test: ensure stage 5 remains locked on conflict

### DIFF
--- a/tests/Installer/Stage5Test.php
+++ b/tests/Installer/Stage5Test.php
@@ -91,6 +91,7 @@ final class Stage5Test extends TestCase
         global $session;
         $this->assertSame('lotgd_', $session['dbinfo']['DB_PREFIX']);
         $this->assertFalse($session['dbinfo']['upgrade']);
+        $this->assertSame(4, $session['stagecompleted']);
 
         $output = Output::getInstance()->getRawOutput();
 


### PR DESCRIPTION
## Summary
- add an assertion in the stage 5 installer test to confirm the session locks the stage until overwrite confirmation

## Testing
- composer test -- tests/Installer/Stage5Test.php

------
https://chatgpt.com/codex/tasks/task_e_68d02fa4756c8329adc9b840090ce6e9