### PR TITLE
test: cover force uninstall cache clearing

### DIFF
--- a/tests/ModuleManagerTest.php
+++ b/tests/ModuleManagerTest.php
@@ -194,9 +194,14 @@ namespace Lotgd\Tests {
             $this->assertContains($expected, \Lotgd\MySQL\Database::$queries);
         }
 
-        public function testForceUninstallReturnsTrue(): void
+        public function testForceUninstallClearsCachesAndLogs(): void
         {
+            $paths = $this->primeCaches(['hook-alpha', 'module-prepare-beta', 'inject-mod']);
+
             $this->assertTrue(ModuleManager::forceUninstall('mod'));
+
+            $this->assertCachesRemoved($paths);
+            $this->assertGamelogEntryContains('Module mod force-uninstalled');
         }
 
         /**


### PR DESCRIPTION
## Summary
- prime the module cache before invoking `ModuleManager::forceUninstall`
- assert the cache files are removed and a gamelog entry is written

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d102554c548329b917ea3605952f81