### PR TITLE
refactor: migrate root entrypoints to service APIs

### DIFF
--- a/clan.php
+++ b/clan.php
@@ -1,6 +1,14 @@
 <?php
 
 use Lotgd\Translator;
+use Lotgd\SuAccess;
+use Lotgd\Nav\SuperuserNav;
+use Lotgd\Commentary;
+use Lotgd\Nav;
+use Lotgd\Nav\VillageNav;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 /**
  * \file clan.php
@@ -9,9 +17,6 @@ use Lotgd\Translator;
  * @see pages/clan
  */
 
-use Lotgd\SuAccess;
-use Lotgd\Nav\SuperuserNav;
-use Lotgd\Commentary;
 
 // translator ready
 // addnews ready
@@ -19,29 +24,27 @@ use Lotgd\Commentary;
 require_once __DIR__ . "/common.php";
 require_once __DIR__ . "/lib/nltoappon.php";
 require_once __DIR__ . "/lib/sanitize.php";
-require_once __DIR__ . "/lib/http.php";
-require_once __DIR__ . "/lib/villagenav.php";
 
 Translator::getInstance()->setSchema("clans");
 
 
-addnav("Village");
-villagenav();
-addnav("Clan Options");
-addnav("C?List Clans", "clan.php?op=list");
+Nav::add("Village");
+VillageNav::render();
+Nav::add("Clan Options");
+Nav::add("C?List Clans", "clan.php?op=list");
 Commentary::addCommentary();
 $gold = getsetting("goldtostartclan", 10000);
 $gems = getsetting("gemstostartclan", 15);
 $ranks = array(CLAN_APPLICANT => "`!Applicant`0",CLAN_MEMBER => "`#Member`0",CLAN_OFFICER => "`^Officer`0",CLAN_ADMINISTRATIVE => "`\$Administrative`0",CLAN_LEADER => "`&Leader`0", CLAN_FOUNDER => "`\$Founder");
-$args = modulehook("clanranks", array("ranks" => $ranks, "clanid" => $session['user']['clanid']));
+$args = HookHandler::hook("clanranks", array("ranks" => $ranks, "clanid" => $session['user']['clanid']));
 $ranks = translate_inline($args['ranks']);
 
 $apply_short = "`@Clan App: `&%s`0";
 $apply_subj = array($apply_short, $session['user']['name']);
 
-$op = httpget('op');
+$op = Http::get('op');
 
