### PR TITLE
Refactor entrypoints to drop legacy lib includes

### DIFF
--- a/battle.php
+++ b/battle.php
@@ -15,13 +15,12 @@ use Lotgd\Translator;
 use Lotgd\Buffs;
 use Lotgd\Battle;
 use Lotgd\Substitute;
+use Lotgd\Http;
 
 // translator ready
 // addnews ready
 // mail ready
-require_once __DIR__ . "/lib/bell_rand.php";
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/http.php";
 
 
 //just in case we're called from within a function.Yuck is this ugly.
@@ -61,7 +60,7 @@ $roundcounter = 0;
 $adjustment = 1;
 
 $count = 1;
-$auto = httpget('auto');
+$auto = Http::get('auto');
 if ($auto == 'full') {
     $count = -1;
 } elseif ($auto == 'five') {
@@ -72,10 +71,10 @@ if ($auto == 'full') {
 $enemycounter = count($enemies);
 $enemies = Battle::autoSetTarget($enemies);
 
-$op = httpget("op");
-$skill = httpget("skill");
-$l = httpget("l");
-$newtarget = httpget('newtarget');
+$op = Http::get("op");
+$skill = Http::get("skill");
+$l = Http::get("l");
+$newtarget = Http::get('newtarget');
 if ($newtarget != "") {
     $op = "newtarget";
 }
@@ -137,7 +136,7 @@ Battle::suspendBuffs((($options['type'] == 'pvp') ? "allowinpvp" : false));
 Battle::suspendCompanions((($options['type'] == 'pvp') ? "allowinpvp" : false));
 
 // Now that the bufflist is sane, see if we should add in the bodyguard.
-$inn = (int)httpget('inn');
+$inn = (int)Http::get('inn');
 if ($options['type'] == 'pvp' && $inn == 1) {
     Battle::applyBodyguard($badguy['bodyguardlevel']);
 }
@@ -154,7 +153,7 @@ if ($op != "run" && $op != "fight" && $op != "newtarget") {
             // By default, surprise is 50/50
             $surprised = e_rand(0, 1) ? true : false;
             // Now, adjust for slum/thrill
-            $type = httpget('type');
+            $type = Http::get('type');
             if ($type == 'slum' || $type == 'thrill') {
                 $num = e_rand(0, 2);
                 $surprised = true;

--- a/create.php
+++ b/create.php
@@ -16,6 +16,8 @@ use Lotgd\Page\Header;
 use Lotgd\Page\Footer;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
+use Lotgd\EmailValidator;
+use Lotgd\PlayerFunctions;
 
 // translator ready
 // addnews ready
@@ -24,7 +26,6 @@ define("ALLOW_ANONYMOUS", true);
 
 
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/is_email.php";
 
 $original = Settings::getInstance();
 $settings_extended = new Settings('settings_extended');
@@ -257,12 +258,12 @@ if (getsetting("allowcreation", 1) == 0) {
                 $msg .= translate_inline("Your character's name cannot exceed 25 characters.`n");
                 $blockaccount = true;
             }
-            if (getsetting("requireemail", 0) == 1 && is_email($email) || getsetting("requireemail", 0) == 0) {
+            if (getsetting("requireemail", 0) == 1 && EmailValidator::isValid($email) || getsetting("requireemail", 0) == 0) {
             } else {
                 $msg .= translate_inline("You must enter a valid email address.`n");
                 $blockaccount = true;
             }
-            $args = HookHandler::hook("check-create", httpallpost());
+            $args = HookHandler::hook("check-create", Http::allPost());
             $args['blockaccount'] = $args['blockaccount'] ?? false;
             $args['msg'] = $args['msg'] ?? '';
 
@@ -293,8 +294,7 @@ if (getsetting("allowcreation", 1) == 0) {
                     if ($sex <> SEX_MALE) {
                         $sex = SEX_FEMALE;
                     }
-                    require_once __DIR__ . "/lib/titles.php";
-                    $title = get_dk_title(0, $sex);
+                    $title = PlayerFunctions::getDkTitle(0, $sex);
                     if (getsetting("requirevalidemail", 0)) {
                         $emailverification = md5(date("Y-m-d H:i:s") . $email);
                     }
@@ -331,7 +331,7 @@ if (getsetting("allowcreation", 1) == 0) {
                         $sql = "SELECT acctid FROM " . Database::prefix("accounts") . " WHERE login='$shortname'";
                         $result = Database::query($sql);
                         $row = Database::fetchAssoc($result);
-                        $args = httpallpost();
+                        $args = Http::allPost();
                         $args['acctid'] = $row['acctid'];
                         //insert output
                         $sql_output = "INSERT INTO " . Database::prefix("accounts_output") . " VALUES ({$row['acctid']},'');";

--- a/gardens.php
+++ b/gardens.php
@@ -8,13 +8,13 @@ use Lotgd\Page\Footer;
 use Lotgd\Page\Header;
 use Lotgd\Settings;
 use Lotgd\Translator;
+use Lotgd\Nav\VillageNav;
+use Lotgd\Events;
 
 // addnews ready
 // translator ready
 // mail ready
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/villagenav.php";
-require_once __DIR__ . "/lib/events.php";
 
 Translator::getInstance()->setSchema("gardens");
 
@@ -24,7 +24,7 @@ $settings  = Settings::getInstance();
 Header::pageHeader("The Gardens");
 
 Commentary::addCommentary();
-$skipgardendesc = handle_event("gardens");
+$skipgardendesc = Events::handleEvent("gardens");
 $op = Http::get('op');
 $com = Http::get('comscroll');
 $refresh = Http::get("refresh");
@@ -56,7 +56,7 @@ if (!$skipgardendesc) {
     $output->output("One of the fairies buzzing about the garden flies up to remind you that the garden is a place for roleplaying and peaceful conversation, and to confine out-of-character comments to the other areas of the game.`n`n");
 }
 
-villagenav();
+VillageNav::render();
 HookHandler::hook("gardens", []);
 
 Commentary::commentDisplay("", "gardens", "Whisper here", 30, "whispers");

--- a/graveyard.php
+++ b/graveyard.php
@@ -10,17 +10,17 @@ use Lotgd\Page\Header;
 use Lotgd\Page\Footer;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
+use Lotgd\Events;
 
 // addnews ready.
 // translator ready
 // mail ready
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/events.php";
 
 Translator::getInstance()->setSchema("graveyard");
 
 Header::pageHeader("The Graveyard");
-$skipgraveyardtext = handle_event("graveyard");
+$skipgraveyardtext = Events::handleEvent("graveyard");
 $deathoverlord = getsetting('deathoverlord', '`$Ramius');
 if (!$skipgraveyardtext) {
     if ($session['user']['alive']) {

--- a/inn.php
+++ b/inn.php
@@ -13,6 +13,7 @@ use Lotgd\Pvp;
 use Lotgd\Nav;
 use Lotgd\Page\Header;
 use Lotgd\Page\Footer;
+use Lotgd\Partner;
 
 // addnews ready
 // translator ready
@@ -50,8 +51,7 @@ $subop = Http::get('subop');
 $com = Http::get('comscroll');
 $comment = Http::post('insertcommentary');
 
-require_once __DIR__ . "/lib/partner.php";
-$partner = get_partner();
+$partner = Partner::getPartner();
 Nav::add("Other");
 VillageNav::render();
 Nav::add("I?Return to the Inn", "inn.php");

--- a/lodge.php
+++ b/lodge.php
@@ -14,7 +14,6 @@ use Lotgd\Modules\HookHandler;
 // addnews ready
 // mail ready
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/sanitize.php";
 
 
 Translator::getInstance()->setSchema("lodge");

--- a/logdnet.php
+++ b/logdnet.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
+use Lotgd\Http;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Nav;
+use Lotgd\ErrorHandler;
+use Lotgd\Backtrace;
+use Lotgd\Sanitize;
+use Lotgd\PullUrl;
 
 // translator ready
 // addnews ready
@@ -14,15 +22,8 @@ if (!isset($_GET['op']) || $_GET['op'] != 'list') {
     //don't want people to be able to visit the list while logged in -- breaks their navs.
     define("OVERRIDE_FORCED_NAV", true);
 }
-use Lotgd\Http;
-use Lotgd\Page\Header;
-use Lotgd\Page\Footer;
-use Lotgd\Nav;
-use Lotgd\ErrorHandler;
-use Lotgd\Backtrace;
 
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/sanitize.php";
 
 Translator::getInstance()->setSchema("logdnet");
 
@@ -90,14 +91,14 @@ function lotgdsort($a, $b)
     return (($costa < $costb) ? -1 : 1);
 }
 
-$op = httpget('op');
+$op = Http::get('op');
 if ($op == "") {
-       $addy  = httpget('addy');
-       $desc  = httpget('desc');
-       $vers  = httpget('version');
-       $admin = httpget('admin');
-       $count = (int)httpget('c');
-       $lang  = httpget('l');
+       $addy  = Http::get('addy');
+       $desc  = Http::get('desc');
+       $vers  = Http::get('version');
+       $admin = Http::get('admin');
+       $count = (int)Http::get('c');
+       $lang  = Http::get('l');
 
     if ($vers == "") {
         $vers = "Unknown";
@@ -112,7 +113,7 @@ if ($op == "") {
     $row = Database::fetchAssoc($result);
 
     // Clean up the desc
-    $desc = logdnet_sanitize($desc);
+    $desc = Sanitize::logdnetSanitize($desc);
     $desc = soap($desc);
     // Limit descs to 75 characters.
     if (strlen($desc) > 75) {
@@ -181,7 +182,7 @@ if ($op == "") {
     Database::query($sql);
 
     //Now, if we're using version 2 of LoGDnet, we'll return the appropriate code.
-    $v = httpget("v");
+    $v = Http::get("v");
     if ((int)$v >= 2) {
         $currency = getsetting("paypalcurrency", "USD");
         $info = array();
@@ -246,7 +247,6 @@ if ($op == "") {
     rawoutput("</td><td>");
     output("Version");
     rawoutput("</td>");
-    require_once __DIR__ . "/lib/pullurl.php";
     $servers = array();
     $u = getsetting("logdnetserver", "http://logdnet.logd.com/");
     $logdnet = getsetting('logdnet', 0);
@@ -256,7 +256,7 @@ if ($op == "") {
     }
     if ($logdnet && $u != "") {
         try {
-            $servers = pullurl($u . "logdnet.php?op=net");
+            $servers = PullUrl::pull($u . "logdnet.php?op=net");
             if (!$servers) {
                 $servers = array();
             }
@@ -314,7 +314,7 @@ if ($op == "") {
                     preg_replace("|<[a-zA-Z0-9/ =]+>|", "", $row['description']);
 
                 // Clean up the desc
-                $row['description'] = logdnet_sanitize($row['description']);
+                $row['description'] = Sanitize::logdnetSanitize($row['description']);
                 $row['description'] = soap($row['description']);
                 // Limit descs to 75 characters.
                 if (strlen($row['description']) > 75) {

--- a/moderate.php
+++ b/moderate.php
@@ -21,7 +21,6 @@ use Lotgd\Redirect;
 // addnews ready
 // mail ready
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/sanitize.php";
 
 
 $output = Output::getInstance();

--- a/motd.php
+++ b/motd.php
@@ -13,6 +13,7 @@ use Lotgd\Page\Footer;
 use Lotgd\Page\Header;
 use Lotgd\Settings;
 use Lotgd\Translator;
+use Lotgd\Nltoappon;
 
 // addnews ready
 // translator ready
@@ -21,7 +22,6 @@ define("ALLOW_ANONYMOUS", true);
 define("OVERRIDE_FORCED_NAV", true);
 require_once __DIR__ . "/common.php";
 $output = Output::getInstance();
-require_once __DIR__ . "/lib/nltoappon.php";
 
 
 Translator::getInstance()->setSchema("motd");
@@ -53,7 +53,7 @@ if ($op == "vote") {
 if (($op == "save" || $op == "savenew") && ($session['user']['superuser'] & SU_POST_MOTD)) {
     if (Http::post('preview')) {
         $title = Http::post('motdtitle');
-        $body = nltoappon((string) Http::post('motdbody'));
+        $body = Nltoappon::convert((string) Http::post('motdbody'));
         Motd::motdItem($title, $body, $session['user']['name'], date('Y-m-d H:i:s'), (int) $id);
         Motd::motdForm((int) $id, $_POST);
     } else {

--- a/newday.php
+++ b/newday.php
@@ -18,12 +18,12 @@ use Lotgd\Page\Footer;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Output;
+use Lotgd\Sanitize;
 
 // translator ready
 // addnews ready
 // mail ready
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/sanitize.php";
 
 $output = Output::getInstance();
 $settings = Settings::getInstance();
@@ -271,7 +271,7 @@ if ($dp < $dkills) {
             Translator::translateInline($sff == 1 ? 'fight' : 'fights')
         );
     }
-    $rp = rtrim(cmd_sanitize($session['user']['restorepage']), '&?');
+    $rp = rtrim(Sanitize::cmdSanitize($session['user']['restorepage']), '&?');
     if (substr($rp, 0, 10) == "badnav.php") {
         Nav::add("Continue", "news.php");
     } else {

--- a/news.php
+++ b/news.php
@@ -67,7 +67,6 @@ if ($totaltoday > $newsperpage) {
 $sql2 = "SELECT " . Database::prefix("motd") . ".*,name AS motdauthorname FROM " . Database::prefix("motd") . " LEFT JOIN " . Database::prefix("accounts") . " ON " . Database::prefix("accounts") . ".acctid = " . Database::prefix("motd") . ".motdauthor ORDER BY motddate DESC LIMIT 1";
 $result2 = Database::queryCached($sql2, "lastmotd");
 while ($row = Database::fetchAssoc($result2)) {
-        require_once __DIR__ . "/lib/nltoappon.php";
     if ($row['motdauthorname'] == "") {
         $row['motdauthorname'] = Translator::translateInline('`@Green Dragon Staff`0');
     }

--- a/prefs.php
+++ b/prefs.php
@@ -17,6 +17,8 @@ use Lotgd\DataCache;
 use Lotgd\DebugLog;
 use Lotgd\EmailValidator;
 use Lotgd\DateTime;
+use Lotgd\AddNews;
+use Lotgd\PlayerFunctions;
 
 // addnews ready
 
@@ -46,8 +48,7 @@ $op = Http::get('op');
 Nav::add("Navigation");
 if ($op == "suicide" && $settings->getSetting('selfdelete', 0) != 0) {
        $userid = (int)Http::get('userid');
-    require_once __DIR__ . "/lib/charcleanup.php";
-    if (char_cleanup($userid, CHAR_DELETE_SUICIDE)) {
+    if (PlayerFunctions::charCleanup($userid, CHAR_DELETE_SUICIDE)) {
         $sql = "DELETE FROM " . Database::prefix("accounts") . " WHERE acctid=$userid";
         Database::query($sql);
         $output->output("Your character has been deleted!");

--- a/runmodule.php
+++ b/runmodule.php
@@ -25,9 +25,6 @@ define("OVERRIDE_FORCED_NAV", true);
 require_once __DIR__ . "/common.php";
 $output = Output::getInstance();
 
-// Legacy Wrappers for Modules
-require_once __DIR__ . "/lib/modules.php";
-
 DateTime::getMicroTime();
 
 // Determine which module should be executed

--- a/superuser.php
+++ b/superuser.php
@@ -11,12 +11,12 @@ use Lotgd\Page\Header;
 use Lotgd\Page\Footer;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
+use Lotgd\Sanitize;
 
 // translator ready
 // addnews ready
 // mail ready
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/sanitize.php";
 
 SuAccess::check(0xFFFFFFFF & ~ SU_DOESNT_GIVE_GROTTO);
 Commentary::addCommentary();
@@ -35,7 +35,7 @@ if ($op == "keepalive") {
     $sql = "DELETE FROM " . Database::prefix("news") . " WHERE newsid='" . Http::get('newsid') . "'";
     Database::query($sql);
     $return = Http::get('return');
-    $return = cmd_sanitize($return);
+    $return = Sanitize::cmdSanitize($return);
     $return = basename($return);
     redirect($return);
 }

--- a/titleedit.php
+++ b/titleedit.php
@@ -11,6 +11,7 @@ use Lotgd\Page\Header;
 use Lotgd\Page\Footer;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
+use Lotgd\PlayerFunctions;
 
 //Author: Lonny Luberts - 3/18/2005
 //Heavily modified by JT Traub
@@ -72,8 +73,6 @@ switch ($op) {
 
 switch ($op) {
     case "reset":
-                require_once __DIR__ . "/lib/titles.php";
-
         $output->output("`^Rebuilding all titles for all players.`0`n`n");
         $sql = "SELECT name,title,dragonkills,acctid,sex,ctitle FROM " . Database::prefix("accounts");
         $result = Database::query($sql);
@@ -84,9 +83,9 @@ switch ($op) {
             $dk = $row['dragonkills'];
             $otitle = $row['title'];
             $dk = (int)($row['dragonkills']);
-            if (!valid_dk_title($otitle, $dk, $row['sex'])) {
+            if (!PlayerFunctions::validDkTitle($otitle, $dk, $row['sex'])) {
                 $sex = translate_inline($row['sex'] ? "female" : "male");
-                $newtitle = get_dk_title($dk, (int)$row['sex']);
+                $newtitle = PlayerFunctions::getDkTitle($dk, (int)$row['sex']);
                 $newname = Names::changePlayerTitle($newtitle, $row);
                 $id = $row['acctid'];
                 if ($oname != $newname) {

--- a/train.php
+++ b/train.php
@@ -16,14 +16,14 @@ use Lotgd\Page\Header;
 use Lotgd\Page\Footer;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
+use Lotgd\Specialty;
+use Lotgd\PlayerFunctions;
 
 //addnews ready
 // mail ready
 // translator ready
 require_once __DIR__ . "/common.php";
 $output = Output::getInstance();
-require_once __DIR__ . "/lib/increment_specialty.php";
-require_once __DIR__ . "/lib/experience.php";
 
 Translator::getInstance()->setSchema("train");
 
@@ -68,7 +68,7 @@ if (Database::numRows($result) > 0 && $session['user']['level'] < getsetting('ma
     //end of old piece
     $level = $session['user']['level'];
     $dks = $session['user']['dragonkills'];
-    $exprequired = exp_for_next_level($level, $dks);
+    $exprequired = PlayerFunctions::expForNextLevel($level, $dks);
 
     $op = Http::get('op');
     if ($op == "") {
@@ -232,7 +232,7 @@ if (Database::numRows($result) > 0 && $session['user']['level'] < getsetting('ma
                 $body = array("`&%s`# has advanced to level `^%s`#, and so you have earned `^%s`# points!", $session['user']['name'], $session['user']['level'], getsetting("refereraward", 25));
                 Mail::systemMail($session['user']['referer'], $subj, $body);
             }
-            increment_specialty("`^");
+            Specialty::increment("`^");
 
             // Level-Up companions
             // We only get one level per pageload. So we just add the per-level-values.

--- a/user.php
+++ b/user.php
@@ -12,11 +12,12 @@ use Lotgd\Page\Header;
 use Lotgd\Page\Footer;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
+use Lotgd\Sanitize;
+use Lotgd\UserLookup;
 
 //addnews ready
 // mail ready
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/sanitize.php";
 
 
 Translator::getInstance()->setSchema("user");
@@ -55,8 +56,7 @@ if (!$query && $sort) {
 }
 
 if ($op == "search" || $op == "") {
-    require_once __DIR__ . "/lib/lookup_user.php";
-    list($searchresult, $err) = lookup_user($query, $order);
+    [$searchresult, $err] = UserLookup::lookup($query, $order);
     $op = "";
     if ($err) {
         $output->output($err);
@@ -98,7 +98,7 @@ $mounts = "0," . translate_inline("None");
 $sql = "SELECT mountid,mountname,mountcategory FROM " . Database::prefix("mounts") .  " ORDER BY mountcategory";
 $result = Database::query($sql);
 while ($row = Database::fetchAssoc($result)) {
-    $mounts .= ",{$row['mountid']},{$row['mountcategory']}: " . color_sanitize($row['mountname']);
+    $mounts .= ",{$row['mountid']},{$row['mountcategory']}: " . Sanitize::colorSanitize($row['mountname']);
 }
 
 $specialties = array("Undecided" => translate_inline("Undecided"));
@@ -120,7 +120,7 @@ foreach ($ranks as $rankid => $rankname) {
     if ($rankstring != "") {
         $rankstring .= ",";
     }
-    $rankstring .= $rankid . "," . sanitize($rankname);
+    $rankstring .= $rankid . "," . Sanitize::sanitize($rankname);
 }
 $races = HookHandler::hook("racenames");
 //all races here expect such ones no module covers, so we add the users race first.

--- a/village.php
+++ b/village.php
@@ -8,13 +8,13 @@ use Lotgd\Page\Header;
 use Lotgd\Page\Footer;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
+use Lotgd\Events;
+use Lotgd\PlayerFunctions;
 
 // translator ready
 // addnews ready
 // mail ready
 require_once __DIR__ . "/common.php";
-require_once __DIR__ . "/lib/events.php";
-require_once __DIR__ . "/lib/experience.php";
 
 $translator = Translator::getInstance();
 
@@ -124,7 +124,7 @@ Header::pageHeader($texts['title']);
 $translator->setSchema();
 
 Commentary::addCommentary();
-$skipvillagedesc = handle_event("village");
+$skipvillagedesc = Events::handleEvent("village");
 checkday();
 
 if ($session['user']['slaydragon'] == 1) {
@@ -141,7 +141,7 @@ if (getsetting("automaster", 1) && $session['user']['seenmaster'] != 1) {
     //masters hunt down truant students
     $level = $session['user']['level'] + 1;
     $dks = $session['user']['dragonkills'];
-    $expreqd = exp_for_next_level($level, $dks);
+    $expreqd = PlayerFunctions::expForNextLevel($level, $dks);
     if (
         $session['user']['experience'] > $expreqd &&
             $session['user']['level'] < (int)getsetting('maxlevel', 15)
@@ -159,7 +159,7 @@ $comment = Http::post('insertcommentary');
 // the commentary (or talking) or dealing with any of the hooks in the village.
 if (!$op && $com == "" && !$comment && !$refresh && !$commenting) {
     // The '1' should really be sysadmin customizable.
-    if (module_events("village", (int)getsetting("villagechance", 0)) != 0) {
+    if (HookHandler::moduleEvents("village", (int)getsetting("villagechance", 0)) != 0) {
         if (checknavs()) {
             Footer::pageFooter();
         } else {


### PR DESCRIPTION
## Summary
- replace legacy wrapper includes with direct calls to the corresponding namespaced services across the remaining entrypoints
- update HTTP, event, and navigation helpers to use `Lotgd\Http`, `Lotgd\Events`, and `Lotgd\Nav\VillageNav` directly instead of legacy wrappers
- clean up logdnet bootstrap to rely on `Sanitize` and `PullUrl` instead of manual `lib/` includes

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d2fa4fafd083299258683cef3970dc