### PR TITLE
fix: ensure Doctrine bootstrap loads legacy globals

### DIFF
--- a/src/Lotgd/Doctrine/Bootstrap.php
+++ b/src/Lotgd/Doctrine/Bootstrap.php
@@ -22,6 +22,8 @@ class Bootstrap
         // The project root is three directories up from this file
         // src/Lotgd/Doctrine/Bootstrap.php -> src/Lotgd -> src -> project root
         $rootDir = dirname(__DIR__, 3);
+        global $DB_HOST, $DB_USER, $DB_PASS, $DB_NAME, $DB_PREFIX, $DB_USEDATACACHE, $DB_DATACACHEPATH;
+
         $dbConfig = realpath($rootDir . '/dbconnect.php');
         if ($dbConfig && strpos($dbConfig, $rootDir) === 0) {
             $settings = require $dbConfig;
@@ -40,8 +42,6 @@ class Bootstrap
                 'DB_DATACACHEPATH' => $DB_DATACACHEPATH ?? '',
             ];
         }
-
-        global $DB_HOST, $DB_USER, $DB_PASS, $DB_NAME, $DB_PREFIX, $DB_USEDATACACHE, $DB_DATACACHEPATH;
 
         $DB_HOST = $settings['DB_HOST'] ?? '';
         $DB_USER = $settings['DB_USER'] ?? '';


### PR DESCRIPTION
## Summary
- declare legacy database globals before requiring dbconnect.php so Doctrine sees their values
- keep the existing fallback and global sync logic intact

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d19208ad8c8329a91020553add2242