### PR TITLE
test: cover module reinstall cache invalidation

### DIFF
--- a/tests/ModuleManagerTest.php
+++ b/tests/ModuleManagerTest.php
@@ -189,9 +189,13 @@ namespace Lotgd\Tests {
 
         public function testReinstallUpdatesDate(): void
         {
+            $paths = $this->primeCaches(['hook-alpha', 'module-prepare-beta', 'inject-mod']);
+
             ModuleManager::reinstall('mod');
             $expected = "UPDATE modules SET filemoddate='" . DATETIME_DATEMIN . "' WHERE modulename='mod'";
             $this->assertContains($expected, \Lotgd\MySQL\Database::$queries);
+            $this->assertCachesRemoved($paths);
+            $this->assertGamelogEntryContains('Module mod reinstalled');
         }
 
         public function testForceUninstallReturnsTrue(): void


### PR DESCRIPTION
## Summary
- prime the hook/module-prepare/inject caches in the module reinstall test before invoking reinstall
- assert that the reinstall operation clears those caches and records the expected gamelog entry

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d10257438483298dff61a49c712381