### PR TITLE
test: cover module manager cache clearing

### DIFF
--- a/tests/ModuleManagerTest.php
+++ b/tests/ModuleManagerTest.php
@@ -6,29 +6,41 @@ namespace Lotgd\Modules {
     class Installer
     {
         public static array $statusReturn = [];
+        public static bool $installShouldSucceed = false;
+        public static bool $uninstallShouldSucceed = false;
+        public static bool $activateShouldSucceed = false;
+        public static bool $deactivateShouldSucceed = false;
         public static function getInstallStatus(bool $withDb = true): array
         {
             return self::$statusReturn;
         }
         public static function install(string $module): bool
         {
-            return false;
+            return self::$installShouldSucceed;
         }
         public static function uninstall(string $module): bool
         {
-            return false;
+            return self::$uninstallShouldSucceed;
         }
         public static function activate(string $module): bool
         {
-            return false;
+            return self::$activateShouldSucceed;
         }
         public static function deactivate(string $module): bool
         {
-            return false;
+            return self::$deactivateShouldSucceed;
         }
         public static function forceUninstall(string $module): bool
         {
             return true;
+        }
+        public static function reset(): void
+        {
+            self::$statusReturn = [];
+            self::$installShouldSucceed = false;
+            self::$uninstallShouldSucceed = false;
+            self::$activateShouldSucceed = false;
+            self::$deactivateShouldSucceed = false;
         }
     }
 }
