### PR TITLE
test: cover mount caching

### DIFF
--- a/tests/MountsTest.php
+++ b/tests/MountsTest.php
@@ -10,20 +10,47 @@ use PHPUnit\Framework\TestCase;
 
 final class MountsTest extends TestCase
 {
+    /**
+     * @var array<string,mixed>
+     */
+    private array $cachedMountRow = [
+        'mountid'   => 7,
+        'mountname' => 'Thunder',
+    ];
+
     protected function setUp(): void
     {
         class_exists(Database::class);
         \Lotgd\MySQL\Database::$lastSql = '';
+        \Lotgd\MySQL\Database::$lastCacheName = '';
+        \Lotgd\MySQL\Database::$queryCacheResults['mountdata-7'] = [
+            $this->cachedMountRow,
+        ];
     }
 
     protected function tearDown(): void
     {
         \Lotgd\MySQL\Database::$lastSql = '';
+        \Lotgd\MySQL\Database::$lastCacheName = '';
+        unset(\Lotgd\MySQL\Database::$queryCacheResults['mountdata-7']);
+        Mounts::getInstance()->setPlayerMount([]);
     }
 
     public function testGetmountExecutesQuery(): void
     {
-        $this->assertSame([], Mounts::getmount(1));
+        $this->assertSame([
+            $this->cachedMountRow,
+        ], \Lotgd\MySQL\Database::$queryCacheResults['mountdata-7']);
+
+        $row = Mounts::getmount(7);
+
+        $this->assertSame($this->cachedMountRow, $row);
+        $this->assertSame('mountdata-7', \Lotgd\MySQL\Database::$lastCacheName);
+        $this->assertSame([
+            $this->cachedMountRow,
+        ], \Lotgd\MySQL\Database::$queryCacheResults['mountdata-7']);
+
+        $this->assertSame($this->cachedMountRow, Mounts::getmount(7));
     }
 
     public function testGetmountReturnsEmptyArrayWhenNoRows(): void
@@ -37,5 +64,8 @@ final class MountsTest extends TestCase
         $mounts = Mounts::getInstance();
         $mounts->setPlayerMount(['mountid' => 5]);
         $this->assertSame(['mountid' => 5], $mounts->getPlayerMount());
+
+        $mounts->loadPlayerMount(7);
+        $this->assertSame($this->cachedMountRow, $mounts->getPlayerMount());
     }
 }


### PR DESCRIPTION
## Summary
- seed a cached mount row for tests and reset singleton state between runs
- assert mount caching behaviour and player mount loading in MountsTest

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d0fb8459c88329934871ad747f8601