### PR TITLE
test: cover installer write failure session state

### DIFF
--- a/tests/Installer/Stage6Test.php
+++ b/tests/Installer/Stage6Test.php
@@ -148,6 +148,10 @@ final class Stage6Test extends TestCase
             self::$simulateWriteFailure = false;
         }
 
+        global $session;
+
+        $this->assertSame(5, $session['stagecompleted'] ?? null);
+
         $output = Output::getInstance()->getRawOutput();
         $this->assertStringContainsString('You will have to create this file yourself', $output);
         $this->assertStringContainsString('The contents of this file should be as follows', $output);


### PR DESCRIPTION
## Summary
- re-import the installer session after stage 6 runs when file creation fails
- assert the installer keeps stagecompleted at 5 if dbconnect.php cannot be written

## Testing
- composer test -- tests/Installer/Stage6Test.php

------
https://chatgpt.com/codex/tasks/task_e_68d02fa5de9083298dfd92796362169c