@@ -37,6 +49,7 @@ namespace Lotgd\Tests {
 
     use Lotgd\ModuleManager;
     use Lotgd\Tests\Stubs\Database;
+    use Lotgd\Tests\Stubs\DummySettings;
     use PHPUnit\Framework\TestCase;
 
 /**
@@ -45,10 +58,50 @@ namespace Lotgd\Tests {
  */
     final class ModuleManagerTest extends TestCase
     {
+        private string $cacheDir = '';
+
         protected function setUp(): void
         {
             class_exists(Database::class);
+            \Lotgd\Modules\Installer::reset();
+            \Lotgd\MySQL\Database::$lastSql = '';
+            \Lotgd\MySQL\Database::$queries = [];
+
+            $this->cacheDir = sys_get_temp_dir() . '/lotgd_module_manager_' . uniqid('', true);
+            mkdir($this->cacheDir, 0700, true);
+
+            $settings = new DummySettings([
+                'usedatacache'  => 1,
+                'datacachepath' => $this->cacheDir,
+            ]);
+
+            \Lotgd\Settings::setInstance($settings);
+            $GLOBALS['settings'] = $settings;
+
+            $this->resetDataCache();
+
             \Lotgd\DataCache::getInstance();
+            \Lotgd\DataCache::getInstance()->updatedatacache('seed', ['primed' => true]);
+            \Lotgd\DataCache::getInstance()->invalidatedatacache('seed');
+            $this->clearCacheDir();
+
+            $GLOBALS['session']['user']['acctid'] = 42;
+        }
+
+        protected function tearDown(): void
+        {
+            $this->clearCacheDir();
+            if (isset($this->cacheDir) && is_dir($this->cacheDir)) {
+                @rmdir($this->cacheDir);
+            }
+
+            unset($GLOBALS['settings'], $GLOBALS['session']);
+            \Lotgd\Settings::setInstance(null);
+
+            $this->resetDataCache();
+
+            \Lotgd\Modules\Installer::reset();
+            \Lotgd\MySQL\Database::$queries = [];
             \Lotgd\MySQL\Database::$lastSql = '';
         }
 
@@ -70,24 +123,68 @@ namespace Lotgd\Tests {
             $this->assertSame(['core' => 1], ModuleManager::getInstalledCategories());
         }
 
-        public function testInstallReturnsTrue(): void
+        public function testInstallReturnsFalseWhenInstallerFails(): void
         {
             $this->assertFalse(ModuleManager::install('mod'));
         }
 
-        public function testUninstallReturnsTrue(): void
+        public function testInstallSuccessClearsCachesAndLogs(): void
+        {
+            $paths = $this->primeCaches(['hook-alpha', 'module-prepare-beta']);
+            \Lotgd\Modules\Installer::$installShouldSucceed = true;
+
+            $this->assertTrue(ModuleManager::install('mod'));
+
+            $this->assertCachesRemoved($paths);
+            $this->assertGamelogEntryContains("Module mod installed");
+        }
+
+        public function testUninstallReturnsFalseWhenInstallerFails(): void
         {
             $this->assertFalse(ModuleManager::uninstall('mod'));
         }
 
-        public function testActivateReturnsTrue(): void
+        public function testUninstallSuccessClearsCachesAndLogs(): void
+        {
+            $paths = $this->primeCaches(['hook-alpha', 'module-prepare-beta', 'inject-mod']);
+            \Lotgd\Modules\Installer::$uninstallShouldSucceed = true;
+
+            $this->assertTrue(ModuleManager::uninstall('mod'));
+
+            $this->assertCachesRemoved($paths);
+            $this->assertGamelogEntryContains("Module mod uninstalled");
+        }
+
+        public function testActivateReturnsFalseWhenInstallerFails(): void
         {
             $this->assertFalse(ModuleManager::activate('mod'));
         }
 
-        public function testDeactivateReturnsTrue(): void
+        public function testActivateSuccessClearsCachesAndLogs(): void
+        {
+            $paths = $this->primeCaches(['hook-alpha', 'module-prepare-beta', 'inject-mod']);
+            \Lotgd\Modules\Installer::$activateShouldSucceed = true;
+
+            $this->assertTrue(ModuleManager::activate('mod'));
+
+            $this->assertCachesRemoved($paths);
+            $this->assertGamelogEntryContains("Module mod activated");
+        }
+
+        public function testDeactivateReturnsFalseWhenInstallerFails(): void
         {
             $this->assertFalse(ModuleManager::deactivate('mod'));
+        }
+
+        public function testDeactivateSuccessClearsCachesAndLogs(): void
+        {
+            $paths = $this->primeCaches(['module-prepare-beta', 'inject-mod']);
+            \Lotgd\Modules\Installer::$deactivateShouldSucceed = true;
+
+            $this->assertTrue(ModuleManager::deactivate('mod'));
+
+            $this->assertCachesRemoved($paths);
+            $this->assertGamelogEntryContains("Module mod deactivated");
         }
 
         public function testReinstallUpdatesDate(): void
@@ -100,6 +197,79 @@ namespace Lotgd\Tests {
         public function testForceUninstallReturnsTrue(): void
         {
             $this->assertTrue(ModuleManager::forceUninstall('mod'));
+        }
+
+        /**
+         * @param list<string> $names
+         * @return array<string,string>
+         */
+        private function primeCaches(array $names): array
+        {
+            $cache = \Lotgd\DataCache::getInstance();
+            $paths = [];
+
+            foreach ($names as $name) {
+                $this->assertTrue($cache->updatedatacache($name, ['name' => $name]));
+                $path = $cache->makecachetempname($name);
+                $this->assertFileExists($path);
+                $paths[$name] = $path;
+            }
+
+            return $paths;
+        }
+
+        /**
+         * @param array<string,string> $paths
+         */
+        private function assertCachesRemoved(array $paths): void
+        {
+            foreach ($paths as $path) {
+                $this->assertFileDoesNotExist($path);
+            }
+
+            $this->assertSame([], $this->listCacheFiles());
+        }
+
+        private function listCacheFiles(): array
+        {
+            $files = glob($this->cacheDir . '/*') ?: [];
+            sort($files);
+
+            return array_values(array_filter($files, 'is_file'));
+        }
+
+        private function assertGamelogEntryContains(string $message): void
+        {
+            $needle = "INSERT INTO gamelog (message,category,filed,date,who) VALUES ('{$message}','modules','0'";
+            $matches = array_filter(
+                \Lotgd\MySQL\Database::$queries,
+                static fn (string $query): bool => str_contains($query, $needle)
+            );
+
+            $this->assertNotEmpty($matches, 'Expected gamelog entry was not written.');
+        }
+
+        private function clearCacheDir(): void
+        {
+            if (! isset($this->cacheDir) || ! is_dir($this->cacheDir)) {
+                return;
+            }
+
+            foreach (glob($this->cacheDir . '/*') ?: [] as $file) {
+                if (is_file($file)) {
+                    @unlink($file);
+                }
+            }
+        }
+
+        private function resetDataCache(): void
+        {
+            $reflection = new \ReflectionClass(\Lotgd\DataCache::class);
+            foreach (['instance' => null, 'cache' => [], 'path' => '', 'checkedOld' => false] as $property => $value) {
+                $prop = $reflection->getProperty($property);
+                $prop->setAccessible(true);
+                $prop->setValue(null, $value);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add success toggles to the ModuleManager installer stub
- configure ModuleManager tests with a temporary data cache path and dummy settings
- assert cache invalidation and gamelog logging for install, uninstall, activate, and deactivate

## Testing
- composer test -- tests/ModuleManagerTest.php
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d0fb828ae08329bb637fc39233bb19