### PR TITLE
refactor: use DateTime::checkDay in entry points

### DIFF
--- a/gardens.php
+++ b/gardens.php
@@ -1,6 +1,7 @@
 <?php
 
 use Lotgd\Commentary;
+use Lotgd\DateTime;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Output;
@@ -48,7 +49,7 @@ if (!$op && $com == "" && !$comment && !$refresh && !$commenting) {
     }
 }
 if (!$skipgardendesc) {
-    checkday();
+    DateTime::checkDay();
 
     $output->output("`b`c`2The Gardens`0`c`b");
 

--- a/graveyard.php
+++ b/graveyard.php
@@ -1,6 +1,7 @@
 <?php
 
 use Lotgd\Buffs;
+use Lotgd\DateTime;
 use Lotgd\DeathMessage;
 use Lotgd\Battle;
 use Lotgd\AddNews;
@@ -27,7 +28,7 @@ if (!$skipgraveyardtext) {
         redirect("village.php");
     }
 
-    checkday();
+    DateTime::checkDay();
 }
 $battle = false;
 Buffs::stripAllBuffs();

--- a/gypsy.php
+++ b/gypsy.php
@@ -1,6 +1,7 @@
 <?php
 
 use Lotgd\Commentary;
+use Lotgd\DateTime;
 use Lotgd\Translator;
 use Lotgd\Nav;
 use Lotgd\Nav\VillageNav;
