### PR TITLE
fix: guard installer seeding on existing data

### DIFF
--- a/tests/Stubs/DoctrineBootstrap.php
+++ b/tests/Stubs/DoctrineBootstrap.php
@@ -32,10 +32,21 @@ class DoctrineConnection
 {
     public array $queries = [];
     public array $params = ['charset' => 'utf8mb4'];
+    /** @var array<int,int> */
+    public array $countResults = [];
 
     public function executeQuery(string $sql): DoctrineResult
     {
         $this->queries[] = $sql;
+        if (stripos($sql, 'count(') !== false) {
+            $value = array_shift($this->countResults);
+            if ($value === null) {
+                $value = 0;
+            }
+
+            return new DoctrineResult([["total_count" => $value]]);
+        }
+
         return new DoctrineResult([["ok" => true]]);
     }
 


### PR DESCRIPTION
## Summary
- guard the legacy installer SQL seeding by checking whether the creatures table is empty
- enhance the Doctrine connection stub to control SELECT COUNT(*) results
- update the stage 9 installer tests to cover re-run behavior and existing data scenarios

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d1bc2928d88329a8e09bab5fe9b5b5