### PR TITLE
Fix installer harness to use Doctrine stub connection

### DIFF
--- a/tests/Installer/run_install.php
+++ b/tests/Installer/run_install.php
@@ -6,6 +6,7 @@ namespace {
     require __DIR__ . '/../../autoload.php';
     require __DIR__ . '/../../src/Lotgd/Config/constants.php';
     require __DIR__ . '/../Stubs/Functions.php';
+    require __DIR__ . '/../Stubs/DoctrineBootstrap.php';
 
     ini_set('mysqli.default_socket', '/tmp/lotgd_mysqld.sock');
     define('IS_INSTALLER', true);
@@ -20,6 +21,8 @@ namespace Lotgd\Installer {
 
 namespace {
     use Lotgd\Installer\Installer;
+    use Lotgd\MySQL\Database;
+    use Lotgd\Tests\Stubs\DoctrineBootstrap;
 
     [$script, $host, $user, $pass, $db] = $argv;
 
@@ -35,6 +38,9 @@ namespace {
     ], 'user' => ['loggedin' => false, 'superuser' => 0, 'acctid' => 0, 'restorepage' => '']];
     $DB_USEDATACACHE = 0;
     $DB_PREFIX = '';
+
+    $connection = DoctrineBootstrap::getEntityManager()->getConnection();
+    Database::setDoctrineConnection($connection);
 
     $installer = new Installer();
 


### PR DESCRIPTION
## Summary
- load the Doctrine test bootstrap in the installer harness so its alias is registered
- preconfigure Lotgd\MySQL\Database with the stub Doctrine connection during installer tests

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d06153e7648329bec77374417d804d