@@ -38,7 +39,7 @@ if ($op == "pay") {
     Commentary::commentDisplay("`5While in a deep trance, you are able to talk with the dead:`n", "shade", "Project", 25, "projects");
     Nav::add("Snap out of your trance", "gypsy.php");
 } else {
-    checkday();
+    DateTime::checkDay();
     Header::pageHeader("Gypsy Seer's tent");
     $output->output("`5You duck into a gypsy tent like many you have seen throughout the realm.");
     $output->output("All of them promise to let you talk with the deceased, and most of them surprisingly seem to work.");

--- a/healer.php
+++ b/healer.php
@@ -1,6 +1,7 @@
 <?php
 
 use Lotgd\Translator;
+use Lotgd\DateTime;
 use Lotgd\Forest;
 use Lotgd\Nav;
 use Lotgd\Nav\VillageNav;
@@ -36,7 +37,7 @@ Translator::getInstance()->setSchema();
 
 $op = Http::get('op');
 if ($op == "") {
-    checkday();
+    DateTime::checkDay();
     $output->output("`3You duck into the small smoke-filled grass hut.");
     $output->output("The pungent aroma makes you cough, attracting the attention of a grizzled old person that does a remarkable job of reminding you of a rock, which probably explains why you didn't notice them until now.");
     $output->output("Couldn't be your failure as a warrior.");

--- a/inn.php
+++ b/inn.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Lotgd\Commentary;
 use Lotgd\Buffs;
+use Lotgd\DateTime;
 use Lotgd\Nav\VillageNav;
 use Lotgd\Sanitize;
 use Lotgd\Http;
@@ -39,7 +40,7 @@ Header::pageHeader(["%s", Sanitize::sanitize($iname)]);
 $skipinndesc = Events::handleEvent("inn");
 
 if (!$skipinndesc) {
-    checkday();
+    DateTime::checkDay();
     $output->rawOutput("<span style='color: #9900FF'>");
     $output->outputNotl("`c`b");
     $output->output($iname);

--- a/lodge.php
+++ b/lodge.php
@@ -1,6 +1,7 @@
 <?php
 
 use Lotgd\Commentary;
+use Lotgd\DateTime;
 use Lotgd\Translator;
 use Lotgd\Names;
 use Lotgd\Nav;
@@ -22,7 +23,7 @@ Commentary::addCommentary();
 
 $op = Http::get('op');
 if ($op == "") {
-    checkday();
+    DateTime::checkDay();
 }
 
 $pointsavailable =

--- a/mercenarycamp.php
+++ b/mercenarycamp.php
@@ -1,5 +1,6 @@
 <?php
 
+use Lotgd\DateTime;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Buffs;
@@ -19,7 +20,7 @@ $translator = Translator::getInstance();
 
 $translator->setSchema("mercenarycamp");
 
-checkday();
+DateTime::checkDay();
 $name = stripslashes(rawurldecode(Http::get('name')));
 if (isset($companions[$name])) {
     $displayname = $companions[$name]['name'];

--- a/pavilion.php
+++ b/pavilion.php
@@ -1,6 +1,7 @@
 <?php
 
 use Lotgd\Commentary;
+use Lotgd\DateTime;
 use Lotgd\Translator;
 use Lotgd\Nav\VillageNav;
 
@@ -12,7 +13,7 @@ require_once 'common.php';
 
 Translator::getInstance()->setSchema('pavilion');
 Commentary::addCommentary();
-checkday();
+DateTime::checkDay();
 
 page_header('Eye-catching Pavilion');
 

--- a/pvp.php
+++ b/pvp.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Lotgd\AddNews;
 use Lotgd\Battle;
+use Lotgd\DateTime;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Nav;
@@ -32,7 +33,7 @@ $op = Http::get('op');
 $act = Http::get('act');
 
 if ($op == "" && $act != "attack") {
-    checkday();
+    DateTime::checkDay();
         Pvp::warn();
     $args = array(
         'atkmsg' => '`4You head out to the fields, where you know some unwitting warriors are sleeping.`n`nYou have `^%s`4 PvP fights left for today.`n`n',

--- a/shades.php
+++ b/shades.php
@@ -1,6 +1,7 @@
 <?php
 
 use Lotgd\Commentary;
+use Lotgd\DateTime;
 use Lotgd\Translator;
 use Lotgd\Output;
 use Lotgd\Nav;
@@ -17,7 +18,7 @@ Translator::getInstance()->setSchema("shades");
 
 page_header("Land of the Shades");
 Commentary::addCommentary();
-checkday();
+DateTime::checkDay();
 
 if ($session['user']['alive']) {
     Redirect::redirect("village.php");

--- a/train.php
+++ b/train.php
@@ -1,5 +1,6 @@
 <?php
 
+use Lotgd\DateTime;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\AddNews;
@@ -72,7 +73,7 @@ if (Database::numRows($result) > 0 && $session['user']['level'] < getsetting('ma
 
     $op = Http::get('op');
     if ($op == "") {
-        checkday();
+        DateTime::checkDay();
         $output->output("The sound of conflict surrounds you.  The clang of weapons in grisly battle inspires your warrior heart. ");
         $output->output(
             "`n`n`^%s stands ready to evaluate you.`0",
@@ -145,7 +146,7 @@ if (Database::numRows($result) > 0 && $session['user']['level'] < getsetting('ma
             }
         }
     } elseif ($op == "question") {
-        checkday();
+        DateTime::checkDay();
         Nav::add("Navigation");
         VillageNav::render();
         Nav::add("Actions");
@@ -310,7 +311,7 @@ if (Database::numRows($result) > 0 && $session['user']['level'] < getsetting('ma
         }
     }
 } else {
-    checkday();
+    DateTime::checkDay();
     $output->output("You stroll into the battle grounds.");
     $output->output("Younger warriors huddle together and point as you pass by.");
     $output->output("You know this place well.");

--- a/village.php
+++ b/village.php
@@ -1,5 +1,6 @@
 <?php
 
+use Lotgd\DateTime;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Commentary;
@@ -125,7 +126,7 @@ $translator->setSchema();
 
 Commentary::addCommentary();
 $skipvillagedesc = Events::handleEvent("village");
-checkday();
+DateTime::checkDay();
 
 if ($session['user']['slaydragon'] == 1) {
     $session['user']['slaydragon'] = 0;

--- a/weapons.php
+++ b/weapons.php
@@ -1,5 +1,6 @@
 <?php
 
+use Lotgd\DateTime;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Nav;
@@ -18,7 +19,7 @@ $translator = Translator::getInstance();
 
 $translator->setSchema("weapon");
 
-checkday();
+DateTime::checkDay();
 $tradeinvalue = round(($session['user']['weaponvalue'] * .75), 0);
 $basetext = array(
     "title"         =>  "MightyE's Weapons",


### PR DESCRIPTION
## Summary
- import `Lotgd\DateTime` anywhere we were still calling the legacy `checkday()` helper
- switch each affected entry point to call `DateTime::checkDay()` instead of the global

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d304cb7fb08329871f07a80e03b13b