### PR TITLE
refactor: use camelCase random helpers

### DIFF
--- a/src/Lotgd/DeathMessage.php
+++ b/src/Lotgd/DeathMessage.php
@@ -27,7 +27,7 @@ class DeathMessage
     {
         global $session, $badguy;
         $where = ($forest ? 'WHERE forest=1' : 'WHERE graveyard=1');
-        $sql = 'SELECT deathmessage,taunt FROM ' . Database::prefix('deathmessages') . " $where ORDER BY rand(" . Random::e_rand() . ') LIMIT 1';
+        $sql = 'SELECT deathmessage,taunt FROM ' . Database::prefix('deathmessages') . " $where ORDER BY rand(" . Random::eRand() . ') LIMIT 1';
         $result = Database::query($sql);
         if ($result) {
             $row = Database::fetchAssoc($result);
@@ -54,7 +54,7 @@ class DeathMessage
     {
         global $session, $badguy;
         $where = ($forest ? 'WHERE forest=1' : 'WHERE graveyard=1');
-        $sql = 'SELECT deathmessage,taunt FROM ' . Database::prefix('deathmessages') . " $where ORDER BY rand(" . Random::e_rand() . ') LIMIT 1';
+        $sql = 'SELECT deathmessage,taunt FROM ' . Database::prefix('deathmessages') . " $where ORDER BY rand(" . Random::eRand() . ') LIMIT 1';
         $result = Database::query($sql);
         if ($result) {
             $row = Database::fetchAssoc($result);

--- a/src/Lotgd/Forest/Outcomes.php
+++ b/src/Lotgd/Forest/Outcomes.php
@@ -49,9 +49,9 @@ class Outcomes
         foreach ($enemies as $badguy) {
             $dropMinGold = $settings->getSetting('dropmingold', 0);
             if ($dropMinGold) {
-                $badguy['creaturegold'] = Random::r_rand(round((int)$badguy['creaturegold'] / 4), round(3 * (int)$badguy['creaturegold'] / 4));
+                $badguy['creaturegold'] = Random::rRand(round((int)$badguy['creaturegold'] / 4), round(3 * (int)$badguy['creaturegold'] / 4));
             } else {
-                $badguy['creaturegold'] = Random::r_rand(0, (int)$badguy['creaturegold']);
+                $badguy['creaturegold'] = Random::rRand(0, (int)$badguy['creaturegold']);
             }
             $gold += $badguy['creaturegold'];
             if (isset($badguy['creaturelose'])) {
@@ -73,7 +73,7 @@ class Outcomes
         $expbonus += (int)$session['user']['dragonkills'] * (int)$session['user']['level'] * $multibonus;
         $totalexp = array_sum($options['experience']);
         $exp = (int) round($totalexp / $count, 0);
-        $gold = (int) round(Random::r_rand(round($gold / $count), round($gold)), 0);
+        $gold = (int) round(Random::rRand(round($gold / $count), round($gold)), 0);
         $expbonus = (int) round($expbonus / $count, 0);
 
         if ($gold) {
@@ -84,7 +84,7 @@ class Outcomes
         $args = HookHandler::hook('alter-gemchance', ['chance' => $gemChance]);
         $gemchances = (int)$args['chance'];
         $maxLevel = $settings->getSetting('maxlevel', 15);
-        if ($session['user']['level'] < $maxLevel && Random::e_rand(1, $gemchances) == 1) {
+        if ($session['user']['level'] < $maxLevel && Random::eRand(1, $gemchances) == 1) {
             $output->output("`&You find A GEM!`n`#");
             $session['user']['gems']++;
             DebugLog::add('found gem when slaying a monster.', false, false, 'forestwingem', 1);
@@ -215,10 +215,10 @@ class Outcomes
             $dk = round($dk * (.25 + $add));
         }
         $expflux = (int) round($badguy['creatureexp'] / 10, 0);
-        $expflux = (int) round(Random::r_rand(-$expflux, $expflux), 0);
+        $expflux = (int) round(Random::rRand(-$expflux, $expflux), 0);
         $badguy['creatureexp'] += $expflux;
-        $atkflux = (int) round(Random::r_rand(0, $dk), 0);
-        $defflux = (int) round(Random::r_rand(0, ($dk - $atkflux)), 0);
+        $atkflux = (int) round(Random::rRand(0, $dk), 0);
+        $defflux = (int) round(Random::rRand(0, ($dk - $atkflux)), 0);
         $hpflux = ($dk - ($atkflux + $defflux)) * 5;
         $badguy['creatureattack'] += $atkflux;
         $badguy['creaturedefense'] += $defflux;

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -1175,7 +1175,7 @@ class Modules
 
         $sql = 'SELECT ' . Database::prefix('module_event_hooks') . '.* FROM ' . Database::prefix('module_event_hooks')
             . ' INNER JOIN ' . Database::prefix('modules') . ' ON ' . Database::prefix('modules') . '.modulename = ' . Database::prefix('module_event_hooks') . '.modulename'
-            . " WHERE $active event_type='$type' ORDER BY RAND(" . Random::e_rand() . ')';
+            . " WHERE $active event_type='$type' ORDER BY RAND(" . Random::eRand() . ')';
         $result = Database::queryCached($sql, 'event-' . $type . '-' . ((int) $allowinactive));
         while ($row = Database::fetchAssoc($result)) {
             ob_start();
@@ -1225,9 +1225,9 @@ class Modules
         }
 
         $output = Output::getInstance();
-        if (Random::e_rand(1, 100) <= $basechance) {
+        if (Random::eRand(1, 100) <= $basechance) {
             $events = self::collectEvents($eventtype, false);
-            $chance = Random::r_rand(1, 100);
+            $chance = Random::rRand(1, 100);
             // debug("C:" . $chance); return 0; // debugging line from original
             $sum = 0;
             foreach ($events as $event) {

--- a/src/Lotgd/PlayerFunctions.php
+++ b/src/Lotgd/PlayerFunctions.php
@@ -482,7 +482,7 @@ class PlayerFunctions
             $useref = "AND ref='$ref'";
             $targetdk = $refdk;
         }
-        $sql = 'SELECT male,female FROM ' . Database::prefix('titles') . " WHERE dk='$targetdk' $useref ORDER BY RAND(" . Random::e_rand() . ") LIMIT 1";
+        $sql = 'SELECT male,female FROM ' . Database::prefix('titles') . " WHERE dk='$targetdk' $useref ORDER BY RAND(" . Random::eRand() . ") LIMIT 1";
         $res = Database::query($sql);
         $row = ['male' => 'God', 'female' => 'Goddess'];
         if (Database::numRows($res) != 0) {


### PR DESCRIPTION
## Summary
- swap remaining core calls to `Random::e_rand()`/`Random::r_rand()` for the camelCase helpers

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d39d0fbb7c8329ae2f380ff28cb454