### PR TITLE
test: cover installer stage10 existing superuser

### DIFF
--- a/tests/Installer/Stage10Test.php
+++ b/tests/Installer/Stage10Test.php
@@ -108,4 +108,24 @@ final class Stage10Test extends TestCase
             $this->assertStringNotContainsString('INSERT INTO accounts', $query);
         }
     }
+
+    public function testStage10SkipsCreationWhenSuperuserAlreadyExists(): void
+    {
+        Database::$mockResults = [
+            [
+                ['login' => 'Admin', 'password' => 'hash'],
+            ],
+        ];
+
+        $_POST = [];
+
+        $installer = new Installer();
+        $installer->stage10();
+
+        $output = Output::getInstance()->getRawOutput();
+        $this->assertStringContainsString('You already have a superuser account', $output);
+
+        $this->assertCount(1, Database::$queries);
+        $this->assertStringContainsString('SELECT login, password FROM accounts', Database::$queries[0]);
+    }
 }


### PR DESCRIPTION
## Summary
- add regression coverage for Installer::stage10 when a superuser already exists
- ensure no additional queries are executed when the installer detects an existing account

## Testing
- composer test -- tests/Installer/Stage10Test.php

------
https://chatgpt.com/codex/tasks/task_e_68d0360aee708329b75b2f642a791aaa