### PR TITLE
fix: support legacy Doctrine dbconnect config

### DIFF
--- a/src/Lotgd/Doctrine/Bootstrap.php
+++ b/src/Lotgd/Doctrine/Bootstrap.php
@@ -29,8 +29,28 @@ class Bootstrap
             throw new \RuntimeException('dbconnect.php not found');
         }
 
-        global $DB_PREFIX;
+        if (! is_array($settings)) {
+            $settings = [
+                'DB_HOST'         => $DB_HOST ?? '',
+                'DB_USER'         => $DB_USER ?? '',
+                'DB_PASS'         => $DB_PASS ?? '',
+                'DB_NAME'         => $DB_NAME ?? '',
+                'DB_PREFIX'       => $DB_PREFIX ?? '',
+                'DB_USEDATACACHE' => $DB_USEDATACACHE ?? 0,
+                'DB_DATACACHEPATH' => $DB_DATACACHEPATH ?? '',
+            ];
+        }
+
+        global $DB_HOST, $DB_USER, $DB_PASS, $DB_NAME, $DB_PREFIX, $DB_USEDATACACHE, $DB_DATACACHEPATH;
+
+        $DB_HOST = $settings['DB_HOST'] ?? '';
+        $DB_USER = $settings['DB_USER'] ?? '';
+        $DB_PASS = $settings['DB_PASS'] ?? '';
+        $DB_NAME = $settings['DB_NAME'] ?? '';
         $DB_PREFIX = $settings['DB_PREFIX'] ?? '';
+        $DB_USEDATACACHE = $settings['DB_USEDATACACHE'] ?? 0;
+        $DB_DATACACHEPATH = $settings['DB_DATACACHEPATH'] ?? '';
+
         Database::setPrefix($DB_PREFIX);
 
         $connection = [

--- a/tests/Doctrine/BootstrapCharsetTest.php
+++ b/tests/Doctrine/BootstrapCharsetTest.php
@@ -9,6 +9,30 @@ use PHPUnit\Framework\TestCase;
 
 final class BootstrapCharsetTest extends TestCase
 {
+    private string $dbConfig;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dbConfig = dirname(__DIR__, 2) . '/dbconnect.php';
+        file_put_contents(
+            $this->dbConfig,
+            "<?php return ['DB_HOST'=>'localhost','DB_USER'=>'user','DB_PASS'=>'pass','DB_NAME'=>'lotgd','DB_PREFIX'=>''];"
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->dbConfig)) {
+            unlink($this->dbConfig);
+        }
+
+        unset($GLOBALS['DB_PREFIX']);
+
+        parent::tearDown();
+    }
+
     public function testEntityManagerUsesUtf8mb4Charset(): void
     {
         $entityManager = Bootstrap::getEntityManager();

--- a/tests/Doctrine/BootstrapLegacyConfigTest.php
+++ b/tests/Doctrine/BootstrapLegacyConfigTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Doctrine;
+
+use Lotgd\Doctrine\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+final class BootstrapLegacyConfigTest extends TestCase
+{
+    private string $dbConfig;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dbConfig = dirname(__DIR__, 2) . '/dbconnect.php';
+        $cachePath = sys_get_temp_dir();
+        $legacyConfig = <<<PHP
+<?php
+\$DB_HOST = 'legacy-host';
+\$DB_USER = 'legacy-user';
+\$DB_PASS = 'legacy-pass';
+\$DB_NAME = 'legacy-name';
+\$DB_PREFIX = 'legacy_';
+\$DB_USEDATACACHE = 1;
+\$DB_DATACACHEPATH = %s;
+PHP;
+        file_put_contents($this->dbConfig, sprintf($legacyConfig, var_export($cachePath, true)));
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->dbConfig)) {
+            unlink($this->dbConfig);
+        }
+
+        unset(
+            $GLOBALS['DB_HOST'],
+            $GLOBALS['DB_USER'],
+            $GLOBALS['DB_PASS'],
+            $GLOBALS['DB_NAME'],
+            $GLOBALS['DB_PREFIX'],
+            $GLOBALS['DB_USEDATACACHE'],
+            $GLOBALS['DB_DATACACHEPATH']
+        );
+
+        parent::tearDown();
+    }
+
+    public function testEntityManagerLoadsLegacyGlobals(): void
+    {
+        $bootstrapClass = $this->resolveBootstrapClass();
+        $entityManager = $bootstrapClass::getEntityManager();
+        $params = $entityManager->getConnection()->getParams();
+
+        self::assertSame('legacy-host', $params['host'] ?? null);
+        self::assertSame('legacy-name', $params['dbname'] ?? null);
+        self::assertSame('legacy-user', $params['user'] ?? null);
+        self::assertSame('legacy-pass', $params['password'] ?? null);
+        self::assertSame('utf8mb4', $params['charset'] ?? null);
+        self::assertSame('legacy_', $GLOBALS['DB_PREFIX'] ?? null);
+    }
+
+    /**
+     * @return class-string
+     */
+    private function resolveBootstrapClass(): string
+    {
+        $originalClass = Bootstrap::class;
+        $bootstrapFile = (new \ReflectionClass($originalClass))->getFileName();
+        $realFile = realpath(__DIR__ . '/../../src/Lotgd/Doctrine/Bootstrap.php');
+
+        if ($realFile === false) {
+            throw new \RuntimeException('Unable to locate Doctrine bootstrap source file');
+        }
+
+        if ($bootstrapFile === $realFile) {
+            return $originalClass;
+        }
+
+        $realClass = '\\Lotgd\\Tests\\Doctrine\\RealBootstrap\\Bootstrap';
+
+        if (!class_exists($realClass)) {
+            $contents = file_get_contents($realFile);
+            $contents = str_replace('namespace Lotgd\\Doctrine;', 'namespace Lotgd\\Tests\\Doctrine\\RealBootstrap;', (string) $contents);
+            $contents = str_replace('dirname(__DIR__, 3)', var_export(dirname(__DIR__, 2), true), (string) $contents);
+            $contents = preg_replace('/^<\\?php\s*/', '', (string) $contents);
+
+            if ($contents === null) {
+                throw new \RuntimeException('Unable to load real Doctrine bootstrap for testing');
+            }
+
+            eval($contents);
+        }
+
+        return $realClass;
+    }
+}


### PR DESCRIPTION
## Summary
- rebuild Doctrine bootstrap settings from legacy `$DB_*` globals when dbconnect.php does not return an array and synchronise the globals for callers
- provision a temporary dbconnect.php fixture in the Doctrine charset test so it no longer depends on external state
- add a regression test that exercises the legacy dbconnect.php format by loading the real Doctrine bootstrap even when the suite replaces it with a stub

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d179c8425883298cf69e43db587554