### PR TITLE
Fix Stage 6 dbconnect parsing loop to avoid false buffer values

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -876,8 +876,7 @@ class Installer
                         $assignments = [];
                         $fp = fopen('dbconnect.php', 'r+');
                 if ($fp) {
-                    while (!feof($fp)) {
-                        $buffer = fgets($fp, 4096);
+                    while (($buffer = fgets($fp, 4096)) !== false) {
                         if (strpos($buffer, '$DB') !== false && preg_match('/\$(DB_[A-Z_]+)\s*=\s*([^;]*);/', $buffer, $matches)) {
                             $assignments[$matches[1]] = trim($matches[2], " \t\"'");
                         }


### PR DESCRIPTION
## Summary
- ensure the Stage 6 upgrade loop only processes string buffers from dbconnect.php to avoid calling string functions on `false`

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d1a312a2c88329977b2e74c58501f2