### PR TITLE
Fix root PHP entry bootstrap and import order

### DIFF
--- a/about.php
+++ b/about.php
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+use Lotgd\DateTime;
+use Lotgd\Http;
+use Lotgd\Nav;
+use Lotgd\Page\Footer;
+use Lotgd\Page\Header;
 use Lotgd\Translator;
 
 // translator ready
@@ -19,12 +24,6 @@ use Lotgd\Translator;
 
 define("ALLOW_ANONYMOUS", true);
 require_once __DIR__ . "/common.php";
-
-use Lotgd\Http;
-use Lotgd\Page\Header;
-use Lotgd\Page\Footer;
-use Lotgd\Nav;
-use Lotgd\DateTime;
 
 Translator::getInstance()->setSchema("about");
 

--- a/armoreditor.php
+++ b/armoreditor.php
@@ -2,7 +2,15 @@
 
 declare(strict_types=1);
 
+use Lotgd\Forms;
+use Lotgd\Http;
 use Lotgd\MySQL\Database;
+use Lotgd\Nav;
+use Lotgd\Nav\SuperuserNav;
+use Lotgd\Output;
+use Lotgd\Page\Footer;
+use Lotgd\Page\Header;
+use Lotgd\SuAccess;
 use Lotgd\Translator;
 
 /**
@@ -11,23 +19,14 @@ use Lotgd\Translator;
  * @see armor.php
  */
 
-use Lotgd\SuAccess;
-use Lotgd\Nav\SuperuserNav;
 // translator ready
-use Lotgd\Forms;
 
 // addnews ready
 // mail ready
-use Lotgd\Output;
 
 require_once __DIR__ . "/common.php";
 
 $output = Output::getInstance();
-
-use Lotgd\Http;
-use Lotgd\Page\Header;
-use Lotgd\Page\Footer;
-use Lotgd\Nav;
 
 SuAccess::check(SU_EDIT_EQUIPMENT);
 

--- a/cron.php
+++ b/cron.php
@@ -24,7 +24,7 @@ BootstrapErrorHandler::register();
 $result = chdir(__DIR__);
 if (!defined('CRON_TEST')) {
     try {
-        require_once 'common.php';
+        require_once __DIR__ . '/common.php';
     } catch (\Throwable $e) {
         $message = sprintf(
             '[%s] Cron common.php failure: %s in %s on line %d%s',

--- a/globaluserfunctions.php
+++ b/globaluserfunctions.php
@@ -13,7 +13,7 @@ use Lotgd\Translator;
 
 use Lotgd\Output;
 
-require_once 'common.php';
+require_once __DIR__ . '/common.php';
 
 $output = Output::getInstance();
 

--- a/login.php
+++ b/login.php
@@ -19,8 +19,7 @@ use Lotgd\Settings;
 
 define("ALLOW_ANONYMOUS", true);
 require_once __DIR__ . "/common.php";
-// This must be after common.php for now
-use Lotgd\ServerFunctions;
+// Lotgd\ServerFunctions relies on the bootstrap inside common.php.
 
 $output = Output::getInstance();
 $settings = Settings::getInstance();
@@ -85,7 +84,7 @@ if ($name != "") {
             // this hook should automatically call page_footer and exit
             // itself.
             HookHandler::hook("check-login");
-            if (ServerFunctions::isTheServerFull() == true && $force !== '1') {
+            if (\Lotgd\ServerFunctions::isTheServerFull() === true && $force !== '1') {
                 //sanity check if the server is / got full --> back to home
                 $session['message'] = Translator::translateInline("`4Sorry, server full!");
                 $session['user'] = array();

--- a/logviewer.php
+++ b/logviewer.php
@@ -13,7 +13,7 @@ use Lotgd\Http;
 
 use Lotgd\Output;
 
-require_once 'common.php';
+require_once __DIR__ . '/common.php';
 
 $output = Output::getInstance();
 

--- a/rock.php
+++ b/rock.php
@@ -16,7 +16,7 @@ use Lotgd\Modules\HookHandler;
 // mail ready
 use Lotgd\Output;
 
-require_once 'common.php';
+require_once __DIR__ . '/common.php';
 
 $output = Output::getInstance();
 

--- a/stats.php
+++ b/stats.php
@@ -17,7 +17,7 @@ use Lotgd\Http;
 // mail ready
 use Lotgd\Output;
 
-require_once 'common.php';
+require_once __DIR__ . '/common.php';
 
 $output = Output::getInstance();
 


### PR DESCRIPTION
## Summary
- reorganize `use` statements in `about.php` and `armoreditor.php` so imports sit before runtime code
- drop the delayed `ServerFunctions` import in `login.php` and use a fully qualified reference instead
- update remaining root entry points to require `common.php` via `__DIR__`-relative paths, including the cron bootstrap

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d3a15bd9508329bd96fe7146153198