### PR TITLE
fix: parameterize installer superuser creation

### DIFF
--- a/tests/Installer/Stage10Test.php
+++ b/tests/Installer/Stage10Test.php
@@ -8,6 +8,8 @@ use Lotgd\Installer\Installer;
 use Lotgd\Output;
 use Lotgd\Settings;
 use Lotgd\Tests\Stubs\Database;
+use Lotgd\Tests\Stubs\DoctrineBootstrap;
+use Lotgd\Tests\Stubs\DoctrineConnection;
 use Lotgd\Tests\Stubs\DummySettings;
 use PHPUnit\Framework\TestCase;
 
@@ -24,11 +26,15 @@ final class Stage10Test extends TestCase
         parent::setUp();
 
         require_once dirname(__DIR__, 2) . '/install/lib/Installer.php';
+        require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
 
         class_exists(Database::class);
         Database::$mockResults = [];
         Database::$queries = [];
         Database::$affected_rows = 0;
+        Database::$doctrineConnection = null;
+
+        DoctrineBootstrap::$conn = null;
 
         $this->settings = new DummySettings(['charset' => 'UTF-8']);
         Settings::setInstance($this->settings);
@@ -53,6 +59,11 @@ final class Stage10Test extends TestCase
         Database::$mockResults = [];
         Database::$queries = [];
         Database::$affected_rows = 0;
+        Database::$doctrineConnection = null;
+
+        if (class_exists(DoctrineBootstrap::class, false)) {
+            DoctrineBootstrap::$conn = null;
+        }
 
         Settings::setInstance(null);
         unset($GLOBALS['settings']);
@@ -64,10 +75,11 @@ final class Stage10Test extends TestCase
     {
         Database::$mockResults = [
             [],    // SELECT returns zero rows
-            true,  // DELETE result
-            true,  // INSERT result
         ];
-        Database::$affected_rows = 1;
+
+        $connection = new DoctrineConnection();
+        DoctrineBootstrap::$conn = $connection;
+        Database::$doctrineConnection = null;
 
         $_POST = [
             'name'  => 'Admin',
@@ -79,8 +91,40 @@ final class Stage10Test extends TestCase
         $installer->stage10();
 
         $queries = Database::$queries;
-        $this->assertGreaterThanOrEqual(3, count($queries));
-        $this->assertStringContainsString('INSERT INTO accounts', $queries[2]);
+        $this->assertCount(1, $queries);
+        $this->assertStringContainsString('SELECT login, password FROM accounts', $queries[0]);
+
+        $this->assertNotEmpty($connection->queries);
+        $this->assertSame('DELETE FROM accounts WHERE login = ?', $connection->queries[0]);
+        $this->assertSame(
+            'INSERT INTO accounts (login, password, superuser, name, playername, ctitle, title, regdate, badguy, companions, allowednavs, restorepage, bufflist, dragonpoints, prefs, donationconfig, specialinc, specialmisc, emailaddress, replaceemail, emailvalidation, hauntedby, bio) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            $connection->queries[1]
+        );
+
+        $expectedPrivileges = SU_MEGAUSER | SU_EDIT_MOUNTS | SU_EDIT_CREATURES |
+            SU_EDIT_PETITIONS | SU_EDIT_COMMENTS | SU_EDIT_DONATIONS |
+            SU_EDIT_USERS | SU_EDIT_CONFIG | SU_INFINITE_DAYS |
+            SU_EDIT_EQUIPMENT | SU_EDIT_PAYLOG | SU_DEVELOPER |
+            SU_POST_MOTD | SU_MODERATE_CLANS | SU_EDIT_RIDDLES |
+            SU_MANAGE_MODULES | SU_AUDIT_MODERATION | SU_RAW_SQL |
+            SU_VIEW_SOURCE | SU_NEVER_EXPIRE;
+
+        $this->assertSame('accounts', $connection->lastDelete['table']);
+        $this->assertSame(['login' => 'Admin'], $connection->lastDelete['criteria']);
+
+        $this->assertSame('accounts', $connection->lastInsert['table']);
+        $this->assertSame('Admin', $connection->lastInsert['data']['login']);
+        $this->assertSame(md5(md5('secret')), $connection->lastInsert['data']['password']);
+        $this->assertSame($expectedPrivileges, $connection->lastInsert['data']['superuser']);
+        $this->assertSame('`%Admin `&Admin`0', $connection->lastInsert['data']['name']);
+        $this->assertSame('`%Admin `&Admin`0', $connection->lastInsert['data']['playername']);
+        $this->assertSame('`%Admin', $connection->lastInsert['data']['ctitle']);
+        $this->assertSame('village.php', $connection->lastInsert['data']['restorepage']);
+        $this->assertSame('', $connection->lastInsert['data']['bio']);
+        $this->assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/',
+            $connection->lastInsert['data']['regdate']
+        );
 
         $output = Output::getInstance()->getRawOutput();
         $this->assertStringContainsString('Your superuser account has been created', $output);
@@ -91,6 +135,10 @@ final class Stage10Test extends TestCase
         Database::$mockResults = [
             [],
         ];
+
+        $connection = new DoctrineConnection();
+        DoctrineBootstrap::$conn = $connection;
+        Database::$doctrineConnection = null;
 
         $_POST = [
             'name'  => 'Admin',
@@ -104,9 +152,7 @@ final class Stage10Test extends TestCase
         $output = Output::getInstance()->getRawOutput();
         $this->assertStringContainsString("Oops, your passwords don't match", $output);
 
-        foreach (Database::$queries as $query) {
-            $this->assertStringNotContainsString('INSERT INTO accounts', $query);
-        }
+        $this->assertEmpty($connection->lastInsert);
     }
 
     public function testStage10SkipsCreationWhenSuperuserAlreadyExists(): void
@@ -116,6 +162,10 @@ final class Stage10Test extends TestCase
                 ['login' => 'Admin', 'password' => 'hash'],
             ],
         ];
+
+        $connection = new DoctrineConnection();
+        DoctrineBootstrap::$conn = $connection;
+        Database::$doctrineConnection = null;
 
         $_POST = [];
 
@@ -127,5 +177,33 @@ final class Stage10Test extends TestCase
 
         $this->assertCount(1, Database::$queries);
         $this->assertStringContainsString('SELECT login, password FROM accounts', Database::$queries[0]);
+
+        $this->assertEmpty($connection->queries);
+    }
+
+    public function testStage10AllowsApostrophesInLogin(): void
+    {
+        Database::$mockResults = [
+            [],
+        ];
+
+        $connection = new DoctrineConnection();
+        DoctrineBootstrap::$conn = $connection;
+        Database::$doctrineConnection = null;
+
+        $_POST = [
+            'name'  => "O'Connor",
+            'pass1' => 'secret',
+            'pass2' => 'secret',
+        ];
+
+        $installer = new Installer();
+        $installer->stage10();
+
+        $this->assertSame("O'Connor", $connection->lastInsert['data']['login']);
+        $this->assertSame("`%Admin `&O'Connor`0", $connection->lastInsert['data']['name']);
+
+        $output = Output::getInstance()->getRawOutput();
+        $this->assertStringContainsString('Your superuser account has been created', $output);
     }
 }


### PR DESCRIPTION
## Summary
- stop concatenating installer superuser credentials into SQL by using the shared Doctrine connection for delete/insert
- populate all account columns through a prepared insert, including a PHP-generated regdate value
- extend the stage 10 installer test suite to cover the new Doctrine path and logins with apostrophes

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d1c2a8cd4c8329b5a231277eb3c33f