### PR TITLE
fix: correct optional chaining syntax

### DIFF
--- a/async/js/lotgd.jaxon.js
+++ b/async/js/lotgd.jaxon.js
@@ -113,7 +113,7 @@
         } else {
             console.error('DEBUG: Polling requirements not met:', {
                 Lotgd: typeof window.Lotgd,
-                pollUpdates: typeof window.Lotgd ? .Async ? .Handler ? .Commentary ? .pollUpdates,
+                pollUpdates: typeof window.Lotgd?.Async?.Handler?.Commentary?.pollUpdates,
                 pollInterval: typeof window.lotgd_poll_interval_ms
             });
         }


### PR DESCRIPTION
## Summary
- replace malformed optional chaining expression in `Lotgd` commentary polling debug logging
- ensure the namespace bootstrap still executes cleanly when the script loads

## Testing
- node --check async/js/lotgd.jaxon.js
- node <<'NODE'
const fs = require('fs');
const vm = require('vm');
function CustomEvent(name) { this.type = name; }
const window = {
  console,
  setTimeout,
  CustomEvent,
  dispatchEvent: (event) => console.log('dispatchEvent', event.type),
};
window.window = window;
const context = {
  window,
  console,
  setTimeout,
  CustomEvent,
};
vm.createContext(context);
const code = fs.readFileSync('async/js/lotgd.jaxon.js', 'utf8');
vm.runInContext(code, context);
console.log('Lotgd namespace exists:', !!window.Lotgd);
console.log('Lotgd.Async.Handler keys:', Object.keys(window.Lotgd.Async.Handler));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d04a0f94388329ad8e2051e5a2a2fc