### PR TITLE
fix: honor table prefix for doctrine migrations

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1463,9 +1463,14 @@ class Installer
     {
         global $session, $DB_PREFIX;
 
-        $db        = require dirname(__DIR__, 2) . '/dbconnect.php';
-        $DB_PREFIX = $db['DB_PREFIX'] ?? '';
-        Database::setPrefix($DB_PREFIX);
+        $db           = require dirname(__DIR__, 2) . '/dbconnect.php';
+        $initialPrefix = $DB_PREFIX ?? '';
+        Database::setPrefix($initialPrefix);
+
+        $DB_PREFIX = $db['DB_PREFIX'] ?? $initialPrefix;
+        if ($DB_PREFIX !== $initialPrefix) {
+            Database::setPrefix($DB_PREFIX);
+        }
         InstallerLogger::log('DB_PREFIX set to ' . $DB_PREFIX);
 
         $config = require dirname(__DIR__, 2) . '/src/Lotgd/Config/migrations.php';
@@ -1473,7 +1478,7 @@ class Installer
         $em = Bootstrap::getEntityManager();
 
         $dependencyFactory = DependencyFactory::fromEntityManager(
-            new ConfigurationArray(['migrations_paths' => $config['migrations_paths']]),
+            new ConfigurationArray($config),
             new ExistingEntityManager($em)
         );
 

--- a/src/Lotgd/Config/migrations.php
+++ b/src/Lotgd/Config/migrations.php
@@ -1,7 +1,15 @@
 <?php
 
+use Lotgd\MySQL\Database;
+
+$db     = require dirname(__DIR__, 3) . '/dbconnect.php';
+$prefix = $db['DB_PREFIX'] ?? '';
+
 return [
     'migrations_paths' => [
         'Lotgd\\Migrations' => dirname(__DIR__, 3) . '/migrations',
+    ],
+    'table_storage' => [
+        'table_name' => Database::prefix('doctrine_migration_versions', $prefix),
     ],
 ];

--- a/tests/Installer/Stage9Test.php
+++ b/tests/Installer/Stage9Test.php
@@ -21,10 +21,33 @@ namespace Doctrine\Migrations {
         public static ?self $instance = null;
         /** @var Version[] */
         public array $migrated = [];
+        public mixed $configuration = null;
+        /** @var array<string,mixed> */
+        public array $configurationData = [];
+        public ?string $metadataTable = null;
 
         public static function fromEntityManager(mixed $config, mixed $em): self
         {
-            return self::$instance = new self();
+            $instance = new self();
+            $instance->configuration = $config;
+
+            if (is_array($config)) {
+                $instance->configurationData = $config;
+                $instance->metadataTable    = $config['table_storage']['table_name'] ?? null;
+            } elseif (is_object($config)) {
+                $ref = new \ReflectionClass($config);
+                if ($ref->hasProperty('configurations')) {
+                    $prop = $ref->getProperty('configurations');
+                    $prop->setAccessible(true);
+                    $data = $prop->getValue($config);
+                    if (is_array($data)) {
+                        $instance->configurationData = $data;
+                        $instance->metadataTable    = $data['table_storage']['table_name'] ?? null;
+                    }
+                }
+            }
+
+            return self::$instance = $instance;
         }
 
         public function getMetadataStorage(): object
@@ -99,6 +122,7 @@ namespace Doctrine\Migrations {
 namespace Lotgd\Tests\Installer {
 
     use Lotgd\Installer\Installer;
+    use Lotgd\MySQL\Database;
     use Lotgd\Output;
     use Lotgd\Tests\Stubs\DummySettings;
     use Lotgd\Tests\Stubs\DoctrineBootstrap;
@@ -114,6 +138,7 @@ namespace Lotgd\Tests\Installer {
             $DB_USEDATACACHE, $settings;
 
             \Lotgd\PhpGenericEnvironment::setRequestUri('/installer.php');
+            \Doctrine\Migrations\DependencyFactory::$instance = null;
             $session            = [
             'dbinfo'            => [
                 'DB_HOST'         => 'localhost',
@@ -151,6 +176,8 @@ namespace Lotgd\Tests\Installer {
             if (file_exists($config)) {
                 unlink($config);
             }
+
+            Database::setPrefix('');
         }
 
         public function testStage9RunsMigrationsAndChecksForAdmin(): void
@@ -191,6 +218,56 @@ namespace Lotgd\Tests\Installer {
             }
 
             $this->assertStringContainsString('superuser account', $outputText);
+        }
+
+        public function testStage9AppliesConfiguredPrefix(): void
+        {
+            global $session;
+
+            file_put_contents(
+                __DIR__ . '/../../dbconnect.php',
+                "<?php return ['DB_HOST'=>'localhost','DB_USER'=>'user','DB_PASS'=>'pass','DB_NAME'=>'lotgd','DB_PREFIX'=>'test_'];"
+            );
+            clearstatcache();
+
+            $session['dbinfo']['DB_PREFIX'] = 'test_';
+
+            $installer = new Installer();
+            $installer->runStage(9);
+
+            self::assertSame('test_', $GLOBALS['DB_PREFIX'] ?? null);
+            $this->assertSame('test_creatures', Database::prefix('creatures'));
+        }
+
+        public function testStage9HonorsPrefixedMetadataTable(): void
+        {
+            global $session;
+
+            file_put_contents(
+                __DIR__ . '/../../dbconnect.php',
+                "<?php return ['DB_HOST'=>'localhost','DB_USER'=>'user','DB_PASS'=>'pass','DB_NAME'=>'lotgd','DB_PREFIX'=>'lotgd_'];"
+            );
+            clearstatcache();
+            if (function_exists('opcache_invalidate')) {
+                opcache_invalidate(__DIR__ . '/../../dbconnect.php', true);
+            }
+
+            $session['dbinfo']['DB_PREFIX'] = 'lotgd_';
+
+            $config = require __DIR__ . '/../../src/Lotgd/Config/migrations.php';
+            $this->assertSame('lotgd_doctrine_migration_versions', $config['table_storage']['table_name']);
+
+            $installer = new Installer();
+
+            $installer->runStage(9);
+
+            $configData = \Doctrine\Migrations\DependencyFactory::$instance->configurationData ?? [];
+
+            $this->assertSame(
+                'lotgd_doctrine_migration_versions',
+                $configData['table_storage']['table_name'] ?? null,
+                'Installer did not request prefixed metadata table'
+            );
         }
 
         public function testStage9RunsOnlyNewerInstallerStatementsOnUpgrade(): void

--- a/tests/Stubs/Database.php
+++ b/tests/Stubs/Database.php
@@ -26,6 +26,7 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
         public static ?object $doctrineConnection = null;
         public static ?object $instance = null;
         public static array $queryCacheResults = [];
+        public static string $tablePrefix = '';
         /**
          * Queue of mock results returned by {@see query} for unit tests.
          * Each call to {@see query} will shift the next entry.
@@ -52,14 +53,18 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
             return self::getInstance()->selectDb($dbname);
         }
 
-        public static function prefix(string $name, bool $force = false): string
+        public static function prefix(string $name, string|false|null $force = null): string
         {
-            return $name;
+            if ($force !== null && $force !== false) {
+                return $force . $name;
+            }
+
+            return self::$tablePrefix . $name;
         }
 
         public static function setPrefix(string $prefix): void
         {
-            // Intentionally left blank for tests.
+            self::$tablePrefix = $prefix;
         }
 
         public static function error(): string
@@ -67,17 +72,17 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
             return self::$instance && method_exists(self::$instance, 'error') ? self::$instance->error() : self::$last_error;
         }
 
-    /**
-     * Executes a database query and returns the result.
-     *
-     * @param string $sql The SQL query to execute.
-     * @param bool   $die Whether to terminate execution on error (default: true).
-     *
-     * @return array|null Returns an array of results for SELECT queries.
-     *                    Returns null if no results are found or for non-SELECT queries.
-     *                    Returns a boolean (true/false) for certain operations (e.g., success/failure).
-     *                    Returns a string in specific cases (e.g., error messages or debug information).
-     */
+        /**
+         * Executes a database query and returns the result.
+         *
+         * @param string $sql The SQL query to execute.
+         * @param bool   $die Whether to terminate execution on error (default: true).
+         *
+         * @return array|null Returns an array of results for SELECT queries.
+         *                    Returns null if no results are found or for non-SELECT queries.
+         *                    Returns a boolean (true/false) for certain operations (e.g., success/failure).
+         *                    Returns a string in specific cases (e.g., error messages or debug information).
+         */
         public static function query(string $sql, bool $die = true): array|bool|object|string|null
         {
             global $accounts_table, $mail_table, $last_query_result;


### PR DESCRIPTION
## Summary
- load the Doctrine migrations configuration with the database prefix and expose the prefixed metadata table name
- pass the full migrations configuration into the installer dependency factory so the prefixed metadata table is respected
- extend the stage 9 installer tests and database stub to cover prefix propagation and prefixed metadata bookkeeping

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d1a03020e0832987178c40c5de8d56