### PR TITLE
Add upgrade path coverage to installer stage 5 test

### DIFF
--- a/tests/Installer/Stage5Test.php
+++ b/tests/Installer/Stage5Test.php
@@ -133,4 +133,24 @@ final class Stage5Test extends TestCase
 
         $this->assertStringNotContainsString('installer.php?stage=5&op=confirm_overwrite', $output);
     }
+
+    public function testStage5UpgradePath(): void
+    {
+        global $session;
+
+        $session['stagecompleted'] = 5;
+        Database::$mockResults = [];
+        $_GET['type'] = 'upgrade';
+
+        $installer = new Installer();
+        $installer->stage5();
+
+        $this->assertTrue($session['dbinfo']['upgrade']);
+        $this->assertSame(5, $session['stagecompleted']);
+
+        $output = Output::getInstance()->getRawOutput();
+
+        $this->assertStringContainsString('This looks like a game upgrade', $output);
+        $this->assertStringNotContainsString('installer.php?stage=5&op=confirm_overwrite', $output);
+    }
 }


### PR DESCRIPTION
## Summary
- add a Stage5 test case that forces the installer upgrade branch
- assert the upgrade flag, stage progression, and relevant output messaging

## Testing
- composer test -- tests/Installer/Stage5Test.php

------
https://chatgpt.com/codex/tasks/task_e_68d058f728e48329a58d8b75c89b0aef