### PR TITLE
Refactor legacy entry points to service APIs

### DIFF
--- a/gardens.php
+++ b/gardens.php
@@ -1,6 +1,12 @@
 <?php
 
 use Lotgd\Commentary;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
+use Lotgd\Output;
+use Lotgd\Page\Footer;
+use Lotgd\Page\Header;
+use Lotgd\Settings;
 use Lotgd\Translator;
 
 // addnews ready
@@ -9,49 +15,51 @@ use Lotgd\Translator;
 require_once __DIR__ . "/common.php";
 require_once __DIR__ . "/lib/villagenav.php";
 require_once __DIR__ . "/lib/events.php";
-require_once __DIR__ . "/lib/http.php";
 
 Translator::getInstance()->setSchema("gardens");
 
-page_header("The Gardens");
+$output    = Output::getInstance();
+$settings  = Settings::getInstance();
+
+Header::pageHeader("The Gardens");
 
 Commentary::addCommentary();
 $skipgardendesc = handle_event("gardens");
-$op = httpget('op');
-$com = httpget('comscroll');
-$refresh = httpget("refresh");
-$commenting = httpget("commenting");
-$comment = httppost('insertcommentary');
+$op = Http::get('op');
+$com = Http::get('comscroll');
+$refresh = Http::get("refresh");
+$commenting = Http::get("commenting");
+$comment = Http::post('insertcommentary');
 // Don't give people a chance at a special event if they are just browsing
 // the commentary (or talking) or dealing with any of the hooks in the village.
 if (!$op && $com == "" && !$comment && !$refresh && !$commenting) {
-    if (module_events("gardens", getsetting("gardenchance", 0)) != 0) {
+    if (HookHandler::moduleEvents("gardens", $settings->getSetting("gardenchance", 0)) != 0) {
         if (checknavs()) {
-            page_footer();
+            Footer::pageFooter();
         } else {
             // Reset the special for good.
             $session['user']['specialinc'] = "";
             $session['user']['specialmisc'] = "";
             $skipgardendesc = true;
             $op = "";
-            httpset("op", "");
+            Http::set("op", "");
         }
     }
 }
 if (!$skipgardendesc) {
     checkday();
 
-    output("`b`c`2The Gardens`0`c`b");
+    $output->output("`b`c`2The Gardens`0`c`b");
 
-    output("`n`nYou walk through a gate and on to one of the many winding paths that makes its way through the well-tended gardens.");
-    output("From the flowerbeds that bloom even in darkest winter, to the hedges whose shadows promise forbidden secrets, these gardens provide a refuge for those seeking out the Green Dragon; a place where they can forget their troubles for a while and just relax.`n`n");
-    output("One of the fairies buzzing about the garden flies up to remind you that the garden is a place for roleplaying and peaceful conversation, and to confine out-of-character comments to the other areas of the game.`n`n");
+    $output->output("`n`nYou walk through a gate and on to one of the many winding paths that makes its way through the well-tended gardens.");
+    $output->output("From the flowerbeds that bloom even in darkest winter, to the hedges whose shadows promise forbidden secrets, these gardens provide a refuge for those seeking out the Green Dragon; a place where they can forget their troubles for a while and just relax.`n`n");
+    $output->output("One of the fairies buzzing about the garden flies up to remind you that the garden is a place for roleplaying and peaceful conversation, and to confine out-of-character comments to the other areas of the game.`n`n");
 }
 
 villagenav();
-modulehook("gardens", array());
+HookHandler::hook("gardens", []);
 
 Commentary::commentDisplay("", "gardens", "Whisper here", 30, "whispers");
 
-module_display_events("gardens", "gardens.php");
-page_footer();
+HookHandler::displayEvents("gardens", "gardens.php");
+Footer::pageFooter();

--- a/mail.php
+++ b/mail.php
@@ -1,5 +1,11 @@
 <?php
 
+use Lotgd\Http;
+use Lotgd\Mail;
+use Lotgd\Modules\HookHandler;
+use Lotgd\Output;
+use Lotgd\Page\Footer;
+use Lotgd\Page\Header;
 use Lotgd\Translator;
 
 // translator ready
@@ -7,20 +13,20 @@ use Lotgd\Translator;
 // mail ready
 define("OVERRIDE_FORCED_NAV", true);
 require_once __DIR__ . "/common.php";
-use Lotgd\Mail;
 
 Translator::getInstance()->setSchema("mail");
-$args = modulehook("header-mail", array("done" => 0));
+$output = Output::getInstance();
+$args   = HookHandler::hook("header-mail", ["done" => 0]);
 
 
-$op = httpget('op');
-$id = (int)httpget('id');
+$op = Http::get('op');
+$id = (int) Http::get('id');
 if ($op == "del" && !$args['done']) {
         Mail::deleteMessage($session['user']['acctid'], $id);
         header("Location: mail.php");
         exit();
 } elseif ($op == "process" && !$args['done']) {
-        $msg = httppost('msg');
+        $msg = Http::post('msg');
     if (!is_array($msg) || count($msg) < 1) {
             $session['message'] = "`n`n`\$`bYou cannot delete zero messages!  What does this mean?  You pressed \"Delete Checked\" but there are no messages checked!  What sort of world is this that people press buttons that have no meaning?!?`b`0";
             header("Location: mail.php");
@@ -36,38 +42,38 @@ if ($op == "del" && !$args['done']) {
         exit();
 }
 
-popup_header("Ye Olde Poste Office");
-$inbox = translate_inline("Inbox");
-$write = translate_inline("Write");
+Header::popupHeader("Ye Olde Poste Office");
+$inbox = Translator::translateInline("Inbox");
+$write = Translator::translateInline("Write");
 
 // Build the initial args array
-$args = array();
-array_push($args, array("mail.php", $inbox));
-array_push($args, array("mail.php?op=address",$write));
+$args = [];
+array_push($args, ["mail.php", $inbox]);
+array_push($args, ["mail.php?op=address", $write]);
 // to use this hook,
 // just call array_push($args, array("pagename", "functionname"));,
 // where "pagename" is the name of the page to forward the user to,
 // and "functionname" is the name of the mail function to add
-$mailfunctions = modulehook("mailfunctions", $args);
+$mailfunctions = HookHandler::hook("mailfunctions", $args);
 
-rawoutput("<table width='50%' border='0' cellpadding='0' cellspacing='2'>");
-rawoutput("<tr>");
+$output->rawOutput("<table width='50%' border='0' cellpadding='0' cellspacing='2'>");
+$output->rawOutput("<tr>");
 $count_mailfunctions = count($mailfunctions);
 for ($i = 0; $i < $count_mailfunctions; ++$i) {
     if (is_array($mailfunctions[$i])) {
         if (count($mailfunctions[$i]) == 2) {
             $page = $mailfunctions[$i][0];
             $name = $mailfunctions[$i][1]; // already translated
-            rawoutput("<td><a href='$page' class='motd'>$name</a></td>");
+            $output->rawOutput("<td><a href='$page' class='motd'>$name</a></td>");
             // No need for addnav since mail function pages are (or should be) outside the page nav system.
         }
     }
 }
-rawoutput("</tr></table>");
-output_notl("`n`n");
-switch (httpget('even')) {
+$output->rawOutput("</tr></table>");
+$output->outputNotl("`n`n");
+switch (Http::get('even')) {
     case "mailsent":
-        output("`vYour message was sent!`n");
+        $output->output("`vYour message was sent!`n");
         break;
 }
 
@@ -86,4 +92,4 @@ switch ($op) {
         require __DIR__ . "/pages/mail/case_default.php";
         break;
 }
-popup_footer();
+Footer::popupFooter();

--- a/motd.php
+++ b/motd.php
@@ -1,14 +1,18 @@
 <?php
 
-use Lotgd\MySQL\Database;
-use Lotgd\Translator;
-use Lotgd\Commentary;
 use Lotgd\Accounts;
-use Lotgd\Output;
+use Lotgd\AddNews;
+use Lotgd\Commentary;
 use Lotgd\DataCache;
-use Lotgd\Motd;
-use Lotgd\Nav;
 use Lotgd\Http;
+use Lotgd\Motd;
+use Lotgd\MySQL\Database;
+use Lotgd\Nav;
+use Lotgd\Output;
+use Lotgd\Page\Footer;
+use Lotgd\Page\Header;
+use Lotgd\Settings;
+use Lotgd\Translator;
 
 // addnews ready
 // translator ready
@@ -21,16 +25,17 @@ require_once __DIR__ . "/lib/nltoappon.php";
 
 
 Translator::getInstance()->setSchema("motd");
+$settings = Settings::getInstance();
 
 $op = Http::get('op');
 $id = Http::get('id');
 
 Commentary::addCommentary();
-popup_header("LoGD Message of the Day (MoTD)");
+Header::popupHeader("LoGD Message of the Day (MoTD)");
 
 if ($session['user']['superuser'] & SU_POST_MOTD) {
-    $addm = translate_inline("Add MoTD");
-    $addp = translate_inline("Add Poll");
+    $addm = Translator::translateInline("Add MoTD");
+    $addp = Translator::translateInline("Add Poll");
     $output->rawOutput(" [ <a href='motd.php?op=add'>$addm</a> | <a href='motd.php?op=addpoll'>$addp</a> ]<br/><br/>");
 }
 
@@ -70,7 +75,7 @@ if ($op == "add" || $op == "addpoll" || $op == "del") {
         } elseif ($op == "del") {
             Motd::motdDel($id);
             $output->output("`^Entry deleted.`0`n");
-            $return = translate_inline("Return to MoTD");
+            $return = Translator::translateInline("Return to MoTD");
             $output->rawOutput("<a href='motd.php'>$return</a>");
             Nav::add('', 'motd.php');
         }
@@ -87,7 +92,7 @@ if ($op == "add" || $op == "addpoll" || $op == "del") {
     }
 }
 if ($op == "") {
-    $count = getsetting("motditems", 5);
+    $count = $settings->getSetting("motditems", 5);
     $newcount = (int)Http::post("newcount");
     if ($newcount == 0 || Http::post('proceed') == '') {
         $newcount = 0;
@@ -158,14 +163,14 @@ if ($op == "") {
     $output->rawOutput("<option value=''>--Current--</option>");
     while ($row = Database::fetchAssoc($result)) {
         $time = strtotime("{$row['d']}-01");
-        $m = translate_inline(date("M", $time));
+        $m = Translator::translateInline(date("M", $time));
         $output->rawOutput("<option value='{$row['d']}'" . ($month_post == $row['d'] ? " selected" : "") . ">$m" . date(", Y", $time) . " ({$row['c']})</option>");
     }
     $output->rawOutput("</select>" . Translator::clearButton());
-    $showmore = translate_inline("Show more");
+    $showmore = Translator::translateInline("Show more");
     $output->rawOutput("<input type='hidden' name='newcount' value='" . ($count + $newcount) . "'>");
     $output->rawOutput("<input type='submit' value='$showmore' name='proceed'  class='button'>");
-    $output->rawOutput(" <input type='submit' value='" . translate_inline("Submit") . "' class='button'>");
+    $output->rawOutput(" <input type='submit' value='" . Translator::translateInline("Submit") . "' class='button'>");
     $output->rawOutput("</form>");
 
     Commentary::commentDisplay("`n`@Commentary:`0`n", "motd");
@@ -184,4 +189,4 @@ if ($row && isset($row['motddate'])) {
     $session['user']['lastmotd'] = '1970-01-01 00:00:00';
 }
 
-popup_footer();
+Footer::popupFooter();

--- a/pvp.php
+++ b/pvp.php
@@ -2,29 +2,32 @@
 
 declare(strict_types=1);
 
+use Lotgd\AddNews;
+use Lotgd\Battle;
+use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
+use Lotgd\Nav;
+use Lotgd\Nav\VillageNav;
+use Lotgd\Output;
+use Lotgd\Page\Footer;
+use Lotgd\Page\Header;
+use Lotgd\Pvp;
+use Lotgd\Settings;
 use Lotgd\Translator;
 
 // translator ready
 // addnews ready
 // mail ready
 require_once __DIR__ . "/common.php";
-use Lotgd\FightNav;
-use Lotgd\Pvp;
-use Lotgd\Battle;
-use Lotgd\AddNews;
-use Lotgd\Nav;
-use Lotgd\Nav\VillageNav;
-use Lotgd\Http;
-use Lotgd\Output;
-
 
 Translator::getInstance()->setSchema("pvp");
 
-$output = Output::getInstance();
-$iname = getsetting("innname", LOCATION_INN);
+$output   = Output::getInstance();
+$settings = Settings::getInstance();
+$iname    = $settings->getSetting("innname", LOCATION_INN);
 $battle = false;
 
-page_header("PvP Combat!");
+Header::pageHeader("PvP Combat!");
 $op = Http::get('op');
 $act = Http::get('act');
 
@@ -35,7 +38,7 @@ if ($op == "" && $act != "attack") {
         'atkmsg' => '`4You head out to the fields, where you know some unwitting warriors are sleeping.`n`nYou have `^%s`4 PvP fights left for today.`n`n',
         'schemas' => array('atkmsg' => 'pvp')
     );
-    $args = modulehook("pvpstart", $args);
+    $args = HookHandler::hook("pvpstart", $args);
     Translator::getInstance()->setSchema($args['schemas']['atkmsg']);
     $output->output($args['atkmsg'], $session['user']['playerfights']);
     Translator::getInstance()->setSchema();
@@ -135,4 +138,4 @@ if ($battle) {
                 Battle::fightnav(false, false, "pvp.php$extra");
     }
 }
-page_footer();
+Footer::pageFooter();

--- a/source.php
+++ b/source.php
@@ -1,7 +1,12 @@
 <?php
 
-use Lotgd\Translator;
 use Lotgd\ErrorHandling;
+use Lotgd\Http;
+use Lotgd\Output;
+use Lotgd\Page\Footer;
+use Lotgd\Page\Header;
+use Lotgd\Settings;
+use Lotgd\Translator;
 
 // translator ready
 // addnews ready
@@ -10,15 +15,16 @@ define("ALLOW_ANONYMOUS", true);
 define("OVERRIDE_FORCED_NAV", true);
 require_once __DIR__ . "/common.php";
 ErrorHandling::configure();
-require_once __DIR__ . "/lib/http.php";
 
 Translator::getInstance()->setSchema("source");
+$output   = Output::getInstance();
+$settings = Settings::getInstance();
 
-$url = httpget('url');
+$url = Http::get('url');
 if ($url) {
-    popup_header("Source code for %s", $url);
+    Header::popupHeader("Source code for %s", $url);
 } else {
-    popup_header("Source code");
+    Header::popupHeader("Source code");
 }
 
 if (
@@ -62,13 +68,13 @@ if (
     );
     $legal_files = array();
 
-    rawoutput("<h1>");
-    output("View Source: ");
-    output_notl("%s", htmlentities($url, ENT_COMPAT, getsetting("charset", "UTF-8")));
-    rawoutput("</h1>");
-    output("<a href='#source'>Click here for the source,</a> OR`n", true);
-    output("`bOther files that you may wish to view the source of:`b");
-    rawoutput("<ul>");
+    $output->rawOutput("<h1>");
+    $output->output("View Source: ");
+    $output->outputNotl("%s", htmlentities($url, ENT_COMPAT, $settings->getSetting("charset", "UTF-8")));
+    $output->rawOutput("</h1>");
+    $output->output("<a href='#source'>Click here for the source,</a> OR`n", true);
+    $output->output("`bOther files that you may wish to view the source of:`b");
+    $output->rawOutput("<ul>");
     // Gather all the legal dirs
     $legal_dirs = array();
     foreach ($legal_start_dirs as $dir => $value) {
@@ -145,59 +151,59 @@ if (
                 if ($illegal_files["$key2$entry"] == "X") {
                     //we're hiding the file completely.
                 } else {
-                    rawoutput("<li>$key1$entry");
-                    $reason = translate_inline($illegal_files[$key2 . $entry]);
-                    output("&#151; This file cannot be viewed: %s", $reason, true);
-                    rawoutput("</li>\n");
+                    $output->rawOutput("<li>$key1$entry");
+                    $reason = Translator::translateInline($illegal_files[$key2 . $entry]);
+                    $output->output("&#151; This file cannot be viewed: %s", $reason, true);
+                    $output->rawOutput("</li>\n");
                 }
             } else {
-                rawoutput("<li><a href='source.php?url=$subdir$key1$entry'>$key1$entry</a> &#151; " . date("Y-m-d H:i:s", filemtime($key . "/" . $entry)) . "</li>\n");
+                $output->rawOutput("<li><a href='source.php?url=$subdir$key1$entry'>$key1$entry</a> &#151; " . date("Y-m-d H:i:s", filemtime($key . "/" . $entry)) . "</li>\n");
                 $legal_files["$subdir$key1$entry"] = true;
             }
         }
     }
-    rawoutput("</ul>");
+    $output->rawOutput("</ul>");
 
-    rawoutput("<h1><a name='source'>");
-    output("Source of: %s", htmlentities($url, ENT_COMPAT, getsetting("charset", "UTF-8")));
-    rawoutput("</a></h1>");
+    $output->rawOutput("<h1><a name='source'>");
+    $output->output("Source of: %s", htmlentities($url, ENT_COMPAT, $settings->getSetting("charset", "UTF-8")));
+    $output->rawOutput("</a></h1>");
 
     $page_name = substr($url, strlen($subdir) - 1);
     if (substr($page_name, 0, 1) == "/") {
         $page_name = substr($page_name, 1);
     }
     if ($legal_files[$url]) {
-        rawoutput("<table bgcolor=#cccccc>");
-        rawoutput("<tr><td>");
-        rawoutput("<font size=-1>");
+        $output->rawOutput("<table bgcolor=#cccccc>");
+        $output->rawOutput("<tr><td>");
+        $output->rawOutput("<font size=-1>");
         ob_start();
         show_source($page_name);
         $t = ob_get_contents();
         ob_end_clean();
-        rawoutput($t);
-        rawoutput("</font>", true);
-        rawoutput("</td></tr></table>", true);
+        $output->rawOutput($t);
+        $output->rawOutput("</font>", true);
+        $output->rawOutput("</td></tr></table>", true);
     } elseif ($illegal_files[$url] != "" && $illegal_files[$url] != "X") {
-        $reason = translate_inline($illegal_files[$url]);
-        output("`nCannot view this file: %s`n", $reason);
+        $reason = Translator::translateInline($illegal_files[$url]);
+        $output->output("`nCannot view this file: %s`n", $reason);
     } else {
-        output("`nCannot view this file.`n");
+        $output->output("`nCannot view this file.`n");
         ;
     }
 } else {
-       output("Due to the behaviour of people in the past, access to the source code online has been restricted.");
-       output("You may download the entirety of the latest publicly released stable version from <a href='http://www.dragonprime.net' target='_blank'>DragonPrime</a>.", true);
-       output("For the +NB version of Legend of the Green Dragon, visit our <a href='https://github.com/NB-Core/lotgd' target='_blank'>GitHub repository</a> where you can download releases or clone the project.", true);
-       output("You may then work with that code within the restrictions of its license.");
-    output("`n`nHopefully this will help put an end to actions like the following:");
-    rawoutput("<ul><li>");
-    output("Releasing code which they do not own without permission.");
-    rawoutput("</li><li>");
-    output("Removing valid copyright information from code and replacing it.");
-    rawoutput("</li><li>");
-    output("Removing portions of the code required to be kept intact by licensing.");
-    rawoutput("</li><li>");
-    output("Claiming copyright of items which they did not create.");
-    rawoutput("</li></ul>");
+       $output->output("Due to the behaviour of people in the past, access to the source code online has been restricted.");
+       $output->output("You may download the entirety of the latest publicly released stable version from <a href='http://www.dragonprime.net' target='_blank'>DragonPrime</a>.", true);
+       $output->output("For the +NB version of Legend of the Green Dragon, visit our <a href='https://github.com/NB-Core/lotgd' target='_blank'>GitHub repository</a> where you can download releases or clone the project.", true);
+       $output->output("You may then work with that code within the restrictions of its license.");
+    $output->output("`n`nHopefully this will help put an end to actions like the following:");
+    $output->rawOutput("<ul><li>");
+    $output->output("Releasing code which they do not own without permission.");
+    $output->rawOutput("</li><li>");
+    $output->output("Removing valid copyright information from code and replacing it.");
+    $output->rawOutput("</li><li>");
+    $output->output("Removing portions of the code required to be kept intact by licensing.");
+    $output->rawOutput("</li><li>");
+    $output->output("Claiming copyright of items which they did not create.");
+    $output->rawOutput("</li></ul>");
 }
-popup_footer();
+Footer::popupFooter();


### PR DESCRIPTION
## Summary
- migrate gardens.php to Header/Footer, Http, HookHandler, Settings, and Output services
- replace legacy http/module/output helpers in mail.php, pvp.php, motd.php, and source.php with modern counterparts

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d2f62957788329bd9a4b4b1094125d