### PR TITLE
Refactor entrypoints to use Output service

### DIFF
--- a/armor.php
+++ b/armor.php
@@ -21,7 +21,11 @@ use Lotgd\Modules\HookHandler;
 * @see village.php
 * @see armoreditor.php
 */
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 $translator = Translator::getInstance();
 
@@ -61,17 +65,17 @@ $schemas = $texts['schemas'];
 
 $translator->setSchema($schemas['title']);
 Header::pageHeader($texts['title']);
-output("`c`b`%" . $texts['title'] . "`0`b`c");
+$output->output("`c`b`%" . $texts['title'] . "`0`b`c");
 $translator->setSchema();
 $op = Http::get('op');
 if ($op == "") {
     $translator->setSchema($schemas['desc']);
     if (is_array($texts['desc'])) {
         foreach ($texts['desc'] as $description) {
-            output_notl($translator->sprintfTranslate($description));
+            $output->outputNotl($translator->sprintfTranslate($description));
         }
     } else {
-        output($basetext['desc']);
+        $output->output($basetext['desc']);
     }
     $translator->setSchema();
 
@@ -85,24 +89,24 @@ if ($op == "") {
     $translator->setSchema($schemas['tradein']);
     if (is_array($texts['tradein'])) {
         foreach ($texts['tradein'] as $description) {
-            output_notl($translator->sprintfTranslate($description));
+            $output->outputNotl($translator->sprintfTranslate($description));
         }
     } else {
-        output($texts['tradein']);
+        $output->output($texts['tradein']);
     }
     $translator->setSchema();
 
     $aname = Translator::translate("`bName`b");
     $adef = Translator::translate("`bDefense`b");
     $acost = Translator::translate("`bCost`b");
-    rawoutput("<table border='0' cellpadding='0'>");
-    rawoutput("<tr class='trhead'><td>");
-    output_notl($aname);
-    rawoutput("</td><td align='center'>");
-    output_notl($adef);
-    rawoutput("</td><td align='right'>");
-    output_notl($acost);
-    rawoutput("</td></tr>");
+    $output->rawOutput("<table border='0' cellpadding='0'>");
+    $output->rawOutput("<tr class='trhead'><td>");
+    $output->outputNotl($aname);
+    $output->rawOutput("</td><td align='center'>");
+    $output->outputNotl($adef);
+    $output->rawOutput("</td><td align='right'>");
+    $output->outputNotl($acost);
+    $output->rawOutput("</td></tr>");
     $i = 0;
     while ($row = Database::fetchAssoc($result)) {
         $link = true;
@@ -113,37 +117,37 @@ if ($op == "") {
         if (isset($row['unavailable']) && $row['unavailable'] == true) {
             $link = false;
         }
-        rawoutput("<tr class='" . ($i % 2 == 1 ? "trlight" : "trdark") . "'>");
-        rawoutput("<td>");
+        $output->rawOutput("<tr class='" . ($i % 2 == 1 ? "trlight" : "trdark") . "'>");
+        $output->rawOutput("<td>");
         $color = "`)";
         if ($row['value'] <= ($session['user']['gold'] + $tradeinvalue)) {
             if ($link) {
                 $color = "`&";
-                rawoutput("<a href='armor.php?op=buy&id={$row['armorid']}'>");
+                $output->rawOutput("<a href='armor.php?op=buy&id={$row['armorid']}'>");
             } else {
                 $color = "`7";
             }
-            output_notl("%s%s`0", $color, $row['armorname']);
+            $output->outputNotl("%s%s`0", $color, $row['armorname']);
             if ($link) {
-                rawoutput("</a>");
+                $output->rawOutput("</a>");
             }
             Nav::add("", "armor.php?op=buy&id={$row['armorid']}");
         } else {
-            output_notl("%s%s`0", $color, $row['armorname']);
+            $output->outputNotl("%s%s`0", $color, $row['armorname']);
             Nav::add("", "armor.php?op=buy&id={$row['armorid']}");
         }
-        rawoutput("</td><td align='center'>");
-        output_notl("%s%s`0", $color, $row['defense']);
-        rawoutput("</td><td align='right'>");
+        $output->rawOutput("</td><td align='center'>");
+        $output->outputNotl("%s%s`0", $color, $row['defense']);
+        $output->rawOutput("</td><td align='right'>");
         if (isset($row['alternatetext']) && $row['alternatetext'] > "") {
-            output("%s%s`0", $color, $row['alternatetext']);
+            $output->output("%s%s`0", $color, $row['alternatetext']);
         } else {
-            output_notl("%s%s`0", $color, $row['value']);
+            $output->outputNotl("%s%s`0", $color, $row['value']);
         }
-        rawoutput("</td></tr>");
+        $output->rawOutput("</td></tr>");
         ++$i;
     }
-    rawoutput("</table>", true);
+    $output->rawOutput("</table>", true);
     VillageNav::render();
 } elseif ($op == "buy") {
     $id = Http::get('id');
@@ -151,7 +155,7 @@ if ($op == "") {
     $result = Database::query($sql);
     if (Database::numRows($result) == 0) {
         $translator->setSchema($schemas['nosuchweapon']);
-        output($texts['nosuchweapon']);
+        $output->output($texts['nosuchweapon']);
         $translator->setSchema();
         $translator->setSchema($schemas['tryagain']);
         Nav::add($texts['tryagain'], "armor.php");
@@ -162,12 +166,12 @@ if ($op == "") {
         $row = HookHandler::hook("modify-armor", $row);
         if ($row['value'] > ($session['user']['gold'] + $tradeinvalue)) {
             $translator->setSchema($schemas['notenoughgold']);
-            output($texts['notenoughgold'], $row['armorname']);
+            $output->output($texts['notenoughgold'], $row['armorname']);
             $translator->setSchema();
             VillageNav::render();
         } else {
             $translator->setSchema($schemas['payarmor']);
-            output($texts['payarmor'], $session['user']['armor'], $row['armorname'], $row['armorname']);
+            $output->output($texts['payarmor'], $session['user']['armor'], $row['armorname'], $row['armorname']);
             $translator->setSchema();
             debuglog("spent " . ($row['value'] - $tradeinvalue) . " gold on the " . $row['armorname'] . " armor");
             $session['user']['gold'] -= $row['value'];

--- a/armoreditor.php
+++ b/armoreditor.php
@@ -18,7 +18,11 @@ use Lotgd\Forms;
 
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 use Lotgd\Http;
 use Lotgd\Page\Header;
@@ -37,7 +41,7 @@ Nav::add("Armor Editor Home", "armoreditor.php?level=$armorlevel");
 
 Nav::add("Add armor", "armoreditor.php?op=add&level=$armorlevel");
 $values = array(1 => 48,225,585,990,1575,2250,2790,3420,4230,5040,5850,6840,8010,9000,10350);
-output("`&<h3>Armor for %s Dragon Kills</h3>`0", $armorlevel, true);
+$output->output("`&<h3>Armor for %s Dragon Kills</h3>`0", $armorlevel, true);
 
 $armorarray = array(
     "Armor,title",
@@ -56,14 +60,14 @@ if ($op == "edit" || $op == "add") {
         $result = Database::query($sql);
         $row = Database::fetchAssoc($result);
     }
-    rawoutput("<form action='armoreditor.php?op=save&level=$armorlevel' method='POST'>");
+    $output->rawOutput("<form action='armoreditor.php?op=save&level=$armorlevel' method='POST'>");
     Nav::add("", "armoreditor.php?op=save&level=$armorlevel");
     Forms::showForm($armorarray, $row);
-    rawoutput("</form>");
+    $output->rawOutput("</form>");
 } elseif ($op == "del") {
     $sql = "DELETE FROM " . Database::prefix("armor") . " WHERE armorid='$id'";
     Database::query($sql);
-    //output($sql);
+    //$output->output($sql);
     $op = "";
     Http::set('op', $op);
 } elseif ($op == "save") {
@@ -102,26 +106,26 @@ if ($op == "") {
     $del = Translator::translate("Del");
     $delconfirm = Translator::translate("Are you sure you wish to delete this armor?");
 
-    rawoutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
-    rawoutput("<tr class='trhead'><td>$ops</td><td>$name</td><td>$cost</td><td>$defense</td><td>$level</td></tr>");
+    $output->rawOutput("<table border=0 cellpadding=2 cellspacing=1 bgcolor='#999999'>");
+    $output->rawOutput("<tr class='trhead'><td>$ops</td><td>$name</td><td>$cost</td><td>$defense</td><td>$level</td></tr>");
     $number = Database::numRows($result);
     for ($i = 0; $i < $number; $i++) {
         $row = Database::fetchAssoc($result);
-        rawoutput("<tr class='" . ($i % 2 ? "trdark" : "trlight") . "'>");
-        rawoutput("<td>[<a href='armoreditor.php?op=edit&id={$row['armorid']}&level=$armorlevel'>$edit</a>|<a href='armoreditor.php?op=del&id={$row['armorid']}&level=$armorlevel' onClick='return confirm(\"$delconfirm\");'>$del</a>]</td>");
+        $output->rawOutput("<tr class='" . ($i % 2 ? "trdark" : "trlight") . "'>");
+        $output->rawOutput("<td>[<a href='armoreditor.php?op=edit&id={$row['armorid']}&level=$armorlevel'>$edit</a>|<a href='armoreditor.php?op=del&id={$row['armorid']}&level=$armorlevel' onClick='return confirm(\"$delconfirm\");'>$del</a>]</td>");
         Nav::add("", "armoreditor.php?op=edit&id={$row['armorid']}&level=$armorlevel");
         Nav::add("", "armoreditor.php?op=del&id={$row['armorid']}&level=$armorlevel");
-        rawoutput("<td>");
-        output_notl($row['armorname']);
-        rawoutput("</td><td>");
-        output_notl((string)$row['value']);
-        rawoutput("</td><td>");
-        output_notl((string)$row['defense']);
-        rawoutput("</td><td>");
-        output_notl((string)$row['level']);
-        rawoutput("</td>");
-        rawoutput("</tr>");
+        $output->rawOutput("<td>");
+        $output->outputNotl($row['armorname']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl((string)$row['value']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl((string)$row['defense']);
+        $output->rawOutput("</td><td>");
+        $output->outputNotl((string)$row['level']);
+        $output->rawOutput("</td>");
+        $output->rawOutput("</tr>");
     }
-    rawoutput("</table>");
+    $output->rawOutput("</table>");
 }
 Footer::pageFooter();

--- a/badnav.php
+++ b/badnav.php
@@ -22,8 +22,13 @@ use Lotgd\Redirect;
 
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 define("OVERRIDE_FORCED_NAV", true);
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema("badnav");
 

--- a/badword.php
+++ b/badword.php
@@ -22,7 +22,11 @@ use Lotgd\DataCache;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 SuAccess::check(SU_EDIT_COMMENTS);
 

--- a/battle.php
+++ b/battle.php
@@ -21,7 +21,11 @@ use Lotgd\Modules\HookHandler;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 
 //just in case we're called from within a function.Yuck is this ugly.
@@ -90,7 +94,7 @@ if ($op == "fight") {
                 if (is_array($badguy['cannotbetarget'])) {
                     $msg = Translator::getInstance()->sprintfTranslate($badguy['cannotbetarget']);
                     $msg = Substitute::apply($msg);
-                    output_notl($msg); //Here it's already translated
+                    $output->outputNotl($msg); //Here it's already translated
                 } else {
                     if ($badguy['cannotbetarget'] === true) {
                         $msg = "{badguy} cannot be selected as target.";
@@ -98,7 +102,7 @@ if ($op == "fight") {
                         $msg = $badguy['cannotbetarget'];
                     }
                     $msg = Substitute::applyArray("`5" . $msg . "`0`n");
-                    output($msg);
+                    $output->output($msg);
                 }
             }
         } else {
@@ -118,14 +122,14 @@ foreach ($enemies as $index => $enemy) {
 }
 
 if ($enemycounter > 0) {
-    output("`\$`c`b~ ~ ~ Fight ~ ~ ~`b`c`0");
+    $output->output("`\$`c`b~ ~ ~ Fight ~ ~ ~`b`c`0");
     HookHandler::hook("battle", $enemies);
     foreach ($enemies as $index => $badguy) {
         if ($badguy['creaturehealth'] > 0 && $session['user']['hitpoints'] > 0) {
-            output("`@You have encountered `^%s`@ which lunges at you with `%%s`@!`0`n", $badguy['creaturename'], $badguy['creatureweapon']);
+            $output->output("`@You have encountered `^%s`@ which lunges at you with `%%s`@!`0`n", $badguy['creaturename'], $badguy['creatureweapon']);
         }
     }
-    output_notl("`n");
+    $output->outputNotl("`n");
         Battle::showEnemies($enemies);
 }
 
@@ -146,7 +150,7 @@ $surprised = false;
 if ($op != "run" && $op != "fight" && $op != "newtarget") {
     if (count($enemies) > 1) {
         $surprised = true;
-        output("`b`^YOUR ENEMIES`\$ surprise you and get the first round of attack!`0`b`n`n");
+        $output->output("`b`^YOUR ENEMIES`\$ surprise you and get the first round of attack!`0`b`n`n");
     } else {
         // Let's try this instead.Biggest change is that it adds possibility of
         // being surprised to all fights.
@@ -166,12 +170,12 @@ if ($op != "run" && $op != "fight" && $op != "newtarget") {
                 }
             }
             if (!$surprised) {
-                output("`b`\$Your skill allows you to get the first attack!`0`b`n`n");
+                $output->output("`b`\$Your skill allows you to get the first attack!`0`b`n`n");
             } else {
                 if ($options['type'] == 'pvp') {
-                    output("`b`^%s`\$'s skill allows them to get the first round of attack!`0`b`n`n", $badguy['creaturename']);
+                    $output->output("`b`^%s`\$'s skill allows them to get the first round of attack!`0`b`n`n", $badguy['creaturename']);
                 } else {
-                    output("`b`^%s`\$ surprises you and gets the first round of attack!`0`b`n`n", $badguy['creaturename']);
+                    $output->output("`b`^%s`\$ surprises you and gets the first round of attack!`0`b`n`n", $badguy['creaturename']);
                 }
                 $op = "run";
             }
@@ -315,7 +319,7 @@ if ($op != "newtarget") {
                                     }
                                 }
                             } elseif ($op == "run" && !$surprised) {
-                                output("`4You are too busy trying to run away like a cowardly dog to try to fight `^%s`4.`n", $badguy['creaturename']);
+                                $output->output("`4You are too busy trying to run away like a cowardly dog to try to fight `^%s`4.`n", $badguy['creaturename']);
                             }
 
                             //Need to insert this here because of auto-fighting!
@@ -401,7 +405,7 @@ if ($op != "newtarget") {
         $selfdmg = 0;
 
         if (($count != 1 || ($needtostopfighting && $count > 1)) && $session['user']['hitpoints'] > 0 && count($enemies) > 0) {
-            output("`2`bNext round:`b`n");
+            $output->output("`2`bNext round:`b`n");
         }
 
         if (count($newenemies) > 0) {
@@ -432,7 +436,7 @@ if ($op != "newtarget") {
                             $cr_xp_gain = $args['experience'];
                             $session['user']['experience'] += $cr_xp_gain;
                             if (isset($badguy['creatureexp'])) {
-                                output("`#You receive `^%s`# experience!`n`0", $cr_xp_gain);
+                                $output->output("`#You receive `^%s`# experience!`n`0", $cr_xp_gain);
                             }
                             $options['experience'][$index] = $badguy['creatureexp'];
                             $options['experiencegained'][$index] = $cr_xp_gain;
@@ -486,7 +490,7 @@ if ($op != "newtarget") {
                     if (is_array($badguy['fleesifalone'])) {
                         $msg = Translator::getInstance()->sprintfTranslate($badguy['fleesifalone']);
                         $msg = Substitute::apply($msg);
-                        output_notl($msg); //Here it's already translated
+                        $output->outputNotl($msg); //Here it's already translated
                     } else {
                         if ($badguy['fleesifalone'] === true) {
                             $msg = "{badguy} flees in panic.";
@@ -494,7 +498,7 @@ if ($op != "newtarget") {
                             $msg = $badguy['fleesifalone'];
                         }
                         $msg = Substitute::applyArray("`5" . $msg . "`0`n");
-                        output($msg);
+                        $output->output($msg);
                     }
                 } else {
                     $newenemies[$index] = $badguy;
@@ -504,7 +508,7 @@ if ($op != "newtarget") {
             if (isset($badguy['essentialleader']) && is_array($badguy['essentialleader'])) {
                 $msg = Translator::getInstance()->sprintfTranslate($badguy['essentialleader']);
                 $msg = Substitute::apply($msg);
-                output_notl($msg); //Here it's already translated
+                $output->outputNotl($msg); //Here it's already translated
             } elseif (isset($badguy['essentialleader'])) {
                 if ($badguy['essentialleader'] === true) {
                     $msg = "All other other enemies flee in panic as `^{badguy}`5 falls to the ground.";
@@ -512,7 +516,7 @@ if ($op != "newtarget") {
                     $msg = $badguy['essentialleader'];
                 }
                 $msg = Substitute::applyArray("`5" . $msg . "`0`n");
-                output($msg);
+                $output->output($msg);
             }
         }
         if (is_array($newenemies)) {
@@ -528,7 +532,7 @@ if ($op != "newtarget") {
 $newenemies = Battle::autoSetTarget($newenemies);
 
 if ($session['user']['hitpoints'] > 0 && count($newenemies) > 0 && ($op == "fight" || $op == "run")) {
-    output("`2`bEnd of Round:`b`n");
+    $output->output("`2`bEnd of Round:`b`n");
         Battle::showEnemies($newenemies);
 }
 
@@ -554,7 +558,7 @@ if ($victory || $defeat) {
     foreach ($companions as $index => $companion) {
         if (isset($companion['expireafterfight']) && $companion['expireafterfight']) {
             if (isset($companion['dyingtext'])) {
-                output($companion['dyingtext']);
+                $output->output($companion['dyingtext']);
             }
             unset($companions[$index]);
         }
@@ -595,11 +599,11 @@ function battle_player_attacks(&$badguy)
             $creaturedmg = Battle::reportPowerMove((int)$atk, (int)$creaturedmg);
     }
     if ($creaturedmg == 0) {
-        output("`4You try to hit `^%s`4 but `\$MISS!`n", $badguy['creaturename']);
+        $output->output("`4You try to hit `^%s`4 but `\$MISS!`n", $badguy['creaturename']);
         Buffs::processDmgshield($buffset['dmgshield'], 0);
         Buffs::processLIfetaps($buffset['lifetap'], 0);
     } elseif ($creaturedmg < 0) {
-        output("`4You try to hit `^%s`4 but are `\$RIPOSTED `4for `\$%s`4 points of damage!`n", $badguy['creaturename'], (0 - $creaturedmg));
+        $output->output("`4You try to hit `^%s`4 but are `\$RIPOSTED `4for `\$%s`4 points of damage!`n", $badguy['creaturename'], (0 - $creaturedmg));
         $badguy['diddamage'] = 1;
         $session['user']['hitpoints'] += $creaturedmg;
         if ($session['user']['hitpoints'] <= 0) {
@@ -611,7 +615,7 @@ function battle_player_attacks(&$badguy)
         Buffs::processDmgshield($buffset['dmgshield'], -$creaturedmg);
         Buffs::processLIfetaps($buffset['lifetap'], $creaturedmg);
     } else {
-        output("`4You hit `^%s`4 for `^%s`4 points of damage!`n", $badguy['creaturename'], $creaturedmg);
+        $output->output("`4You hit `^%s`4 for `^%s`4 points of damage!`n", $badguy['creaturename'], $creaturedmg);
         $badguy['creaturehealth'] -= $creaturedmg;
         Buffs::processDmgshield($buffset['dmgshield'], -$creaturedmg);
         Buffs::processLIfetaps($buffset['lifetap'], $creaturedmg);
@@ -670,16 +674,16 @@ function battle_badguy_attacks(&$badguy)
         $companions = $newcompanions;
         if ($defended == false) {
             if ($selfdmg == 0) {
-                output("`^%s`4 tries to hit you but `^MISSES!`n", $badguy['creaturename']);
+                $output->output("`^%s`4 tries to hit you but `^MISSES!`n", $badguy['creaturename']);
                 Buffs::processDmgshield($buffset['dmgshield'], 0);
                 Buffs::processLifetaps($buffset['lifetap'], 0);
             } elseif ($selfdmg < 0) {
-                output("`^%s`4 tries to hit you but you `^RIPOSTE`4 for `^%s`4 points of damage!`n", $badguy['creaturename'], (0 - $selfdmg));
+                $output->output("`^%s`4 tries to hit you but you `^RIPOSTE`4 for `^%s`4 points of damage!`n", $badguy['creaturename'], (0 - $selfdmg));
                 $badguy['creaturehealth'] += $selfdmg;
                 Buffs::processLifetaps($buffset['lifetap'], -$selfdmg);
                 Buffs::processDmgshield($buffset['dmgshield'], $selfdmg);
             } else {
-                output("`^%s`4 hits you for `\$%s`4 points of damage!`n", $badguy['creaturename'], $selfdmg);
+                $output->output("`^%s`4 hits you for `\$%s`4 points of damage!`n", $badguy['creaturename'], $selfdmg);
                 $session['user']['hitpoints'] -= $selfdmg;
                 if ($session['user']['hitpoints'] <= 0) {
                     $badguy['killedplayer'] = true;

--- a/bios.php
+++ b/bios.php
@@ -22,7 +22,11 @@ use Lotgd\Nav;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema("bio");
 SuAccess::check(SU_EDIT_COMMENTS);
@@ -47,14 +51,14 @@ $sql = "SELECT name,acctid,bio,biotime FROM " . Database::prefix("accounts") . "
 $result = Database::query($sql);
 Header::pageHeader("User Bios");
 $block = Translator::translate("Block");
-output("`b`&Player Bios:`0`b`n");
+$output->output("`b`&Player Bios:`0`b`n");
 while ($row = Database::fetchAssoc($result)) {
     if ($row['biotime'] > $session['user']['recentcomments']) {
-        rawoutput("<img src='images/new.gif' alt='&gt;' width='3' height='5' align='absmiddle'> ");
+        $output->rawOutput("<img src='images/new.gif' alt='&gt;' width='3' height='5' align='absmiddle'> ");
     }
-    output_notl("`![<a href='bios.php?op=block&userid={$row['acctid']}'>$block</a>]", true);
+    $output->outputNotl("`![<a href='bios.php?op=block&userid={$row['acctid']}'>$block</a>]", true);
     Nav::add("", "bios.php?op=block&userid={$row['acctid']}");
-    output_notl("`&%s`0: `^%s`0`n", $row['name'], soap($row['bio']));
+    $output->outputNotl("`&%s`0: `^%s`0`n", $row['name'], soap($row['bio']));
 }
 Database::freeResult($result);
 SuperuserNav::render();
@@ -68,15 +72,15 @@ if ($session['user']['superuser'] & SU_EDIT_COMMENTS) {
 Nav::add("Refresh", "bios.php");
 $sql = "SELECT name,acctid,bio,biotime FROM " . Database::prefix("accounts") . " WHERE biotime>'9000-01-01' AND bio>'' ORDER BY biotime DESC LIMIT 100";
 $result = Database::query($sql);
-output("`n`n`b`&Blocked Bios:`0`b`n");
+$output->output("`n`n`b`&Blocked Bios:`0`b`n");
 $unblock = Translator::translate("Unblock");
 $number = Database::numRows($result);
 for ($i = 0; $i < $number; $i++) {
     $row = Database::fetchAssoc($result);
 
-    output_notl("`![<a href='bios.php?op=unblock&userid={$row['acctid']}'>$unblock</a>]", true);
+    $output->outputNotl("`![<a href='bios.php?op=unblock&userid={$row['acctid']}'>$unblock</a>]", true);
     Nav::add("", "bios.php?op=unblock&userid={$row['acctid']}");
-    output_notl("`&%s`0: `^%s`0`n", $row['name'], soap($row['bio']));
+    $output->outputNotl("`&%s`0: `^%s`0`n", $row['name'], soap($row['bio']));
 }
 Database::freeResult($result);
 Footer::pageFooter();

--- a/create.php
+++ b/create.php
@@ -22,10 +22,13 @@ use Lotgd\PlayerFunctions;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 define("ALLOW_ANONYMOUS", true);
 
-
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 // Keep this variable named $original: loading the extended settings table may
 // temporarily overwrite the singleton/global $settings instance.

--- a/creatures.php
+++ b/creatures.php
@@ -15,7 +15,11 @@ use Lotgd\Http;
 
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 SuAccess::check(SU_EDIT_CREATURES);
 

--- a/deathmessages.php
+++ b/deathmessages.php
@@ -15,7 +15,11 @@ use Lotgd\Translator;
 // addnews ready
 // mail ready
 // translator ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema("deathmessage");
 

--- a/debug.php
+++ b/debug.php
@@ -12,7 +12,11 @@ use Lotgd\Http;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema("debug");
 

--- a/donators.php
+++ b/donators.php
@@ -14,7 +14,11 @@ use Lotgd\Modules\HookHandler;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 
 SuAccess::check(SU_EDIT_DONATIONS);

--- a/dragon.php
+++ b/dragon.php
@@ -17,7 +17,11 @@ use Lotgd\Modules\HookHandler;
 // addnews ready
 // translator ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 
 Translator::getInstance()->setSchema("dragon");

--- a/globaluserfunctions.php
+++ b/globaluserfunctions.php
@@ -11,7 +11,11 @@ use Lotgd\ServerFunctions;
 use Lotgd\Http;
 use Lotgd\Translator;
 
+use Lotgd\Output;
+
 require_once 'common.php';
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema('globaluserfunctions');
 

--- a/graveyard.php
+++ b/graveyard.php
@@ -16,7 +16,11 @@ use Lotgd\Events;
 // addnews ready.
 // translator ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema("graveyard");
 

--- a/gypsy.php
+++ b/gypsy.php
@@ -13,7 +13,11 @@ use Lotgd\Modules\HookHandler;
 // addnews ready
 // translator ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema("gypsy");
 

--- a/healer.php
+++ b/healer.php
@@ -13,7 +13,11 @@ use Lotgd\Modules\HookHandler;
 // addnews ready
 // translator ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 
 Translator::getInstance()->setSchema("healer");

--- a/hof.php
+++ b/hof.php
@@ -18,7 +18,11 @@ use Lotgd\Modules\HookHandler;
 // New Hall of Fame features by anpera
 // http://www.anpera.net/forum/viewforum.php?f=27
 
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema("hof");
 

--- a/inn.php
+++ b/inn.php
@@ -19,7 +19,11 @@ use Lotgd\Partner;
 // addnews ready
 // translator ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 
 Translator::getInstance()->setSchema("inn");

--- a/installer.php
+++ b/installer.php
@@ -13,6 +13,8 @@ use Lotgd\Settings;
 //addnews ready
 //mail ready
 
+use Lotgd\Output;
+
 define("ALLOW_ANONYMOUS", true);
 define("OVERRIDE_FORCED_NAV", true);
 define("IS_INSTALLER", true);
@@ -54,7 +56,10 @@ if (!file_exists("dbconnect.php")) {
 }
 chdir(__DIR__);
 
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 if (file_exists("dbconnect.php")) {
     require_once __DIR__ . "/dbconnect.php";
 }

--- a/lodge.php
+++ b/lodge.php
@@ -14,7 +14,11 @@ use Lotgd\Modules\HookHandler;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 
 Translator::getInstance()->setSchema("lodge");

--- a/logdnet.php
+++ b/logdnet.php
@@ -17,13 +17,18 @@ use Lotgd\PullUrl;
 // addnews ready
 // mail ready
 
+use Lotgd\Output;
+
 define("ALLOW_ANONYMOUS", true);
 if (!isset($_GET['op']) || $_GET['op'] != 'list') {
     //don't want people to be able to visit the list while logged in -- breaks their navs.
     define("OVERRIDE_FORCED_NAV", true);
 }
 
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema("logdnet");
 
@@ -228,25 +233,25 @@ if ($op == "") {
 } else {
     Header::pageHeader("LoGD Net");
     Nav::add("Login page", "index.php");
-    output("`@Below are a list of other LoGD servers that have registered with the LoGD Net.`n");
-    output("`2It should be noted that this list is subject to editing and culling by the administrators of logdnet.logd.com. ");
-    output("Normally this list is a comprehensive list of all servers that have elected to register with LoGDnet, but I'm making changes to that. ");
-    output("Because this list is a free service provided by logdnet.logd.com, we reserve the right to remove those who we don't want in the list.`n");
-    output("Reasons we might remove a server:`n");
-    output("&#149; Altering our copyright statement outside of the provisions we have provided within the code,`n", true);
-    output("&#149; Removing our PayPal link,`n", true);
-    output("&#149; Providing deceptive, inappropriate, or false information in the server listing,`n", true);
-    output("&#149; Not linking back to LoGDnet`n", true);
-    output("Or really, any other reason that we want.`n");
-    output("If you've been banned already, chances are you know why, and chances are we've got no interest in removing the ban.");
-    output("We provide this free of charge, at the expense of considerable bandwidth and server load, so if you've had the gall to abuse our charity, don't expect it to be won back very easily.`n`n");
-    output("If you are well behaved, we don't have an interest in blocking you from this listing. `0`n");
-    rawoutput("<table border='0' cellpadding='1' cellspacing='0'>");
-    rawoutput("<tr class='trhead'><td>");
-    output("Server");
-    rawoutput("</td><td>");
-    output("Version");
-    rawoutput("</td>");
+    $output->output("`@Below are a list of other LoGD servers that have registered with the LoGD Net.`n");
+    $output->output("`2It should be noted that this list is subject to editing and culling by the administrators of logdnet.logd.com. ");
+    $output->output("Normally this list is a comprehensive list of all servers that have elected to register with LoGDnet, but I'm making changes to that. ");
+    $output->output("Because this list is a free service provided by logdnet.logd.com, we reserve the right to remove those who we don't want in the list.`n");
+    $output->output("Reasons we might remove a server:`n");
+    $output->output("&#149; Altering our copyright statement outside of the provisions we have provided within the code,`n", true);
+    $output->output("&#149; Removing our PayPal link,`n", true);
+    $output->output("&#149; Providing deceptive, inappropriate, or false information in the server listing,`n", true);
+    $output->output("&#149; Not linking back to LoGDnet`n", true);
+    $output->output("Or really, any other reason that we want.`n");
+    $output->output("If you've been banned already, chances are you know why, and chances are we've got no interest in removing the ban.");
+    $output->output("We provide this free of charge, at the expense of considerable bandwidth and server load, so if you've had the gall to abuse our charity, don't expect it to be won back very easily.`n`n");
+    $output->output("If you are well behaved, we don't have an interest in blocking you from this listing. `0`n");
+    $output->rawOutput("<table border='0' cellpadding='1' cellspacing='0'>");
+    $output->rawOutput("<tr class='trhead'><td>");
+    $output->output("Server");
+    $output->rawOutput("</td><td>");
+    $output->output("Version");
+    $output->rawOutput("</td>");
     $servers = array();
     $u = getsetting("logdnetserver", "http://logdnet.logd.com/");
     $logdnet = getsetting('logdnet', 0);
@@ -336,12 +341,12 @@ if ($op == "") {
                 }
 
                 // Output the information we have.
-                rawoutput("<tr class='" . ($i % 2 == 0 ? "trlight" : "trdark") . "'>");
-                rawoutput("<td><a href=\"" . HTMLEntities($row['address'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" target='_blank'>");
-                output_notl("`&%s`0", $row['description'], true);
-                rawoutput("</a></td><td>");
-                output_notl("`^%s`0", $row['version']); // so we are able to translate "`^Unknown`0"
-                rawoutput("</td></tr>");
+                $output->rawOutput("<tr class='" . ($i % 2 == 0 ? "trlight" : "trdark") . "'>");
+                $output->rawOutput("<td><a href=\"" . HTMLEntities($row['address'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" target='_blank'>");
+                $output->outputNotl("`&%s`0", $row['description'], true);
+                $output->rawOutput("</a></td><td>");
+                $output->outputNotl("`^%s`0", $row['version']); // so we are able to translate "`^Unknown`0"
+                $output->rawOutput("</td></tr>");
                 $i++;
             }
         } catch (\Throwable $e) {
@@ -356,15 +361,15 @@ if ($op == "") {
             }
         }
     } elseif (!$logdnet) {
-        rawoutput("<tr><td colspan='2'>");
-        output("LoGDnet server listings are currently disabled.");
-        rawoutput("</td></tr>");
+        $output->rawOutput("<tr><td colspan='2'>");
+        $output->output("LoGDnet server listings are currently disabled.");
+        $output->rawOutput("</td></tr>");
     } else {
-        rawoutput("<tr><td colspan='2'>");
-        output("Sorry, no logdnet host server was defined in the game settings");
-        rawoutput("</td></tr>");
+        $output->rawOutput("<tr><td colspan='2'>");
+        $output->output("Sorry, no logdnet host server was defined in the game settings");
+        $output->rawOutput("</td></tr>");
     }
-    rawoutput("</table>");
+    $output->rawOutput("</table>");
     Footer::pageFooter();
 }
 

--- a/logviewer.php
+++ b/logviewer.php
@@ -11,7 +11,11 @@ use Lotgd\Page\Footer;
 use Lotgd\Http;
 
 
+use Lotgd\Output;
+
 require_once 'common.php';
+
+$output = Output::getInstance();
 
 SuAccess::check(SU_EDIT_CONFIG);
 

--- a/masters.php
+++ b/masters.php
@@ -12,7 +12,11 @@ use Lotgd\Http;
 // Initially written as a module by Chris Vorndran.
 // Moved into core by JT Traub
 
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 SuAccess::check(SU_EDIT_CREATURES);
 

--- a/mercenarycamp.php
+++ b/mercenarycamp.php
@@ -14,7 +14,11 @@ use Lotgd\Modules\HookHandler;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 $translator = Translator::getInstance();
 

--- a/mounts.php
+++ b/mounts.php
@@ -13,7 +13,11 @@ use Lotgd\Modules\HookHandler;
 // addnews ready
 // mail ready
 // translator ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 $op = Http::get('op');
 $id = Http::get('id');

--- a/paylog.php
+++ b/paylog.php
@@ -15,7 +15,11 @@ use Lotgd\Modules\HookHandler;
 // mail ready
 // addnews ready
 // translator ready
+use Lotgd\Output;
+
 require_once 'common.php';
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema("paylog");
 

--- a/rawsql.php
+++ b/rawsql.php
@@ -15,7 +15,11 @@ use Lotgd\Modules\HookHandler;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once 'common.php';
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema("rawsql");
 

--- a/referers.php
+++ b/referers.php
@@ -15,7 +15,11 @@ use Lotgd\Http;
 // mail ready
 
 
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema("referers");
 

--- a/referral.php
+++ b/referral.php
@@ -12,8 +12,13 @@ use Lotgd\Page\Footer;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 define("ALLOW_ANONYMOUS", true);
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 global $session;
 

--- a/rock.php
+++ b/rock.php
@@ -14,7 +14,11 @@ use Lotgd\Modules\HookHandler;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once 'common.php';
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema('rock');
 

--- a/stats.php
+++ b/stats.php
@@ -15,7 +15,11 @@ use Lotgd\Http;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once 'common.php';
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema('stats');
 

--- a/superuser.php
+++ b/superuser.php
@@ -16,7 +16,11 @@ use Lotgd\Sanitize;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 SuAccess::check(0xFFFFFFFF & ~ SU_DOESNT_GIVE_GROTTO);
 Commentary::addCommentary();

--- a/taunt.php
+++ b/taunt.php
@@ -16,7 +16,11 @@ use Lotgd\Translator;
 // addnews ready
 // mail ready
 // translator ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema("taunt");
 

--- a/titleedit.php
+++ b/titleedit.php
@@ -15,7 +15,11 @@ use Lotgd\PlayerFunctions;
 
 //Author: Lonny Luberts - 3/18/2005
 //Heavily modified by JT Traub
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 SuAccess::check(SU_EDIT_USERS);
 

--- a/translatorlounge.php
+++ b/translatorlounge.php
@@ -14,7 +14,11 @@ use Lotgd\Translator;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 SuAccess::check(SU_IS_TRANSLATOR);
 Commentary::addCommentary();

--- a/translatortool.php
+++ b/translatortool.php
@@ -9,8 +9,13 @@ use Lotgd\Http;
 // addnews ready
 // translator ready
 // mail ready
+use Lotgd\Output;
+
 define("OVERRIDE_FORCED_NAV", true);
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 Translator::getInstance()->setSchema("translatortool");
 
 SuAccess::check(SU_IS_TRANSLATOR);
@@ -30,15 +35,15 @@ if ($op == "") {
     $translation = Translator::translate("Translation:");
     $saveclose = htmlentities(Translator::translate("Save & Close"), ENT_COMPAT, getsetting("charset", "UTF-8"));
     $savenotclose = htmlentities(Translator::translate("Save No Close"), ENT_COMPAT, getsetting("charset", "UTF-8"));
-    rawoutput("<form action='translatortool.php?op=save' method='POST'>");
-    rawoutput("$namespace <input name='uri' value=\"" . htmlentities(stripslashes($uri), ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" readonly><br/>");
-    rawoutput("$texta<br>");
-    rawoutput("<textarea name='text' cols='60' rows='5' readonly>" . htmlentities($text, ENT_COMPAT, getsetting("charset", "UTF-8")) . "</textarea><br/>");
-    rawoutput("$translation<br>");
-    rawoutput("<textarea name='trans' cols='60' rows='5'>" . htmlentities(stripslashes($trans), ENT_COMPAT, getsetting("charset", "UTF-8")) . "</textarea><br/>");
-    rawoutput("<input type='submit' value=\"$saveclose\" class='button'>");
-    rawoutput("<input type='submit' value=\"$savenotclose\" class='button' name='savenotclose'>");
-    rawoutput("</form>");
+    $output->rawOutput("<form action='translatortool.php?op=save' method='POST'>");
+    $output->rawOutput("$namespace <input name='uri' value=\"" . htmlentities(stripslashes($uri), ENT_COMPAT, getsetting("charset", "UTF-8")) . "\" readonly><br/>");
+    $output->rawOutput("$texta<br>");
+    $output->rawOutput("<textarea name='text' cols='60' rows='5' readonly>" . htmlentities($text, ENT_COMPAT, getsetting("charset", "UTF-8")) . "</textarea><br/>");
+    $output->rawOutput("$translation<br>");
+    $output->rawOutput("<textarea name='trans' cols='60' rows='5'>" . htmlentities(stripslashes($trans), ENT_COMPAT, getsetting("charset", "UTF-8")) . "</textarea><br/>");
+    $output->rawOutput("<input type='submit' value=\"$saveclose\" class='button'>");
+    $output->rawOutput("<input type='submit' value=\"$savenotclose\" class='button' name='savenotclose'>");
+    $output->rawOutput("</form>");
     popup_footer();
 } elseif ($op == 'save') {
     $uri = (string) Http::post('uri');
@@ -97,56 +102,56 @@ if ($op == "") {
         exit();
     } else {
         popup_header("Updated");
-        rawoutput("<script language='javascript'>window.close();</script>");
+        $output->rawOutput("<script language='javascript'>window.close();</script>");
         popup_footer();
     }
 } elseif ($op == "list") {
     popup_header("Translation List");
     $sql = "SELECT uri,count(*) AS c FROM " . Database::prefix("translations") . " WHERE language='" . LANGUAGE . "' GROUP BY uri ORDER BY uri ASC";
     $result = Database::query($sql);
-    output_notl("<form action='translatortool.php' method='GET'>", true);
-    output_notl("<input type='hidden' name='op' value='list'>", true);
-        output_notl("<label for='u'>", true);
-        output("Known Namespaces:");
-        output_notl("</label>", true);
-        output_notl("<select name='u' id='u'>", true);
+    $output->outputNotl("<form action='translatortool.php' method='GET'>", true);
+    $output->outputNotl("<input type='hidden' name='op' value='list'>", true);
+        $output->outputNotl("<label for='u'>", true);
+        $output->output("Known Namespaces:");
+        $output->outputNotl("</label>", true);
+        $output->outputNotl("<select name='u' id='u'>", true);
     while ($row = Database::fetchAssoc($result)) {
-        output_notl("<option value=\"" . htmlentities($row['uri']) . "\">" . htmlentities($row['uri'], ENT_COMPAT, getsetting("charset", "UTF-8")) . " ({$row['c']})</option>", true);
+        $output->outputNotl("<option value=\"" . htmlentities($row['uri']) . "\">" . htmlentities($row['uri'], ENT_COMPAT, getsetting("charset", "UTF-8")) . " ({$row['c']})</option>", true);
     }
-    output_notl("</select>", true);
+    $output->outputNotl("</select>", true);
     $show = Translator::translate("Show");
-    output_notl("<input type='submit' class='button' value=\"$show\">", true);
-    output_notl("</form>", true);
+    $output->outputNotl("<input type='submit' class='button' value=\"$show\">", true);
+    $output->outputNotl("</form>", true);
     $ops = Translator::translate("Ops");
     $from = Translator::translate("From");
     $to = Translator::translate("To");
     $version = Translator::translate("Version");
     $author = Translator::translate("Author");
     $norows = Translator::translate("No rows found");
-    output_notl("<table border='0' cellpadding='2' cellspacing='0'>", true);
-    output_notl("<tr class='trhead'><td>$ops</td><td>$from</td><td>$to</td><td>$version</td><td>$author</td></tr>", true);
+    $output->outputNotl("<table border='0' cellpadding='2' cellspacing='0'>", true);
+    $output->outputNotl("<tr class='trhead'><td>$ops</td><td>$from</td><td>$to</td><td>$version</td><td>$author</td></tr>", true);
     $sql = "SELECT * FROM " . Database::prefix("translations") . " WHERE language='" . LANGUAGE . "' AND uri='" . (string) Http::get('u') . "'";
     $result = Database::query($sql);
     if (Database::numRows($result) > 0) {
         $i = 0;
         while ($row = Database::fetchAssoc($result)) {
             $i++;
-            output_notl("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'><td>", true);
+            $output->outputNotl("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'><td>", true);
             $edit = Translator::translate("Edit");
-            output_notl("<a href='translatortool.php?u=" . rawurlencode($row['uri']) . "&t=" . rawurlencode($row['intext']) . "'>$edit</a>", true);
-            output_notl("</td><td>", true);
-            rawoutput(htmlentities($row['intext'], ENT_COMPAT, getsetting("charset", "UTF-8")));
-            output_notl("</td><td>", true);
-            rawoutput(htmlentities($row['outtext'], ENT_COMPAT, getsetting("charset", "UTF-8")));
-            output_notl("</td><td>", true);
-            output_notl($row['version']);
-            output_notl("</td><td>", true);
-            output_notl($row['author']);
-            output_notl("</td></tr>", true);
+            $output->outputNotl("<a href='translatortool.php?u=" . rawurlencode($row['uri']) . "&t=" . rawurlencode($row['intext']) . "'>$edit</a>", true);
+            $output->outputNotl("</td><td>", true);
+            $output->rawOutput(htmlentities($row['intext'], ENT_COMPAT, getsetting("charset", "UTF-8")));
+            $output->outputNotl("</td><td>", true);
+            $output->rawOutput(htmlentities($row['outtext'], ENT_COMPAT, getsetting("charset", "UTF-8")));
+            $output->outputNotl("</td><td>", true);
+            $output->outputNotl($row['version']);
+            $output->outputNotl("</td><td>", true);
+            $output->outputNotl($row['author']);
+            $output->outputNotl("</td></tr>", true);
         }
     } else {
-        output_notl("<tr><td colspan='5'>$norows</td></tr>", true);
+        $output->outputNotl("<tr><td colspan='5'>$norows</td></tr>", true);
     }
-    output_notl("</table>", true);
+    $output->outputNotl("</table>", true);
     popup_footer();
 }

--- a/untranslated.php
+++ b/untranslated.php
@@ -16,12 +16,17 @@ use Lotgd\Translator;
 // mail ready
 
 // Okay, someone wants to use this outside of normal game flow.. no real harm
+use Lotgd\Output;
+
 define("OVERRIDE_FORCED_NAV", true);
 
 // Translate Untranslated Strings
 // Originally Written by Christian Rutsch
 // Slightly modified by JT Traub
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 SuAccess::check(SU_IS_TRANSLATOR);
 
@@ -70,31 +75,31 @@ if ($op == "list") {
         $output->rawOutput("</label>");
         $output->rawOutput("<select name='ns' id='ns'>");
     while ($row = Database::fetchAssoc($result)) {
-        rawoutput("<option value=\"" . htmlentities($row['namespace'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"" . ((htmlentities($row['namespace'], ENT_COMPAT, getsetting("charset", "UTF-8")) == $namespace) ? "selected" : "") . ">" . htmlentities($row['namespace'], ENT_COMPAT, getsetting("charset", "UTF-8")) . " ({$row['c']})</option>");
+        $output->rawOutput("<option value=\"" . htmlentities($row['namespace'], ENT_COMPAT, getsetting("charset", "UTF-8")) . "\"" . ((htmlentities($row['namespace'], ENT_COMPAT, getsetting("charset", "UTF-8")) == $namespace) ? "selected" : "") . ">" . htmlentities($row['namespace'], ENT_COMPAT, getsetting("charset", "UTF-8")) . " ({$row['c']})</option>");
     }
     $output->rawOutput("</select>");
     $output->rawOutput("<input type='submit' class='button' value='" . Translator::translate("Show") . "'>");
     $output->rawOutput("<br>");
 
     if ($mode == "edit") {
-        rawoutput(Translator::translate("Text:") . "<br>");
-        rawoutput("<textarea name='intext' cols='60' rows='5' readonly>" . htmlentities(stripslashes(Http::get('intext')), ENT_COMPAT, getsetting("charset", "UTF-8")) . "</textarea><br/>");
-        rawoutput(Translator::translate("Translation:") . "<br>");
-        rawoutput("<textarea name='outtext' cols='60' rows='5'></textarea><br/>");
-        rawoutput("<input type='submit' value='" . Translator::translate("Save") . "' class='button'>");
+        $output->rawOutput(Translator::translate("Text:") . "<br>");
+        $output->rawOutput("<textarea name='intext' cols='60' rows='5' readonly>" . htmlentities(stripslashes(Http::get('intext')), ENT_COMPAT, getsetting("charset", "UTF-8")) . "</textarea><br/>");
+        $output->rawOutput(Translator::translate("Translation:") . "<br>");
+        $output->rawOutput("<textarea name='outtext' cols='60' rows='5'></textarea><br/>");
+        $output->rawOutput("<input type='submit' value='" . Translator::translate("Save") . "' class='button'>");
     } else {
-        rawoutput("<table border='0' cellpadding='2' cellspacing='0'>");
-        rawoutput("<tr class='trhead'><td>" . Translator::translate("Ops") . "</td><td>" . Translator::translate("Text") . "</td></tr>");
+        $output->rawOutput("<table border='0' cellpadding='2' cellspacing='0'>");
+        $output->rawOutput("<tr class='trhead'><td>" . Translator::translate("Ops") . "</td><td>" . Translator::translate("Text") . "</td></tr>");
         $sql = "SELECT * FROM " . Database::prefix("untranslated") . " WHERE language='" . $session['user']['prefs']['language'] . "' AND namespace='" . $namespace . "'";
         $result = Database::query($sql);
         if (Database::numRows($result) > 0) {
             $i = 0;
             while ($row = Database::fetchAssoc($result)) {
                 $i++;
-                rawoutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'><td>");
-                rawoutput("<a href='untranslated.php?op=list&mode=edit&ns=" . rawurlencode($row['namespace']) . "&intext=" . rawurlencode($row['intext']) . "'>" . Translator::translate("Edit") . "</a>");
+                $output->rawOutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'><td>");
+                $output->rawOutput("<a href='untranslated.php?op=list&mode=edit&ns=" . rawurlencode($row['namespace']) . "&intext=" . rawurlencode($row['intext']) . "'>" . Translator::translate("Edit") . "</a>");
                 Nav::add("", "untranslated.php?op=list&mode=edit&ns=" . rawurlencode($row['namespace']) . "&intext=" . rawurlencode($row['intext']));
-                rawoutput("</td><td>");
+                $output->rawOutput("</td><td>");
                 $output->rawOutput(htmlentities($row['intext'], ENT_COMPAT, getsetting("charset", "UTF-8")));
                 $output->rawOutput("</td></tr>");
             }

--- a/user.php
+++ b/user.php
@@ -17,7 +17,11 @@ use Lotgd\UserLookup;
 
 //addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 
 Translator::getInstance()->setSchema("user");

--- a/viewpetition.php
+++ b/viewpetition.php
@@ -17,7 +17,11 @@ use Lotgd\Modules\HookHandler;
 // addnews ready
 // mail ready
 
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 Translator::getInstance()->setSchema('petition');
 

--- a/village.php
+++ b/village.php
@@ -16,7 +16,11 @@ use Lotgd\Settings;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 $settings = Settings::getInstance();
 

--- a/weaponeditor.php
+++ b/weaponeditor.php
@@ -15,7 +15,11 @@ use Lotgd\Http;
 
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 SuAccess::check(SU_EDIT_EQUIPMENT);
 

--- a/weapons.php
+++ b/weapons.php
@@ -13,7 +13,11 @@ use Lotgd\Modules\HookHandler;
 // translator ready
 // addnews ready
 // mail ready
+use Lotgd\Output;
+
 require_once __DIR__ . "/common.php";
+
+$output = Output::getInstance();
 
 $translator = Translator::getInstance();
 


### PR DESCRIPTION
## Summary
- import the Output singleton in entrypoint scripts and capture the instance after the common bootstrap so each page has an explicit handle
- replace legacy output(), output_notl(), and rawoutput() helper calls with the corresponding Output instance methods across the entrypoints

## Testing
- composer static
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d315ff81008329b3fff25a73845ee3