### PR TITLE
fix: restore db prefix registration during migrations

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1465,6 +1465,7 @@ class Installer
 
         $db        = require dirname(__DIR__, 2) . '/dbconnect.php';
         $DB_PREFIX = $db['DB_PREFIX'] ?? '';
+        Database::setPrefix($DB_PREFIX);
         InstallerLogger::log('DB_PREFIX set to ' . $DB_PREFIX);
 
         $config = require dirname(__DIR__, 2) . '/src/Lotgd/Config/migrations.php';


### PR DESCRIPTION
## Summary
- call `Lotgd\MySQL\Database::setPrefix()` within the installer once dbconnect.php is loaded so Doctrine migrations use the configured prefix

## Testing
- composer test
- composer static
- ran installer via web flow with custom prefix `test_` and confirmed prefixed tables plus Stage 9 seeds populated


------
https://chatgpt.com/codex/tasks/task_e_68d19b7789ac8329b71520d5778b274d