### PR TITLE
refactor: replace legacy helpers in entry scripts

### DIFF
--- a/armor.php
+++ b/armor.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
+use Lotgd\Http;
+use Lotgd\Page\Header;
+use Lotgd\Page\Footer;
+use Lotgd\Nav\VillageNav;
+use Lotgd\Nav;
+use Lotgd\DateTime;
+use Lotgd\Modules\HookHandler;
 
 // translator ready
 // addnews ready
@@ -15,13 +22,6 @@ use Lotgd\Translator;
 * @see armoreditor.php
 */
 require_once __DIR__ . "/common.php";
-
-use Lotgd\Http;
-use Lotgd\Page\Header;
-use Lotgd\Page\Footer;
-use Lotgd\Nav\VillageNav;
-use Lotgd\Nav;
-use Lotgd\DateTime;
 
 $translator = Translator::getInstance();
 
@@ -56,7 +56,7 @@ $schemas = array(
 );
 
 $basetext['schemas'] = $schemas;
-$texts = modulehook("armortext", $basetext);
+$texts = HookHandler::hook("armortext", $basetext);
 $schemas = $texts['schemas'];
 
 $translator->setSchema($schemas['title']);
@@ -106,7 +106,7 @@ if ($op == "") {
     $i = 0;
     while ($row = Database::fetchAssoc($result)) {
         $link = true;
-        $row = modulehook("modify-armor", $row);
+        $row = HookHandler::hook("modify-armor", $row);
         if (isset($row['skip']) && $row['skip'] === true) {
             continue;
         }
@@ -159,7 +159,7 @@ if ($op == "") {
         VillageNav::render();
     } else {
         $row = Database::fetchAssoc($result);
-        $row = modulehook("modify-armor", $row);
+        $row = HookHandler::hook("modify-armor", $row);
         if ($row['value'] > ($session['user']['gold'] + $tradeinvalue)) {
             $translator->setSchema($schemas['notenoughgold']);
             output($texts['notenoughgold'], $row['armorname']);

--- a/battle.php
+++ b/battle.php
@@ -16,6 +16,7 @@ use Lotgd\Buffs;
 use Lotgd\Battle;
 use Lotgd\Substitute;
 use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // translator ready
 // addnews ready
@@ -118,7 +119,7 @@ foreach ($enemies as $index => $enemy) {
 
 if ($enemycounter > 0) {
     output("`\$`c`b~ ~ ~ Fight ~ ~ ~`b`c`0");
-    modulehook("battle", $enemies);
+    HookHandler::hook("battle", $enemies);
     foreach ($enemies as $index => $badguy) {
         if ($badguy['creaturehealth'] > 0 && $session['user']['hitpoints'] > 0) {
             output("`@You have encountered `^%s`@ which lunges at you with `%%s`@!`0`n", $badguy['creaturename'], $badguy['creatureweapon']);
@@ -427,7 +428,7 @@ if ($op != "newtarget") {
                     if (getsetting("instantexp", false) == true && $session['user']['alive'] && $options['type'] != "pvp" && $options['type'] != "train") {
                         if (!isset($badguy['expgained']) || $badguy['expgained'] == false) {
                             $cr_xp_gain = round($badguy['creatureexp'] / count($newenemies));
-                            $args = modulehook("forest-victory-xp", $args = array('experience' => $cr_xp_gain));
+                            $args = HookHandler::hook("forest-victory-xp", $args = array('experience' => $cr_xp_gain));
                             $cr_xp_gain = $args['experience'];
                             $session['user']['experience'] += $cr_xp_gain;
                             if (isset($badguy['creatureexp'])) {
@@ -568,10 +569,10 @@ if ($victory || $defeat) {
             $badguy['type'] = $options['type'];
 
             if ($victory) {
-                $badguy = modulehook("battle-victory", $badguy);
+                $badguy = HookHandler::hook("battle-victory", $badguy);
             }
             if ($defeat) {
-                $badguy = modulehook("battle-defeat", $badguy);
+                $badguy = HookHandler::hook("battle-defeat", $badguy);
             }
 //          unset($badguy['fightoutput']);
         }

--- a/common.php
+++ b/common.php
@@ -28,6 +28,7 @@ use Lotgd\DateTime;
 use Lotgd\Cookies;
 use Lotgd\ErrorHandler;
 use Lotgd\Page;
+use Lotgd\Modules\HookHandler;
 
 BootstrapErrorHandler::register();
 // translator ready
@@ -587,13 +588,13 @@ if (
 
 // After setup, allow modification of colors and nested tags
 $output = \Lotgd\Output::getInstance();
-$colors = modulehook("core-colors", $output->getColors());
+$colors = HookHandler::hook("core-colors", $output->getColors());
 $output->setColors($colors);
 // and nested tag handling
-$nestedtags = modulehook("core-nestedtags", $output->getNestedTags());
+$nestedtags = HookHandler::hook("core-nestedtags", $output->getNestedTags());
 $output->setNestedTags($nestedtags);
 // and nested tag eval
-$nestedeval = modulehook("core-nestedtags-eval", $output->getNestedTagEval());
+$nestedeval = HookHandler::hook("core-nestedtags-eval", $output->getNestedTagEval());
 $output->setNestedTagEval($nestedeval);
 
 
@@ -605,5 +606,5 @@ $output->setNestedTagEval($nestedeval);
 // You should do as LITTLE as possible here and consider if you can hook on
 // a page header instead.
 if (!defined('IS_INSTALLER') || (defined('IS_INSTALLER') && !IS_INSTALLER)) {
-    modulehook('everyhit');
+    HookHandler::hook('everyhit');
 }

--- a/gardens.php
+++ b/gardens.php
@@ -8,6 +8,7 @@ use Lotgd\Page\Footer;
 use Lotgd\Page\Header;
 use Lotgd\Settings;
 use Lotgd\Translator;
+use Lotgd\Nav;
 use Lotgd\Nav\VillageNav;
 use Lotgd\Events;
 
@@ -34,7 +35,7 @@ $comment = Http::post('insertcommentary');
 // the commentary (or talking) or dealing with any of the hooks in the village.
 if (!$op && $com == "" && !$comment && !$refresh && !$commenting) {
     if (HookHandler::moduleEvents("gardens", $settings->getSetting("gardenchance", 0)) != 0) {
-        if (checknavs()) {
+        if (Nav::checkNavs()) {
             Footer::pageFooter();
         } else {
             // Reset the special for good.

--- a/hof.php
+++ b/hof.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
-// translator ready
-// addnews ready
-// mail ready
-
-// New Hall of Fame features by anpera
-// http://www.anpera.net/forum/viewforum.php?f=27
-
 use Lotgd\Http;
 use Lotgd\Page\Header;
 use Lotgd\Page\Footer;
 use Lotgd\Nav\VillageNav;
 use Lotgd\Nav;
 use Lotgd\DateTime;
+use Lotgd\Modules\HookHandler;
+// translator ready
+// addnews ready
+// mail ready
+
+// New Hall of Fame features by anpera
+// http://www.anpera.net/forum/viewforum.php?f=27
 
 require_once __DIR__ . "/common.php";
 
@@ -79,7 +79,7 @@ Nav::add("Sorting");
 Nav::add("Best", "hof.php?op=$op&subop=most&page=$page");
 Nav::add("Worst", "hof.php?op=$op&subop=least&page=$page");
 Nav::add("Other Stats");
-modulehook("hof-add", array());
+HookHandler::hook("hof-add", array());
 if ($totalplayers > $playersperpage) {
     Nav::add("Pages");
     for ($i = 0; $i < $totalplayers; $i += $playersperpage) {

--- a/list.php
+++ b/list.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
-
-// addnews ready
-// translator ready
-// mail ready
-define("ALLOW_ANONYMOUS", true);
 use Lotgd\Http;
 use Lotgd\Page\Header;
 use Lotgd\Page\Footer;
@@ -16,6 +11,12 @@ use Lotgd\Nav\VillageNav;
 use Lotgd\Nav;
 use Lotgd\DateTime;
 use Lotgd\Output;
+use Lotgd\Modules\HookHandler;
+
+// addnews ready
+// translator ready
+// mail ready
+define("ALLOW_ANONYMOUS", true);
 
 require_once __DIR__ . "/common.php";
 $output = Output::getInstance();
@@ -147,7 +148,7 @@ while ($row = Database::fetchAssoc($result)) {
 $rows = array_slice($rows, 0, $max);
 
 // let modules modify the data before we display it
-$rows = modulehook("warriorlist", $rows);
+$rows = HookHandler::hook("warriorlist", $rows);
 
 if ($page == "" && $op == "") {
     // Count how many warriors are online by the loggedin field in the $rows array

--- a/pavilion.php
+++ b/pavilion.php
@@ -2,9 +2,9 @@
 
 use Lotgd\Commentary;
 use Lotgd\Translator;
+use Lotgd\Nav\VillageNav;
 
 require_once 'common.php';
-require_once 'lib/villagenav.php';
 
 // translator ready
 // addnews ready
@@ -19,7 +19,7 @@ page_header('Eye-catching Pavilion');
 output("`b`cThe Pavilion`c`b`n");
 output("This page is a placeholder for beta features. Customize it to showcase experimental content.`n");
 
-villagenav();
+VillageNav::render();
 Commentary::commentDisplay('', 'beta', 'Talk with other testers:', 25);
 
 page_footer();

--- a/paylog.php
+++ b/paylog.php
@@ -10,6 +10,7 @@ use Lotgd\Nav;
 use Lotgd\Page\Header;
 use Lotgd\Page\Footer;
 use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // mail ready
 // addnews ready
@@ -37,7 +38,7 @@ SuAccess::check(SU_EDIT_PAYLOG);
 */
 Header::pageHeader('Payment Log');
 SuperuserNav::render();
-modulehook("paylog", array());
+HookHandler::hook("paylog", array());
 
 $op = (string) Http::get('op');
 if ($op == "") {

--- a/rawsql.php
+++ b/rawsql.php
@@ -10,6 +10,7 @@ use Lotgd\Nav;
 use Lotgd\Page\Header;
 use Lotgd\Page\Footer;
 use Lotgd\Http;
+use Lotgd\Modules\HookHandler;
 
 // translator ready
 // addnews ready
@@ -31,7 +32,7 @@ if ($op == "" || $op == "sql") {
     $sql = (string) Http::post('sql');
     if ($sql != "") {
         $sql = stripslashes($sql);
-        modulehook("rawsql-execsql", array("sql" => $sql));
+        HookHandler::hook("rawsql-execsql", array("sql" => $sql));
         $r = Database::query($sql, false);
         if (!$r) {
             $output->output("`\$SQL Error:`& %s`0`n`n", Database::error($r));
@@ -68,7 +69,7 @@ if ($op == "" || $op == "sql") {
 
     $output->output("Type your query");
     $execute = translate_inline("Execute");
-    $ret = modulehook("rawsql-modsql", array("sql" => $sql));
+    $ret = HookHandler::hook("rawsql-modsql", array("sql" => $sql));
     $sql = $ret['sql'];
     $output->rawOutput("<form action='rawsql.php' method='post'>");
     $output->rawOutput("<textarea name='sql' class='input' cols='60' rows='10'>" . htmlentities($sql, ENT_COMPAT, getsetting("charset", "UTF-8")) . "</textarea><br>");
@@ -84,14 +85,14 @@ if ($op == "" || $op == "sql") {
         $output->rawOutput(highlight_string("<?php\n$php\n?>", true));
         $output->rawOutput("</div>");
         $output->output("`bResults:`b`n");
-        modulehook("rawsql-execphp", array("php" => $php));
+        HookHandler::hook("rawsql-execphp", array("php" => $php));
         ob_start();
         eval($php);
         $output->output(ob_get_contents(), true);
         ob_end_clean();
     }
     $output->output("`n`nType your code:");
-    $ret = modulehook("rawsql-modphp", array("php" => $php));
+    $ret = HookHandler::hook("rawsql-modphp", array("php" => $php));
     $php = $ret['php'];
     $output->rawOutput("<form action='rawsql.php?op=php' method='post'>");
     $output->rawOutput("&lt;?php<br><textarea name='php' class='input' cols='60' rows='10'>" . htmlentities($php, ENT_COMPAT, getsetting("charset", "UTF-8")) . "</textarea><br>?&gt;<br>");

--- a/rock.php
+++ b/rock.php
@@ -9,6 +9,7 @@ use Lotgd\Nav;
 use Lotgd\Nav\VillageNav;
 use Lotgd\DateTime;
 use Lotgd\Translator;
+use Lotgd\Modules\HookHandler;
 
 // translator ready
 // addnews ready
@@ -43,7 +44,7 @@ if (
     $output->output("It somehow reminds you of the head of one of the great serpents from legend.`n`n");
     $output->output("You have discovered The Veteran's Club.`n`n");
 
-    modulehook("rock");
+    HookHandler::hook("rock");
 
     Commentary::commentDisplay("", "veterans", "Boast here", 30, "boasts");
 } else {

--- a/shades.php
+++ b/shades.php
@@ -5,6 +5,7 @@ use Lotgd\Translator;
 use Lotgd\Output;
 use Lotgd\Nav;
 use Lotgd\Redirect;
+use Lotgd\Modules\HookHandler;
 
 // translator ready
 // addnews ready
@@ -35,7 +36,7 @@ Nav::add("The Graveyard", "graveyard.php");
 
 Nav::add("Return to the news", "news.php");
 
-modulehook("shades", array()); // if this is too low, you can use footer-shades...
+HookHandler::hook("shades", array()); // if this is too low, you can use footer-shades...
 
 Commentary::commentDisplay("`n`QNearby, some lost souls lament:`n", "shade", "Despair", 25, "despairs");
 

--- a/translatortool.php
+++ b/translatortool.php
@@ -4,6 +4,7 @@ use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
+use Lotgd\Http;
 
 // addnews ready
 // translator ready
@@ -13,11 +14,11 @@ require_once __DIR__ . "/common.php";
 Translator::getInstance()->setSchema("translatortool");
 
 SuAccess::check(SU_IS_TRANSLATOR);
-$op = httpget("op");
+$op = (string) Http::get('op');
 if ($op == "") {
     popup_header("Translator Tool");
-    $uri = rawurldecode(httpget('u'));
-    $text = stripslashes(rawurldecode(httpget('t')));
+    $uri = rawurldecode((string) Http::get('u'));
+    $text = stripslashes(rawurldecode((string) Http::get('t')));
     $translation = translate_loadnamespace($uri);
     if (isset($translation[$text])) {
         $trans = $translation[$text];
@@ -40,9 +41,9 @@ if ($op == "") {
     rawoutput("</form>");
     popup_footer();
 } elseif ($op == 'save') {
-    $uri = httppost('uri');
-    $text = httppost('text');
-    $trans = httppost('trans');
+    $uri = (string) Http::post('uri');
+    $text = (string) Http::post('text');
+    $trans = (string) Http::post('trans');
 
     $page = $uri;
     if (strpos($page, "?") !== false) {
@@ -91,7 +92,7 @@ if ($op == "") {
         }
     }
     Database::query($sql);
-    if (httppost("savenotclose") > "") {
+    if ((string) Http::post('savenotclose') > "") {
         header("Location: translatortool.php?op=list&u=$page");
         exit();
     } else {
@@ -124,7 +125,7 @@ if ($op == "") {
     $norows = translate_inline("No rows found");
     output_notl("<table border='0' cellpadding='2' cellspacing='0'>", true);
     output_notl("<tr class='trhead'><td>$ops</td><td>$from</td><td>$to</td><td>$version</td><td>$author</td></tr>", true);
-    $sql = "SELECT * FROM " . Database::prefix("translations") . " WHERE language='" . LANGUAGE . "' AND uri='" . httpget("u") . "'";
+    $sql = "SELECT * FROM " . Database::prefix("translations") . " WHERE language='" . LANGUAGE . "' AND uri='" . (string) Http::get('u') . "'";
     $result = Database::query($sql);
     if (Database::numRows($result) > 0) {
         $i = 0;

--- a/village.php
+++ b/village.php
@@ -160,7 +160,7 @@ $comment = Http::post('insertcommentary');
 if (!$op && $com == "" && !$comment && !$refresh && !$commenting) {
     // The '1' should really be sysadmin customizable.
     if (HookHandler::moduleEvents("village", (int)getsetting("villagechance", 0)) != 0) {
-        if (checknavs()) {
+        if (Nav::checkNavs()) {
             Footer::pageFooter();
         } else {
             // Reset the special for good.


### PR DESCRIPTION
## Summary
- replace remaining legacy helper calls in core entry scripts with HookHandler and service-based APIs
- update entry points to use Http and Nav services for request handling and navigation fallbacks

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d2fec6fd5c8329afdc0ca00930e8eb