### PR TITLE
fix: load newline converter in clan hall

### DIFF
--- a/pages/clan/clan_default.php
+++ b/pages/clan/clan_default.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Lotgd\Commentary;
 use Lotgd\Modules;
 use Lotgd\Nav;
+use Lotgd\Nltoappon;
 use Lotgd\Repository\ClanRepository;
 use Lotgd\Translator;
 
@@ -29,7 +30,7 @@ function renderClanDefault(): void
     if (isset($claninfo['clanmotd']) && $claninfo['clanmotd'] !== null && $claninfo['clanmotd'] !== '') {
         $output->rawOutput("<div style='margin-left: 15px; padding-left: 15px;'>");
         $output->output("`&`bCurrent MoTD:`b `#by %s`2`n", $motdAuthorName);
-        $output->outputNotl(nltoappon($claninfo['clanmotd']) . "`n");
+        $output->outputNotl(Nltoappon::convert($claninfo['clanmotd']) . "`n");
         $output->rawOutput('</div>');
         $output->outputNotl("`n");
     }
@@ -47,7 +48,7 @@ function renderClanDefault(): void
     if (isset($claninfo['clandesc']) && $claninfo['clandesc'] !== null && $claninfo['clandesc'] !== '') {
         Modules::hook('collapse{', ['name' => 'collapsedesc']);
         $output->output("`n`n`&`bCurrent Description:`b `#by %s`2`n", $descAuthorName);
-        $output->outputNotl(nltoappon($claninfo['clandesc']));
+        $output->outputNotl(Nltoappon::convert($claninfo['clandesc']));
         Modules::hook('}collapse');
     }
 


### PR DESCRIPTION
## Summary
- import the modern Lotgd\Nltoappon helper in the clan hall default page
- replace legacy nltoappon() calls with the namespaced converter to avoid missing function errors

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d395e2acd08329b4cd64bcdd1afeab