### PR TITLE
fix: align installer admin allowed navs default

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -262,7 +262,7 @@ class Installer
                         'regdate'         => $regdate,
                         'badguy'          => '',
                         'companions'      => '',
-                        'allowednavs'     => '',
+                        'allowednavs'     => serialize(['village.php' => true]),
                         'restorepage'     => 'village.php',
                         'bufflist'        => '',
                         'dragonpoints'    => '',

--- a/tests/Installer/Stage10Test.php
+++ b/tests/Installer/Stage10Test.php
@@ -119,6 +119,7 @@ final class Stage10Test extends TestCase
         $this->assertSame('`%Admin `&Admin`0', $connection->lastInsert['data']['name']);
         $this->assertSame('`%Admin `&Admin`0', $connection->lastInsert['data']['playername']);
         $this->assertSame('`%Admin', $connection->lastInsert['data']['ctitle']);
+        $this->assertSame(serialize(['village.php' => true]), $connection->lastInsert['data']['allowednavs']);
         $this->assertSame('village.php', $connection->lastInsert['data']['restorepage']);
         $this->assertSame('', $connection->lastInsert['data']['bio']);
         $this->assertMatchesRegularExpression(


### PR DESCRIPTION
## Summary
- ensure the installer seeds superuser accounts with the same allowednavs default as regular account creation
- extend the Stage 10 installer test to cover the allowednavs value

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d1c60f2184832991bbd3bf61d0ac59