### PR TITLE
chore: exclude async js from phpcs

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,6 +3,7 @@
 	<rule ref="PSR12">
 		<exclude name="Generic.Files.LineLength"/>
 	</rule>
-	<exclude-pattern>vendor/*</exclude-pattern>
+        <exclude-pattern>vendor/*</exclude-pattern>
         <exclude-pattern>src/Lotgd/md5.js</exclude-pattern>
+        <exclude-pattern>async/js/*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
## Summary
- exclude the legacy async/js sources from phpcs linting to avoid invalid rewrites

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d04991d5cc832990c11607f456f536