### PR TITLE
Declare strict types in root PHP entry points

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $autoloadPath = __DIR__ . '/vendor/autoload.php';
 if (!file_exists($autoloadPath)) {
     throw new RuntimeException("The vendor autoload file was not found at: {$autoloadPath}");

--- a/clan.php
+++ b/clan.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\Settings;
 use Lotgd\Translator;
 use Lotgd\SuAccess;

--- a/common.php
+++ b/common.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\Translator;
 
 require_once __DIR__ . '/autoload.php';

--- a/configuration.php
+++ b/configuration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;

--- a/corenews.php
+++ b/corenews.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use ErrorException;
 use Exception;
 use Lotgd\DataCache;

--- a/create.php
+++ b/create.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;

--- a/creatures.php
+++ b/creatures.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;

--- a/cron.php
+++ b/cron.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/autoload.php';
 
 use Lotgd\BootstrapErrorHandler;

--- a/debug.php
+++ b/debug.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;

--- a/donators.php
+++ b/donators.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;

--- a/dragon.php
+++ b/dragon.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Buffs;

--- a/forest.php
+++ b/forest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Forest;

--- a/gamelog.php
+++ b/gamelog.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;

--- a/gardens.php
+++ b/gardens.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\Commentary;
 use Lotgd\DateTime;
 use Lotgd\Http;

--- a/graveyard.php
+++ b/graveyard.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\Buffs;
 use Lotgd\DateTime;
 use Lotgd\DeathMessage;

--- a/gypsy.php
+++ b/gypsy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\Commentary;
 use Lotgd\DateTime;
 use Lotgd\Translator;

--- a/healer.php
+++ b/healer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\Translator;
 use Lotgd\DateTime;
 use Lotgd\Forest;

--- a/installer.php
+++ b/installer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\Translator;
 use Lotgd\DataCache;
 use Lotgd\Http;

--- a/lodge.php
+++ b/lodge.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\Commentary;
 use Lotgd\DateTime;
 use Lotgd\Translator;

--- a/login.php
+++ b/login.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;

--- a/mail.php
+++ b/mail.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\Http;
 use Lotgd\Mail;
 use Lotgd\Modules\HookHandler;

--- a/masters.php
+++ b/masters.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;

--- a/mercenarycamp.php
+++ b/mercenarycamp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\DateTime;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;

--- a/moderate.php
+++ b/moderate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Settings;
 use Lotgd\Translator;

--- a/modules.php
+++ b/modules.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
 use Lotgd\Translator;

--- a/motd.php
+++ b/motd.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\Accounts;
 use Lotgd\AddNews;
 use Lotgd\Commentary;

--- a/mounts.php
+++ b/mounts.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;

--- a/newday.php
+++ b/newday.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Settings;
 use Lotgd\Translator;

--- a/news.php
+++ b/news.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Settings;
 use Lotgd\Translator;

--- a/pavilion.php
+++ b/pavilion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\Commentary;
 use Lotgd\DateTime;
 use Lotgd\Nav\VillageNav;

--- a/prefs.php
+++ b/prefs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Settings;
 use Lotgd\Translator;

--- a/referers.php
+++ b/referers.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;

--- a/referral.php
+++ b/referral.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Settings;

--- a/shades.php
+++ b/shades.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\Commentary;
 use Lotgd\Modules\HookHandler;
 use Lotgd\DateTime;

--- a/source.php
+++ b/source.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\ErrorHandling;
 use Lotgd\Http;
 use Lotgd\Output;

--- a/stables.php
+++ b/stables.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Settings;
 use Lotgd\Translator;

--- a/superuser.php
+++ b/superuser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;

--- a/titleedit.php
+++ b/titleedit.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;

--- a/train.php
+++ b/train.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\DateTime;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;

--- a/translatortool.php
+++ b/translatortool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;

--- a/user.php
+++ b/user.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;

--- a/village.php
+++ b/village.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\DateTime;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;

--- a/weaponeditor.php
+++ b/weaponeditor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\SuAccess;

--- a/weapons.php
+++ b/weapons.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Lotgd\DateTime;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;


### PR DESCRIPTION
## Summary
- add `declare(strict_types=1);` to the remaining root-level entry points so they follow the repository guidelines

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d3a6e8355483299f87402ccf9e3323