-$detail = httpget('detail');
+$detail = Http::get('detail');
 if ($detail > 0) {
         require_once __DIR__ . "/pages/clan/detail.php";
 } elseif ($op == "list") {
@@ -55,19 +58,19 @@ if ($detail > 0) {
 }
 
 
-page_footer();
+Footer::pageFooter();
 
 function clanform()
 {
-    rawoutput("<form action='clan.php?op=new&apply=1' method='POST'>");
-    addnav("", "clan.php?op=new&apply=1");
-    output("`b`cNew Clan Application Form`c`b");
-    output("Clan Name: ");
-    rawoutput("<input name='clanname' maxlength='50' value=\"" . htmlentities(stripslashes(httppost('clanname')), ENT_COMPAT, getsetting("charset", "UTF-8")) . "\">");
-    output("`nShort Name: ");
-    rawoutput("<input name='clanshort' maxlength='5' size='5' value=\"" . htmlentities(stripslashes(httppost('clanshort')), ENT_COMPAT, getsetting("charset", "UTF-8")) . "\">");
-    output("`nNote, color codes are permitted in neither clan names nor short names.");
-    output("The clan name is shown on player bios and on clan overview pages while the short name is displayed next to players' names in comment areas and such.`n");
+    $output->rawOutput("<form action='clan.php?op=new&apply=1' method='POST'>");
+    Nav::add("", "clan.php?op=new&apply=1");
+    $output->output("`b`cNew Clan Application Form`c`b");
+    $output->output("Clan Name: ");
+    $output->rawOutput("<input name='clanname' maxlength='50' value=\"" . htmlentities(stripslashes(Http::post('clanname')), ENT_COMPAT, getsetting("charset", "UTF-8")) . "\">");
+    $output->output("`nShort Name: ");
+    $output->rawOutput("<input name='clanshort' maxlength='5' size='5' value=\"" . htmlentities(stripslashes(Http::post('clanshort')), ENT_COMPAT, getsetting("charset", "UTF-8")) . "\">");
+    $output->output("`nNote, color codes are permitted in neither clan names nor short names.");
+    $output->output("The clan name is shown on player bios and on clan overview pages while the short name is displayed next to players' names in comment areas and such.`n");
     $apply = translate_inline("Apply");
-    rawoutput("<input type='submit' class='button' value='$apply'></form>");
+    $output->rawOutput("<input type='submit' class='button' value='$apply'></form>");
 }

--- a/companions.php
+++ b/companions.php
@@ -75,7 +75,7 @@ if ($op == "deactivate") {
     $op = "";
     Http::set("op", "");
 } elseif ($op == "save") {
-    $subop = httpget("subop");
+    $subop = Http::get("subop");
     if ($subop == "") {
         $companion = Http::post('companion');
         if ($companion) {
@@ -328,7 +328,7 @@ function companionform($companion)
 
     $output->rawOutput("<form action='companions.php?op=save&id={$companion['companionid']}' method='POST'>");
     $output->rawOutput("<input type='hidden' name='companion[companionactive]' value=\"" . $companion['companionactive'] . "\">");
-    addnav("", "companions.php?op=save&id={$companion['companionid']}");
+    Nav::add("", "companions.php?op=save&id={$companion['companionid']}");
     $output->rawOutput("<table width='100%'>");
     $output->rawOutput("<tr><td nowrap>");
     $output->output("Companion Name:");

--- a/create.php
+++ b/create.php
@@ -4,11 +4,6 @@ use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
-
-// translator ready
-// addnews ready
-// mail ready
-define("ALLOW_ANONYMOUS", true);
 use Lotgd\Mail;
 use Lotgd\CheckBan;
 use Lotgd\Settings;
@@ -16,6 +11,17 @@ use Lotgd\Sanitize;
 use Lotgd\DebugLog;
 use Lotgd\Cookies;
 use Lotgd\ServerFunctions;
+use Lotgd\Nav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
+
+// translator ready
+// addnews ready
+// mail ready
+define("ALLOW_ANONYMOUS", true);
+
 
 require_once __DIR__ . "/common.php";
 require_once __DIR__ . "/lib/is_email.php";
@@ -34,42 +40,42 @@ $old = getsetting("expireoldacct", 45);
 $msg = '';
 
 CheckBan::check();
-$op = httpget('op');
+$op = Http::get('op');
 if ($op == 'val' || $op == 'forgotval') {
     if (ServerFunctions::isTheServerFull() == true) {
         //server is full, your "cheat" does not work here buddy ;) you can't bypass this!
-        page_header("Account Validation");
-        output("Sorry, there are too many people online. Click at the link you used to get here later on. Thank you.");
-        addnav("Login", "index.php");
+        Header::pageHeader("Account Validation");
+        $output->output("Sorry, there are too many people online. Click at the link you used to get here later on. Thank you.");
+        Nav::add("Login", "index.php");
 
-        page_footer();
+        Footer::pageFooter();
     }
 }
 
 if ($op == "forgotval") {
-    $id = httpget('id');
+    $id = Http::get('id');
     $sql = "SELECT acctid,login,superuser,password,name,replaceemail,emailaddress,emailvalidation FROM " . Database::prefix("accounts") . " WHERE forgottenpassword='" . Database::escape($id) . "' AND forgottenpassword!=''";
     $result = Database::query($sql);
     if (Database::numRows($result) > 0) {
         $row = Database::fetchAssoc($result);
         $sql = "UPDATE " . Database::prefix("accounts") . " SET forgottenpassword='' WHERE forgottenpassword='$id';";
         Database::query($sql);
-        output("`#`cYour login request has been validated.  You may now log in.`c`0");
-        rawoutput("<form action='login.php' method='POST'>");
-        rawoutput("<input name='name' value=\"{$row['login']}\" type='hidden'>");
-        rawoutput("<input name='password' value=\"!md52!{$row['password']}\" type='hidden'>");
-        rawoutput("<input name='force' value='1' type='hidden'>");
+        $output->output("`#`cYour login request has been validated.  You may now log in.`c`0");
+        $output->rawOutput("<form action='login.php' method='POST'>");
+        $output->rawOutput("<input name='name' value=\"{$row['login']}\" type='hidden'>");
+        $output->rawOutput("<input name='password' value=\"!md52!{$row['password']}\" type='hidden'>");
+        $output->rawOutput("<input name='force' value='1' type='hidden'>");
         $click = translate_inline("Click here to log in");
-        rawoutput("<input type='submit' class='button' value='$click'></form>");
-        output_notl("`n");
+        $output->rawOutput("<input type='submit' class='button' value='$click'></form>");
+        $output->outputNotl("`n");
         if ($trash > 0) {
-            output("`^Characters that have never been logged into will be deleted after %s day(s) of no activity.`n`0", $trash);
+            $output->output("`^Characters that have never been logged into will be deleted after %s day(s) of no activity.`n`0", $trash);
         }
         if ($new > 0) {
-            output("`^Characters that have never reached level 2 will be deleted after %s days of no activity.`n`0", $new);
+            $output->output("`^Characters that have never reached level 2 will be deleted after %s days of no activity.`n`0", $new);
         }
         if ($old > 0) {
-            output("`^Characters that have reached level 2 at least once will be deleted after %s days of no activity.`n`0", $old);
+            $output->output("`^Characters that have reached level 2 at least once will be deleted after %s days of no activity.`n`0", $old);
         }
         //rare case: we have somebody who deleted his first validation email and then requests a forgotten PW...
         if ($row['emailvalidation'] != "" && substr($row['emailvalidation'], 0, 1) != "x") {
@@ -77,12 +83,12 @@ if ($op == "forgotval") {
             Database::query($sql);
         }
     } else {
-        output("`#Your request could not be verified.`n`n");
-        output("This may be because the link you used is invalid.");
-        output("Try to log in, and if that doesn't help, use the 'Forgotten Password' option to retrieve a new mail.`n`nIn case of all hope lost, use the petition link at the bottom of the page and provide ALL details with what you did and what info you got.`n`n");
+        $output->output("`#Your request could not be verified.`n`n");
+        $output->output("This may be because the link you used is invalid.");
+        $output->output("Try to log in, and if that doesn't help, use the 'Forgotten Password' option to retrieve a new mail.`n`nIn case of all hope lost, use the petition link at the bottom of the page and provide ALL details with what you did and what info you got.`n`n");
     }
 } elseif ($op == "val") {
-    $id = httpget('id');
+    $id = Http::get('id');
     $sql = "SELECT acctid,login,superuser,password,name,replaceemail,emailaddress FROM " . Database::prefix("accounts") . " WHERE emailvalidation='" . Database::escape($id) . "' AND emailvalidation!=''";
     $result = Database::query($sql);
     if (Database::numRows($result) > 0) {
@@ -93,7 +99,7 @@ if ($op == "forgotval") {
             //note: remove any forgotten password request!
             $sql = "UPDATE " . Database::prefix("accounts") . " SET emailaddress='" . $replaceemail . "', replaceemail='',forgottenpassword='' WHERE emailvalidation='$id';";
             Database::query($sql);
-            output("`#`c Email changed successfully!`c`0`n");
+            $output->output("`#`c Email changed successfully!`c`0`n");
                         DebugLog::add("Email change request validated by link from " . $row['emailaddress'] . " to " . $replaceemail, $row['acctid'], $row['acctid'], "Email");
             //If a superuser changes email, we want to know about it... at least those who can ee it anyway, the user editors...
             if ($row['superuser'] > 0) {
@@ -116,40 +122,40 @@ if ($op == "forgotval") {
         }
         $sql = "UPDATE " . Database::prefix("accounts") . " SET emailvalidation='' WHERE emailvalidation='$id';";
         Database::query($sql);
-        output("`#`cYour email has been validated.  You may now log in.`c`0");
-        output(
+        $output->output("`#`cYour email has been validated.  You may now log in.`c`0");
+        $output->output(
             "Your email has been validated, your login name is `^%s`0.`n`n",
             $row['login']
         );
         if ($row['replaceemail'] == '') {
             //no auto-login for email changers
-            rawoutput("<form action='login.php' method='POST'>");
-            rawoutput("<input name='name' value=\"{$row['login']}\" type='hidden'>");
-            rawoutput("<input name='password' value=\"!md52!{$row['password']}\" type='hidden'>");
-            rawoutput("<input name='force' value='1' type='hidden'>");
+            $output->rawOutput("<form action='login.php' method='POST'>");
+            $output->rawOutput("<input name='name' value=\"{$row['login']}\" type='hidden'>");
+            $output->rawOutput("<input name='password' value=\"!md52!{$row['password']}\" type='hidden'>");
+            $output->rawOutput("<input name='force' value='1' type='hidden'>");
             $click = translate_inline("Click here to log in");
-            rawoutput("<input type='submit' class='button' value='$click'></form>");
+            $output->rawOutput("<input type='submit' class='button' value='$click'></form>");
         }
-        output_notl("`n");
+        $output->outputNotl("`n");
         if ($trash > 0) {
-            output("`^Characters that have never been logged into will be deleted after %s day(s) of no activity.`n`0", $trash);
+            $output->output("`^Characters that have never been logged into will be deleted after %s day(s) of no activity.`n`0", $trash);
         }
         if ($new > 0) {
-            output("`^Characters that have never reached level 2 will be deleted after %s days of no activity.`n`0", $new);
+            $output->output("`^Characters that have never reached level 2 will be deleted after %s days of no activity.`n`0", $new);
         }
         if ($old > 0) {
-            output("`^Characters that have reached level 2 at least once will be deleted after %s days of no activity.`n`0", $old);
+            $output->output("`^Characters that have reached level 2 at least once will be deleted after %s days of no activity.`n`0", $old);
         }
         savesetting("newestplayer", $row['acctid']);
     } else {
-        output("`#Your email could not be verified.`n`n");
-        output("This may be because you already validated your email.");
-        output("Try to log in, and if that doesn't help, use the 'Forgotten Password' option to retrieve a new mail.`n`nIn case of all hope lost, use the petition link at the bottom of the page and provide ALL details with what you did and what info you got.`n`n");
+        $output->output("`#Your email could not be verified.`n`n");
+        $output->output("This may be because you already validated your email.");
+        $output->output("Try to log in, and if that doesn't help, use the 'Forgotten Password' option to retrieve a new mail.`n`nIn case of all hope lost, use the petition link at the bottom of the page and provide ALL details with what you did and what info you got.`n`n");
     }
 }
 
 if ($op == "forgot") {
-    $charname = httppost('charname');
+    $charname = Http::post('charname');
     if ($charname != "") {
         $sql = "SELECT acctid,login,emailaddress,forgottenpassword,password FROM " . Database::prefix("accounts") . " WHERE login='" . Database::escape($charname) . "'";
         $result = Database::query($sql);
@@ -181,44 +187,44 @@ if ($op == "forgot") {
                                 $to_array = array($row['emailaddress'] => $row['login']);
                                 $from_array = array(getsetting("gameadminemail", "postmaster@localhost") => getsetting("gameadminemail", "postmaster@localhost"));
                                 \Lotgd\Mail::send($to_array, $msg, $subj, $from_array, false, "text/plain");
-                output("`#Sent a new validation email to the address on file for that account.");
-                output("You may use the validation email to log in and change your password.");
+                $output->output("`#Sent a new validation email to the address on file for that account.");
+                $output->output("You may use the validation email to log in and change your password.");
             } else {
-                output("`#We're sorry, but that account does not have an email address associated with it, and so we cannot help you with your forgotten password.");
-                output("Use the Petition for Help link at the bottom of the page to request help with resolving your problem.");
+                $output->output("`#We're sorry, but that account does not have an email address associated with it, and so we cannot help you with your forgotten password.");
+                $output->output("Use the Petition for Help link at the bottom of the page to request help with resolving your problem.");
             }
         } else {
-            output("`#Could not locate a character with that name.");
-            output("Look at the List Warriors page off the login page to make sure that the character hasn't expired and been deleted.");
+            $output->output("`#Could not locate a character with that name.");
+            $output->output("Look at the List Warriors page off the login page to make sure that the character hasn't expired and been deleted.");
         }
     } else {
-        rawoutput("<form action='create.php?op=forgot' method='POST'>");
-        output("`bForgotten Passwords:`b`n`n");
-        output("Enter your character's name: ");
-        rawoutput("<input name='charname'>");
-        output_notl("`n");
+        $output->rawOutput("<form action='create.php?op=forgot' method='POST'>");
+        $output->output("`bForgotten Passwords:`b`n`n");
+        $output->output("Enter your character's name: ");
+        $output->rawOutput("<input name='charname'>");
+        $output->outputNotl("`n");
         $send = translate_inline("Email me my password");
-        rawoutput("<input type='submit' class='button' value='$send'>");
-        rawoutput("</form>");
+        $output->rawOutput("<input type='submit' class='button' value='$send'>");
+        $output->rawOutput("</form>");
     }
 }
-page_header("Create A Character");
+Header::pageHeader("Create A Character");
 if (getsetting("allowcreation", 1) == 0) {
-    output("`\$Creation of new accounts is disabled on this server.");
-    output("You may try it again another day or contact an administrator.");
+    $output->output("`\$Creation of new accounts is disabled on this server.");
+    $output->output("You may try it again another day or contact an administrator.");
 } else {
     if ($op == "create") {
         $emailverification = "";
-                $shortname = Sanitize::sanitizeName(getsetting("spaceinname", 0), httppost('name'));
+                $shortname = Sanitize::sanitizeName(getsetting("spaceinname", 0), Http::post('name'));
 
         if (soap($shortname) != $shortname) {
-            output("`\$Error`^: Bad language was found in your name, please consider revising it.`n");
+            $output->output("`\$Error`^: Bad language was found in your name, please consider revising it.`n");
             $op = "";
         } else {
             $blockaccount = false;
-            $email = httppost('email');
-            $pass1 = httppost('pass1');
-            $pass2 = httppost('pass2');
+            $email = Http::post('email');
+            $pass1 = Http::post('pass1');
+            $pass2 = Http::post('pass2');
             if (getsetting("blockdupeemail", 0) == 1 && getsetting("requireemail", 0) == 1) {
                 $sql = "SELECT login FROM " . Database::prefix("accounts") . " WHERE emailaddress='" . Database::escape($email) . "'";
                 $result = Database::query($sql);
@@ -228,7 +234,7 @@ if (getsetting("allowcreation", 1) == 0) {
                 }
             }
 
-            $passlen = (int)httppost("passlen");
+            $passlen = (int)Http::post("passlen");
             if (
                 substr($pass1, 0, 5) != "!md5!" &&
                     substr($pass1, 0, 6) != "!md52!"
@@ -256,7 +262,7 @@ if (getsetting("allowcreation", 1) == 0) {
                 $msg .= translate_inline("You must enter a valid email address.`n");
                 $blockaccount = true;
             }
-            $args = modulehook("check-create", httpallpost());
+            $args = HookHandler::hook("check-create", httpallpost());
             $args['blockaccount'] = $args['blockaccount'] ?? false;
             $args['msg'] = $args['msg'] ?? '';
 
@@ -278,10 +284,10 @@ if (getsetting("allowcreation", 1) == 0) {
                     }
                 }
                 if ($count > 0) {
-                    output("`\$Error`^: Someone is already known by that name in this realm, please try again.");
+                    $output->output("`\$Error`^: Someone is already known by that name in this realm, please try again.");
                     $op = "";
                 } else {
-                    $sex = (int)httppost('sex');
+                    $sex = (int)Http::post('sex');
                     // Inserted the following line to prevent hacking
                     // Reported by Eliwood
                     if ($sex <> SEX_MALE) {
@@ -292,7 +298,7 @@ if (getsetting("allowcreation", 1) == 0) {
                     if (getsetting("requirevalidemail", 0)) {
                         $emailverification = md5(date("Y-m-d H:i:s") . $email);
                     }
-                    $refer = httpget('r');
+                    $refer = Http::get('r');
                     if ($refer > "") {
                         $sql = "SELECT acctid FROM " . Database::prefix("accounts") . " WHERE login='" . Database::escape($refer) . "'";
                         $result = Database::query($sql);
@@ -301,7 +307,7 @@ if (getsetting("allowcreation", 1) == 0) {
                             $referer = $ref['acctid'];
                         } else {
                             //expired, deleted...
-                            output("`\$The referral code you used is not active anymore - please get in touch with the provider, if you want the referral to count. Thank you!`n`nThen either create a new char or let us now in a timely manner who referred you!`n`n");
+                            $output->output("`\$The referral code you used is not active anymore - please get in touch with the provider, if you want the referral to count. Thank you!`n`nThen either create a new char or let us now in a timely manner who referred you!`n`n");
                             $referer = 0;
                         }
                     } else {
@@ -320,7 +326,7 @@ if (getsetting("allowcreation", 1) == 0) {
                                                 ('$shortname','$title $shortname', '" . getsetting("defaultsuperuser", 0) . "', '$title', '$dbpass', '$sex', '$shortname', '" . date("Y-m-d H:i:s", strtotime("-1 day")) . "', '" . (Cookies::getLgi() ?? '') . "', '" . $_SERVER['REMOTE_ADDR'] . "', " . getsetting("newplayerstartgold", 50) . ", '" . addslashes(getsetting('villagename', LOCATION_FIELDS)) . "', '$email', '$emailverification', '$referer', NOW(),'','" . $allowednavs . "', 'village.php','','','',0,'','','','','','','','')";
                     Database::query($sql);
                     if (Database::affectedRows() <= 0) {
-                        output("`\$Error`^: Your account was not created for an unknown reason, please try again. ");
+                        $output->output("`\$Error`^: Your account was not created for an unknown reason, please try again. ");
                     } else {
                         $sql = "SELECT acctid FROM " . Database::prefix("accounts") . " WHERE login='$shortname'";
                         $result = Database::query($sql);
@@ -331,7 +337,7 @@ if (getsetting("allowcreation", 1) == 0) {
                         $sql_output = "INSERT INTO " . Database::prefix("accounts_output") . " VALUES ({$row['acctid']},'');";
                         Database::query($sql_output);
                         //end
-                        modulehook("process-create", $args);
+                        HookHandler::hook("process-create", $args);
                         if ($emailverification != "") {
                             $subj = translate_mail($settings_extended->getSetting('verificationmailsubject'), 0);
                             $msg = translate_mail($settings_extended->getSetting('verificationmailtext'), 0);
@@ -350,44 +356,44 @@ if (getsetting("allowcreation", 1) == 0) {
                                                         $to_array = array($email => $shortname);
                                                         $from_array = array(getsetting("gameadminemail", "postmaster@localhost") => getsetting("gameadminemail", "postmaster@localhost"));
                                                         \Lotgd\Mail::send($to_array, $msg, $subj, $from_array, false, "text/plain");
-                            output("`4An email was sent to `\$%s`4 to validate your address.  Click the link in the email to activate your account.`0`n`n", $email);
+                            $output->output("`4An email was sent to `\$%s`4 to validate your address.  Click the link in the email to activate your account.`0`n`n", $email);
                         } else {
-                            rawoutput("<form action='login.php' method='POST'>");
-                            rawoutput("<input name='name' value=\"$shortname\" type='hidden'>");
-                            rawoutput("<input name='password' value=\"$pass1\" type='hidden'>");
+                            $output->rawOutput("<form action='login.php' method='POST'>");
+                            $output->rawOutput("<input name='name' value=\"$shortname\" type='hidden'>");
+                            $output->rawOutput("<input name='password' value=\"$pass1\" type='hidden'>");
                             $click = translate_inline("Click here to log in");
-                            rawoutput("<input type='submit' class='button' value='$click'>");
-                            rawoutput("</form>");
-                            output_notl("`n");
+                            $output->rawOutput("<input type='submit' class='button' value='$click'>");
+                            $output->rawOutput("</form>");
+                            $output->outputNotl("`n");
                             savesetting("newestplayer", $row['acctid']);
                         }
-                        output("`\$Your account was created, your login name is `^%s`\$.`n`n", $shortname);
+                        $output->output("`\$Your account was created, your login name is `^%s`\$.`n`n", $shortname);
                         if ($trash > 0) {
-                            output("`^Characters that have never been logged into will be deleted after %s day(s) of no activity.`n`0", $trash);
+                            $output->output("`^Characters that have never been logged into will be deleted after %s day(s) of no activity.`n`0", $trash);
                         }
                         if ($new > 0) {
-                            output("`^Characters that have never reached level 2 will be deleted after %s days of no activity.`n`0", $new);
+                            $output->output("`^Characters that have never reached level 2 will be deleted after %s days of no activity.`n`0", $new);
                         }
                         if ($old > 0) {
-                            output("`^Characters that have reached level 2 at least once will be deleted after %s days of no activity.`n`0", $old);
+                            $output->output("`^Characters that have reached level 2 at least once will be deleted after %s days of no activity.`n`0", $old);
                         }
                     }
                 }
             } else {
-                output("`\$Error`^:`n%s", $msg);
+                $output->output("`\$Error`^:`n%s", $msg);
                 $op = "";
             }
         }
     }
     if ($op == "") {
-        output("`&`c`bCreate a Character`b`c`0");
-        $refer = httpget('r');
+        $output->output("`&`c`bCreate a Character`b`c`0");
+        $refer = Http::get('r');
         if ($refer) {
             $refer = "&r=" . htmlentities($refer, ENT_COMPAT, getsetting("charset", "UTF-8"));
         }
 
-        rawoutput("<script src='src/Lotgd/md5.js' defer></script>");
-        rawoutput("<script language='JavaScript'>
+        $output->rawOutput("<script src='src/Lotgd/md5.js' defer></script>");
+        $output->rawOutput("<script language='JavaScript'>
 				<!--
 				function md5pass(){
 				// encode passwords
@@ -406,18 +412,18 @@ if (getsetting("allowcreation", 1) == 0) {
 				}
 				//-->
 				</script>");
-                rawoutput("<form action=\"create.php?op=create$refer\" method='POST' onSubmit=\"md5pass();\">");
+                $output->rawOutput("<form action=\"create.php?op=create$refer\" method='POST' onSubmit=\"md5pass();\">");
                 // this is the first thing a new player will se, so let's make it look
                 // better
-                rawoutput("<input type='hidden' name='passlen' id='passlen' value='0'>");
-                rawoutput("<table><tr valign='top'><td>");
-                output("How will you be known to this world? ");
-                rawoutput("</td><td><input name='name'></td></tr><tr valign='top'><td>");
-                output("Enter a password: ");
-                rawoutput("</td><td><input type='password' name='pass1' id='pass1'></td></tr><tr valign='top'><td>");
-                output("Re-enter it for confirmation: ");
-                rawoutput("</td><td><input type='password' name='pass2' id='pass2'></td></tr><tr valign='top'><td>");
-                output("Enter your email address: ");
+                $output->rawOutput("<input type='hidden' name='passlen' id='passlen' value='0'>");
+                $output->rawOutput("<table><tr valign='top'><td>");
+                $output->output("How will you be known to this world? ");
+                $output->rawOutput("</td><td><input name='name'></td></tr><tr valign='top'><td>");
+                $output->output("Enter a password: ");
+                $output->rawOutput("</td><td><input type='password' name='pass1' id='pass1'></td></tr><tr valign='top'><td>");
+                $output->output("Re-enter it for confirmation: ");
+                $output->rawOutput("</td><td><input type='password' name='pass2' id='pass2'></td></tr><tr valign='top'><td>");
+                $output->output("Enter your email address: ");
                 $r1 = translate_inline("`^(optional -- however, if you choose not to enter one, there will be no way that you can reset your password if you forget it!)`0");
                 $r2 = translate_inline("`\$(required)`0");
                 $r3 = translate_inline("`\$(required, an email will be sent to this address to verify it before you can log in)`0");
@@ -428,30 +434,30 @@ if (getsetting("allowcreation", 1) == 0) {
         } else {
             $req = $r3;
         }
-                rawoutput("</td><td><input name='email'>");
-                output_notl("%s", $req);
-                rawoutput("</td></tr></table>");
-                output(
+                $output->rawOutput("</td><td><input name='email'>");
+                $output->outputNotl("%s", $req);
+                $output->rawOutput("</td></tr></table>");
+                $output->output(
                     "`nAnd are you a %s Female or a %s Male?`n",
                     "<input type='radio' name='sex' value='1'>",
                     "<input type='radio' name='sex' value='0' checked>",
                     true
                 );
-                modulehook("create-form");
+                HookHandler::hook("create-form");
                 $createbutton = translate_inline("Create your character");
-                rawoutput("<input type='submit' class='button' value='$createbutton'>");
-                output_notl("`n`n");
+                $output->rawOutput("<input type='submit' class='button' value='$createbutton'>");
+                $output->outputNotl("`n`n");
         if ($trash > 0) {
-            output("`^Characters that have never been logged into will be deleted after %s day(s) of no activity.`n`0", $trash);
+            $output->output("`^Characters that have never been logged into will be deleted after %s day(s) of no activity.`n`0", $trash);
         }
         if ($new > 0) {
-            output("`^Characters that have never reached level 2 will be deleted after %s days of no activity.`n`0", $new);
+            $output->output("`^Characters that have never reached level 2 will be deleted after %s days of no activity.`n`0", $new);
         }
         if ($old > 0) {
-            output("`^Characters that have reached level 2 at least once will be deleted after %s days of no activity.`n`0", $old);
+            $output->output("`^Characters that have reached level 2 at least once will be deleted after %s days of no activity.`n`0", $old);
         }
-                rawoutput("</form>");
+                $output->rawOutput("</form>");
     }
 }
-addnav("Login", "index.php");
-page_footer();
+Nav::add("Login", "index.php");
+Footer::pageFooter();

--- a/debug.php
+++ b/debug.php
@@ -4,44 +4,47 @@ use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
+use Lotgd\Nav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
 
 // translator ready
 // addnews ready
 // mail ready
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/http.php";
 
 Translator::getInstance()->setSchema("debug");
 
 SuAccess::check(SU_EDIT_CONFIG);
 
 SuperuserNav::render();
-addnav("Debug Options");
-addnav("", $_SERVER['REQUEST_URI']);
-$sort = httpget('sort');
-addnav("Get Pageruntimes", "debug.php?debug=pageruntime&sort=" . URLEncode($sort));
-addnav("Get Modulehooktimes", "debug.php?debug=hooksort&sort=" . URLEncode($sort));
+Nav::add("Debug Options");
+Nav::add("", $_SERVER['REQUEST_URI']);
+$sort = Http::get('sort');
+Nav::add("Get Pageruntimes", "debug.php?debug=pageruntime&sort=" . URLEncode($sort));
+Nav::add("Get Modulehooktimes", "debug.php?debug=hooksort&sort=" . URLEncode($sort));
 
 
-page_header("Debug Analysis");
+Header::pageHeader("Debug Analysis");
 $order = "sum";
 if ($sort != "") {
     $order = $sort;
 }
-$debug = httpget('debug');
+$debug = Http::get('debug');
 if ($debug == '') {
     $debug = 'pageruntime';
 }
-$ascdesc_raw = (int)httpget('direction');
+$ascdesc_raw = (int)Http::get('direction');
 if ($ascdesc_raw) {
     $ascdesc = "ASC";
 } else {
     $ascdesc = "DESC";
 }
-addnav("Sorting");
-addnav("By Total", "debug.php?debug=" . $debug . "&sort=sum&direction=" . $ascdesc_raw);
-addnav("By Average", "debug.php?debug=" . $debug . "&sort=medium&direction=" . $ascdesc_raw);
-addnav("Switch ASC/DESC", "debug.php?debug=" . $debug . "&sort=" . URLEncode($sort) . "&direction=" . (!$ascdesc_raw));
+Nav::add("Sorting");
+Nav::add("By Total", "debug.php?debug=" . $debug . "&sort=sum&direction=" . $ascdesc_raw);
+Nav::add("By Average", "debug.php?debug=" . $debug . "&sort=medium&direction=" . $ascdesc_raw);
+Nav::add("Switch ASC/DESC", "debug.php?debug=" . $debug . "&sort=" . URLEncode($sort) . "&direction=" . (!$ascdesc_raw));
 
 
 switch ($debug) {
@@ -92,23 +95,23 @@ switch ($debug) {
 }
 $none = translate_inline("`iNone`i");
 $notset = translate_inline("`iNot set`i");
-rawoutput("<table border=0 cellpadding=2 cellspacing=1><tr class='trhead'><td>$category</td><td>$subcategory</td><td>$sum_desc</td><td>$med_desc</td><td>$hits</td></tr>");
+$output->rawOutput("<table border=0 cellpadding=2 cellspacing=1><tr class='trhead'><td>$category</td><td>$subcategory</td><td>$sum_desc</td><td>$med_desc</td><td>$hits</td></tr>");
 debug($sql);
 $result = Database::query($sql);
 $i = true;
 while ($row = Database::fetchAssoc($result)) {
     $i = !$i;
-    rawoutput("<tr class='" . ($i ? 'trdark' : 'trlight') . "'><td valign='top'>");
-    output_notl("`b" . $row['category'] . "`b");
-    rawoutput("</td><td valign='top'>");
-    output_notl("`b" . $row['subcategory'] . "`b");
-    rawoutput("</td><td valign='top'>");
-    output_notl($row['sum']);
-    rawoutput("</td><td valign='top'>");
-    output_notl($row['medium']);
-    rawoutput("</td><td valign='top'>");
-    output_notl($row['counter']);
-    rawoutput("</td></tr>");
+    $output->rawOutput("<tr class='" . ($i ? 'trdark' : 'trlight') . "'><td valign='top'>");
+    $output->outputNotl("`b" . $row['category'] . "`b");
+    $output->rawOutput("</td><td valign='top'>");
+    $output->outputNotl("`b" . $row['subcategory'] . "`b");
+    $output->rawOutput("</td><td valign='top'>");
+    $output->outputNotl($row['sum']);
+    $output->rawOutput("</td><td valign='top'>");
+    $output->outputNotl($row['medium']);
+    $output->rawOutput("</td><td valign='top'>");
+    $output->outputNotl($row['counter']);
+    $output->rawOutput("</td></tr>");
 }
-rawoutput("</table>");
-page_footer();
+$output->rawOutput("</table>");
+Footer::pageFooter();

--- a/donators.php
+++ b/donators.php
@@ -4,93 +4,98 @@ use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
+use Lotgd\Mail;
+use Lotgd\Nav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // translator ready
 // addnews ready
 // mail ready
 require_once __DIR__ . "/common.php";
-use Lotgd\Mail;
-require_once __DIR__ . "/lib/http.php";
+
 
 SuAccess::check(SU_EDIT_DONATIONS);
 
 Translator::getInstance()->setSchema("donation");
 
-page_header("Donator's Page");
+Header::pageHeader("Donator's Page");
 SuperuserNav::render();
 
 
-$ret = httpget('ret');
+$ret = Http::get('ret');
 $return = cmd_sanitize($ret);
 $return = basename($return);
 Translator::getInstance()->setSchema("nav");
-addnav("Return whence you came", $return);
+Nav::add("Return whence you came", $return);
 Translator::getInstance()->setSchema();
 
 $add = translate_inline("Add Donation");
-rawoutput("<form action='donators.php?op=add1&ret=" . rawurlencode($ret) . "' method='POST'>");
-addnav("", "donators.php?op=add1&ret=" . rawurlencode($ret) . "");
-$name = httppost("name");
+$output->rawOutput("<form action='donators.php?op=add1&ret=" . rawurlencode($ret) . "' method='POST'>");
+Nav::add("", "donators.php?op=add1&ret=" . rawurlencode($ret) . "");
+$name = Http::post("name");
 if ($name == "") {
-    $name = httpget("name");
+    $name = Http::get("name");
 }
-$amt = httppost("amt");
+$amt = Http::post("amt");
 if ($amt == "") {
-    $amt = httpget("amt");
+    $amt = Http::get("amt");
 }
-$reason = httppost("reason");
+$reason = Http::post("reason");
 if ($reason == "") {
-    $reason = httpget("reason");
+    $reason = Http::get("reason");
 }
-$txnid = httppost("txnid");
+$txnid = Http::post("txnid");
 if ($txnid == "") {
-    $txnid = httpget("txnid");
+    $txnid = Http::get("txnid");
 }
 if ($reason == "") {
     $reason = translate_inline("manual donation entry");
 }
 
 
-output("`bAdd Donation Points:`b`n");
-output("Character: ");
-rawoutput("<input name='name' value=\"" . htmlentities($name, ENT_COMPAT, getsetting("charset", "UTF-8")) . "\">");
-output("`nPoints: ");
-rawoutput("<input name='amt' size='3' value=\"" . htmlentities($amt, ENT_COMPAT, getsetting("charset", "UTF-8")) . "\">");
-output("`nReason: ");
-rawoutput("<input name='reason' size='30' value=\"" . htmlentities($reason, ENT_COMPAT, getsetting("charset", "UTF-8")) . "\">");
-rawoutput("<input type='hidden' name='txnid' value=\"" . htmlentities($txnid, ENT_COMPAT, getsetting("charset", "UTF-8")) . "\">");
-output_notl("`n");
+$output->output("`bAdd Donation Points:`b`n");
+$output->output("Character: ");
+$output->rawOutput("<input name='name' value=\"" . htmlentities($name, ENT_COMPAT, getsetting("charset", "UTF-8")) . "\">");
+$output->output("`nPoints: ");
+$output->rawOutput("<input name='amt' size='3' value=\"" . htmlentities($amt, ENT_COMPAT, getsetting("charset", "UTF-8")) . "\">");
+$output->output("`nReason: ");
+$output->rawOutput("<input name='reason' size='30' value=\"" . htmlentities($reason, ENT_COMPAT, getsetting("charset", "UTF-8")) . "\">");
+$output->rawOutput("<input type='hidden' name='txnid' value=\"" . htmlentities($txnid, ENT_COMPAT, getsetting("charset", "UTF-8")) . "\">");
+$output->outputNotl("`n");
 if ($txnid > "") {
-    output("For transaction: %s`n", $txnid);
+    $output->output("For transaction: %s`n", $txnid);
 }
-rawoutput("<input type='submit' class='button' value='$add'>");
-rawoutput("</form>");
+$output->rawOutput("<input type='submit' class='button' value='$add'>");
+$output->rawOutput("</form>");
 
-addnav("Donations");
+Nav::add("Donations");
 if (
     ($session['user']['superuser'] & SU_EDIT_PAYLOG) &&
         file_exists("paylog.php")
 ) {
-    addnav("Payment Log", "paylog.php");
+    Nav::add("Payment Log", "paylog.php");
 }
-$op = httpget('op');
+$op = Http::get('op');
 if ($op == "add2") {
-    $id = httpget('id');
-    $amt = httpget('amt');
-    $reason = httpget('reason');
+    $id = Http::get('id');
+    $amt = Http::get('amt');
+    $reason = Http::get('reason');
 
     $sql = "SELECT name FROM " . Database::prefix("accounts") . " WHERE acctid=$id;";
     $result = Database::query($sql);
     $row = Database::fetchAssoc($result);
-    output("%s donation points added to %s`0, reason: `^%s`0", $amt, $row['name'], $reason);
+    $output->output("%s donation points added to %s`0, reason: `^%s`0", $amt, $row['name'], $reason);
 
-    $txnid = httpget("txnid");
-    $ret = httpget('ret');
+    $txnid = Http::get("txnid");
+    $ret = Http::get('ret');
     if ($id == $session['user']['acctid']) {
         $session['user']['donation'] += $amt;
     }
     if ($txnid > "") {
-        $result = modulehook("donation_adjustments", array("points" => $amt,"amount" => $amt / getsetting('dpointspercurrencyunit', 100),"acctid" => $id,"messages" => array()));
+        $result = HookHandler::hook("donation_adjustments", array("points" => $amt,"amount" => $amt / getsetting('dpointspercurrencyunit', 100),"acctid" => $id,"messages" => array()));
         $points = $result['points'];
         if (!is_array($result['messages'])) {
             $result['messages'] = array($result['messages']);
@@ -106,7 +111,7 @@ if ($op == "add2") {
     // table to update in real time.
     $sql = "UPDATE " . Database::prefix("accounts") . " SET donation=donation+'$points' WHERE acctid='$id'";
     Database::query($sql);
-    modulehook("donation", array("id" => $id, "amt" => $points, "manual" => ($txnid > "" ? false : true)));
+    HookHandler::hook("donation", array("id" => $id, "amt" => $points, "manual" => ($txnid > "" ? false : true)));
 
     if ($txnid > "") {
         $sql = "UPDATE " . Database::prefix("paylog") . " SET acctid='$id', processed=1 WHERE txnid='$txnid'";
@@ -117,7 +122,7 @@ if ($op == "add2") {
         debuglog("Received donator points -- Manually assigned, not based on a known dollar donation [$reason]", false, $id, "donation", $amt, false);
     }
     Mail::systemMail($id, "Donation Points Added", Translator::getInstance()->sprintfTranslate("`2You have received %s donation points for %s.", $points, $reason));
-    httpset('op', "");
+    Http::set('op', "");
     $op = "";
 }
 
@@ -129,27 +134,27 @@ if ($op == "") {
     $points = translate_inline("Points");
     $spent = translate_inline("Spent");
 
-    rawoutput("<table border='0' cellpadding='3' cellspacing='1' bgcolor='#999999'>");
-    rawoutput("<tr class='trhead'><td>$name</td><td>$points</td><td>$spent</td></tr>");
+    $output->rawOutput("<table border='0' cellpadding='3' cellspacing='1' bgcolor='#999999'>");
+    $output->rawOutput("<tr class='trhead'><td>$name</td><td>$points</td><td>$spent</td></tr>");
     $number = Database::numRows($result);
     for ($i = 0; $i < $number; $i++) {
         $row = Database::fetchAssoc($result);
-        rawoutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'>");
-        rawoutput("<td>");
-        output_notl("`^%s`0", $row['name']);
-        rawoutput("</td><td>");
-        output_notl("`@%s`0", number_format($row['donation']));
-        rawoutput("</td><td>");
-        output_notl("`%%s`0", number_format($row['donationspent']));
-        rawoutput("</td>");
-        rawoutput("</tr>");
+        $output->rawOutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'>");
+        $output->rawOutput("<td>");
+        $output->outputNotl("`^%s`0", $row['name']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("`@%s`0", number_format($row['donation']));
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("`%%s`0", number_format($row['donationspent']));
+        $output->rawOutput("</td>");
+        $output->rawOutput("</tr>");
     }
-    rawoutput("</table>", true);
+    $output->rawOutput("</table>", true);
 } elseif ($op == "add1") {
     $search = "%";
-    $name = httppost('name');
+    $name = Http::post('name');
     if ($name == '') {
-        $name = httpget('name');
+        $name = Http::get('name');
     }
     $search = str_replace("'", "\'", $name);
     $sql = "SELECT name,acctid,donation,donationspent FROM " . Database::prefix("accounts") . " WHERE login LIKE '$search' or name LIKE '$search' LIMIT 100";
@@ -166,39 +171,39 @@ if ($op == "") {
         $sql = "SELECT name,acctid,donation,donationspent FROM " . Database::prefix("accounts") . " WHERE login LIKE '$search' or name LIKE '$search' LIMIT 100";
         $result = Database::query($sql);
     }
-    $ret = httpget('ret');
-    $amt = httppost('amt');
+    $ret = Http::get('ret');
+    $amt = Http::post('amt');
     if ($amt == '') {
-        $amt = httpget("amt");
+        $amt = Http::get("amt");
     }
-    $reason = httppost("reason");
+    $reason = Http::post("reason");
     if ($reason == "") {
-        $reason = httpget("reason");
+        $reason = Http::get("reason");
     }
-    $txnid = httppost('txnid');
+    $txnid = Http::post('txnid');
     if ($txnid == '') {
-        $txnid = httpget("txnid");
+        $txnid = Http::get("txnid");
     }
-    output("Confirm the addition of %s points to:`n", $amt);
+    $output->output("Confirm the addition of %s points to:`n", $amt);
     if ($reason) {
-        output("(Reason: `^`b`i%s`i`b`0)`n`n", $reason);
+        $output->output("(Reason: `^`b`i%s`i`b`0)`n`n", $reason);
     }
     $number = Database::numRows($result);
     for ($i = 0; $i < $number; $i++) {
         $row = Database::fetchAssoc($result);
         if ($ret != "") {
-            rawoutput("<a href='donators.php?op=add2&id={$row['acctid']}&amt=$amt&ret=" . rawurlencode($ret) . "&reason=" . rawurlencode($reason) . "'>");
+            $output->rawOutput("<a href='donators.php?op=add2&id={$row['acctid']}&amt=$amt&ret=" . rawurlencode($ret) . "&reason=" . rawurlencode($reason) . "'>");
         } else {
-            rawoutput("<a href='donators.php?op=add2&id={$row['acctid']}&amt=$amt&reason=" . rawurlencode($reason) . "&txnid=$txnid'>");
+            $output->rawOutput("<a href='donators.php?op=add2&id={$row['acctid']}&amt=$amt&reason=" . rawurlencode($reason) . "&txnid=$txnid'>");
         }
-        output_notl("%s (%s/%s)", $row['name'], $row['donation'], $row['donationspent']);
-        rawoutput("</a>");
-        output_notl("`n");
+        $output->outputNotl("%s (%s/%s)", $row['name'], $row['donation'], $row['donationspent']);
+        $output->rawOutput("</a>");
+        $output->outputNotl("`n");
         if ($ret != "") {
-            addnav("", "donators.php?op=add2&id={$row['acctid']}&amt=$amt&ret=" . rawurlencode($ret) . "&reason=" . rawurlencode($reason));
+            Nav::add("", "donators.php?op=add2&id={$row['acctid']}&amt=$amt&ret=" . rawurlencode($ret) . "&reason=" . rawurlencode($reason));
         } else {
-            addnav("", "donators.php?op=add2&id={$row['acctid']}&amt=$amt&reason=" . rawurlencode($reason) . "&txnid=$txnid");
+            Nav::add("", "donators.php?op=add2&id={$row['acctid']}&amt=$amt&reason=" . rawurlencode($reason) . "&txnid=$txnid");
         }
     }
 }
-page_footer();
+Footer::pageFooter();

--- a/dragon.php
+++ b/dragon.php
@@ -3,26 +3,31 @@
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Buffs;
-
-// addnews ready
-// translator ready
-// mail ready
-require_once __DIR__ . "/common.php";
 use Lotgd\FightNav;
 use Lotgd\PlayerFunctions;
 use Lotgd\Http;
 use Lotgd\Battle;
 use Lotgd\Names;
 use Lotgd\AddNews;
+use Lotgd\Nav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Modules\HookHandler;
+
+// addnews ready
+// translator ready
+// mail ready
+require_once __DIR__ . "/common.php";
+
 
 Translator::getInstance()->setSchema("dragon");
 $battle = false;
-page_header("The Green Dragon!");
+Header::pageHeader("The Green Dragon!");
 $op = Http::get('op');
 if ($op == "") {
     if (!Http::get('nointro')) {
-        output("`\$Fighting down every urge to flee, you cautiously enter the cave entrance, intent on catching the great green dragon sleeping, so that you might slay it with a minimum of pain.");
-        output("Sadly, this is not to be the case, for as you round a corner within the cave you discover the great beast sitting on its haunches on a huge pile of gold, picking its teeth with a rib.");
+        $output->output("`\$Fighting down every urge to flee, you cautiously enter the cave entrance, intent on catching the great green dragon sleeping, so that you might slay it with a minimum of pain.");
+        $output->output("Sadly, this is not to be the case, for as you round a corner within the cave you discover the great beast sitting on its haunches on a huge pile of gold, picking its teeth with a rib.");
     }
     $badguy = array(
         "creaturename" => translate_inline("`@The Green Dragon`0"),
@@ -54,39 +59,39 @@ if ($op == "") {
     $badguy['creaturedefense'] += $defflux;
     $badguy['creaturehealth'] += $hpflux;
 
-    $badguy = modulehook("buffdragon", $badguy);
+    $badguy = HookHandler::hook("buffdragon", $badguy);
 
     $session['user']['badguy'] = createstring($badguy);
     $battle = true;
 } elseif ($op == "prologue1") {
-    output("`@Victory!`n`n");
+    $output->output("`@Victory!`n`n");
         $flawless = (int)(Http::get('flawless'));
     if ($flawless) {
-        output("`b`c`&~~ Flawless Fight ~~`0`c`b`n`n");
+        $output->output("`b`c`&~~ Flawless Fight ~~`0`c`b`n`n");
     }
-    output("`2Before you, the great dragon lies immobile, its heavy breathing like acid to your lungs.");
-    output("You are covered, head to toe, with the foul creature's thick black blood.");
-    output("The great beast begins to move its mouth.  You spring back, angry at yourself for having been fooled by its ploy of death, and watch for its huge tail to come sweeping your way.");
-    output("But it does not.");
-    output("Instead the dragon begins to speak.`n`n");
-    output("\"`^Why have you come here mortal?  What have I done to you?`2\" it says with obvious effort.");
-    output("\"`^Always my kind are sought out to be destroyed.  Why?  Because of stories from distant lands that tell of dragons preying on the weak?  I tell you that these stories come only from misunderstanding of us, and not because we devour your children.`2\"");
-    output("The beast pauses, breathing heavily before continuing, \"`^I will tell you a secret.  Behind me now are my eggs.  They will hatch, and the young will battle each other.  Only one will survive, but she will be the strongest.  She will quickly grow, and be as powerful as me.`2\"");
-    output("Breath comes shorter and shallower for the great beast.`n`n");
-    output("\"`#Why do you tell me this?  Don't you know that I will destroy your eggs?`2\" you ask.`n`n");
-    output("\"`^No, you will not, for I know of one more secret that you do not.`2\"`n`n");
-    output("\"`#Pray tell oh mighty beast!`2\"`n`n");
-    output("The great beast pauses, gathering the last of its energy.  \"`^Your kind cannot tolerate the blood of my kind.  Even if you survive, you will be a feeble creature, barely able to hold a weapon, your mind blank of all that you have learned.  No, you are no threat to my children, for you are already dead!`2\"`n`n");
-    output("Realizing that already the edges of your vision are a little dim, you flee from the cave, bound to reach the healer's hut before it is too late.");
-    output("Somewhere along the way you lose your weapon, and finally you trip on a stone in a shallow stream, sight now limited to only a small circle that seems to float around your head.");
-    output("As you lay, staring up through the trees, you think that nearby you can hear the sounds of the village.");
-    output("Your final thought is that although you defeated the dragon, you reflect on the irony that it defeated you.`n`n");
-    output("As your vision winks out, far away in the dragon's lair, an egg shuffles to its side, and a small crack appears in its thick leathery skin.");
+    $output->output("`2Before you, the great dragon lies immobile, its heavy breathing like acid to your lungs.");
+    $output->output("You are covered, head to toe, with the foul creature's thick black blood.");
+    $output->output("The great beast begins to move its mouth.  You spring back, angry at yourself for having been fooled by its ploy of death, and watch for its huge tail to come sweeping your way.");
+    $output->output("But it does not.");
+    $output->output("Instead the dragon begins to speak.`n`n");
+    $output->output("\"`^Why have you come here mortal?  What have I done to you?`2\" it says with obvious effort.");
+    $output->output("\"`^Always my kind are sought out to be destroyed.  Why?  Because of stories from distant lands that tell of dragons preying on the weak?  I tell you that these stories come only from misunderstanding of us, and not because we devour your children.`2\"");
+    $output->output("The beast pauses, breathing heavily before continuing, \"`^I will tell you a secret.  Behind me now are my eggs.  They will hatch, and the young will battle each other.  Only one will survive, but she will be the strongest.  She will quickly grow, and be as powerful as me.`2\"");
+    $output->output("Breath comes shorter and shallower for the great beast.`n`n");
+    $output->output("\"`#Why do you tell me this?  Don't you know that I will destroy your eggs?`2\" you ask.`n`n");
+    $output->output("\"`^No, you will not, for I know of one more secret that you do not.`2\"`n`n");
+    $output->output("\"`#Pray tell oh mighty beast!`2\"`n`n");
+    $output->output("The great beast pauses, gathering the last of its energy.  \"`^Your kind cannot tolerate the blood of my kind.  Even if you survive, you will be a feeble creature, barely able to hold a weapon, your mind blank of all that you have learned.  No, you are no threat to my children, for you are already dead!`2\"`n`n");
+    $output->output("Realizing that already the edges of your vision are a little dim, you flee from the cave, bound to reach the healer's hut before it is too late.");
+    $output->output("Somewhere along the way you lose your weapon, and finally you trip on a stone in a shallow stream, sight now limited to only a small circle that seems to float around your head.");
+    $output->output("As you lay, staring up through the trees, you think that nearby you can hear the sounds of the village.");
+    $output->output("Your final thought is that although you defeated the dragon, you reflect on the irony that it defeated you.`n`n");
+    $output->output("As your vision winks out, far away in the dragon's lair, an egg shuffles to its side, and a small crack appears in its thick leathery skin.");
 
     if ($flawless) {
-        output("`n`nYou fall forward, and remember at the last moment that you at least managed to grab some of the dragon's treasure, so maybe it wasn't all a total loss.");
+        $output->output("`n`nYou fall forward, and remember at the last moment that you at least managed to grab some of the dragon's treasure, so maybe it wasn't all a total loss.");
     }
-    addnav("It is a new day", "news.php");
+    Nav::add("It is a new day", "news.php");
     Buffs::stripAllBuffs();
     $sql = "DESCRIBE " . Database::prefix("accounts");
     $result = Database::query($sql);
@@ -106,7 +111,7 @@ if ($op == "") {
                     ($session['user']['level'] * 10),
             'base' => $dkpoints + ($session['user']['level'] * 10),
             );
-    $hpgain = modulehook("hprecalc", $hpgain);
+    $hpgain = HookHandler::hook("hprecalc", $hpgain);
     calculate_buff_fields();
 
     $nochange = array("acctid" => 1
@@ -159,7 +164,7 @@ if ($op == "") {
                    ,"forgottenpassword" => 1
                    );
 
-    $nochange = modulehook("dk-preserve", $nochange);
+    $nochange = HookHandler::hook("dk-preserve", $nochange);
 
     $badguys = $session['user']['badguy']; //needed for the dragons name later
 
@@ -253,11 +258,11 @@ if ($op == "") {
     $companions = array();
     $session['user']['companions'] = array();
 
-    output("`n`nYou wake up in the midst of some trees.  Nearby you hear the sounds of a village.");
-    output("Dimly you remember that you are a new warrior, and something of a dangerous Green Dragon that is plaguing the area.  You decide you would like to earn a name for yourself by perhaps some day confronting this vile creature.");
+    $output->output("`n`nYou wake up in the midst of some trees.  Nearby you hear the sounds of a village.");
+    $output->output("Dimly you remember that you are a new warrior, and something of a dangerous Green Dragon that is plaguing the area.  You decide you would like to earn a name for yourself by perhaps some day confronting this vile creature.");
 
     // allow explanative text as well.
-    modulehook("dragonkilltext");
+    HookHandler::hook("dragonkilltext");
 
     $regname = Names::getPlayerBasename();
     //get the dragons name
@@ -278,19 +283,19 @@ if ($op == "") {
 
     $howoften = ($session['user']['dragonkills'] > 1 ? "times" : "time"); // no translation, we never know who is viewing...
     AddNews::add("`#%s`# has earned the title `&%s`# for having slain `@%s`& `^%s`# %s!", $regname, $session['user']['title'], $badguy['creaturename'], $session['user']['dragonkills'], $howoften);
-    output("`n`n`^You are now known as `&%s`^!!", $session['user']['name']);
-    output("`n`n`&Because you have slain %s`& %s %s, you start with some extras.  You also keep additional permanent hitpoints you've earned.`n", $badguy['creaturename'], $session['user']['dragonkills'], $howoften);
+    $output->output("`n`n`^You are now known as `&%s`^!!", $session['user']['name']);
+    $output->output("`n`n`&Because you have slain %s`& %s %s, you start with some extras.  You also keep additional permanent hitpoints you've earned.`n", $badguy['creaturename'], $session['user']['dragonkills'], $howoften);
     $session['user']['charm'] += 5;
-    output("`^You gain FIVE charm points for having defeated the dragon!`n");
+    $output->output("`^You gain FIVE charm points for having defeated the dragon!`n");
     debuglog("slew the dragon and starts with {$session['user']['gold']} gold and {$session['user']['gems']} gems");
 
     // Moved this hear to make some things easier.
-    modulehook("dragonkill", array());
+    HookHandler::hook("dragonkill", array());
     invalidatedatacache("list.php-warsonline");
 }
 
 if ($op == "run") {
-    output("The creature's tail blocks the only exit to its lair!");
+    $output->output("The creature's tail blocks the only exit to its lair!");
     $op = "fight";
         Http::set('op', 'fight');
 }
@@ -306,15 +311,15 @@ if ($battle) {
             $flawless = 1;
         }
         $session['user']['dragonkills']++;
-        output("`&With a mighty final blow, `@%s`& lets out a tremendous bellow and falls at your feet, dead at last.", $badguy['creaturename']);
+        $output->output("`&With a mighty final blow, `@%s`& lets out a tremendous bellow and falls at your feet, dead at last.", $badguy['creaturename']);
         AddNews::add("`&%s has slain the hideous creature known as `@%s`&.  All across the land, people rejoice!", $session['user']['name'], $badguy['creaturename']);
         Translator::getInstance()->setSchema("nav");
-        addnav("Continue", "dragon.php?op=prologue1&flawless=$flawless");
+        Nav::add("Continue", "dragon.php?op=prologue1&flawless=$flawless");
         Translator::getInstance()->setSchema();
     } else {
         if ($defeat) {
             Translator::getInstance()->setSchema("nav");
-            addnav("Daily news", "news.php");
+            Nav::add("Daily news", "news.php");
             Translator::getInstance()->setSchema();
                         $taunt = Battle::selectTauntArray();
             if ($session['user']['sex']) {
@@ -326,18 +331,18 @@ if ($battle) {
             debuglog("lost {$session['user']['gold']} gold when they were slain");
             $session['user']['gold'] = 0;
             $session['user']['hitpoints'] = 0;
-            output("`b`&You have been slain by `@%s`&!!!`n", $badguy['creaturename']);
-            output("`4All gold on hand has been lost!`n");
+            $output->output("`b`&You have been slain by `@%s`&!!!`n", $badguy['creaturename']);
+            $output->output("`4All gold on hand has been lost!`n");
             //grant modules a chance to exclusively hook in here and do worse things to the user =)
-            output_notl("`n");
-            modulehook("dragondeath", array());
-            output_notl("`n");
-            output("You may begin fighting again tomorrow.");
+            $output->outputNotl("`n");
+            HookHandler::hook("dragondeath", array());
+            $output->outputNotl("`n");
+            $output->output("You may begin fighting again tomorrow.");
 
-            page_footer();
+            Footer::pageFooter();
         } else {
                   Battle::fightnav(true, false);
         }
     }
 }
-page_footer();
+Footer::pageFooter();

--- a/forest.php
+++ b/forest.php
@@ -2,33 +2,38 @@
 
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
+use Lotgd\Forest;
+use Lotgd\Buffs;
+use Lotgd\Forest\Outcomes;
+use Lotgd\Battle;
+use Lotgd\Nav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // addnews ready
 // translator ready
 // mail ready
 require_once __DIR__ . "/common.php";
-use Lotgd\Forest;
-use Lotgd\Buffs;
-use Lotgd\Forest\Outcomes;
-require_once __DIR__ . "/lib/http.php";
 require_once __DIR__ . "/lib/events.php";
-use Lotgd\Battle;
+
 
 Translator::getInstance()->setSchema("forest");
 
 $fight = false;
-page_header("The Forest");
+Header::pageHeader("The Forest");
 $dontdisplayforestmessage = handle_event("forest");
 
-$op = httpget("op");
+$op = Http::get("op");
 
 $battle = false;
 
 if ($op == "run") {
     if (e_rand() % 3 == 0) {
-        output("`c`b`&You have successfully fled your opponent!`0`b`c`n");
+        $output->output("`c`b`&You have successfully fled your opponent!`0`b`c`n");
         $op = "";
-        httpset('op', "");
+        Http::set('op', "");
                 Battle::unsuspendBuffs();
         foreach ($companions as $index => $companion) {
             if (isset($companion['expireafterfight']) && $companion['expireafterfight']) {
@@ -36,39 +41,39 @@ if ($op == "run") {
             }
         }
     } else {
-        output("`c`b`\$You failed to flee your opponent!`0`b`c");
+        $output->output("`c`b`\$You failed to flee your opponent!`0`b`c");
     }
 }
 
 if ($op == "dragon") {
     require_once __DIR__ . "/lib/partner.php";
-    addnav("Enter the cave", "dragon.php");
-    addnav("Run away like a baby", "inn.php?op=fleedragon");
-    output("`\$You approach the blackened entrance of a cave deep in the forest, though the trees are scorched to stumps for a hundred yards all around.");
-    output("A thin tendril of smoke escapes the roof of the cave's entrance, and is whisked away by a suddenly cold and brisk wind.");
-    output("The mouth of the cave lies up a dozen feet from the forest floor, set in the side of a cliff, with debris making a conical ramp to the opening.");
-    output("Stalactites and stalagmites near the entrance trigger your imagination to inspire thoughts that the opening is really the mouth of a great leech.`n`n");
-    output("You cautiously approach the entrance of the cave, and as you do, you hear, or perhaps feel a deep rumble that lasts thirty seconds or so, before silencing to a breeze of sulfur-air which wafts out of the cave.");
-    output("The sound starts again, and stops again in a regular rhythm.`n`n");
-    output("You clamber up the debris pile leading to the mouth of the cave, your feet crunching on the apparent remains of previous heroes, or perhaps hors d'oeuvres.`n`n");
-    output("Every instinct in your body wants to run, and run quickly, back to the warm inn, and the even warmer %s`\$.", get_partner());
-    output("What do you do?`0");
+    Nav::add("Enter the cave", "dragon.php");
+    Nav::add("Run away like a baby", "inn.php?op=fleedragon");
+    $output->output("`\$You approach the blackened entrance of a cave deep in the forest, though the trees are scorched to stumps for a hundred yards all around.");
+    $output->output("A thin tendril of smoke escapes the roof of the cave's entrance, and is whisked away by a suddenly cold and brisk wind.");
+    $output->output("The mouth of the cave lies up a dozen feet from the forest floor, set in the side of a cliff, with debris making a conical ramp to the opening.");
+    $output->output("Stalactites and stalagmites near the entrance trigger your imagination to inspire thoughts that the opening is really the mouth of a great leech.`n`n");
+    $output->output("You cautiously approach the entrance of the cave, and as you do, you hear, or perhaps feel a deep rumble that lasts thirty seconds or so, before silencing to a breeze of sulfur-air which wafts out of the cave.");
+    $output->output("The sound starts again, and stops again in a regular rhythm.`n`n");
+    $output->output("You clamber up the debris pile leading to the mouth of the cave, your feet crunching on the apparent remains of previous heroes, or perhaps hors d'oeuvres.`n`n");
+    $output->output("Every instinct in your body wants to run, and run quickly, back to the warm inn, and the even warmer %s`\$.", get_partner());
+    $output->output("What do you do?`0");
     $session['user']['seendragon'] = 1;
 }
 
 if ($op == "search") {
     checkday();
     if ($session['user']['turns'] <= 0) {
-        output("`\$`bYou are too tired to search the forest any longer today.  Perhaps tomorrow you will have more energy.`b`0");
+        $output->output("`\$`bYou are too tired to search the forest any longer today.  Perhaps tomorrow you will have more energy.`b`0");
         $op = "";
-        httpset('op', "");
+        Http::set('op', "");
     } else {
-        modulehook("forestsearch", array());
+        HookHandler::hook("forestsearch", array());
         $args = array(
             'soberval' => 0.9,
             'sobermsg' => "`&Faced with the prospect of death, you sober up a little.`n",
             'schema' => 'forest');
-        modulehook("soberup", $args);
+        HookHandler::hook("soberup", $args);
         if (module_events("forest", getsetting("forestchance", 15)) != 0) {
             if (!checknavs()) {
                 // If we're showing the forest, make sure to reset the special
@@ -77,12 +82,12 @@ if ($op == "search") {
                 $session['user']['specialmisc'] = "";
                 $dontdisplayforestmessage = true;
                 $op = "";
-                httpset("op", "");
+                Http::set("op", "");
             } else {
-                page_footer();
+                Footer::pageFooter();
             }
         } else {
-            modulehook("forestsearch_noevent", array());
+            HookHandler::hook("forestsearch_noevent", array());
             $session['user']['turns']--;
             $battle = true;
             if (e_rand(0, 2) == 1) {
@@ -92,14 +97,14 @@ if ($op == "search") {
                 $plev = 0;
                 $nlev = 0;
             }
-            $type = httpget('type');
+            $type = Http::get('type');
             if ($type == "slum") {
                 $nlev++;
-                output("`\$You head for the section of forest you know to contain foes that you're a bit more comfortable with.`0`n");
+                $output->output("`\$You head for the section of forest you know to contain foes that you're a bit more comfortable with.`0`n");
             }
             if ($type == "thrill") {
                 $plev++;
-                output("`\$You head for the section of forest which contains creatures of your nightmares, hoping to find one of them injured.`0`n");
+                $output->output("`\$You head for the section of forest which contains creatures of your nightmares, hoping to find one of them injured.`0`n");
             }
             $extrabuff = 0;
             if ($type == "suicide") {
@@ -113,7 +118,7 @@ if ($op == "search") {
                     $plev++;
                     $extrabuff = .4;
                 }
-                output("`\$You head for the section of forest which contains creatures of your nightmares, looking for the biggest and baddest ones there.`0`n");
+                $output->output("`\$You head for the section of forest which contains creatures of your nightmares, looking for the biggest and baddest ones there.`0`n");
             }
             $multi = 1;
             $targetlevel = ($session['user']['level'] + $plev - $nlev );
@@ -235,7 +240,7 @@ if ($op == "search") {
                         $stack[$i] = $badguy;
                     }
                     if ($multi > 1) {
-                        output("`2You encounter a group of `^%i`2 %s`2.`n`n", $multi, $badguy['creaturename']);
+                        $output->output("`2You encounter a group of `^%i`2 %s`2.`n`n", $multi, $badguy['creaturename']);
                     }
                 } else {
                     while ($badguy = Database::fetchAssoc($result)) {
@@ -289,13 +294,13 @@ if ($op == "search") {
                     "type" => "forest"
                 )
             );
-            $attackstack = modulehook("forestfight-start", $attackstack);
+            $attackstack = HookHandler::hook("forestfight-start", $attackstack);
             $session['user']['badguy'] = createstring($attackstack);
             // If someone for any reason wanted to add a nav where the user cannot choose the number of rounds anymore
             // because they are already set in the nav itself, we need this here.
             // It will not break anything else. I hope.
-            if (httpget('auto') != "") {
-                httpset('op', 'fight');
+            if (Http::get('auto') != "") {
+                Http::set('op', 'fight');
                 $op = 'fight';
             }
         }
@@ -311,7 +316,7 @@ if ($battle) {
 
     if ($victory) {
             $op = "";
-            httpset('op', "");
+            Http::set('op', "");
             Outcomes::victory($newenemies, isset($options['denyflawless']) ? $options['denyflawless'] : false);
             $dontdisplayforestmessage = true;
     } elseif ($defeat) {
@@ -324,7 +329,7 @@ if ($battle) {
 if ($op == "") {
     // Need to pass the variable here so that we show the forest message
     // sometimes, but not others.
-    modulehook("forest_enter", array());
+    HookHandler::hook("forest_enter", array());
         Forest::forest($dontdisplayforestmessage);
 }
-page_footer();
+Footer::pageFooter();

--- a/gamelog.php
+++ b/gamelog.php
@@ -3,6 +3,11 @@
 use Lotgd\MySQL\Database;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
+use Lotgd\Nav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+use Lotgd\Output;
 
 // translator ready
 // addnews ready
@@ -12,21 +17,24 @@ use Lotgd\Nav\SuperuserNav;
 
 if (!defined('GAMELOG_TEST')) {
     require_once __DIR__ . "/common.php";
-    require_once __DIR__ . "/lib/http.php";
+}
+
+if (!isset($output)) {
+    $output = Output::getInstance();
 }
 
 SuAccess::check(SU_EDIT_CONFIG);
 
 
-page_header("Game Log");
-addnav("Navigation");
+Header::pageHeader("Game Log");
+Nav::add("Navigation");
 SuperuserNav::render();
 
 $step = 500; // hardcoded stepping
-$category = httpget('cat');
-$start = (int)httpget('start'); //starting
-$sortorder = (int) httpget('sortorder'); // 0 = DESC 1= ASC
-$sortby = httpget('sortby');
+$category = Http::get('cat');
+$start = (int)Http::get('start'); //starting
+$sortorder = (int) Http::get('sortorder'); // 0 = DESC 1= ASC
+$sortby = Http::get('sortby');
 if ($category > "") {
     $cat = "&cat=$category";
     $sqlcat = "AND " . Database::prefix("gamelog") . ".category = '$category'";
@@ -51,17 +59,17 @@ $max = $row['c'];
 $sql = "SELECT " . Database::prefix("gamelog") . ".*, " . Database::prefix("accounts") . ".name AS name FROM " . Database::prefix("gamelog") . " LEFT JOIN " . Database::prefix("accounts") . " ON " . Database::prefix("gamelog") . ".who = " . Database::prefix("accounts") . ".acctid WHERE 1 $sqlcat $sqlsort LIMIT $start,$step";
 $next = $start + $step;
 $prev = $start - $step;
-addnav("Operations");
-addnav("Refresh", "gamelog.php?start=$start$cat&sortorder=$sortorder&sortby=$sortby");
+Nav::add("Operations");
+Nav::add("Refresh", "gamelog.php?start=$start$cat&sortorder=$sortorder&sortby=$sortby");
 if ($category > "") {
-    addnav("View all", "gamelog.php");
+    Nav::add("View all", "gamelog.php");
 }
-addnav("Game Log");
+Nav::add("Game Log");
 if ($next < $max) {
-    addnav("Next page", "gamelog.php?start=$next$cat&sortorder=$sortorder&sortby=$sortby");
+    Nav::add("Next page", "gamelog.php?start=$next$cat&sortorder=$sortorder&sortby=$sortby");
 }
 if ($start > 0) {
-    addnav("Previous page", "gamelog.php?start=$prev$cat&sortorder=$sortorder&sortby=$sortby");
+    Nav::add("Previous page", "gamelog.php?start=$prev$cat&sortorder=$sortorder&sortby=$sortby");
 }
 $result = Database::query($sql);
 $odate = "";
@@ -71,14 +79,14 @@ $i = 0;
 while ($row = Database::fetchAssoc($result)) {
     $dom = date("D, M d", strtotime($row['date']));
     if ($odate != $dom) {
-        output_notl("`n`b`@%s`0`b`n", $dom);
+        $output->outputNotl("`n`b`@%s`0`b`n", $dom);
         $odate = $dom;
     }
     $time = date("H:i:s", strtotime($row['date'])) . " (" . reltime(strtotime($row['date'])) . ")";
     if ($row['name'] != '' && (int) ($row['who'] ?? 0) !== 0) {
-        output_notl("`7(`\$%s`7) %s `7(`&%s`7) (`v%s`7)", $row['category'], $row['message'], $row['name'], $time);
+        $output->outputNotl("`7(`\$%s`7) %s `7(`&%s`7) (`v%s`7)", $row['category'], $row['message'], $row['name'], $time);
     } else {
-        output_notl(
+        $output->outputNotl(
             "`7(`\$%s`7) %s: %s `7(`v%s`7)",
             $row['category'],
             'System',
@@ -87,16 +95,16 @@ while ($row = Database::fetchAssoc($result)) {
         );
     }
     if (!isset($categories[$row['category']]) && $category == "") {
-        addnav("Operations");
-        addnav(array("View by `i%s`i", $row['category']), "gamelog.php?cat=" . $row['category']);
+        Nav::add("Operations");
+        Nav::add(array("View by `i%s`i", $row['category']), "gamelog.php?cat=" . $row['category']);
         $categories[$row['category']] = 1;
     }
-    output_notl("`n");
+    $output->outputNotl("`n");
 }
-addnav("Sorting");
-addnav("Sort by date ascending", "gamelog.php?start=$start$cat&sortorder=1&sortby=date");
-addnav("Sort by date descending", "gamelog.php?start=$start$cat&sortorder=0&sortby=date");
-addnav("Sort by category ascending", "gamelog.php?start=$start$cat&sortorder=1&sortby=category");
-addnav("Sort by category descending", "gamelog.php?start=$start$cat&sortorder=0&sortby=category");
+Nav::add("Sorting");
+Nav::add("Sort by date ascending", "gamelog.php?start=$start$cat&sortorder=1&sortby=date");
+Nav::add("Sort by date descending", "gamelog.php?start=$start$cat&sortorder=0&sortby=date");
+Nav::add("Sort by category ascending", "gamelog.php?start=$start$cat&sortorder=1&sortby=category");
+Nav::add("Sort by category descending", "gamelog.php?start=$start$cat&sortorder=0&sortby=category");
 
-page_footer();
+Footer::pageFooter();

--- a/graveyard.php
+++ b/graveyard.php
@@ -5,17 +5,21 @@ use Lotgd\DeathMessage;
 use Lotgd\Battle;
 use Lotgd\AddNews;
 use Lotgd\Translator;
+use Lotgd\Nav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // addnews ready.
 // translator ready
 // mail ready
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/http.php";
 require_once __DIR__ . "/lib/events.php";
 
 Translator::getInstance()->setSchema("graveyard");
 
-page_header("The Graveyard");
+Header::pageHeader("The Graveyard");
 $skipgraveyardtext = handle_event("graveyard");
 $deathoverlord = getsetting('deathoverlord', '`$Ramius');
 if (!$skipgraveyardtext) {
@@ -28,11 +32,11 @@ if (!$skipgraveyardtext) {
 $battle = false;
 Buffs::stripAllBuffs();
 $max = $session['user']['level'] * 10 + $session['user']['dragonkills'] * 2 + 50;
-$favortoheal = modulehook("favortoheal", array("favor" => round(10 * ($max - $session['user']['soulpoints']) / $max)));
+$favortoheal = HookHandler::hook("favortoheal", array("favor" => round(10 * ($max - $session['user']['soulpoints']) / $max)));
 
 $favortoheal = (int)$favortoheal['favor'];
 
-$op = httpget('op');
+$op = Http::get('op');
 switch ($op) {
     case "search":
             require_once __DIR__ . "/pages/graveyard/case_battle_search.php";
@@ -40,20 +44,20 @@ switch ($op) {
         break;
     case "run":
         if (e_rand(0, 2) == 1) {
-            output("`\$%s`) curses you for your cowardice.`n`n", $deathoverlord);
+            $output->output("`\$%s`) curses you for your cowardice.`n`n", $deathoverlord);
             $favor = 5 + e_rand(0, $session['user']['level']);
             if ($favor > $session['user']['deathpower']) {
                 $favor = $session['user']['deathpower'];
             }
             if ($favor > 0) {
-                output("`)You have `\$LOST `^%s`) favor with `\$%s`).", $favor, $deathoverlord);
+                $output->output("`)You have `\$LOST `^%s`) favor with `\$%s`).", $favor, $deathoverlord);
                 $session['user']['deathpower'] -= $favor;
             }
             Translator::getInstance()->setSchema("nav");
-            addnav("G?Return to the Graveyard", "graveyard.php");
+            Nav::add("G?Return to the Graveyard", "graveyard.php");
             Translator::getInstance()->setSchema();
         } else {
-            output("`)As you try to flee, you are summoned back to the fight!`n`n");
+            $output->output("`)As you try to flee, you are summoned back to the fight!`n`n");
             $battle = true;
         }
         break;
@@ -84,12 +88,12 @@ if ($battle) {
         Translator::getInstance()->setSchema("battle");
         $msg = translate_inline($badguy['creaturelose']);
         Translator::getInstance()->setSchema();
-        output_notl("`b`&%s`0`b`n", $msg);
-        output("`b`\$You have tormented %s!`0`b`n", $badguy['creaturename']);
-        output("`#You receive `^%s`# favor with `\$%s`#!`n`0", $badguy['creatureexp'], $deathoverlord);
+        $output->outputNotl("`b`&%s`0`b`n", $msg);
+        $output->output("`b`\$You have tormented %s!`0`b`n", $badguy['creaturename']);
+        $output->output("`#You receive `^%s`# favor with `\$%s`#!`n`0", $badguy['creatureexp'], $deathoverlord);
         $session['user']['deathpower'] += $badguy['creatureexp'];
         $op = "";
-        httpset('op', "");
+        Http::set('op', "");
         $skipgraveyardtext = true;
     } else {
         if ($defeat) {
@@ -102,11 +106,11 @@ if ($battle) {
                 AddNews::add("%s", $deathmessage['deathmessage']);
             }
 //          AddNews::add("`)%s`) has been defeated in the graveyard by %s.`n%s",$session['user']['name'],$badguy['creaturename'],$taunt);
-            output("`b`&You have been defeated by `%%s`&!!!`n", $badguy['creaturename']);
-            output("You may not torment any more souls today.");
+            $output->output("`b`&You have been defeated by `%%s`&!!!`n", $badguy['creaturename']);
+            $output->output("You may not torment any more souls today.");
             $session['user']['gravefights'] = 0;
             Translator::getInstance()->setSchema("nav");
-            addnav("G?Return to the Graveyard", "graveyard.php");
+            Nav::add("G?Return to the Graveyard", "graveyard.php");
             Translator::getInstance()->setSchema();
         } else {
                 Battle::fightnav(false, true, "graveyard.php");
@@ -114,7 +118,7 @@ if ($battle) {
     }
 }
 
-modulehook("deathoverlord", array());
+HookHandler::hook("deathoverlord", array());
 
 switch ($op) {
     case "search":
@@ -147,4 +151,4 @@ switch ($op) {
         break;
 }
 
-page_footer();
+Footer::pageFooter();

--- a/gypsy.php
+++ b/gypsy.php
@@ -2,22 +2,26 @@
 
 use Lotgd\Commentary;
 use Lotgd\Translator;
+use Lotgd\Nav;
+use Lotgd\Nav\VillageNav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // addnews ready
 // translator ready
 // mail ready
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/http.php";
-require_once __DIR__ . "/lib/villagenav.php";
 
 Translator::getInstance()->setSchema("gypsy");
 
 Commentary::addCommentary();
 
 $cost = $session['user']['level'] * 20;
-$op = httpget('op');
-addnav("Navigation");
-addnav("Forget it", "village.php");
+$op = Http::get('op');
+Nav::add("Navigation");
+Nav::add("Forget it", "village.php");
 
 if ($op == "pay") {
     if ($session['user']['gold'] >= $cost) { // Gunnar Kreitz
@@ -25,27 +29,27 @@ if ($op == "pay") {
         debuglog("spent $cost gold to speak to the dead");
         redirect("gypsy.php?op=talk");
     } else {
-        page_header("Gypsy Seer's tent");
-        villagenav();
-        output("`5You offer the old gypsy woman your `^%s`5 gold for your gen-u-wine say-ance, however she informs you that the dead may be dead, but they ain't cheap.", $session['user']['gold']);
+        Header::pageHeader("Gypsy Seer's tent");
+        VillageNav::render();
+        $output->output("`5You offer the old gypsy woman your `^%s`5 gold for your gen-u-wine say-ance, however she informs you that the dead may be dead, but they ain't cheap.", $session['user']['gold']);
     }
 } elseif ($op == "talk") {
-    page_header("In a deep trance, you talk with the shades");
+    Header::pageHeader("In a deep trance, you talk with the shades");
     Commentary::commentDisplay("`5While in a deep trance, you are able to talk with the dead:`n", "shade", "Project", 25, "projects");
-    addnav("Snap out of your trance", "gypsy.php");
+    Nav::add("Snap out of your trance", "gypsy.php");
 } else {
     checkday();
-    page_header("Gypsy Seer's tent");
-    output("`5You duck into a gypsy tent like many you have seen throughout the realm.");
-    output("All of them promise to let you talk with the deceased, and most of them surprisingly seem to work.");
-    output("There are also rumors that the gypsy have the power to speak over distances other than just those of the afterlife.");
-    output("In typical gypsy style, the old woman sitting behind a somewhat smudgy crystal ball informs you that the dead only speak with the paying.");
-    output("\"`!For you, %s, the price is a trifling `^%s`! gold.`5\", she rasps.", translate_inline($session['user']['sex'] ? "my pretty" : "my handsome"), $cost);
-    addnav("Seance");
-    addnav(array("Pay to talk to the dead (%s gold)", $cost), "gypsy.php?op=pay");
+    Header::pageHeader("Gypsy Seer's tent");
+    $output->output("`5You duck into a gypsy tent like many you have seen throughout the realm.");
+    $output->output("All of them promise to let you talk with the deceased, and most of them surprisingly seem to work.");
+    $output->output("There are also rumors that the gypsy have the power to speak over distances other than just those of the afterlife.");
+    $output->output("In typical gypsy style, the old woman sitting behind a somewhat smudgy crystal ball informs you that the dead only speak with the paying.");
+    $output->output("\"`!For you, %s, the price is a trifling `^%s`! gold.`5\", she rasps.", translate_inline($session['user']['sex'] ? "my pretty" : "my handsome"), $cost);
+    Nav::add("Seance");
+    Nav::add(array("Pay to talk to the dead (%s gold)", $cost), "gypsy.php?op=pay");
     if ($session['user']['superuser'] & SU_EDIT_COMMENTS) {
-        addnav("Superuser Entry", "gypsy.php?op=talk");
+        Nav::add("Superuser Entry", "gypsy.php?op=talk");
     }
-    modulehook("gypsy");
+    HookHandler::hook("gypsy");
 }
-page_footer();
+Footer::pageFooter();

--- a/healer.php
+++ b/healer.php
@@ -1,62 +1,67 @@
 <?php
 
 use Lotgd\Translator;
+use Lotgd\Forest;
+use Lotgd\Nav;
+use Lotgd\Nav\VillageNav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // addnews ready
 // translator ready
 // mail ready
 require_once __DIR__ . "/common.php";
-use Lotgd\Forest;
-require_once __DIR__ . "/lib/http.php";
-require_once __DIR__ . "/lib/villagenav.php";
+
 
 Translator::getInstance()->setSchema("healer");
 
 $config = unserialize($session['user']['donationconfig']);
 
-$return = httpget("return");
+$return = Http::get("return");
 $returnline = $return > "" ? "&return=$return" : "";
 
-page_header("Healer's Hut");
-output("`#`b`cHealer's Hut`c`b`n");
+Header::pageHeader("Healer's Hut");
+$output->output("`#`b`cHealer's Hut`c`b`n");
 
 $cost = log($session['user']['level']) * (($session['user']['maxhitpoints'] - $session['user']['hitpoints']) + 10);
-$result = modulehook("healmultiply", array("alterpct" => 1.0));
+$result = HookHandler::hook("healmultiply", array("alterpct" => 1.0));
 $cost *= $result['alterpct'];
 $cost = round($cost, 0);
 
 Translator::getInstance()->setSchema("nav");
-addnav("`bNavigation`b");
+Nav::add("`bNavigation`b");
 Translator::getInstance()->setSchema();
 
-$op = httpget('op');
+$op = Http::get('op');
 if ($op == "") {
     checkday();
-    output("`3You duck into the small smoke-filled grass hut.");
-    output("The pungent aroma makes you cough, attracting the attention of a grizzled old person that does a remarkable job of reminding you of a rock, which probably explains why you didn't notice them until now.");
-    output("Couldn't be your failure as a warrior.");
-    output("Nope, definitely not.`n`n");
+    $output->output("`3You duck into the small smoke-filled grass hut.");
+    $output->output("The pungent aroma makes you cough, attracting the attention of a grizzled old person that does a remarkable job of reminding you of a rock, which probably explains why you didn't notice them until now.");
+    $output->output("Couldn't be your failure as a warrior.");
+    $output->output("Nope, definitely not.`n`n");
     if ($session['user']['hitpoints'] < $session['user']['maxhitpoints']) {
-        output("\"`6See you, I do.  Before you did see me, I think, hmm?`3\" the old thing remarks.");
-        output("\"`6Know you, I do; healing you seek.  Willing to heal am I, but only if willing to pay are you.`3\"`n`n");
-        output("\"`5Uh, um.  How much?`3\" you ask, ready to be rid of the smelly old thing.`n`n");
-        output("The old being thumps your ribs with a gnarly staff.  \"`6For you... `$`b%s`b`6 gold pieces for a complete heal!!`3\" it says as it bends over and pulls a clay vial from behind a pile of skulls sitting in the corner.", $cost);
-        output("The view of the thing bending over to remove the vial almost does enough mental damage to require a larger potion.");
-        output("\"`6I also have some, erm... 'bargain' potions available,`3\" it says as it gestures at a pile of dusty, cracked vials.");
-        output("\"`6They'll heal a certain percent of your `idamage`i.`3\"");
+        $output->output("\"`6See you, I do.  Before you did see me, I think, hmm?`3\" the old thing remarks.");
+        $output->output("\"`6Know you, I do; healing you seek.  Willing to heal am I, but only if willing to pay are you.`3\"`n`n");
+        $output->output("\"`5Uh, um.  How much?`3\" you ask, ready to be rid of the smelly old thing.`n`n");
+        $output->output("The old being thumps your ribs with a gnarly staff.  \"`6For you... `$`b%s`b`6 gold pieces for a complete heal!!`3\" it says as it bends over and pulls a clay vial from behind a pile of skulls sitting in the corner.", $cost);
+        $output->output("The view of the thing bending over to remove the vial almost does enough mental damage to require a larger potion.");
+        $output->output("\"`6I also have some, erm... 'bargain' potions available,`3\" it says as it gestures at a pile of dusty, cracked vials.");
+        $output->output("\"`6They'll heal a certain percent of your `idamage`i.`3\"");
     } elseif ($session['user']['hitpoints'] == $session['user']['maxhitpoints']) {
-        output("`3The old creature grunts as it looks your way. \"`6Need a potion, you do not.  Wonder why you bother me, I do.`3\" says the hideous thing.");
-        output("The aroma of its breath makes you wish you hadn't come in here in the first place.  You think you had best leave.");
+        $output->output("`3The old creature grunts as it looks your way. \"`6Need a potion, you do not.  Wonder why you bother me, I do.`3\" says the hideous thing.");
+        $output->output("The aroma of its breath makes you wish you hadn't come in here in the first place.  You think you had best leave.");
     } else {
-        output("`3The old creature glances at you, then in a `^whirlwind of movement`3 that catches you completely off guard, brings its gnarled staff squarely in contact with the back of your head.");
-        output("You gasp as you collapse to the ground.`n`n");
-        output("Slowly you open your eyes and realize the beast is emptying the last drops of a clay vial down your throat.`n`n");
-        output("\"`6No charge for that potion.`3\" is all it has to say.");
-        output("You feel a strong urge to leave as quickly as you can.");
+        $output->output("`3The old creature glances at you, then in a `^whirlwind of movement`3 that catches you completely off guard, brings its gnarled staff squarely in contact with the back of your head.");
+        $output->output("You gasp as you collapse to the ground.`n`n");
+        $output->output("Slowly you open your eyes and realize the beast is emptying the last drops of a clay vial down your throat.`n`n");
+        $output->output("\"`6No charge for that potion.`3\" is all it has to say.");
+        $output->output("You feel a strong urge to leave as quickly as you can.");
         $session['user']['hitpoints'] = $session['user']['maxhitpoints'];
     }
 } elseif ($op == "buy") {
-    $pct = httpget('pct');
+    $pct = Http::get('pct');
     $newcost = round($pct * $cost / 100, 0);
     if ($session['user']['gold'] >= $newcost) {
         $session['user']['gold'] -= $newcost;
@@ -64,51 +69,51 @@ if ($op == "") {
         $diff = round(($session['user']['maxhitpoints'] - $session['user']['hitpoints']) * $pct / 100, 0);
         $session['user']['hitpoints'] += $diff;
         if ($newcost) {
-            output("`3With a grimace, you up-end the potion the creature hands you, and despite the foul flavor, you feel a warmth spreading through your veins as your muscles knit back together.");
-            output("Staggering some, you hand it your gold and are ready to be out of here.");
+            $output->output("`3With a grimace, you up-end the potion the creature hands you, and despite the foul flavor, you feel a warmth spreading through your veins as your muscles knit back together.");
+            $output->output("Staggering some, you hand it your gold and are ready to be out of here.");
         } else {
-            output("`3With a grimace, you up-end the potion the creature hands you, and despite the foul flavor, you feel a warmth spreading through your veins.");
-            output("Staggering some you are ready to be out of here.");
+            $output->output("`3With a grimace, you up-end the potion the creature hands you, and despite the foul flavor, you feel a warmth spreading through your veins.");
+            $output->output("Staggering some you are ready to be out of here.");
         }
-        output("`n`n`#You have been healed for %s points!", $diff);
+        $output->output("`n`n`#You have been healed for %s points!", $diff);
     } else {
-        output("`3The old creature pierces you with a gaze hard and cruel.");
-        output("Your lightning quick reflexes enable you to dodge the blow from its gnarled staff.");
-        output("Perhaps you should get some more money before you attempt to engage in local commerce.`n`n");
-        output("You recall that the creature had asked for `b`\$%s`3`b gold.", $newcost);
+        $output->output("`3The old creature pierces you with a gaze hard and cruel.");
+        $output->output("Your lightning quick reflexes enable you to dodge the blow from its gnarled staff.");
+        $output->output("Perhaps you should get some more money before you attempt to engage in local commerce.`n`n");
+        $output->output("You recall that the creature had asked for `b`\$%s`3`b gold.", $newcost);
     }
 } elseif ($op == "companion") {
-    $compcost = httpget('compcost');
+    $compcost = Http::get('compcost');
 
     if ($session['user']['gold'] < $compcost) {
-        output("`3The old creature pierces you with a gaze hard and cruel.`n");
-        output("Your lightning quick reflexes enable you to dodge the blow from its gnarled staff.`n");
-        output("Perhaps you should get some more money before you attempt to engage in local commerce.`n`n");
-        output("You recall that the creature had asked for `b`\$%s`3`b gold.", $compcost);
+        $output->output("`3The old creature pierces you with a gaze hard and cruel.`n");
+        $output->output("Your lightning quick reflexes enable you to dodge the blow from its gnarled staff.`n");
+        $output->output("Perhaps you should get some more money before you attempt to engage in local commerce.`n`n");
+        $output->output("You recall that the creature had asked for `b`\$%s`3`b gold.", $compcost);
     } else {
-        $name = stripslashes(rawurldecode(httpget('name')));
+        $name = stripslashes(rawurldecode(Http::get('name')));
         $session['user']['gold'] -= $compcost;
         $companions[$name]['hitpoints'] = $companions[$name]['maxhitpoints'];
         $session['user']['companions'] = serialize($companions);
-        output("`3With a grimace, %s`3 up-ends the potion from the creature.`n", $companions[$name]['name']);
-        output("Muscles knit back together, cuts close and bruises fade. %s`3 is ready to battle once again!`n", $companions[$name]['name']);
-        output("You hand the creature your gold and are ready to be out of here.");
+        $output->output("`3With a grimace, %s`3 up-ends the potion from the creature.`n", $companions[$name]['name']);
+        $output->output("Muscles knit back together, cuts close and bruises fade. %s`3 is ready to battle once again!`n", $companions[$name]['name']);
+        $output->output("You hand the creature your gold and are ready to be out of here.");
     }
 }
 $playerheal = false;
 if ($session['user']['hitpoints'] < $session['user']['maxhitpoints']) {
     $playerheal = true;
-    addnav("Potions");
-    addnav("`^Complete Healing`0", "healer.php?op=buy&pct=100$returnline");
+    Nav::add("Potions");
+    Nav::add("`^Complete Healing`0", "healer.php?op=buy&pct=100$returnline");
     //if cost is 0, usually on level 1 due to log algorithm, a free full healing is always preferred instead of a partial one
     if ($cost >= 0) {
         for ($i = 90; $i > 0; $i -= 10) {
-            addnav(array("%s%% - %s gold", $i, round($cost * $i / 100, 0)), "healer.php?op=buy&pct=$i$returnline");
+            Nav::add(array("%s%% - %s gold", $i, round($cost * $i / 100, 0)), "healer.php?op=buy&pct=$i$returnline");
         }
     }
-    modulehook('potion');
+    HookHandler::hook('potion');
 }
-addnav("`bHeal Companions`b");
+Nav::add("`bHeal Companions`b");
 $compheal = false;
 foreach ($companions as $name => $companion) {
     //inverse logic to if it set and value is true
@@ -117,7 +122,7 @@ foreach ($companions as $name => $companion) {
             $points = $companion['maxhitpoints'] - $companion['hitpoints'];
             if ($points > 0) {
                 $compcost = round(log($session['user']['level'] + 1) * ($points + 10) * 1.33);
-                addnav(array("%s`0 (`^%s Gold`0)", $companion['name'], $compcost), "healer.php?op=companion&name=" . rawurlencode($name) . "&compcost=$compcost$returnline");
+                Nav::add(array("%s`0 (`^%s Gold`0)", $companion['name'], $compcost), "healer.php?op=companion&name=" . rawurlencode($name) . "&compcost=$compcost$returnline");
                 $compheal = true;
             }
         }
@@ -125,19 +130,19 @@ foreach ($companions as $name => $companion) {
 }
 //needs to be after the code
 Translator::getInstance()->setSchema("nav");
-addnav("`bNavigation`b");
+Nav::add("`bNavigation`b");
 if ($return == "") {
     if ($playerheal || $compheal) {
-        addnav("F?Back to the Forest", "forest.php");
-        villagenav();
+        Nav::add("F?Back to the Forest", "forest.php");
+        VillageNav::render();
     } else {
                 Forest::forest(true);
     }
 } elseif ($return == "village.php") {
-    villagenav();
+    VillageNav::render();
 } else {
-    addnav("R?Return whence you came", $return);
+    Nav::add("R?Return whence you came", $return);
 }
 Translator::getInstance()->setSchema("");
-output_notl("`0");
-page_footer();
+$output->outputNotl("`0");
+Footer::pageFooter();

--- a/inn.php
+++ b/inn.php
@@ -9,12 +9,16 @@ use Lotgd\Sanitize;
 use Lotgd\Http;
 use Lotgd\Events;
 use Lotgd\Translator;
+use Lotgd\Pvp;
+use Lotgd\Nav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
 
 // addnews ready
 // translator ready
 // mail ready
 require_once __DIR__ . "/common.php";
-use Lotgd\Pvp;
+
 
 Translator::getInstance()->setSchema("inn");
 
@@ -30,7 +34,7 @@ if ($op == "fleedragon") {
     $session['user']['location'] = $vname;
 }
 
-page_header(["%s", Sanitize::sanitize($iname)]);
+Header::pageHeader(["%s", Sanitize::sanitize($iname)]);
 $skipinndesc = Events::handleEvent("inn");
 
 if (!$skipinndesc) {
@@ -48,9 +52,9 @@ $comment = Http::post('insertcommentary');
 
 require_once __DIR__ . "/lib/partner.php";
 $partner = get_partner();
-addnav("Other");
+Nav::add("Other");
 VillageNav::render();
-addnav("I?Return to the Inn", "inn.php");
+Nav::add("I?Return to the Inn", "inn.php");
 
 switch ($op) {
     case "":
@@ -74,4 +78,4 @@ if (!$skipinndesc) {
     $output->rawOutput("</span>");
 }
 
-page_footer();
+Footer::pageFooter();

--- a/installer.php
+++ b/installer.php
@@ -1,6 +1,13 @@
 <?php
 
 use Lotgd\Translator;
+use Lotgd\DataCache;
+use Lotgd\Http;
+use Lotgd\PageParts;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Nav;
+use Lotgd\Settings;
 
 //translator ready
 //addnews ready
@@ -9,14 +16,6 @@ use Lotgd\Translator;
 define("ALLOW_ANONYMOUS", true);
 define("OVERRIDE_FORCED_NAV", true);
 define("IS_INSTALLER", true);
-
-use Lotgd\DataCache;
-use Lotgd\Http;
-use Lotgd\PageParts;
-use Lotgd\Page\Header;
-use Lotgd\Page\Footer;
-use Lotgd\Nav;
-use Lotgd\Settings;
 
 //PHP 8.3 or higher is required for this version
 //MySQL 5.0.3 and the mysqli extension are required for this version
@@ -120,8 +119,8 @@ if (
     $stage == 5
     )
 ) {
-        output("`%This stage was completed during a previous installation.");
-        output("`2If you wish to perform stages 4 through 6 again, please delete the file named \"dbconnect.php\" from your site.`n`n");
+        $output->output("`%This stage was completed during a previous installation.");
+        $output->output("`2If you wish to perform stages 4 through 6 again, please delete the file named \"dbconnect.php\" from your site.`n`n");
         $stage = 6;
 }
 if ($stage > $session['stagecompleted']) {
@@ -135,7 +134,7 @@ $installer->runStage($stage);
 
 if (!$noinstallnavs) {
     if ($session['user']['loggedin']) {
-        addnav("Back to the game", $session['user']['restorepage']);
+        Nav::add("Back to the game", $session['user']['restorepage']);
     }
     Nav::add("Install Stages");
 

--- a/lodge.php
+++ b/lodge.php
@@ -2,21 +2,26 @@
 
 use Lotgd\Commentary;
 use Lotgd\Translator;
+use Lotgd\Names;
+use Lotgd\Nav;
+use Lotgd\Nav\VillageNav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // translator ready
 // addnews ready
 // mail ready
 require_once __DIR__ . "/common.php";
 require_once __DIR__ . "/lib/sanitize.php";
-require_once __DIR__ . "/lib/http.php";
-require_once __DIR__ . "/lib/villagenav.php";
-use Lotgd\Names;
+
 
 Translator::getInstance()->setSchema("lodge");
 
 Commentary::addCommentary();
 
-$op = httpget('op');
+$op = Http::get('op');
 if ($op == "") {
     checkday();
 }
@@ -28,44 +33,44 @@ if ($pointsavailable < 0) {
     $pointsavailable = 0; // something weird.
 }
 
-page_header("Hunter's Lodge");
-addnav("Navigation");
-villagenav();
-addnav("General");
+Header::pageHeader("Hunter's Lodge");
+Nav::add("Navigation");
+VillageNav::render();
+Nav::add("General");
 
-addnav("Referrals", "referral.php");
+Nav::add("Referrals", "referral.php");
 if ($op != "" && $entry) {
-    addnav("L?Back to the Lodge", "lodge.php");
+    Nav::add("L?Back to the Lodge", "lodge.php");
 }
-addnav("Describe Points", "lodge.php?op=points");
+Nav::add("Describe Points", "lodge.php?op=points");
 
 
 if ($op == "") {
-    output("`b`c`!The Hunter's Lodge`0`c`b");
-    output("`7You follow a narrow path away from the stables and come across a rustic Hunter's Lodge.");
-    output("A guard stops you at the door and asks to see your membership card.`n`n");
+    $output->output("`b`c`!The Hunter's Lodge`0`c`b");
+    $output->output("`7You follow a narrow path away from the stables and come across a rustic Hunter's Lodge.");
+    $output->output("A guard stops you at the door and asks to see your membership card.`n`n");
 
     if ($entry) {
-        modulehook("lodge-desc");
-        output("Upon showing it to him, he says, `3\"Very good %s, welcome to the J. C. Petersen Hunting Lodge.", translate_inline($session['user']['sex'] ? "ma'am" : "sir"));
-        output("You have earned `^%s`3 points and have `^%s`3 points available to spend,\"`7 and admits you in.`n`n", $session['user']['donation'], $pointsavailable);
-        output("You enter a room dominated by a large fireplace at the far end.");
-        output("The wood-panelled walls are covered with weapons, shields, and mounted hunting trophies, including the heads of several dragons that seem to move in the flickering light.`n`n");
-        output("Many high-backed leather chairs fill the room.");
-        output("In the chair closest to the fire sits J. C. Petersen, reading a heavy tome entitled \"Alchemy Today.\"`n`n");
-        output("As you approach, a large hunting dog at his feet raises her head and looks at you.");
-        output("Sensing that you belong, she lays down and goes back to sleep.`n`n");
+        HookHandler::hook("lodge-desc");
+        $output->output("Upon showing it to him, he says, `3\"Very good %s, welcome to the J. C. Petersen Hunting Lodge.", translate_inline($session['user']['sex'] ? "ma'am" : "sir"));
+        $output->output("You have earned `^%s`3 points and have `^%s`3 points available to spend,\"`7 and admits you in.`n`n", $session['user']['donation'], $pointsavailable);
+        $output->output("You enter a room dominated by a large fireplace at the far end.");
+        $output->output("The wood-panelled walls are covered with weapons, shields, and mounted hunting trophies, including the heads of several dragons that seem to move in the flickering light.`n`n");
+        $output->output("Many high-backed leather chairs fill the room.");
+        $output->output("In the chair closest to the fire sits J. C. Petersen, reading a heavy tome entitled \"Alchemy Today.\"`n`n");
+        $output->output("As you approach, a large hunting dog at his feet raises her head and looks at you.");
+        $output->output("Sensing that you belong, she lays down and goes back to sleep.`n`n");
             Commentary::commentDisplay("Nearby some other rugged hunters talk:`n", "hunterlodge", "Talk quietly", 25);
-        addnav("Use Points");
-        modulehook("lodge");
+        Nav::add("Use Points");
+        HookHandler::hook("lodge");
     } else {
         $iname = getsetting("innname", LOCATION_INN);
-        output("You pull out your Frequent Boozer Card from %s, with 9 out of the 10 slots punched out with a small profile of %s`7's Head.`n`n", $iname, getsetting('barkeep', '`tCedrik'));
-        output("The guard glances at it, advises you not to drink so much, and directs you down the path.");
+        $output->output("You pull out your Frequent Boozer Card from %s, with 9 out of the 10 slots punched out with a small profile of %s`7's Head.`n`n", $iname, getsetting('barkeep', '`tCedrik'));
+        $output->output("The guard glances at it, advises you not to drink so much, and directs you down the path.");
     }
 } elseif ($op == "points") {
-    output("`b`3Points:`b`n`n");
-    $points_messages = modulehook(
+    $output->output("`b`3Points:`b`n`n");
+    $points_messages = HookHandler::hook(
         "donator_point_messages",
         array(
             'messages' => array(
@@ -74,28 +79,28 @@ if ($op == "") {
         )
     );
     foreach ($points_messages['messages'] as $id => $message) {
-        output_notl($message . "`n", true);
+        $output->outputNotl($message . "`n", true);
     }
-    output("`n`n\"`&But what are points,`7\" you ask?");
-    output("Points can be redeemed for various advantages in the game.");
-    output("You'll find access to these advantages in the Hunter's Lodge.");
-    output("As time goes on, more advantages will likely be added, which can be purchased when they are made available.`n`n");
-    output("Donating even one %s will gain you a membership card to the Hunter's Lodge, an area reserved exclusively for contributors.", getsetting('paypalcurrency', 'USD'));
-    output("Donations are accepted in whole %s increments only.`n`n", getsetting('paypalcurrency', 'USD'));
-    output("\"`&But I don't have access to a PayPal account, or I otherwise can't donate to your very wonderful project!`7\"`n");
+    $output->output("`n`n\"`&But what are points,`7\" you ask?");
+    $output->output("Points can be redeemed for various advantages in the game.");
+    $output->output("You'll find access to these advantages in the Hunter's Lodge.");
+    $output->output("As time goes on, more advantages will likely be added, which can be purchased when they are made available.`n`n");
+    $output->output("Donating even one %s will gain you a membership card to the Hunter's Lodge, an area reserved exclusively for contributors.", getsetting('paypalcurrency', 'USD'));
+    $output->output("Donations are accepted in whole %s increments only.`n`n", getsetting('paypalcurrency', 'USD'));
+    $output->output("\"`&But I don't have access to a PayPal account, or I otherwise can't donate to your very wonderful project!`7\"`n");
            // yes, "referer" is misspelt here, but the game setting was also misspelt
     if (getsetting("refereraward", 25)) {
-        output("Well, there is another way that you can obtain points: by referring other people to our site!");
-        output("You'll get %s points for each person whom you've referred who makes it to level %s.", getsetting("refereraward", 25), getsetting("referminlevel", 4));
-        output("Even one person making it to level %s will gain you access to the Hunter's Lodge.`n`n", getsetting("referminlevel", 4));
+        $output->output("Well, there is another way that you can obtain points: by referring other people to our site!");
+        $output->output("You'll get %s points for each person whom you've referred who makes it to level %s.", getsetting("refereraward", 25), getsetting("referminlevel", 4));
+        $output->output("Even one person making it to level %s will gain you access to the Hunter's Lodge.`n`n", getsetting("referminlevel", 4));
     }
-    output("You can also gain contributor points for contributing in other ways that the administration may specify.");
-    output("So, don't despair if you cannot send cash, there will always be non-cash ways of gaining contributor points.`n`n");
-    output("`b`3Purchases that are currently available:`0`b`n");
-    $args = modulehook("pointsdesc", array("format" => "`#&#149;`7 %s`n", "count" => 0));
+    $output->output("You can also gain contributor points for contributing in other ways that the administration may specify.");
+    $output->output("So, don't despair if you cannot send cash, there will always be non-cash ways of gaining contributor points.`n`n");
+    $output->output("`b`3Purchases that are currently available:`0`b`n");
+    $args = HookHandler::hook("pointsdesc", array("format" => "`#&#149;`7 %s`n", "count" => 0));
     if ($args['count'] == 0) {
-        output("`#&#149;`7None -- Please talk to your admin about creating some.`n", true);
+        $output->output("`#&#149;`7None -- Please talk to your admin about creating some.`n", true);
     }
 }
 
-page_footer();
+Footer::pageFooter();

--- a/logviewer.php
+++ b/logviewer.php
@@ -5,20 +5,24 @@ declare(strict_types=1);
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
 use Lotgd\Translator;
+use Lotgd\Nav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+
 
 require_once 'common.php';
-require_once 'lib/http.php';
 
 SuAccess::check(SU_EDIT_CONFIG);
 
 Translator::getInstance()->setSchema('logviewer');
 
-page_header('Log Viewer');
-addnav('Navigation');
+Header::pageHeader('Log Viewer');
+Nav::add('Navigation');
 SuperuserNav::render();
 
 $logDir = __DIR__ . '/logs';
-$param = httpget('file');
+$param = Http::get('file');
 $requested = $param !== false ? basename($param) : '';
 $files = [];
 if (is_dir($logDir)) {
@@ -27,18 +31,18 @@ if (is_dir($logDir)) {
     }));
 }
 
-addnav('Logs');
+Nav::add('Logs');
 foreach ($files as $file) {
-    addnav($file, "logviewer.php?file=" . rawurlencode($file));
+    Nav::add($file, "logviewer.php?file=" . rawurlencode($file));
 }
 
 if ($requested && in_array($requested, $files, true)) {
     $content = file_get_contents($logDir . '/' . $requested);
-    rawoutput('<pre>');
-    rawoutput(htmlentities($content));
-    rawoutput('</pre>');
+    $output->rawOutput('<pre>');
+    $output->rawOutput(htmlentities($content));
+    $output->rawOutput('</pre>');
 } else {
-    output('Select a log file from the navigation to view its contents.');
+    $output->output('Select a log file from the navigation to view its contents.');
 }
 
-page_footer();
+Footer::pageFooter();

--- a/masters.php
+++ b/masters.php
@@ -4,36 +4,39 @@ use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
+use Lotgd\Nav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
 
 // Initially written as a module by Chris Vorndran.
 // Moved into core by JT Traub
 
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/http.php";
 
 SuAccess::check(SU_EDIT_CREATURES);
 
 Translator::getInstance()->setSchema("masters");
 
-$op = httpget('op');
-$id = (int)httpget('id');
-$act = httpget('act');
+$op = Http::get('op');
+$id = (int)Http::get('id');
+$act = Http::get('act');
 
-page_header("Masters Editor");
+Header::pageHeader("Masters Editor");
 SuperuserNav::render();
 
 if ($op == "del") {
     $sql = "DELETE FROM " . Database::prefix("masters") . " WHERE creatureid=$id";
     Database::query($sql);
-    output("`^Master deleted.`0");
+    $output->output("`^Master deleted.`0");
     $op = "";
-    httpset("op", "");
+    Http::set("op", "");
 } elseif ($op == "save") {
-    $name = addslashes(httppost('name'));
-    $weapon = addslashes(httppost('weapon'));
-    $win = addslashes(httppost('win'));
-    $lose = addslashes(httppost('lose'));
-    $lev = (int)httppost('level');
+    $name = addslashes(Http::post('name'));
+    $weapon = addslashes(Http::post('weapon'));
+    $win = addslashes(Http::post('win'));
+    $lose = addslashes(Http::post('lose'));
+    $lev = (int)Http::post('level');
     if ($id != 0) {
         $sql = "UPDATE " . Database::prefix("masters") . " SET creaturelevel=$lev, creaturename='$name', creatureweapon='$weapon',  creaturewin='$win', creaturelose='$lose' WHERE creatureid=$id";
     } else {
@@ -47,15 +50,15 @@ if ($op == "del") {
     }
     Database::query($sql);
     if ($id == 0) {
-        output("`^Master %s`^ added.", stripslashes($name));
+        $output->output("`^Master %s`^ added.", stripslashes($name));
     } else {
-        output("`^Master %s`^ updated.", stripslashes($name));
+        $output->output("`^Master %s`^ updated.", stripslashes($name));
     }
     $op = "";
-    httpset("op", "");
+    Http::set("op", "");
 } elseif ($op == "edit") {
-    addnav("Functions");
-    addnav("Return to Masters Editor", "masters.php");
+    Nav::add("Functions");
+    Nav::add("Return to Masters Editor", "masters.php");
     $sql = "SELECT * FROM " . Database::prefix("masters") . " WHERE creatureid=$id";
     $res = Database::query($sql);
     if (Database::numRows($res) == 0) {
@@ -69,51 +72,51 @@ if ($op == "del") {
     } else {
         $row = Database::fetchAssoc($res);
     }
-    addnav("", "masters.php?op=save&id=$id");
-    rawoutput("<form action='masters.php?op=save&id=$id' method='POST'>");
-        rawoutput("<label for='level'>");
-        output("`^Master's level:`n");
-        rawoutput("</label>");
-        rawoutput("<select name='level' id='level'>");
+    Nav::add("", "masters.php?op=save&id=$id");
+    $output->rawOutput("<form action='masters.php?op=save&id=$id' method='POST'>");
+        $output->rawOutput("<label for='level'>");
+        $output->output("`^Master's level:`n");
+        $output->rawOutput("</label>");
+        $output->rawOutput("<select name='level' id='level'>");
     $maxlevel = getsetting('maxlevel');
     for ($i = 0; $i < $maxlevel; $i++) {
         $selected = ($i == $row['creaturelevel'] ? ' selected' : '');
-        rawoutput("<option$selected>$i</option>");
+        $output->rawOutput("<option$selected>$i</option>");
     }
-    rawoutput("</select>");
-    output_notl("`n");
-    output("`^Master's name:`n");
-    rawoutput("<input id='input' name='name' value='" . htmlentities($row['creaturename'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "'>");
-    output_notl("`n");
-    output("`^Master's weapon:`n");
-    rawoutput("<input id='input' name='weapon' value='" . htmlentities($row['creatureweapon'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "'>");
-    output_notl("`n");
-    output("`^Master's speech when player wins:`n");
-    rawoutput("<textarea name='lose' rows='5' cols='30' class='input'>" . htmlentities($row['creaturelose'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "</textarea>");
-    output_notl("`n");
-    output("`^Master's speech when player loses:`n");
-    rawoutput("<textarea name='win' rows='5' cols='30' class='input'>" . htmlentities($row['creaturewin'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "</textarea>");
-    output_notl("`n");
+    $output->rawOutput("</select>");
+    $output->outputNotl("`n");
+    $output->output("`^Master's name:`n");
+    $output->rawOutput("<input id='input' name='name' value='" . htmlentities($row['creaturename'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "'>");
+    $output->outputNotl("`n");
+    $output->output("`^Master's weapon:`n");
+    $output->rawOutput("<input id='input' name='weapon' value='" . htmlentities($row['creatureweapon'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "'>");
+    $output->outputNotl("`n");
+    $output->output("`^Master's speech when player wins:`n");
+    $output->rawOutput("<textarea name='lose' rows='5' cols='30' class='input'>" . htmlentities($row['creaturelose'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "</textarea>");
+    $output->outputNotl("`n");
+    $output->output("`^Master's speech when player loses:`n");
+    $output->rawOutput("<textarea name='win' rows='5' cols='30' class='input'>" . htmlentities($row['creaturewin'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "</textarea>");
+    $output->outputNotl("`n");
     $submit = translate_inline("Submit");
-    rawoutput("<input type='submit' class='button' value='$submit'>");
-    rawoutput("</form>");
-    output_notl("`n`n");
-    output("`#The following codes are supported in both the win and lose speeches (case matters):`n");
-    output("The following codes are supported (case matters):`n");
-    output("{goodguyname}	= The player's name (also can be specified as {goodguy}`n");
-    output("{weaponname}	= The player's weapon (also can be specified as {weapon}`n");
-    output("{armorname}	= The player's armor (also can be specified as {armor}`n");
-    output("{himher}	= Subjective pronoun for the player (him her)`n");
-    output("{hisher}	= Possessive pronoun for the player (his her)`n");
-    output("{heshe}		= Objective pronoun for the player (he she)`n");
-    output("{badguyname}	= The monster's name (also can be specified as {badguy}`n");
-    output("{badguyweapon}	= The monster's weapon (also can be specified as {creatureweapon}`n");
+    $output->rawOutput("<input type='submit' class='button' value='$submit'>");
+    $output->rawOutput("</form>");
+    $output->outputNotl("`n`n");
+    $output->output("`#The following codes are supported in both the win and lose speeches (case matters):`n");
+    $output->output("The following codes are supported (case matters):`n");
+    $output->output("{goodguyname}	= The player's name (also can be specified as {goodguy}`n");
+    $output->output("{weaponname}	= The player's weapon (also can be specified as {weapon}`n");
+    $output->output("{armorname}	= The player's armor (also can be specified as {armor}`n");
+    $output->output("{himher}	= Subjective pronoun for the player (him her)`n");
+    $output->output("{hisher}	= Possessive pronoun for the player (his her)`n");
+    $output->output("{heshe}		= Objective pronoun for the player (he she)`n");
+    $output->output("{badguyname}	= The monster's name (also can be specified as {badguy}`n");
+    $output->output("{badguyweapon}	= The monster's weapon (also can be specified as {creatureweapon}`n");
 }
 
 if ($op == "") {
-    addnav("Functions");
-    addnav("Refresh list", "masters.php");
-    addnav("Add master", "masters.php?op=edit&id=0");
+    Nav::add("Functions");
+    Nav::add("Refresh list", "masters.php");
+    Nav::add("Add master", "masters.php?op=edit&id=0");
     $sql = "SELECT * FROM " . Database::prefix("masters") . " ORDER BY creaturelevel";
     $res = Database::query($sql);
     $count = Database::numRows($res);
@@ -126,35 +129,35 @@ if ($op == "") {
     $lose = translate_inline("Lose to Master");
     $win = translate_inline("Win against Master");
     $weapon = translate_inline("Weapon");
-    rawoutput("<table border='0' cellpadding='2' cellspacing='1' align='center' bgcolor='#999999'>");
-    rawoutput("<tr class='trhead'><td>$ops</td><td>$level</td><td>$name</td><td>$weapon</td><td>$win</td><td>$lose</tr>");
+    $output->rawOutput("<table border='0' cellpadding='2' cellspacing='1' align='center' bgcolor='#999999'>");
+    $output->rawOutput("<tr class='trhead'><td>$ops</td><td>$level</td><td>$name</td><td>$weapon</td><td>$win</td><td>$lose</tr>");
     $i = false;
     while ($row = Database::fetchAssoc($res)) {
         $id = $row['creatureid'];
-        rawoutput("<tr class='" . ($i ? "trdark" : "trlight") . "'><td nowrap>");
-        rawoutput("[ <a href='masters.php?op=edit&id=$id'>");
-        output_notl($edit);
-        rawoutput("</a> | <a href='masters.php?op=del&id=$id' onClick='return confirm(\"$delconfirm\");'>");
-        output_notl($del);
-        rawoutput("] </a>");
-        addnav("", "masters.php?op=edit&id=$id");
-        addnav("", "masters.php?op=del&id=$id");
-        rawoutput("</td><td>");
-        output_notl("`%%s`0", $row['creaturelevel']);
-        rawoutput("</td><td>");
-        output_notl("`#%s`0", stripslashes($row['creaturename']));
-        rawoutput("</td><td>");
-        output_notl("`!%s`0", stripslashes($row['creatureweapon']));
-        rawoutput("</td><td>");
-        output_notl("`&%s`0", stripslashes($row['creaturelose']));
-        rawoutput("</td><td>");
-        output_notl("`^%s`0", stripslashes($row['creaturewin']));
-        rawoutput("</td></tr>");
+        $output->rawOutput("<tr class='" . ($i ? "trdark" : "trlight") . "'><td nowrap>");
+        $output->rawOutput("[ <a href='masters.php?op=edit&id=$id'>");
+        $output->outputNotl($edit);
+        $output->rawOutput("</a> | <a href='masters.php?op=del&id=$id' onClick='return confirm(\"$delconfirm\");'>");
+        $output->outputNotl($del);
+        $output->rawOutput("] </a>");
+        Nav::add("", "masters.php?op=edit&id=$id");
+        Nav::add("", "masters.php?op=del&id=$id");
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("`%%s`0", $row['creaturelevel']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("`#%s`0", stripslashes($row['creaturename']));
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("`!%s`0", stripslashes($row['creatureweapon']));
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("`&%s`0", stripslashes($row['creaturelose']));
+        $output->rawOutput("</td><td>");
+        $output->outputNotl("`^%s`0", stripslashes($row['creaturewin']));
+        $output->rawOutput("</td></tr>");
         $i = !$i;
     }
-    rawoutput("</table>");
-    output("`n`#You can change the names, weapons and messages of all of the Training Masters.");
-    output("`n`3You can add masters up to the maximum level where the dragon appears in the forest and which can be set in your game settings -> game setup. You cannot assign higher masters, but if you choose not to make one master for each level, the earlier master will appear again to the player to test him.`n");
-    output("`#  It is suggested, that you do not toy around with this, unless you know what you are doing.`0`n");
+    $output->rawOutput("</table>");
+    $output->output("`n`#You can change the names, weapons and messages of all of the Training Masters.");
+    $output->output("`n`3You can add masters up to the maximum level where the dragon appears in the forest and which can be set in your game settings -> game setup. You cannot assign higher masters, but if you choose not to make one master for each level, the earlier master will appear again to the player to test him.`n");
+    $output->output("`#  It is suggested, that you do not toy around with this, unless you know what you are doing.`0`n");
 }
-page_footer();
+Footer::pageFooter();

--- a/motd.php
+++ b/motd.php
@@ -6,6 +6,9 @@ use Lotgd\Commentary;
 use Lotgd\Accounts;
 use Lotgd\Output;
 use Lotgd\DataCache;
+use Lotgd\Motd;
+use Lotgd\Nav;
+use Lotgd\Http;
 
 // addnews ready
 // translator ready
@@ -15,13 +18,12 @@ define("OVERRIDE_FORCED_NAV", true);
 require_once __DIR__ . "/common.php";
 $output = Output::getInstance();
 require_once __DIR__ . "/lib/nltoappon.php";
-require_once __DIR__ . "/lib/http.php";
-use Lotgd\Motd;
+
 
 Translator::getInstance()->setSchema("motd");
 
-$op = httpget('op');
-$id = httpget('id');
+$op = Http::get('op');
+$id = Http::get('id');
 
 Commentary::addCommentary();
 popup_header("LoGD Message of the Day (MoTD)");
@@ -33,8 +35,8 @@ if ($session['user']['superuser'] & SU_POST_MOTD) {
 }
 
 if ($op == "vote") {
-    $motditem = httppost('motditem');
-    $choice = (string)httppost('choice');
+    $motditem = Http::post('motditem');
+    $choice = (string)Http::post('choice');
     $sql = "DELETE FROM " . Database::prefix("pollresults") . " WHERE motditem='$motditem' AND account='{$session['user']['acctid']}'";
     Database::query($sql);
     $sql = "INSERT INTO " . Database::prefix("pollresults") . " (choice,account,motditem) VALUES ('$choice','{$session['user']['acctid']}','$motditem')";
@@ -44,9 +46,9 @@ if ($op == "vote") {
     exit();
 }
 if (($op == "save" || $op == "savenew") && ($session['user']['superuser'] & SU_POST_MOTD)) {
-    if (httppost('preview')) {
-        $title = httppost('motdtitle');
-        $body = nltoappon((string) httppost('motdbody'));
+    if (Http::post('preview')) {
+        $title = Http::post('motdtitle');
+        $body = nltoappon((string) Http::post('motdbody'));
         Motd::motdItem($title, $body, $session['user']['name'], date('Y-m-d H:i:s'), (int) $id);
         Motd::motdForm((int) $id, $_POST);
     } else {
@@ -70,7 +72,7 @@ if ($op == "add" || $op == "addpoll" || $op == "del") {
             $output->output("`^Entry deleted.`0`n");
             $return = translate_inline("Return to MoTD");
             $output->rawOutput("<a href='motd.php'>$return</a>");
-            addnav('', 'motd.php');
+            Nav::add('', 'motd.php');
         }
     } else {
         if ($session['user']['loggedin']) {
@@ -86,14 +88,14 @@ if ($op == "add" || $op == "addpoll" || $op == "del") {
 }
 if ($op == "") {
     $count = getsetting("motditems", 5);
-    $newcount = (int)httppost("newcount");
-    if ($newcount == 0 || httppost('proceed') == '') {
+    $newcount = (int)Http::post("newcount");
+    if ($newcount == 0 || Http::post('proceed') == '') {
         $newcount = 0;
     }
         /*
         Motd::motditem("Beta!","Please see the beta message below.","","", "");
         */
-    $month_post = httppost("month");
+    $month_post = Http::post("month");
     //SQL Injection attack possible -> kill it off after 7 letters as format is i.e. "2000-05"
     $month_post = substr($month_post, 0, 7);
     if (preg_match("/[0-9][0-9][0-9][0-9]-[0-9][0-9]/", $month_post) !== 1) {

--- a/mounts.php
+++ b/mounts.php
@@ -4,15 +4,19 @@ use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
+use Lotgd\Nav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // addnews ready
 // mail ready
 // translator ready
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/http.php";
 
-$op = httpget('op');
-$id = httpget('id');
+$op = Http::get('op');
+$id = Http::get('id');
 
 if ($op == "xml") {
     header("Content-Type: text/xml");
@@ -36,24 +40,24 @@ SuAccess::check(SU_EDIT_MOUNTS);
 
 Translator::getInstance()->setSchema("mounts");
 
-page_header("Mount Editor");
+Header::pageHeader("Mount Editor");
 
 SuperuserNav::render();
 
-addnav("Mount Editor");
-addnav("Add a mount", "mounts.php?op=add");
+Nav::add("Mount Editor");
+Nav::add("Add a mount", "mounts.php?op=add");
 
 if ($op == "deactivate") {
     $sql = "UPDATE " . Database::prefix("mounts") . " SET mountactive=0 WHERE mountid='$id'";
     Database::query($sql);
     $op = "";
-    httpset("op", "");
+    Http::set("op", "");
     invalidatedatacache("mountdata-$id");
 } elseif ($op == "activate") {
     $sql = "UPDATE " . Database::prefix("mounts") . " SET mountactive=1 WHERE mountid='$id'";
     Database::query($sql);
     $op = "";
-    httpset("op", "");
+    Http::set("op", "");
     invalidatedatacache("mountdata-$id");
 } elseif ($op == "del") {
     //refund for anyone who has a mount of this type.
@@ -67,7 +71,7 @@ if ($op == "deactivate") {
     Database::query($sql);
     module_delete_objprefs('mounts', $id);
     $op = "";
-    httpset("op", "");
+    Http::set("op", "");
     invalidatedatacache("mountdata-$id");
 } elseif ($op == "give") {
     $session['user']['hashorse'] = $id;
@@ -81,12 +85,12 @@ if ($op == "deactivate") {
     }
     Buffs::applyBuff("mount", $buff);
     $op = "";
-    httpset("op", "");
+    Http::set("op", "");
 } elseif ($op == "save") {
-    $subop = httpget("subop");
+    $subop = Http::get("subop");
     if ($subop == "") {
         $buff = array();
-        $mount = httppost('mount');
+        $mount = Http::post('mount');
         if ($mount) {
             reset($mount['mountbuff']);
             foreach ($mount['mountbuff'] as $key => $val) {
@@ -108,27 +112,27 @@ if ($op == "deactivate") {
             Database::query($sql);
             invalidatedatacache("mountdata-$id");
             if (Database::affectedRows() > 0) {
-                output("`^Mount saved!`0`n");
+                $output->output("`^Mount saved!`0`n");
             } else {
-                output("`^Mount `\$not`^ saved: `\$%s`0`n", $sql);
+                $output->output("`^Mount `\$not`^ saved: `\$%s`0`n", $sql);
             }
         }
     } elseif ($subop == "module") {
         // Save modules settings
-        $module = httpget("module");
+        $module = Http::get("module");
         $post = httpallpost();
         unset($post['showFormTabIndex']);
         foreach ($post as $key => $val) {
             set_module_objpref("mounts", $id, $key, $val, $module);
         }
-        output("`^Saved!`0`n");
+        $output->output("`^Saved!`0`n");
     }
     if ($id) {
         $op = "edit";
     } else {
         $op = "";
     }
-    httpset("op", $op);
+    Http::set("op", $op);
 }
 
 if ($op == "") {
@@ -138,7 +142,7 @@ if ($op == "") {
     while ($row = Database::fetchAssoc($result)) {
         $mounts[$row['hashorse']] = $row['c'];
     }
-    rawoutput("<script language='JavaScript'>
+    $output->rawOutput("<script language='JavaScript'>
 	function getUserInfo(id,divid){
 		var filename='mounts.php?op=xml&id='+id;
 		var xmldom;
@@ -174,8 +178,8 @@ if ($op == "") {
 
     $conf = translate_inline("There are %s user(s) who own this mount, are you sure you wish to delete it?");
 
-    rawoutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
-    rawoutput("<tr class='trhead'><td nowrap>$ops</td><td>$name</td><td>$cost</td><td>$feat</td><td nowrap>$owners</td></tr>");
+    $output->rawOutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
+    $output->rawOutput("<tr class='trhead'><td nowrap>$ops</td><td>$name</td><td>$cost</td><td>$feat</td><td nowrap>$owners</td></tr>");
     $result = Database::query($sql);
     $cat = "";
     $count = 0;
@@ -184,9 +188,9 @@ if ($op == "") {
     for ($i = 0; $i < $number; $i++) {
         $row = Database::fetchAssoc($result);
         if ($cat != $row['mountcategory']) {
-            rawoutput("<tr class='trlight'><td colspan='5'>");
-            output("Category: %s", $row['mountcategory']);
-            rawoutput("</td></tr>");
+            $output->rawOutput("<tr class='trlight'><td colspan='5'>");
+            $output->output("Category: %s", $row['mountcategory']);
+            $output->rawOutput("</td></tr>");
             $cat = $row['mountcategory'];
             $count = 0;
         }
@@ -195,75 +199,75 @@ if ($op == "") {
         } else {
             $mounts[$row['mountid']] = 0;
         }
-        rawoutput("<tr class='" . ($count % 2 ? "trlight" : "trdark") . "'>");
-        rawoutput("<td nowrap>[ <a href='mounts.php?op=edit&id={$row['mountid']}'>$edit</a> |");
-        addnav("", "mounts.php?op=edit&id={$row['mountid']}");
-        rawoutput("<a href='mounts.php?op=give&id={$row['mountid']}'>$give</a> |", true);
-        addnav("", "mounts.php?op=give&id={$row['mountid']}");
+        $output->rawOutput("<tr class='" . ($count % 2 ? "trlight" : "trdark") . "'>");
+        $output->rawOutput("<td nowrap>[ <a href='mounts.php?op=edit&id={$row['mountid']}'>$edit</a> |");
+        Nav::add("", "mounts.php?op=edit&id={$row['mountid']}");
+        $output->rawOutput("<a href='mounts.php?op=give&id={$row['mountid']}'>$give</a> |", true);
+        Nav::add("", "mounts.php?op=give&id={$row['mountid']}");
         if ($row['mountactive']) {
-            rawoutput("$del |");
+            $output->rawOutput("$del |");
         } else {
             $mconf = sprintf($conf, $mounts[$row['mountid']]);
-            rawoutput("<a href='mounts.php?op=del&id={$row['mountid']}' onClick=\"return confirm('$mconf');\">$del</a> |");
-            addnav("", "mounts.php?op=del&id={$row['mountid']}");
+            $output->rawOutput("<a href='mounts.php?op=del&id={$row['mountid']}' onClick=\"return confirm('$mconf');\">$del</a> |");
+            Nav::add("", "mounts.php?op=del&id={$row['mountid']}");
         }
         if ($row['mountactive']) {
-            rawoutput("<a href='mounts.php?op=deactivate&id={$row['mountid']}'>$deac</a> ]</td>");
-            addnav("", "mounts.php?op=deactivate&id={$row['mountid']}");
+            $output->rawOutput("<a href='mounts.php?op=deactivate&id={$row['mountid']}'>$deac</a> ]</td>");
+            Nav::add("", "mounts.php?op=deactivate&id={$row['mountid']}");
         } else {
-            rawoutput("<a href='mounts.php?op=activate&id={$row['mountid']}'>$act</a> ]</td>");
-            addnav("", "mounts.php?op=activate&id={$row['mountid']}");
+            $output->rawOutput("<a href='mounts.php?op=activate&id={$row['mountid']}'>$act</a> ]</td>");
+            Nav::add("", "mounts.php?op=activate&id={$row['mountid']}");
         }
-        rawoutput("<td>");
-        output_notl("`&%s`0", $row['mountname']);
-        rawoutput("</td><td>");
-        output("`%%s gems`0, `^%s gold`0", $row['mountcostgems'], $row['mountcostgold']);
-        rawoutput("</td><td>");
+        $output->rawOutput("<td>");
+        $output->outputNotl("`&%s`0", $row['mountname']);
+        $output->rawOutput("</td><td>");
+        $output->output("`%%s gems`0, `^%s gold`0", $row['mountcostgems'], $row['mountcostgold']);
+        $output->rawOutput("</td><td>");
         $features = array("FF" => $row['mountforestfights'],"DKs" => $row['mountdkcost']);
         $args = array("id" => $row['mountid'],"features" => &$features);
-        $args = modulehook("mountfeatures", $args);
+        $args = HookHandler::hook("mountfeatures", $args);
         reset($features);
         $mcount = 1;
         $max = count($features);
         foreach ($features as $fname => $fval) {
             $fname = translate_inline($fname);
-            output_notl("%s: %s%s", $fname, $fval, ($mcount == $max ? "" : ", "));
+            $output->outputNotl("%s: %s%s", $fname, $fval, ($mcount == $max ? "" : ", "));
             $mcount++;
         }
-        rawoutput("</td><td nowrap>");
+        $output->rawOutput("</td><td nowrap>");
         $file = "mounts.php?op=xml&id=" . $row['mountid'];
-        rawoutput("<div id='mountusers$i'><a href='$file' target='_blank' onClick=\"getUserInfo('" . $row['mountid'] . "', $i); return false\">");
-        output_notl("`#%s`0", $mounts[$row['mountid']]);
-        addnav("", $file);
-        rawoutput("</a></div>");
-        rawoutput("</td></tr>");
+        $output->rawOutput("<div id='mountusers$i'><a href='$file' target='_blank' onClick=\"getUserInfo('" . $row['mountid'] . "', $i); return false\">");
+        $output->outputNotl("`#%s`0", $mounts[$row['mountid']]);
+        Nav::add("", $file);
+        $output->rawOutput("</a></div>");
+        $output->rawOutput("</td></tr>");
         $count++;
     }
-    rawoutput("</table>");
-    output("`nIf you wish to delete a mount, you have to deactivate it first.");
-    output("If there are any owners of the mount when it is deleted, they will no longer have a mount, but they will get a FULL refund of the price of the mount at the time of deletion.");
+    $output->rawOutput("</table>");
+    $output->output("`nIf you wish to delete a mount, you have to deactivate it first.");
+    $output->output("If there are any owners of the mount when it is deleted, they will no longer have a mount, but they will get a FULL refund of the price of the mount at the time of deletion.");
 } elseif ($op == "add") {
-    output("Add a mount:`n");
-    addnav("Mount Editor Home", "mounts.php");
+    $output->output("Add a mount:`n");
+    Nav::add("Mount Editor Home", "mounts.php");
     mountform(array());
 } elseif ($op == "edit") {
-    addnav("Mount Editor Home", "mounts.php");
+    Nav::add("Mount Editor Home", "mounts.php");
     $sql = "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid='$id'";
     $result = Database::queryCached($sql, "mountdata-$id", 3600);
     if (Database::numRows($result) <= 0) {
-        output("`iThis mount was not found.`i");
+        $output->output("`iThis mount was not found.`i");
     } else {
-        addnav("Mount properties", "mounts.php?op=edit&id=$id");
+        Nav::add("Mount properties", "mounts.php?op=edit&id=$id");
         module_editor_navs("prefs-mounts", "mounts.php?op=edit&subop=module&id=$id&module=");
-        $subop = httpget("subop");
+        $subop = Http::get("subop");
         if ($subop == "module") {
-            $module = httpget("module");
-            rawoutput("<form action='mounts.php?op=save&subop=module&id=$id&module=$module' method='POST'>");
+            $module = Http::get("module");
+            $output->rawOutput("<form action='mounts.php?op=save&subop=module&id=$id&module=$module' method='POST'>");
             module_objpref_edit("mounts", $module, $id);
-            rawoutput("</form>");
-            addnav("", "mounts.php?op=save&subop=module&id=$id&module=$module");
+            $output->rawOutput("</form>");
+            Nav::add("", "mounts.php?op=save&subop=module&id=$id&module=$module");
         } else {
-            output("Mount Editor:`n");
+            $output->output("Mount Editor:`n");
             $row = Database::fetchAssoc($result);
             $row['mountbuff'] = unserialize($row['mountbuff']);
             mountform($row);
@@ -384,141 +388,141 @@ function mountform($mount)
         $mount['mountbuff']['badguydefmod'] = "";
     }
 
-    rawoutput("<form action='mounts.php?op=save&id={$mount['mountid']}' method='POST'>");
-    rawoutput("<input type='hidden' name='mount[mountactive]' value=\"" . $mount['mountactive'] . "\">");
-    addnav("", "mounts.php?op=save&id={$mount['mountid']}");
-    rawoutput("<table>");
-    rawoutput("<tr><td nowrap>");
-    output("Mount Name:");
-    rawoutput("</td><td><input name='mount[mountname]' value=\"" . htmlentities($mount['mountname'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Mount Description:");
-    rawoutput("</td><td><input name='mount[mountdesc]' value=\"" . htmlentities($mount['mountdesc'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Mount Category:");
-    rawoutput("</td><td><input name='mount[mountcategory]' value=\"" . htmlentities($mount['mountcategory'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"></td></tr>");
-    rawoutput("<tr><td nowrap>");
-        rawoutput("<label for='mount_location'>");
-        output("Mount Availability:");
-        rawoutput("</label></td><td nowrap>");
+    $output->rawOutput("<form action='mounts.php?op=save&id={$mount['mountid']}' method='POST'>");
+    $output->rawOutput("<input type='hidden' name='mount[mountactive]' value=\"" . $mount['mountactive'] . "\">");
+    Nav::add("", "mounts.php?op=save&id={$mount['mountid']}");
+    $output->rawOutput("<table>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Mount Name:");
+    $output->rawOutput("</td><td><input name='mount[mountname]' value=\"" . htmlentities($mount['mountname'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Mount Description:");
+    $output->rawOutput("</td><td><input name='mount[mountdesc]' value=\"" . htmlentities($mount['mountdesc'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Mount Category:");
+    $output->rawOutput("</td><td><input name='mount[mountcategory]' value=\"" . htmlentities($mount['mountcategory'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+        $output->rawOutput("<label for='mount_location'>");
+        $output->output("Mount Availability:");
+        $output->rawOutput("</label></td><td nowrap>");
     // Run a modulehook to find out where stables are located.  By default
     // they are located in 'Degolburg' (ie, getgamesetting('villagename'));
     // Some later module can remove them however.
     $vname = getsetting('villagename', LOCATION_FIELDS);
     $locs = array($vname => Translator::getInstance()->sprintfTranslate("The Village of %s", $vname));
-    $locs = modulehook("stablelocs", $locs);
+    $locs = HookHandler::hook("stablelocs", $locs);
     $locs['all'] = translate_inline("Everywhere");
     ksort($locs);
     reset($locs);
-        rawoutput("<select name='mount[mountlocation]' id='mount_location'>");
+        $output->rawOutput("<select name='mount[mountlocation]' id='mount_location'>");
     foreach ($locs as $loc => $name) {
-        rawoutput("<option value='$loc'" . ($mount['mountlocation'] == $loc ? " selected" : "") . ">$name</option>");
+        $output->rawOutput("<option value='$loc'" . ($mount['mountlocation'] == $loc ? " selected" : "") . ">$name</option>");
     }
 
-    rawoutput("<tr><td nowrap>");
-    output("Mount Cost (DKs):");
-    rawoutput("</td><td><input name='mount[mountdkcost]' value=\"" . htmlentities((int)$mount['mountdkcost'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Mount Cost (Gems):");
-    rawoutput("</td><td><input name='mount[mountcostgems]' value=\"" . htmlentities((int)$mount['mountcostgems'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Mount Cost (Gold):");
-    rawoutput("</td><td><input name='mount[mountcostgold]' value=\"" . htmlentities((int)$mount['mountcostgold'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Mount Feed Cost`n(Gold per level):");
-    rawoutput("</td><td><input name='mount[mountfeedcost]' value=\"" . htmlentities((int)$mount['mountfeedcost'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Delta Forest Fights:");
-    rawoutput("</td><td><input name='mount[mountforestfights]' value=\"" . htmlentities((int)$mount['mountforestfights'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='5'></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("`bMount Messages:`b");
-    rawoutput("</td><td></td></tr><tr><td nowrap>");
-    output("New Day:");
-    rawoutput("</td><td><input name='mount[newday]' value=\"" . htmlentities($mount['newday'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='40'></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Full Recharge:");
-    rawoutput("</td><td><input name='mount[recharge]' value=\"" . htmlentities($mount['recharge'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='40'></td></tr>");
-    rawoutput("<tr><td nowrap>");
-    output("Partial Recharge:");
-    rawoutput("</td><td><input name='mount[partrecharge]' value=\"" . htmlentities($mount['partrecharge'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='40'></td></tr>");
-    rawoutput("<tr><td valign='top' nowrap>");
-    output("Mount Buff:");
-    rawoutput("</td><td>");
-    output("Buff name:");
-    rawoutput("<input name='mount[mountbuff][name]' value=\"" . htmlentities($mount['mountbuff']['name'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
-    output("`bBuff Messages:`b`n");
-    output("Each round:");
-    rawoutput("<input name='mount[mountbuff][roundmsg]' value=\"" . htmlentities($mount['mountbuff']['roundmsg'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
-    output("Wear off:");
-    rawoutput("<input name='mount[mountbuff][wearoff]' value=\"" . htmlentities($mount['mountbuff']['wearoff'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
-    output("Effect:");
-    rawoutput("<input name='mount[mountbuff][effectmsg]' value=\"" . htmlentities($mount['mountbuff']['effectmsg'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
-    output("Effect No Damage:");
-    rawoutput("<input name='mount[mountbuff][effectnodmgmsg]' value=\"" . htmlentities($mount['mountbuff']['effectnodmgmsg'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
-    output("Effect Fail:");
-    rawoutput("<input name='mount[mountbuff][effectfailmsg]' value=\"" . htmlentities($mount['mountbuff']['effectfailmsg'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
-    output("(message replacements: {badguy}, {goodguy}, {weapon}, {armor}, {creatureweapon}, and where applicable {damage}.)`n");
-    output("`n`bEffects:`b`n");
-    output("Rounds to last (from new day):");
-    rawoutput("<input name='mount[mountbuff][rounds]' value=\"" . htmlentities((int)$mount['mountbuff']['rounds'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
-    output("Player Atk mod:");
-    rawoutput("<input name='mount[mountbuff][atkmod]' value=\"" . htmlentities($mount['mountbuff']['atkmod'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'>");
-    output("(multiplier)`n");
-    output("Player Def mod:");
-    rawoutput("<input name='mount[mountbuff][defmod]' value=\"" . htmlentities($mount['mountbuff']['defmod'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'>");
-    output("(multiplier)`n");
-    output("Player is invulnerable (1 = yes, 0 = no):");
-    rawoutput("<input name='mount[mountbuff][invulnerable]' value=\"" . htmlentities($mount['mountbuff']['invulnerable'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size=50><br/>");
-    output("Regen:");
-    rawoutput("<input name='mount[mountbuff][regen]' value=\"" . htmlentities($mount['mountbuff']['regen'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
-    output("Minion Count:");
-    rawoutput("<input name='mount[mountbuff][minioncount]' value=\"" . htmlentities($mount['mountbuff']['minioncount'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Mount Cost (DKs):");
+    $output->rawOutput("</td><td><input name='mount[mountdkcost]' value=\"" . htmlentities((int)$mount['mountdkcost'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Mount Cost (Gems):");
+    $output->rawOutput("</td><td><input name='mount[mountcostgems]' value=\"" . htmlentities((int)$mount['mountcostgems'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Mount Cost (Gold):");
+    $output->rawOutput("</td><td><input name='mount[mountcostgold]' value=\"" . htmlentities((int)$mount['mountcostgold'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Mount Feed Cost`n(Gold per level):");
+    $output->rawOutput("</td><td><input name='mount[mountfeedcost]' value=\"" . htmlentities((int)$mount['mountfeedcost'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Delta Forest Fights:");
+    $output->rawOutput("</td><td><input name='mount[mountforestfights]' value=\"" . htmlentities((int)$mount['mountforestfights'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='5'></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("`bMount Messages:`b");
+    $output->rawOutput("</td><td></td></tr><tr><td nowrap>");
+    $output->output("New Day:");
+    $output->rawOutput("</td><td><input name='mount[newday]' value=\"" . htmlentities($mount['newday'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='40'></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Full Recharge:");
+    $output->rawOutput("</td><td><input name='mount[recharge]' value=\"" . htmlentities($mount['recharge'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='40'></td></tr>");
+    $output->rawOutput("<tr><td nowrap>");
+    $output->output("Partial Recharge:");
+    $output->rawOutput("</td><td><input name='mount[partrecharge]' value=\"" . htmlentities($mount['partrecharge'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='40'></td></tr>");
+    $output->rawOutput("<tr><td valign='top' nowrap>");
+    $output->output("Mount Buff:");
+    $output->rawOutput("</td><td>");
+    $output->output("Buff name:");
+    $output->rawOutput("<input name='mount[mountbuff][name]' value=\"" . htmlentities($mount['mountbuff']['name'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
+    $output->output("`bBuff Messages:`b`n");
+    $output->output("Each round:");
+    $output->rawOutput("<input name='mount[mountbuff][roundmsg]' value=\"" . htmlentities($mount['mountbuff']['roundmsg'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
+    $output->output("Wear off:");
+    $output->rawOutput("<input name='mount[mountbuff][wearoff]' value=\"" . htmlentities($mount['mountbuff']['wearoff'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
+    $output->output("Effect:");
+    $output->rawOutput("<input name='mount[mountbuff][effectmsg]' value=\"" . htmlentities($mount['mountbuff']['effectmsg'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
+    $output->output("Effect No Damage:");
+    $output->rawOutput("<input name='mount[mountbuff][effectnodmgmsg]' value=\"" . htmlentities($mount['mountbuff']['effectnodmgmsg'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
+    $output->output("Effect Fail:");
+    $output->rawOutput("<input name='mount[mountbuff][effectfailmsg]' value=\"" . htmlentities($mount['mountbuff']['effectfailmsg'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
+    $output->output("(message replacements: {badguy}, {goodguy}, {weapon}, {armor}, {creatureweapon}, and where applicable {damage}.)`n");
+    $output->output("`n`bEffects:`b`n");
+    $output->output("Rounds to last (from new day):");
+    $output->rawOutput("<input name='mount[mountbuff][rounds]' value=\"" . htmlentities((int)$mount['mountbuff']['rounds'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
+    $output->output("Player Atk mod:");
+    $output->rawOutput("<input name='mount[mountbuff][atkmod]' value=\"" . htmlentities($mount['mountbuff']['atkmod'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'>");
+    $output->output("(multiplier)`n");
+    $output->output("Player Def mod:");
+    $output->rawOutput("<input name='mount[mountbuff][defmod]' value=\"" . htmlentities($mount['mountbuff']['defmod'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'>");
+    $output->output("(multiplier)`n");
+    $output->output("Player is invulnerable (1 = yes, 0 = no):");
+    $output->rawOutput("<input name='mount[mountbuff][invulnerable]' value=\"" . htmlentities($mount['mountbuff']['invulnerable'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size=50><br/>");
+    $output->output("Regen:");
+    $output->rawOutput("<input name='mount[mountbuff][regen]' value=\"" . htmlentities($mount['mountbuff']['regen'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
+    $output->output("Minion Count:");
+    $output->rawOutput("<input name='mount[mountbuff][minioncount]' value=\"" . htmlentities($mount['mountbuff']['minioncount'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
 
-    output("Min Badguy Damage:");
-    rawoutput("<input name='mount[mountbuff][minbadguydamage]' value=\"" . htmlentities($mount['mountbuff']['minbadguydamage'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
-    output("Max Badguy Damage:");
-    rawoutput("<input name='mount[mountbuff][maxbadguydamage]' value=\"" . htmlentities($mount['mountbuff']['maxbadguydamage'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
-    output("Min Goodguy Damage:");
-    rawoutput("<input name='mount[mountbuff][mingoodguydamage]' value=\"" . htmlentities($mount['mountbuff']['mingoodguydamage'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
-    output("Max Goodguy Damage:");
-    rawoutput("<input name='mount[mountbuff][maxgoodguydamage]' value=\"" . htmlentities($mount['mountbuff']['maxgoodguydamage'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
+    $output->output("Min Badguy Damage:");
+    $output->rawOutput("<input name='mount[mountbuff][minbadguydamage]' value=\"" . htmlentities($mount['mountbuff']['minbadguydamage'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
+    $output->output("Max Badguy Damage:");
+    $output->rawOutput("<input name='mount[mountbuff][maxbadguydamage]' value=\"" . htmlentities($mount['mountbuff']['maxbadguydamage'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
+    $output->output("Min Goodguy Damage:");
+    $output->rawOutput("<input name='mount[mountbuff][mingoodguydamage]' value=\"" . htmlentities($mount['mountbuff']['mingoodguydamage'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
+    $output->output("Max Goodguy Damage:");
+    $output->rawOutput("<input name='mount[mountbuff][maxgoodguydamage]' value=\"" . htmlentities($mount['mountbuff']['maxgoodguydamage'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'><br/>");
 
-    output("Lifetap:");
-    rawoutput("<input name='mount[mountbuff][lifetap]' value=\"" . htmlentities($mount['mountbuff']['lifetap'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'>");
-    output("(multiplier)`n");
-    output("Damage shield:");
-    rawoutput("<input name='mount[mountbuff][damageshield]' value=\"" . htmlentities($mount['mountbuff']['damageshield'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'>");
-    output("(multiplier)`n");
-    output("Badguy Damage mod:");
-    rawoutput("<input name='mount[mountbuff][badguydmgmod]' value=\"" . htmlentities($mount['mountbuff']['badguydmgmod'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'>");
-    output("(multiplier)`n");
-    output("Badguy Atk mod:");
-    rawoutput("<input name='mount[mountbuff][badguyatkmod]' value=\"" . htmlentities($mount['mountbuff']['badguyatkmod'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'>");
-    output("(multiplier)`n");
-    output("Badguy Def mod:");
-    rawoutput("<input name='mount[mountbuff][badguydefmod]' value=\"" . htmlentities($mount['mountbuff']['badguydefmod'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'>");
-    output("(multiplier)`n");
-    output("`bOn Dynamic Buffs`b`n");
-    output("`@In the above, for most fields, you can choose to enter valid PHP code, substituting <fieldname> for fields in the user's account table.`n");
-    output("Examples of code you might enter:`n");
-    output("`^<charm>`n");
-    output("round(<maxhitpoints>/10)`n");
-    output("round(<level>/max(<gems>,1))`n");
-    output("`@Fields you might be interested in for this: `n");
-    output_notl("`3name, sex `7(0=male 1=female)`3, specialty `7(DA=darkarts MP=mystical TS=thief)`3,`n");
-    output_notl("experience, gold, weapon `7(name)`3, armor `7(name)`3, level,`n");
-    output_notl("defense, attack, alive, goldinbank,`n");
-    output_notl("spirits `7(-2 to +2 or -6 for resurrection)`3, hitpoints, maxhitpoints, gems,`n");
-    output_notl("weaponvalue `7(gold value)`3, armorvalue `7(gold value)`3, turns, title, weapondmg, armordef,`n");
-    output_notl("age `7(days since last DK)`3, charm, playerfights, dragonkills, resurrections `7(times died since last DK)`3,`n");
-    output_notl("soulpoints, gravefights, deathpower `7(%s favor)`3,`n", getsetting("deathoverlord", '`$Ramius'));
-    output_notl("race, dragonage, bestdragonage`n`n");
-    output("You can also use module preferences by using <modulename|preference> (for instance '<specialtymystic|uses>' or '<drinks|drunkeness>'`n`n");
-    output("`@Finally, starting a field with 'debug:' will enable debug output for that field to help you locate errors in your implementation.");
-    output("While testing new buffs, you should be sure to debug fields before you release them on the world, as the PHP script will otherwise throw errors to the user if you have any, and this can break the site at various spots (as in places that redirects should happen).");
-    rawoutput("</td></tr></table>");
+    $output->output("Lifetap:");
+    $output->rawOutput("<input name='mount[mountbuff][lifetap]' value=\"" . htmlentities($mount['mountbuff']['lifetap'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'>");
+    $output->output("(multiplier)`n");
+    $output->output("Damage shield:");
+    $output->rawOutput("<input name='mount[mountbuff][damageshield]' value=\"" . htmlentities($mount['mountbuff']['damageshield'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'>");
+    $output->output("(multiplier)`n");
+    $output->output("Badguy Damage mod:");
+    $output->rawOutput("<input name='mount[mountbuff][badguydmgmod]' value=\"" . htmlentities($mount['mountbuff']['badguydmgmod'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'>");
+    $output->output("(multiplier)`n");
+    $output->output("Badguy Atk mod:");
+    $output->rawOutput("<input name='mount[mountbuff][badguyatkmod]' value=\"" . htmlentities($mount['mountbuff']['badguyatkmod'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'>");
+    $output->output("(multiplier)`n");
+    $output->output("Badguy Def mod:");
+    $output->rawOutput("<input name='mount[mountbuff][badguydefmod]' value=\"" . htmlentities($mount['mountbuff']['badguydefmod'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" size='50'>");
+    $output->output("(multiplier)`n");
+    $output->output("`bOn Dynamic Buffs`b`n");
+    $output->output("`@In the above, for most fields, you can choose to enter valid PHP code, substituting <fieldname> for fields in the user's account table.`n");
+    $output->output("Examples of code you might enter:`n");
+    $output->output("`^<charm>`n");
+    $output->output("round(<maxhitpoints>/10)`n");
+    $output->output("round(<level>/max(<gems>,1))`n");
+    $output->output("`@Fields you might be interested in for this: `n");
+    $output->outputNotl("`3name, sex `7(0=male 1=female)`3, specialty `7(DA=darkarts MP=mystical TS=thief)`3,`n");
+    $output->outputNotl("experience, gold, weapon `7(name)`3, armor `7(name)`3, level,`n");
+    $output->outputNotl("defense, attack, alive, goldinbank,`n");
+    $output->outputNotl("spirits `7(-2 to +2 or -6 for resurrection)`3, hitpoints, maxhitpoints, gems,`n");
+    $output->outputNotl("weaponvalue `7(gold value)`3, armorvalue `7(gold value)`3, turns, title, weapondmg, armordef,`n");
+    $output->outputNotl("age `7(days since last DK)`3, charm, playerfights, dragonkills, resurrections `7(times died since last DK)`3,`n");
+    $output->outputNotl("soulpoints, gravefights, deathpower `7(%s favor)`3,`n", getsetting("deathoverlord", '`$Ramius'));
+    $output->outputNotl("race, dragonage, bestdragonage`n`n");
+    $output->output("You can also use module preferences by using <modulename|preference> (for instance '<specialtymystic|uses>' or '<drinks|drunkeness>'`n`n");
+    $output->output("`@Finally, starting a field with 'debug:' will enable debug output for that field to help you locate errors in your implementation.");
+    $output->output("While testing new buffs, you should be sure to debug fields before you release them on the world, as the PHP script will otherwise throw errors to the user if you have any, and this can break the site at various spots (as in places that redirects should happen).");
+    $output->rawOutput("</td></tr></table>");
     $save = translate_inline("Save");
-    rawoutput("<input type='submit' class='button' value='$save'></form>");
+    $output->rawOutput("<input type='submit' class='button' value='$save'></form>");
 }
 
-page_footer();
+Footer::pageFooter();

--- a/news.php
+++ b/news.php
@@ -5,6 +5,12 @@ use Lotgd\Translator;
 use Lotgd\Motd;
 use Lotgd\Battle;
 use Lotgd\Output;
+use Lotgd\Nav;
+use Lotgd\Nav\VillageNav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // translator ready
 // addnews ready
@@ -12,14 +18,12 @@ use Lotgd\Output;
 define("ALLOW_ANONYMOUS", true);
 require_once __DIR__ . "/common.php";
 $output = Output::getInstance();
-require_once __DIR__ . "/lib/http.php";
-require_once __DIR__ . "/lib/villagenav.php";
 
 $translator = Translator::getInstance();
 
 $translator->setSchema("news");
 
-modulehook("news-intercept", array());
+HookHandler::hook("news-intercept", array());
 
 
 if ($session['user']['loggedin']) {
@@ -27,13 +31,13 @@ if ($session['user']['loggedin']) {
 }
 $newsperpage = 50;
 
-$offset = (int)httpget('offset');
+$offset = (int)Http::get('offset');
 $timestamp = strtotime((0 - $offset) . " days");
 $sql = "SELECT count(newsid) AS c FROM " . Database::prefix("news") . " WHERE newsdate='" . date("Y-m-d", $timestamp) . "'";
 $result = Database::query($sql);
 $row = Database::fetchAssoc($result);
 $totaltoday = $row['c'];
-$page = (int)httpget('page');
+$page = (int)Http::get('page');
 if (!$page) {
     $page = 1;
 }
@@ -44,7 +48,7 @@ if ($pageoffset > 0) {
 $pageoffset *= $newsperpage;
 $sql = "SELECT * FROM " . Database::prefix("news") . " WHERE newsdate='" . date("Y-m-d", $timestamp) . "' ORDER BY newsid DESC LIMIT $pageoffset,$newsperpage";
 $result = Database::query($sql);
-page_header("LoGD News");
+Header::pageHeader("LoGD News");
 $date = date("D, M j, Y", $timestamp);
 
 $pagestr = "";
@@ -78,7 +82,7 @@ while ($row = Database::fetchAssoc($result)) {
     if ($session['user']['superuser'] & SU_EDIT_COMMENTS) {
         $del = translate_inline("Del");
         $output->rawOutput("[ <a href='superuser.php?op=newsdelete&newsid=" . $row['newsid'] . "&return=" . URLEncode($_SERVER['REQUEST_URI']) . "'>$del</a> ]&nbsp;");
-        addnav("", "superuser.php?op=newsdelete&newsid={$row['newsid']}&return=" . URLEncode($_SERVER['REQUEST_URI']));
+        Nav::add("", "superuser.php?op=newsdelete&newsid={$row['newsid']}&return=" . URLEncode($_SERVER['REQUEST_URI']));
     }
     $translator->setSchema($row['tlschema']);
     if ($row['arguments'] > "") {
@@ -102,60 +106,60 @@ if (Database::numRows($result) == 0) {
 }
  $output->outputNotl("`c`2-=-`@=-=`2-=-`@=-=`2-=-`@=-=`2-=-`0`c");
 if (!$session['user']['loggedin']) {
-    addnav("Login Screen", "index.php");
+    Nav::add("Login Screen", "index.php");
 } elseif ($session['user']['alive']) {
-    villagenav();
+    VillageNav::render();
 } else {
     $translator->setSchema("nav");
-    addnav("Log Out");
-    addnav("Log out", "login.php?op=logout");
+    Nav::add("Log Out");
+    Nav::add("Log out", "login.php?op=logout");
 
     if ($session['user']['sex'] == 1) {
-        addnav("`!`bYou're dead, Jane!`b`0");
+        Nav::add("`!`bYou're dead, Jane!`b`0");
     } else {
-        addnav("`!`bYou're dead, Jim!`b`0");
+        Nav::add("`!`bYou're dead, Jim!`b`0");
     }
-    addnav("S?Land of Shades", "shades.php");
-    addnav("G?The Graveyard", "graveyard.php");
+    Nav::add("S?Land of Shades", "shades.php");
+    Nav::add("G?The Graveyard", "graveyard.php");
         Battle::suspendCompanions("allowinshades", true);
     $translator->setSchema();
 }
-addnav("News");
-addnav("Previous News", "news.php?offset=" . ($offset + 1));
+Nav::add("News");
+Nav::add("Previous News", "news.php?offset=" . ($offset + 1));
 if ($offset > 0) {
-    addnav("Next News", "news.php?offset=" . ($offset - 1));
+    Nav::add("Next News", "news.php?offset=" . ($offset - 1));
 }
 if ($session['user']['loggedin']) {
-    addnav("Preferences", "prefs.php");
+    Nav::add("Preferences", "prefs.php");
 }
-addnav("About this game", "about.php");
+Nav::add("About this game", "about.php");
 
 $translator->setSchema("nav");
 if ($session['user']['superuser'] & SU_EDIT_COMMENTS) {
-    addnav("Superuser");
-    addnav(",?Comment Moderation", "moderate.php");
+    Nav::add("Superuser");
+    Nav::add(",?Comment Moderation", "moderate.php");
 }
 if ($session['user']['superuser'] & ~SU_DOESNT_GIVE_GROTTO) {
-    addnav("Superuser");
-    addnav("X?Superuser Grotto", "superuser.php");
+    Nav::add("Superuser");
+    Nav::add("X?Superuser Grotto", "superuser.php");
 }
 if ($session['user']['superuser'] & SU_INFINITE_DAYS) {
-    addnav("Superuser");
-    addnav("/?New Day", "newday.php");
+    Nav::add("Superuser");
+    Nav::add("/?New Day", "newday.php");
 }
 $translator->setSchema();
 
-addnav("", "news.php");
+Nav::add("", "news.php");
 if ($totaltoday > $newsperpage) {
-    addnav("Today's news");
+    Nav::add("Today's news");
     for ($i = 0; $i < $totaltoday; $i += $newsperpage) {
         $pnum = $i / $newsperpage + 1;
         if ($pnum == $page) {
-            addnav(array("`b`#Page %s`0`b", $pnum), "news.php?offset=$offset&page=$pnum");
+            Nav::add(array("`b`#Page %s`0`b", $pnum), "news.php?offset=$offset&page=$pnum");
         } else {
-            addnav(array("Page %s", $pnum), "news.php?offset=$offset&page=$pnum");
+            Nav::add(array("Page %s", $pnum), "news.php?offset=$offset&page=$pnum");
         }
     }
 }
 
-page_footer();
+Footer::pageFooter();

--- a/referers.php
+++ b/referers.php
@@ -4,13 +4,18 @@ use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
+use Lotgd\Dhms;
+use Lotgd\Nav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+
 // translator ready
 // addnews ready
 // mail ready
-use Lotgd\Dhms;
+
 
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/http.php";
 
 Translator::getInstance()->setSchema("referers");
 
@@ -18,7 +23,7 @@ SuAccess::check(SU_EDIT_CONFIG);
 
 $sql = "DELETE FROM " . Database::prefix("referers") . " WHERE last<'" . date("Y-m-d H:i:s", strtotime("-" . getsetting("expirecontent", 180) . " days")) . "'";
 Database::query($sql);
-$op = httpget('op');
+$op = Http::get('op');
 
 if ($op == "rebuild") {
     $sql = "SELECT * FROM " . Database::prefix("referers");
@@ -33,17 +38,17 @@ if ($op == "rebuild") {
     }
 }
 SuperuserNav::render();
-addnav("Referer Options");
-addnav("", $_SERVER['REQUEST_URI']);
-$sort = httpget('sort');
-addnav("Refresh", "referers.php?sort=" . URLEncode($sort) . "");
-addnav("C?Sort by Count", "referers.php?sort=count" . ($sort == "count DESC" ? "" : "+DESC"));
-addnav("U?Sort by URL", "referers.php?sort=uri" . ($sort == "uri" ? "+DESC" : ""));
-addnav("T?Sort by Time", "referers.php?sort=last" . ($sort == "last DESC" ? "" : "+DESC"));
+Nav::add("Referer Options");
+Nav::add("", $_SERVER['REQUEST_URI']);
+$sort = Http::get('sort');
+Nav::add("Refresh", "referers.php?sort=" . URLEncode($sort) . "");
+Nav::add("C?Sort by Count", "referers.php?sort=count" . ($sort == "count DESC" ? "" : "+DESC"));
+Nav::add("U?Sort by URL", "referers.php?sort=uri" . ($sort == "uri" ? "+DESC" : ""));
+Nav::add("T?Sort by Time", "referers.php?sort=last" . ($sort == "last DESC" ? "" : "+DESC"));
 
-addnav("Rebuild Sites", "referers.php?op=rebuild");
+Nav::add("Rebuild Sites", "referers.php?op=rebuild");
 
-page_header("Referers");
+Header::pageHeader("Referers");
 $order = "count DESC";
 if ($sort != "") {
     $order = $sort;
@@ -55,18 +60,18 @@ $dest = translate_inline("Destination");
 $none = translate_inline("`iNone`i");
 $notset = translate_inline("`iNot set`i");
 $skipped = translate_inline("`i%s records skipped (over a week old)`i");
-rawoutput("<table border=0 cellpadding=2 cellspacing=1><tr class='trhead'><td>$count</td><td>$last</td><td>URL</td><td>$dest</td><td>IP</td></tr>");
+$output->rawOutput("<table border=0 cellpadding=2 cellspacing=1><tr class='trhead'><td>$count</td><td>$last</td><td>URL</td><td>$dest</td><td>IP</td></tr>");
 $result = Database::query($sql);
 while ($row = Database::fetchAssoc($result)) {
-    rawoutput("<tr class='trdark'><td valign='top'>");
-    output_notl("`b" . $row['count'] . "`b");
-    rawoutput("</td><td valign='top'>");
+    $output->rawOutput("<tr class='trdark'><td valign='top'>");
+    $output->outputNotl("`b" . $row['count'] . "`b");
+    $output->rawOutput("</td><td valign='top'>");
     $diffsecs = strtotime("now") - strtotime($row['last']);
-    //output((int)($diffsecs/86400)."d ".(int)($diffsecs/3600%3600)."h ".(int)($diffsecs/60%60)."m ".(int)($diffsecs%60)."s");
-    output_notl("`b" . Dhms::format($diffsecs) . "`b");
-    rawoutput("</td><td valign='top' colspan='3'>");
-    output_notl("`b" . ($row['site'] == "" ? $none : $row['site']) . "`b");
-    rawoutput("</td></tr>");
+    //$output->output((int)($diffsecs/86400)."d ".(int)($diffsecs/3600%3600)."h ".(int)($diffsecs/60%60)."m ".(int)($diffsecs%60)."s");
+    $output->outputNotl("`b" . Dhms::format($diffsecs) . "`b");
+    $output->rawOutput("</td><td valign='top' colspan='3'>");
+    $output->outputNotl("`b" . ($row['site'] == "" ? $none : $row['site']) . "`b");
+    $output->rawOutput("</td></tr>");
 
     $sql = "SELECT count,last,uri,dest,ip FROM " . Database::prefix("referers") . " WHERE site='" . addslashes($row['site']) . "' ORDER BY {$order} LIMIT 25";
     $result1 = Database::query($sql);
@@ -77,34 +82,34 @@ while ($row = Database::fetchAssoc($result)) {
         $row1 = Database::fetchAssoc($result1);
         $diffsecs = strtotime("now") - strtotime($row1['last']);
         if ($diffsecs <= 604800) {
-            rawoutput("<tr class='trlight'><td>");
-            output_notl($row1['count']);
-            rawoutput("</td><td valign='top'>");
-            //output((int)($diffsecs/86400)."d".(int)($diffsecs/3600%3600)."h".(int)($diffsecs/60%60)."m".(int)($diffsecs%60)."s");
-            output_notl(Dhms::format($diffsecs));
-            rawoutput("</td><td valign='top'>");
+            $output->rawOutput("<tr class='trlight'><td>");
+            $output->outputNotl($row1['count']);
+            $output->rawOutput("</td><td valign='top'>");
+            //$output->output((int)($diffsecs/86400)."d".(int)($diffsecs/3600%3600)."h".(int)($diffsecs/60%60)."m".(int)($diffsecs%60)."s");
+            $output->outputNotl(Dhms::format($diffsecs));
+            $output->rawOutput("</td><td valign='top'>");
             if ($row1['uri'] > "") {
-                rawoutput("<a href='" . HTMLEntities($row1['uri'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "' target='_blank'>" . HTMLEntities(substr($row1['uri'], 0, 100)) . "</a>");
+                $output->rawOutput("<a href='" . HTMLEntities($row1['uri'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "' target='_blank'>" . HTMLEntities(substr($row1['uri'], 0, 100)) . "</a>");
             } else {
-                output_notl($none);
+                $output->outputNotl($none);
             }
-            output_notl("`n");
-            rawoutput("</td><td valign='top'>");
-            output_notl($row1['dest'] == '' ? $notset : $row1['dest']);
-            rawoutput("</td><td valign='top'>");
-            output_notl($row1['ip'] == '' ? $notset : $row1['ip']);
-            rawoutput("</td></tr>");
+            $output->outputNotl("`n");
+            $output->rawOutput("</td><td valign='top'>");
+            $output->outputNotl($row1['dest'] == '' ? $notset : $row1['dest']);
+            $output->rawOutput("</td><td valign='top'>");
+            $output->outputNotl($row1['ip'] == '' ? $notset : $row1['ip']);
+            $output->rawOutput("</td></tr>");
         } else {
             $skippedcount++;
             $skippedtotal += $row1['count'];
         }
     }
     if ($skippedcount > 0) {
-        rawoutput("<tr class='trlight'><td>$skippedtotal</td><td valign='top' colspan='4'>");
-        output_notl(sprintf($skipped, $skippedcount));
-        rawoutput("</td></tr>");
+        $output->rawOutput("<tr class='trlight'><td>$skippedtotal</td><td valign='top' colspan='4'>");
+        $output->outputNotl(sprintf($skipped, $skippedcount));
+        $output->rawOutput("</td></tr>");
     }
-    //output("</td></tr>",true);
+    //$output->output("</td></tr>",true);
 }
-rawoutput("</table>");
-page_footer();
+$output->rawOutput("</table>");
+Footer::pageFooter();

--- a/referral.php
+++ b/referral.php
@@ -4,6 +4,10 @@ use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Settings;
 use Lotgd\Http;
+use Lotgd\Nav;
+use Lotgd\Nav\VillageNav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
 
 // translator ready
 // addnews ready
@@ -18,14 +22,13 @@ $translator = Translator::getInstance();
 $translator->setSchema("referral");
 
 if ($session['user']['loggedin']) {
-    page_header("Referral Page");
+    Header::pageHeader("Referral Page");
     if (file_exists("lodge.php")) {
-        addnav("L?Return to the Lodge", "lodge.php");
+        Nav::add("L?Return to the Lodge", "lodge.php");
     } else {
-        require_once __DIR__ . "/lib/villagenav.php";
-        villagenav();
+        VillageNav::render();
     }
-    output("You will automatically receive %s points for each person that you refer to this website who makes it to level %s.`n`n", $settings->getSetting("refereraward", 25), $settings->getSetting("referminlevel", 4));
+    $output->output("You will automatically receive %s points for each person that you refer to this website who makes it to level %s.`n`n", $settings->getSetting("refereraward", 25), $settings->getSetting("referminlevel", 4));
 
     $url = $settings->getSetting(
         "serverurl",
@@ -38,11 +41,11 @@ if ($session['user']['loggedin']) {
         $settings->saveSetting("serverurl", $url);
     }
 
-    output("How does the site know that I referred a person?`n");
-    output("Easy!  When you tell your friends about this site, give out the following link:`n`n");
-    output_notl("%sreferral.php?r=%s`n`n", $url, rawurlencode($session['user']['login']));
-    output("If you do, the site will know that you were the one who sent them here.");
-    output("When they reach level %s for the first time, you'll get your points!", $settings->getSetting("referminlevel", 4));
+    $output->output("How does the site know that I referred a person?`n");
+    $output->output("Easy!  When you tell your friends about this site, give out the following link:`n`n");
+    $output->outputNotl("%sreferral.php?r=%s`n`n", $url, rawurlencode($session['user']['login']));
+    $output->output("If you do, the site will know that you were the one who sent them here.");
+    $output->output("When they reach level %s for the first time, you'll get your points!", $settings->getSetting("referminlevel", 4));
 
     $sql = "SELECT name,level,refererawarded FROM " . Database::prefix("accounts") . " WHERE referer={$session['user']['acctid']} ORDER BY dragonkills,level";
     $result = Database::query($sql);
@@ -52,31 +55,31 @@ if ($session['user']['loggedin']) {
     $yes = $translator->translateInline("`@Yes!`0");
     $no = $translator->translateInline("`\$No!`0");
     $none = $translator->translateInline("`iNone`i");
-    output("`n`nAccounts which you referred:`n");
-    rawoutput("<table border='0' cellpadding='3' cellspacing='0'><tr><td>$name</td><td>$level</td><td>$awarded</td></tr>");
+    $output->output("`n`nAccounts which you referred:`n");
+    $output->rawOutput("<table border='0' cellpadding='3' cellspacing='0'><tr><td>$name</td><td>$level</td><td>$awarded</td></tr>");
     $number = Database::numRows($result);
     for ($i = 0; $i < $number; $i++) {
         $row = Database::fetchAssoc($result);
-        rawoutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'><td>");
-        output_notl($row['name']);
-        rawoutput("</td><td>");
-        output_notl($row['level']);
-        rawoutput("</td><td>");
-        output_notl($row['refererawarded'] ? $yes : $no);
-        rawoutput("</td></tr>");
+        $output->rawOutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'><td>");
+        $output->outputNotl($row['name']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl($row['level']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl($row['refererawarded'] ? $yes : $no);
+        $output->rawOutput("</td></tr>");
     }
     if (Database::numRows($result) == 0) {
-        rawoutput("<tr><td colspan='3' align='center'>");
-        output_notl($none);
-        rawoutput("</td></tr>");
+        $output->rawOutput("<tr><td colspan='3' align='center'>");
+        $output->outputNotl($none);
+        $output->rawOutput("</td></tr>");
     }
-    rawoutput("</table>", true);
-    page_footer();
+    $output->rawOutput("</table>", true);
+    Footer::pageFooter();
 } else {
-    page_header("Welcome to Legend of the Green Dragon");
-    output("`@Legend of the Green Dragon is a remake of the classic BBS Door Game Legend of the Red Dragon.");
-    output("Adventure into the classic realm that was one of the world's very first multiplayer roleplaying games!");
-    addnav("Create a character", "create.php?r=" . HTMLEntities(Http::get('r'), ENT_COMPAT, $settings->getSetting("charset", "UTF-8")));
-    addnav("Login Page", "index.php");
-    page_footer();
+    Header::pageHeader("Welcome to Legend of the Green Dragon");
+    $output->output("`@Legend of the Green Dragon is a remake of the classic BBS Door Game Legend of the Red Dragon.");
+    $output->output("Adventure into the classic realm that was one of the world's very first multiplayer roleplaying games!");
+    Nav::add("Create a character", "create.php?r=" . HTMLEntities(Http::get('r'), ENT_COMPAT, $settings->getSetting("charset", "UTF-8")));
+    Nav::add("Login Page", "index.php");
+    Footer::pageFooter();
 }

--- a/runmodule.php
+++ b/runmodule.php
@@ -3,6 +3,16 @@
 declare(strict_types=1);
 
 use Lotgd\Translator;
+use Lotgd\Http;
+use Lotgd\Modules;
+use Lotgd\Modules\ModuleManager;
+use Lotgd\Nav\VillageNav;
+use Lotgd\ForcedNavigation;
+use Lotgd\DateTime;
+use Lotgd\Output;
+use Lotgd\Nav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
 
 // translator ready
 // addnews ready
@@ -11,21 +21,12 @@ use Lotgd\Translator;
 define("ALLOW_ANONYMOUS", true);
 define("OVERRIDE_FORCED_NAV", true);
 
-use Lotgd\Http;
-use Lotgd\Modules;
-use Lotgd\Modules\ModuleManager;
-use Lotgd\Nav\VillageNav;
-use Lotgd\ForcedNavigation;
-use Lotgd\DateTime;
-use Lotgd\Output;
 
 require_once __DIR__ . "/common.php";
 $output = Output::getInstance();
 
 // Legacy Wrappers for Modules
-require_once __DIR__ . "/lib/http.php";
 require_once __DIR__ . "/lib/modules.php";
-require_once __DIR__ . "/lib/villagenav.php";
 
 DateTime::getMicroTime();
 
@@ -56,7 +57,7 @@ if (Modules::inject($module, Http::get('admin') ? true : false)) {
     $fname();
         $endtime = DateTime::getMicroTime();
     if (($endtime - $starttime >= 1.00 && ($session['user']['superuser'] & SU_DEBUG_OUTPUT))) {
-        //On a side note, you won't ever see this text. A normal module calls page_footer(), which ends execution here....
+        //On a side note, you won't ever see this text. A normal module calls Footer::pageFooter(), which ends execution here....
         $output->debug("Slow Module (" . round($endtime - $starttime, 2) . "s): $moduleName`n");
         $stats = array (
             "modulename" => $moduleName,
@@ -73,12 +74,12 @@ if (Modules::inject($module, Http::get('admin') ? true : false)) {
 
         Translator::getInstance()->setSchema("badnav");
 
-        page_header("Error");
+        Header::pageHeader("Error");
     if ($session['user']['loggedin']) {
             VillageNav::render();
     } else {
-        addnav("L?Return to the Login", "index.php");
+        Nav::add("L?Return to the Login", "index.php");
     }
     $output->output("You are attempting to use a module which is no longer active, or has been uninstalled.");
-        page_footer();
+        Footer::pageFooter();
 }

--- a/stables.php
+++ b/stables.php
@@ -5,14 +5,18 @@ use Lotgd\Translator;
 use Lotgd\Buffs;
 use Lotgd\MountName;
 use Lotgd\Mounts;
+use Lotgd\Nav;
+use Lotgd\Nav\VillageNav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // translator ready
 // addnews ready
 // mail ready
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/http.php";
 require_once __DIR__ . "/lib/sanitize.php";
-require_once __DIR__ . "/lib/villagenav.php";
 
 $translator = Translator::getInstance();
 
@@ -68,16 +72,16 @@ $schemas = array(
     'offer' => 'stables',
 );
 $basetext['schemas'] = $schemas;
-$texts = modulehook("stabletext", $basetext);
+$texts = HookHandler::hook("stabletext", $basetext);
 $schemas = $texts['schemas'];
 
 $translator->setSchema($schemas['title']);
-page_header($texts['title']);
+Header::pageHeader($texts['title']);
 $translator->setSchema();
 
-addnav("Other");
-villagenav();
-modulehook("stables-nav");
+Nav::add("Other");
+VillageNav::render();
+HookHandler::hook("stables-nav");
 
 list($name, $lcname) = MountName::getmountname();
 
@@ -95,8 +99,8 @@ if ($playerMount) {
 }
 $confirm = 0;
 
-$op = httpget('op');
-$id = httpget('id');
+$op = Http::get('op');
+$id = Http::get('id');
 
 
 if ($op == "") {
@@ -104,49 +108,49 @@ if ($op == "") {
     $translator->setSchema($schemas['desc']);
     if (is_array($texts['desc'])) {
         foreach ($texts['desc'] as $description) {
-            output_notl($translator->sprintfTranslate($description));
+            $output->outputNotl($translator->sprintfTranslate($description));
         }
     } else {
-        output($texts['desc']);
+        $output->output($texts['desc']);
     }
     $translator->setSchema();
-    modulehook("stables-desc");
+    HookHandler::hook("stables-desc");
 } elseif ($op == "examine") {
     $sql = "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid='$id'";
     $result = Database::queryCached($sql, "mountdata-$id", 3600);
     if (Database::numRows($result) <= 0) {
         $translator->setSchema($schemas['nosuchbeast']);
-        output($texts['nosuchbeast']);
+        $output->output($texts['nosuchbeast']);
         $translator->setSchema();
     } else {
         // Idea taken from Robert of dragonprime.cawsquad.net
         $t = e_rand(0, count($texts['finebeast']) - 1);
         $translator->setSchema($schemas['finebeast']);
-        output($texts['finebeast'][$t]);
+        $output->output($texts['finebeast'][$t]);
         $translator->setSchema();
         $mount = Database::fetchAssoc($result);
-        $mount = modulehook("mount-modifycosts", $mount);
-        output("`7Creature: `&%s`0`n", $mount['mountname']);
-        output("`7Description: `&%s`0`n", $mount['mountdesc']);
-        output("`7Cost: `^%s`& gold, `%%s`& gems`n`n", $mount['mountcostgold'], $mount['mountcostgems']);
-        addnav(array("New %s", $mount['mountname']));
-        addnav("Buy this creature", "stables.php?op=buymount&id={$mount['mountid']}");
+        $mount = HookHandler::hook("mount-modifycosts", $mount);
+        $output->output("`7Creature: `&%s`0`n", $mount['mountname']);
+        $output->output("`7Description: `&%s`0`n", $mount['mountdesc']);
+        $output->output("`7Cost: `^%s`& gold, `%%s`& gems`n`n", $mount['mountcostgold'], $mount['mountcostgems']);
+        Nav::add(array("New %s", $mount['mountname']));
+        Nav::add("Buy this creature", "stables.php?op=buymount&id={$mount['mountid']}");
     }
 } elseif ($op == 'buymount') {
     if ($session['user']['hashorse']) {
         $translator->setSchema($schemas['confirmsale']);
-        output(
+        $output->output(
             $texts['confirmsale'],
             translate_inline($session['user']['sex'] ? $texts["lass"] : $texts["lad"])
         );
         $translator->setSchema();
-        addnav("Confirm trade");
-        addnav("Yes", "stables.php?op=confirmbuy&id=$id");
-        addnav("No", "stables.php");
+        Nav::add("Confirm trade");
+        Nav::add("Yes", "stables.php?op=confirmbuy&id=$id");
+        Nav::add("No", "stables.php");
         $confirm = 1;
     } else {
         $op = "confirmbuy";
-        httpset("op", $op);
+        Http::set("op", $op);
     }
 }
 if ($op == 'confirmbuy') {
@@ -154,26 +158,26 @@ if ($op == 'confirmbuy') {
     $result = Database::queryCached($sql, "mountdata-$id", 3600);
     if (Database::numRows($result) <= 0) {
         $translator->setSchema($schemas['nosuchbeast']);
-        output($texts['nosuchbeast']);
+        $output->output($texts['nosuchbeast']);
         $translator->setSchema();
     } else {
         $mount = Database::fetchAssoc($result);
-        $mount = modulehook("mount-modifycosts", $mount);
+        $mount = HookHandler::hook("mount-modifycosts", $mount);
         if (
             ($session['user']['gold'] + $repaygold) < $mount['mountcostgold'] ||
             ($session['user']['gems'] + $repaygems) < $mount['mountcostgems']
         ) {
             $translator->setSchema($schemas['toolittle']);
-            output($texts['toolittle'], $mount['mountname'], $mount['mountcostgold'], $mount['mountcostgems']);
+            $output->output($texts['toolittle'], $mount['mountname'], $mount['mountcostgold'], $mount['mountcostgems']);
             $translator->setSchema();
         } else {
             if ($session['user']['hashorse'] > 0) {
                 $translator->setSchema($schemas['replacemount']);
-                output($texts['replacemount'], $lcname, $mount['mountname']);
+                $output->output($texts['replacemount'], $lcname, $mount['mountname']);
                 $translator->setSchema();
             } else {
                 $translator->setSchema($schemas['newmount']);
-                output($texts['newmount'], $mount['mountname']);
+                $output->output($texts['newmount'], $mount['mountname']);
                 $translator->setSchema();
             }
             if (isset($playerMount['mountname'])) {
@@ -202,8 +206,8 @@ if ($op == 'confirmbuy') {
             $repaygold = round($playerMount['mountcostgold'] * 2 / 3, 0);
             $repaygems = round($playerMount['mountcostgems'] * 2 / 3, 0);
             // Recalculate the special name as well.
-            modulehook("stable-mount", array());
-            modulehook("boughtmount");
+            HookHandler::hook("stable-mount", array());
+            HookHandler::hook("boughtmount");
                         list($name, $lcname) = MountName::getmountname();
             $grubprice = round($session['user']['level'] * $playerMount['mountfeedcost'], 0);
         }
@@ -211,7 +215,7 @@ if ($op == 'confirmbuy') {
 } elseif ($op == 'feed') {
     if (getsetting("allowfeed", 0) == 0) {
         $translator->setSchema($schemas['nofeed']);
-        output(
+        $output->output(
             $texts['nofeed'],
             translate_inline($session['user']['sex'] ? $texts["lass"] : $texts["lad"])
         );
@@ -223,26 +227,26 @@ if ($op == 'confirmbuy') {
         }
         if (isset($session['bufflist']['mount']['rounds']) && $session['bufflist']['mount']['rounds'] == $buff['rounds']) {
             $translator->setSchema($schemas['nothungry']);
-            output($texts['nothungry'], $name);
+            $output->output($texts['nothungry'], $name);
             $translator->setSchema();
         } else {
             if (isset($session['bufflist']['mount']['rounds']) && $session['bufflist']['mount']['rounds'] > $buff['rounds'] * .5) {
                 $grubprice = round($grubprice / 2, 0);
                 $translator->setSchema($schemas['halfhungry']);
-                output($texts['halfhungry'], $name, $name, $grubprice);
+                $output->output($texts['halfhungry'], $name, $name, $grubprice);
                 $translator->setSchema();
                 $session['user']['gold'] -= $grubprice;
             } else {
                 $session['user']['gold'] -= $grubprice;
                 $translator->setSchema($schemas['hungry']);
-                output($texts['hungry'], $name, $name, $grubprice);
+                $output->output($texts['hungry'], $name, $name, $grubprice);
                 $translator->setSchema();
             }
             debuglog("spent $grubprice feeding their mount");
             Buffs::applyBuff('mount', $buff);
             $session['user']['fedmount'] = 1;
             $translator->setSchema($schemas['mountfull']);
-            output(
+            $output->output(
                 $texts['mountfull'],
                 translate_inline($session['user']['sex'] ? $texts["lass"] : $texts["lad"]),
                 (isset($playerMount['basename']) && $playerMount['basename'] ?
@@ -252,19 +256,19 @@ if ($op == 'confirmbuy') {
         }
     } else {
         $translator->setSchema($schemas['nofeedgold']);
-        output($texts['nofeedgold'], $lcname);
+        $output->output($texts['nofeedgold'], $lcname);
         $translator->setSchema();
     }
 } elseif ($op == 'sellmount') {
     $translator->setSchema($schemas['confirmsale']);
-    output(
+    $output->output(
         $texts['confirmsale'],
         translate_inline($session['user']['sex'] ? $texts["lass"] : $texts["lad"])
     );
     $translator->setSchema();
-    addnav("Confirm sale");
-    addnav("Yes", "stables.php?op=confirmsell");
-    addnav("No", "stables.php");
+    Nav::add("Confirm sale");
+    Nav::add("Yes", "stables.php?op=confirmsell");
+    Nav::add("No", "stables.php");
     $confirm = 1;
 } elseif ($op == 'confirmsell') {
     $session['user']['gold'] += $repaygold;
@@ -273,7 +277,7 @@ if ($op == 'confirmbuy') {
     debuglog("gained $repaygold gold and $repaygems gems selling their mount, a $debugmount");
     Buffs::stripBuff('mount');
     $session['user']['hashorse'] = 0;
-    modulehook("soldmount");
+    HookHandler::hook("soldmount");
 
     $amtstr = "";
     if ($repaygold > 0) {
@@ -294,7 +298,7 @@ if ($op == 'confirmbuy') {
     }
 
     $translator->setSchema($schemas['mountsold']);
-    output(
+    $output->output(
         $texts['mountsold'],
         (isset($playerMount['newname']) ?
                $playerMount['newname'] : $playerMount['mountname']),
@@ -305,13 +309,13 @@ if ($op == 'confirmbuy') {
 
 if ($confirm == 0) {
     if ($session['user']['hashorse'] > 0) {
-        addnav(array("%s", color_sanitize($name)));
+        Nav::add(array("%s", color_sanitize($name)));
         $translator->setSchema($schemas['offer']);
-        output($texts['offer'], $repaygold, $repaygems, $lcname);
+        $output->output($texts['offer'], $repaygold, $repaygems, $lcname);
         $translator->setSchema();
-        addnav(array("Sell %s`0", $lcname), "stables.php?op=sellmount");
+        Nav::add(array("Sell %s`0", $lcname), "stables.php?op=sellmount");
         if (getsetting("allowfeed", 0) && $session['user']['fedmount'] == 0) {
-            addnav(
+            Nav::add(
                 array("Feed %s`0 (`^%s`0 gold)", $lcname, $grubprice),
                 "stables.php?op=feed"
             );
@@ -325,13 +329,13 @@ if ($confirm == 0) {
     for ($i = 0; $i < $number; $i++) {
         $row = Database::fetchAssoc($result);
         if ($category != $row['mountcategory']) {
-            addnav(array("%s", $row['mountcategory']));
+            Nav::add(array("%s", $row['mountcategory']));
             $category = $row['mountcategory'];
         }
         if ($row['mountdkcost'] <= $session['user']['dragonkills']) {
-            addnav(array("Examine %s`0", $row['mountname']), "stables.php?op=examine&id={$row['mountid']}");
+            Nav::add(array("Examine %s`0", $row['mountname']), "stables.php?op=examine&id={$row['mountid']}");
         }
     }
 }
 
-page_footer();
+Footer::pageFooter();

--- a/superuser.php
+++ b/superuser.php
@@ -6,174 +6,178 @@ use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
 use Lotgd\Commentary;
 use Lotgd\PhpGenericEnvironment;
+use Lotgd\Nav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // translator ready
 // addnews ready
 // mail ready
 require_once __DIR__ . "/common.php";
 require_once __DIR__ . "/lib/sanitize.php";
-require_once __DIR__ . "/lib/http.php";
 
 SuAccess::check(0xFFFFFFFF & ~ SU_DOESNT_GIVE_GROTTO);
 Commentary::addCommentary();
 Translator::getInstance()->setSchema("superuser");
 
 SuperuserNav::render();
-addnav("Q?`%Quit`0 to the heavens", "login.php?op=logout", true);
+Nav::add("Q?`%Quit`0 to the heavens", "login.php?op=logout", true);
 
-$op = httpget('op');
+$op = Http::get('op');
 if ($op == "keepalive") {
     $sql = "UPDATE " . Database::prefix("accounts") . " SET laston='" . date("Y-m-d H:i:s") . "' WHERE acctid='{$session['user']['acctid']}'";
     Database::query($sql);
     echo '<html><meta http-equiv="Refresh" content="30;url=' . PhpGenericEnvironment::getRequestUri() . '"></html><body>' . date("Y-m-d H:i:s") . "</body></html>";
     exit();
 } elseif ($op == "newsdelete") {
-    $sql = "DELETE FROM " . Database::prefix("news") . " WHERE newsid='" . httpget('newsid') . "'";
+    $sql = "DELETE FROM " . Database::prefix("news") . " WHERE newsid='" . Http::get('newsid') . "'";
     Database::query($sql);
-    $return = httpget('return');
+    $return = Http::get('return');
     $return = cmd_sanitize($return);
     $return = basename($return);
     redirect($return);
 }
 
-page_header("Superuser Grotto");
+Header::pageHeader("Superuser Grotto");
 
-$lines = modulehook("superuser-headlines", array());
-output_notl("`c");
+$lines = HookHandler::hook("superuser-headlines", array());
+$output->outputNotl("`c");
 foreach ($lines as $line) {
     //output it like an announcement, if any argument is given, automatically(!) centered
     //ATTENTION! pre-translate your stuff in your own schema with translate_inline or Translator::getInstance()->sprintfTranslate()!
     if (is_array($line)) {
-        call_user_func_array('output_notl', $line);
+        call_user_func_array([$output, 'outputNotl'], $line);
     } else {
-        output_notl($line);
+        $output->outputNotl($line);
     }
-    output_notl("`n`n"); //separate lines
+    $output->outputNotl("`n`n"); //separate lines
 }
-output_notl("`c");
+$output->outputNotl("`c");
 
-output("`^You duck into a secret cave that few know about. ");
+$output->output("`^You duck into a secret cave that few know about. ");
 if ($session['user']['sex'] == SEX_FEMALE) {
-    output("Inside you are greeted by the sight of numerous muscular bare-chested men who wave palm fronds at you and offer to feed you grapes as you lounge on Greco-Roman couches draped with silk.`n`n");
+    $output->output("Inside you are greeted by the sight of numerous muscular bare-chested men who wave palm fronds at you and offer to feed you grapes as you lounge on Greco-Roman couches draped with silk.`n`n");
 } else {
-    output("Inside you are greeted by the sight of numerous scantily clad buxom women who wave palm fronds at you and offer to feed you grapes as you lounge on Greco-Roman couches draped with silk.`n`n");
+    $output->output("Inside you are greeted by the sight of numerous scantily clad buxom women who wave palm fronds at you and offer to feed you grapes as you lounge on Greco-Roman couches draped with silk.`n`n");
 }
 //comment visible only for those who are MORE than translators
 //make section customizable for view / switching to different superuser chats possible
-$args = modulehook("superusertop", array("section" => "superuser"));
+$args = HookHandler::hook("superusertop", array("section" => "superuser"));
 if ($session['user']['superuser'] != SU_IS_TRANSLATOR) {
      Commentary::commentDisplay("", $args['section'], "Engage in idle conversation with other gods:", 25);
 }
 
-addnav("Actions");
+Nav::add("Actions");
 if ($session['user']['superuser'] & SU_EDIT_PETITIONS) {
-    addnav("Petition Viewer", "viewpetition.php");
+    Nav::add("Petition Viewer", "viewpetition.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_COMMENTS) {
-    addnav("C?Comment Moderation", "moderate.php");
+    Nav::add("C?Comment Moderation", "moderate.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_COMMENTS) {
-    addnav("B?Player Bios", "bios.php");
+    Nav::add("B?Player Bios", "bios.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_DONATIONS) {
-    addnav("Donator Page", "donators.php");
+    Nav::add("Donator Page", "donators.php");
 }
 if (
     file_exists("paylog.php")  &&
         ($session['user']['superuser'] & SU_EDIT_PAYLOG)
 ) {
-    addnav("Payment Log", "paylog.php");
+    Nav::add("Payment Log", "paylog.php");
 }
 if ($session['user']['superuser'] & SU_RAW_SQL) {
-    addnav("Q?Run Raw SQL", "rawsql.php");
+    Nav::add("Q?Run Raw SQL", "rawsql.php");
 }
 if ($session['user']['superuser'] & SU_IS_TRANSLATOR) {
-    addnav("U?Untranslated Texts", "untranslated.php");
+    Nav::add("U?Untranslated Texts", "untranslated.php");
 }
 
-addnav("Places");
+Nav::add("Places");
 if ($session['user']['superuser'] & SU_IS_TRANSLATOR) {
-    addnav("L?Translator Lounge", "translatorlounge.php");
+    Nav::add("L?Translator Lounge", "translatorlounge.php");
 }
 
 
-addnav("Editors");
+Nav::add("Editors");
 if ($session['user']['superuser'] & SU_EDIT_USERS) {
-    addnav("User Editor", "user.php");
+    Nav::add("User Editor", "user.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_BANS) {
-    addnav("Ban Editor", "bans.php");
+    Nav::add("Ban Editor", "bans.php");
 }
 
 if ($session['user']['superuser'] & SU_EDIT_USERS) {
-    addnav("Title Editor", "titleedit.php");
+    Nav::add("Title Editor", "titleedit.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_CREATURES) {
-    addnav("E?Creature Editor", "creatures.php");
+    Nav::add("E?Creature Editor", "creatures.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_MOUNTS) {
-    addnav("Mount Editor", "mounts.php");
+    Nav::add("Mount Editor", "mounts.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_MOUNTS) {
-    addnav("Companion Editor", "companions.php");
+    Nav::add("Companion Editor", "companions.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_CREATURES) {
-    addnav("Taunt Editor", "taunt.php");
+    Nav::add("Taunt Editor", "taunt.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_CREATURES) {
-    addnav("Deathmessage Editor", "deathmessages.php");
+    Nav::add("Deathmessage Editor", "deathmessages.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_CREATURES) {
-    addnav("Master Editor", "masters.php");
+    Nav::add("Master Editor", "masters.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_EQUIPMENT) {
-    addnav("Weapon Editor", "weaponeditor.php");
+    Nav::add("Weapon Editor", "weaponeditor.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_EQUIPMENT) {
-    addnav("Armor Editor", "armoreditor.php");
+    Nav::add("Armor Editor", "armoreditor.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_COMMENTS) {
-    addnav("Nasty Word Editor", "badword.php");
+    Nav::add("Nasty Word Editor", "badword.php");
 }
 if ($session['user']['superuser'] & SU_MANAGE_MODULES) {
-    addnav("Manage Modules", "modules.php");
+    Nav::add("Manage Modules", "modules.php");
 }
 
 if ($session['user']['superuser'] & SU_EDIT_CONFIG) {
-    addnav("Mechanics");
+    Nav::add("Mechanics");
 }
 if ($session['user']['superuser'] & SU_EDIT_CONFIG) {
-    addnav("Game Settings", "configuration.php");
+    Nav::add("Game Settings", "configuration.php");
 }
 if ($session['user']['superuser'] & SU_MEGAUSER) {
-    addnav("Core News", "corenews.php");
+    Nav::add("Core News", "corenews.php");
 }
 if ($session['user']['superuser'] & SU_MEGAUSER) {
-    addnav("Global User Functions", "globaluserfunctions.php");
+    Nav::add("Global User Functions", "globaluserfunctions.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_CONFIG) {
-    addnav("Debug Analysis", "debug.php");
+    Nav::add("Debug Analysis", "debug.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_CONFIG) {
-    addnav("Referring URLs", "referers.php");
+    Nav::add("Referring URLs", "referers.php");
 }
 if ($session['user']['superuser'] & SU_EDIT_CONFIG) {
-    addnav("Stats", "stats.php");
+    Nav::add("Stats", "stats.php");
 }
 /*//*/if (
     file_exists("gamelog.php") &&
 /*//*/      $session['user']['superuser'] & SU_EDIT_CONFIG
 ) {
-/*//*/  addnav("Gamelog Viewer", "gamelog.php");
+/*//*/  Nav::add("Gamelog Viewer", "gamelog.php");
 /*//*/
 }
 
 if ($session['user']['superuser'] & SU_EDIT_CONFIG) {
-                    addnav('L?View Log Files', 'logviewer.php');
+                    Nav::add('L?View Log Files', 'logviewer.php');
 }
 
-addnav("Module Configurations");
+Nav::add("Module Configurations");
 
-modulehook("superuser", array(), true);
+HookHandler::hook("superuser", array(), true);
 
-page_footer();
+Footer::pageFooter();

--- a/tests/GameLogSystemLabelTest.php
+++ b/tests/GameLogSystemLabelTest.php
@@ -24,6 +24,21 @@ final class GameLogSystemLabelTest extends TestCase
         if (!class_exists('\\Lotgd\\Nav\\SuperuserNav', false)) {
             eval('namespace Lotgd\\Nav; class SuperuserNav { public static function render(): void {} }');
         }
+        if (!class_exists('\\Lotgd\\Output', false)) {
+            eval('namespace Lotgd; class Output { public static function getInstance() { return new class { public function outputNotl(string $format, ...$args): void { global $forms_output; $forms_output .= vsprintf($format, $args); } }; } }');
+        }
+        if (!class_exists('\\Lotgd\\Page\\Header', false)) {
+            eval('namespace Lotgd\\Page; class Header { public static function pageHeader(...$args): void {} }');
+        }
+        if (!class_exists('\\Lotgd\\Page\\Footer', false)) {
+            eval('namespace Lotgd\\Page; class Footer { public static function pageFooter(...$args): void {} }');
+        }
+        if (!class_exists('\\Lotgd\\Nav', false)) {
+            eval('namespace Lotgd; class Nav { public static function add(...$args): void {} }');
+        }
+        if (!class_exists('\\Lotgd\\Http', false)) {
+            eval('namespace Lotgd; class Http { public static function get(string $name) { return $_GET[$name] ?? false; } }');
+        }
         if (!function_exists('page_header')) {
             eval('function page_header($title): void {}');
         }

--- a/village.php
+++ b/village.php
@@ -3,12 +3,16 @@
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Commentary;
+use Lotgd\Nav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // translator ready
 // addnews ready
 // mail ready
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/http.php";
 require_once __DIR__ . "/lib/events.php";
 require_once __DIR__ . "/lib/experience.php";
 
@@ -22,7 +26,7 @@ $valid_loc = array();
 $vname = getsetting("villagename", LOCATION_FIELDS);
 $iname = getsetting("innname", LOCATION_INN);
 $valid_loc[$vname] = "village";
-$valid_loc = modulehook("validlocation", $valid_loc);
+$valid_loc = HookHandler::hook("validlocation", $valid_loc);
 if (!isset($valid_loc[$session['user']['location']])) {
     $session['user']['location'] = $vname;
 }
@@ -110,13 +114,13 @@ $origtexts['schemas'] = $schemas;
 // instead.
 // This hook is specifically to allow modules that do other villages to create
 // ambience.
-$texts = modulehook("villagetext", $origtexts);
+$texts = HookHandler::hook("villagetext", $origtexts);
 //and now a special hook for the village
-$texts = modulehook("villagetext-{$session['user']['location']}", $texts);
+$texts = HookHandler::hook("villagetext-{$session['user']['location']}", $texts);
 $schemas = $texts['schemas'];
 
 $translator->setSchema($schemas['title']);
-page_header($texts['title']);
+Header::pageHeader($texts['title']);
 $translator->setSchema();
 
 Commentary::addCommentary();
@@ -146,177 +150,177 @@ if (getsetting("automaster", 1) && $session['user']['seenmaster'] != 1) {
     }
 }
 
-$op = httpget('op');
-$com = httpget('comscroll');
-$refresh = httpget("refresh");
-$commenting = httpget("commenting");
-$comment = httppost('insertcommentary');
+$op = Http::get('op');
+$com = Http::get('comscroll');
+$refresh = Http::get("refresh");
+$commenting = Http::get("commenting");
+$comment = Http::post('insertcommentary');
 // Don't give people a chance at a special event if they are just browsing
 // the commentary (or talking) or dealing with any of the hooks in the village.
 if (!$op && $com == "" && !$comment && !$refresh && !$commenting) {
     // The '1' should really be sysadmin customizable.
     if (module_events("village", (int)getsetting("villagechance", 0)) != 0) {
         if (checknavs()) {
-            page_footer();
+            Footer::pageFooter();
         } else {
             // Reset the special for good.
             $session['user']['specialinc'] = "";
             $session['user']['specialmisc'] = "";
             $skipvillagedesc = true;
             $op = "";
-            httpset("op", "");
+            Http::set("op", "");
         }
     }
 }
 
 $translator->setSchema($schemas['fields']);
-addnav($texts['fields']);
-addnav("Q?`%Quit`0 to the fields", "login.php?op=logout", true);
+Nav::add($texts['fields']);
+Nav::add("Q?`%Quit`0 to the fields", "login.php?op=logout", true);
 $translator->setSchema();
 
 $translator->setSchema($schemas['gatenav']);
-addnav($texts['gatenav']);
+Nav::add($texts['gatenav']);
 $translator->setSchema();
 
-addnav("F?Forest", "forest.php");
+Nav::add("F?Forest", "forest.php");
 if (getsetting("pvp", 1)) {
-    addnav("S?Slay Other Players", "pvp.php");
+    Nav::add("S?Slay Other Players", "pvp.php");
 }
 if (getsetting("enablecompanions", true)) {
     $translator->setSchema($schemas['mercenarycamp']);
-    addnav($texts['mercenarycamp'], "mercenarycamp.php");
+    Nav::add($texts['mercenarycamp'], "mercenarycamp.php");
     $translator->setSchema();
 }
 
 $translator->setSchema($schemas['fightnav']);
-addnav($texts['fightnav']);
+Nav::add($texts['fightnav']);
 $translator->setSchema();
-addnav("u?Bluspring's Warrior Training", "train.php");
+Nav::add("u?Bluspring's Warrior Training", "train.php");
 if (@file_exists("lodge.php")) {
-    addnav("J?JCP's Hunter Lodge", "lodge.php");
+    Nav::add("J?JCP's Hunter Lodge", "lodge.php");
 }
 
 $translator->setSchema($schemas['marketnav']);
-addnav($texts['marketnav']);
+Nav::add($texts['marketnav']);
 $translator->setSchema();
 $translator->setSchema($schemas['weaponshop']);
-addnav("W?" . $texts['weaponshop'], "weapons.php");
+Nav::add("W?" . $texts['weaponshop'], "weapons.php");
 $translator->setSchema();
 $translator->setSchema($schemas['armorshop']);
-addnav("A?" . $texts['armorshop'], "armor.php");
+Nav::add("A?" . $texts['armorshop'], "armor.php");
 $translator->setSchema();
-addnav("B?Ye Olde Bank", "bank.php");
-addnav("Z?Ze Gypsy Tent", "gypsy.php");
+Nav::add("B?Ye Olde Bank", "bank.php");
+Nav::add("Z?Ze Gypsy Tent", "gypsy.php");
 if (getsetting("betaperplayer", 1) == 1 && @file_exists("pavilion.php")) {
-    addnav("E?Eye-catching Pavilion", "pavilion.php");
+    Nav::add("E?Eye-catching Pavilion", "pavilion.php");
 }
 
 $translator->setSchema($schemas['tavernnav']);
-addnav($texts['tavernnav']);
+Nav::add($texts['tavernnav']);
 $translator->setSchema();
 $translator->setSchema($schemas['innname']);
-addnav("I?" . $texts['innname'] . "`0", "inn.php", true);
+Nav::add("I?" . $texts['innname'] . "`0", "inn.php", true);
 $translator->setSchema();
 $translator->setSchema($schemas['stablename']);
-addnav("M?" . $texts['stablename'] . "`0", "stables.php");
+Nav::add("M?" . $texts['stablename'] . "`0", "stables.php");
 $translator->setSchema();
 
-addnav("G?The Gardens", "gardens.php");
-addnav("R?Curious Looking Rock", "rock.php");
+Nav::add("G?The Gardens", "gardens.php");
+Nav::add("R?Curious Looking Rock", "rock.php");
 if (getsetting("allowclans", 1)) {
-    addnav("C?Clan Halls", "clan.php");
+    Nav::add("C?Clan Halls", "clan.php");
 }
 
 $translator->setSchema($schemas['infonav']);
-addnav($texts['infonav']);
+Nav::add($texts['infonav']);
 $translator->setSchema();
-addnav("??F.A.Q. (newbies start here)", "petition.php?op=faq", false, true);
-addnav("N?Daily News", "news.php");
-addnav("L?List Warriors", "list.php");
-addnav("o?Hall o' Fame", "hof.php");
+Nav::add("??F.A.Q. (newbies start here)", "petition.php?op=faq", false, true);
+Nav::add("N?Daily News", "news.php");
+Nav::add("L?List Warriors", "list.php");
+Nav::add("o?Hall o' Fame", "hof.php");
 
 $translator->setSchema($schemas['othernav']);
-addnav($texts['othernav']);
+Nav::add($texts['othernav']);
 $translator->setSchema();
-addnav("A?Account Info", "account.php");
-addnav("P?Preferences", "prefs.php");
+Nav::add("A?Account Info", "account.php");
+Nav::add("P?Preferences", "prefs.php");
 if (!file_exists("lodge.php")) {
-    addnav("Refer a Friend", "referral.php");
+    Nav::add("Refer a Friend", "referral.php");
 }
 
 $translator->setSchema('nav');
-addnav("Superuser");
+Nav::add("Superuser");
 if ($session['user']['superuser'] & SU_EDIT_COMMENTS) {
-    addnav(",?Comment Moderation", "moderate.php");
+    Nav::add(",?Comment Moderation", "moderate.php");
 }
 if ($session['user']['superuser'] & ~SU_DOESNT_GIVE_GROTTO) {
-    addnav("X?`bSuperuser Grotto`b", "superuser.php");
+    Nav::add("X?`bSuperuser Grotto`b", "superuser.php");
 }
 if ($session['user']['superuser'] & SU_INFINITE_DAYS) {
-    addnav("/?New Day", "newday.php");
+    Nav::add("/?New Day", "newday.php");
 }
 $translator->setSchema();
 //let users try to cheat, we protect against this and will know if they try.
-addnav("", "superuser.php");
-addnav("", "user.php");
-addnav("", "taunt.php");
-addnav("", "creatures.php");
-addnav("", "configuration.php");
-addnav("", "badword.php");
-addnav("", "armoreditor.php");
-addnav("", "bios.php");
-addnav("", "badword.php");
-addnav("", "donators.php");
-addnav("", "referers.php");
-addnav("", "retitle.php");
-addnav("", "stats.php");
-addnav("", "viewpetition.php");
-addnav("", "weaponeditor.php");
+Nav::add("", "superuser.php");
+Nav::add("", "user.php");
+Nav::add("", "taunt.php");
+Nav::add("", "creatures.php");
+Nav::add("", "configuration.php");
+Nav::add("", "badword.php");
+Nav::add("", "armoreditor.php");
+Nav::add("", "bios.php");
+Nav::add("", "badword.php");
+Nav::add("", "donators.php");
+Nav::add("", "referers.php");
+Nav::add("", "retitle.php");
+Nav::add("", "stats.php");
+Nav::add("", "viewpetition.php");
+Nav::add("", "weaponeditor.php");
 
 if (!$skipvillagedesc) {
-    modulehook("collapse{", array("name" => "villagedesc-" . $session['user']['location']));
+    HookHandler::hook("collapse{", array("name" => "villagedesc-" . $session['user']['location']));
     $translator->setSchema($schemas['text']);
-    output($texts['text']);
+    $output->output($texts['text']);
     $translator->setSchema();
-    modulehook("}collapse");
-    modulehook("collapse{", array("name" => "villageclock-" . $session['user']['location']));
+    HookHandler::hook("}collapse");
+    HookHandler::hook("collapse{", array("name" => "villageclock-" . $session['user']['location']));
     $translator->setSchema($schemas['clock']);
-    output($texts['clock'], getgametime());
+    $output->output($texts['clock'], getgametime());
     $translator->setSchema();
-    modulehook("}collapse");
-    modulehook("village-desc", $texts);
+    HookHandler::hook("}collapse");
+    HookHandler::hook("village-desc", $texts);
     //support for a special village-only hook
-    modulehook("village-desc-{$session['user']['location']}", $texts);
+    HookHandler::hook("village-desc-{$session['user']['location']}", $texts);
     if ($texts['newestplayer'] > "" && $texts['newest']) {
-        modulehook("collapse{", array("name" => "villagenewest-" . $session['user']['location']));
+        HookHandler::hook("collapse{", array("name" => "villagenewest-" . $session['user']['location']));
         $translator->setSchema($schemas['newest']);
-        output($texts['newest'], $texts['newestplayer']);
+        $output->output($texts['newest'], $texts['newestplayer']);
         $translator->setSchema();
         $id = $texts['newestid'];
         if ($session['user']['superuser'] & SU_EDIT_USERS && $id) {
             $edit = translate_inline("Edit");
-            rawoutput(" [<a href='user.php?op=edit&userid=$id'>$edit</a>]");
-            addnav("", "user.php?op=edit&userid=$id");
+            $output->rawOutput(" [<a href='user.php?op=edit&userid=$id'>$edit</a>]");
+            Nav::add("", "user.php?op=edit&userid=$id");
         }
-        output_notl("`n");
-        modulehook("}collapse");
+        $output->outputNotl("`n");
+        HookHandler::hook("}collapse");
     }
 }
-$texts = modulehook("village", $texts);
+$texts = HookHandler::hook("village", $texts);
 //special hook for all villages... saves queries...
-$texts = modulehook("village-{$session['user']['location']}", $texts);
+$texts = HookHandler::hook("village-{$session['user']['location']}", $texts);
 
 if ($skipvillagedesc) {
-    output("`n");
+    $output->output("`n");
 }
 
-$args = modulehook("blockcommentarea", array("section" => $texts['section']));
+$args = HookHandler::hook("blockcommentarea", array("section" => $texts['section']));
 if (!isset($args['block']) || $args['block'] != 'yes') {
         $translator->setSchema($schemas['talk']);
-        output($texts['talk']);
+        $output->output($texts['talk']);
         $translator->setSchema();
             Commentary::commentDisplay("", $texts['section'], "Speak", 25, $texts['sayline'], $schemas['sayline']);
 }
 
 module_display_events("village", "village.php");
-page_footer();
+Footer::pageFooter();

--- a/weapons.php
+++ b/weapons.php
@@ -2,13 +2,17 @@
 
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
+use Lotgd\Nav;
+use Lotgd\Nav\VillageNav;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // translator ready
 // addnews ready
 // mail ready
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/http.php";
-require_once __DIR__ . "/lib/villagenav.php";
 
 $translator = Translator::getInstance();
 
@@ -47,24 +51,24 @@ $schemas = array(
 );
 
 $basetext['schemas'] = $schemas;
-$texts = modulehook("weaponstext", $basetext);
+$texts = HookHandler::hook("weaponstext", $basetext);
 $schemas = $texts['schemas'];
 
 $translator->setSchema($schemas['title']);
-page_header($texts['title']);
-output("`c`b`&" . $texts['title'] . "`0`b`c");
+Header::pageHeader($texts['title']);
+$output->output("`c`b`&" . $texts['title'] . "`0`b`c");
 $translator->setSchema();
 
-$op = httpget("op");
+$op = Http::get("op");
 
 if ($op == "") {
     $translator->setSchema($schemas['desc']);
     if (is_array($texts['desc'])) {
         foreach ($texts['desc'] as $description) {
-            output_notl($translator->sprintfTranslate($description));
+            $output->outputNotl($translator->sprintfTranslate($description));
         }
     } else {
-        output($texts['desc']);
+        $output->output($texts['desc']);
     }
     $translator->setSchema();
 
@@ -79,88 +83,88 @@ if ($op == "") {
     $translator->setSchema($schemas['tradein']);
     if (is_array($texts['tradein'])) {
         foreach ($texts['tradein'] as $description) {
-            output_notl($translator->sprintfTranslate($description));
+            $output->outputNotl($translator->sprintfTranslate($description));
         }
     } else {
-        output($texts['tradein']);
+        $output->output($texts['tradein']);
     }
     $translator->setSchema();
 
     $wname = translate_inline("`bName`b");
     $wdam = translate_inline("`bDamage`b");
     $wcost = translate_inline("`bCost`b");
-    rawoutput("<table border='0' cellpadding='0'>");
-    rawoutput("<tr class='trhead'><td>");
-    output_notl($wname);
-    rawoutput("</td><td align='center'>");
-    output_notl($wdam);
-    rawoutput("</td><td align='right'>");
-    output_notl($wcost);
-    rawoutput("</td></tr>");
+    $output->rawOutput("<table border='0' cellpadding='0'>");
+    $output->rawOutput("<tr class='trhead'><td>");
+    $output->outputNotl($wname);
+    $output->rawOutput("</td><td align='center'>");
+    $output->outputNotl($wdam);
+    $output->rawOutput("</td><td align='right'>");
+    $output->outputNotl($wcost);
+    $output->rawOutput("</td></tr>");
     $i = 0;
     while ($row = Database::fetchAssoc($result)) {
         $link = true;
-        $row = modulehook("modify-weapon", $row);
+        $row = HookHandler::hook("modify-weapon", $row);
         if (isset($row['skip']) && $row['skip'] === true) {
             continue;
         }
         if (isset($row['unavailable']) && $row['unavailable'] == true) {
             $link = false;
         }
-        rawoutput("<tr class='" . ($i % 2 == 1 ? "trlight" : "trdark") . "'><td>");
+        $output->rawOutput("<tr class='" . ($i % 2 == 1 ? "trlight" : "trdark") . "'><td>");
         $color = "`)";
         if ($row['value'] <= ($session['user']['gold'] + $tradeinvalue)) {
             if ($link) {
                 $color = "`&";
-                rawoutput("<a href='weapons.php?op=buy&id={$row['weaponid']}'>");
+                $output->rawOutput("<a href='weapons.php?op=buy&id={$row['weaponid']}'>");
             } else {
                 $color = "`7";
             }
-            output_notl("%s%s`0", $color, $row['weaponname']);
+            $output->outputNotl("%s%s`0", $color, $row['weaponname']);
             if ($link) {
-                rawoutput("</a>");
+                $output->rawOutput("</a>");
             }
-            addnav("", "weapons.php?op=buy&id={$row['weaponid']}");
+            Nav::add("", "weapons.php?op=buy&id={$row['weaponid']}");
         } else {
-            output_notl("%s%s`0", $color, $row['weaponname']);
-            addnav("", "weapons.php?op=buy&id={$row['weaponid']}");
+            $output->outputNotl("%s%s`0", $color, $row['weaponname']);
+            Nav::add("", "weapons.php?op=buy&id={$row['weaponid']}");
         }
-        rawoutput("</td><td align='center'>");
-        output_notl("%s%s`0", $color, $row['damage']);
-        rawoutput("</td><td align='right'>");
+        $output->rawOutput("</td><td align='center'>");
+        $output->outputNotl("%s%s`0", $color, $row['damage']);
+        $output->rawOutput("</td><td align='right'>");
         if (isset($row['alternatetext']) && $row['alternatetext'] > "") {
-            output("%s%s`0", $color, $row['alternatetext']);
+            $output->output("%s%s`0", $color, $row['alternatetext']);
         } else {
-            output_notl("%s%s`0", $color, $row['value']);
+            $output->outputNotl("%s%s`0", $color, $row['value']);
         }
-        rawoutput("</td></tr>");
+        $output->rawOutput("</td></tr>");
         ++$i;
     }
-    rawoutput("</table>");
-    villagenav();
+    $output->rawOutput("</table>");
+    VillageNav::render();
 } elseif ($op == "buy") {
-    $id = httpget("id");
+    $id = Http::get("id");
     $sql = "SELECT * FROM " . Database::prefix("weapons") . " WHERE weaponid='$id'";
     $result = Database::query($sql);
     if (Database::numRows($result) == 0) {
         $translator->setSchema($schemas['nosuchweapon']);
-        output($texts['nosuchweapon']);
+        $output->output($texts['nosuchweapon']);
         $translator->setSchema();
         $translator->setSchema($schemas['tryagain']);
-        addnav($texts['tryagain'], "weapons.php");
+        Nav::add($texts['tryagain'], "weapons.php");
         $translator->setSchema();
-        villagenav();
+        VillageNav::render();
     } else {
         $row = Database::fetchAssoc($result);
-        $row = modulehook("modify-weapon", $row);
+        $row = HookHandler::hook("modify-weapon", $row);
         if ($row['value'] > ($session['user']['gold'] + $tradeinvalue)) {
             $translator->setSchema($schemas['notenoughgold']);
-            output($texts['notenoughgold'], $row['weaponname']);
+            $output->output($texts['notenoughgold'], $row['weaponname']);
             $translator->setSchema();
-            villagenav();
+            VillageNav::render();
         } else {
             $translator->setSchema($schemas['payweapon']);
-            output($texts['payweapon'], $session['user']['weapon'], $row['weaponname']);
+            $output->output($texts['payweapon'], $session['user']['weapon'], $row['weaponname']);
             $translator->setSchema();
             debuglog("spent " . ($row['value'] - $tradeinvalue) . " gold on the " . $row['weaponname'] . " weapon");
             $session['user']['gold'] -= $row['value'];
@@ -170,9 +174,9 @@ if ($op == "") {
             $session['user']['weapondmg'] = $row['damage'];
             $session['user']['attack'] += $session['user']['weapondmg'];
             $session['user']['weaponvalue'] = $row['value'];
-            villagenav();
+            VillageNav::render();
         }
     }
 }
 
-page_footer();
+Footer::pageFooter();


### PR DESCRIPTION
## Summary
- replace legacy helpers in top-level entrypoints with Lotgd service classes for navigation, headers/footers, HTTP and module hooks
- drop redundant legacy includes and import the appropriate namespaced classes across the converted scripts
- adjust the gamelog test harness for the new APIs and ensure compatibility when common bootstrap is skipped

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d2d8181f5483298d541b9b4ebfaa63