### PR TITLE
fix: guard optional request parameters

### DIFF
--- a/mercenarycamp.php
+++ b/mercenarycamp.php
@@ -27,7 +27,12 @@ $translator = Translator::getInstance();
 $translator->setSchema("mercenarycamp");
 
 DateTime::checkDay();
-$name = stripslashes(rawurldecode(Http::get('name')));
+$nameParam = Http::get('name');
+if ($nameParam !== false) {
+    $name = stripslashes(rawurldecode($nameParam));
+} else {
+    $name = '';
+}
 if (isset($companions[$name])) {
     $displayname = $companions[$name]['name'];
 } else {

--- a/motd.php
+++ b/motd.php
@@ -103,6 +103,9 @@ if ($op == "") {
         Motd::motditem("Beta!","Please see the beta message below.","","", "");
         */
     $month_post = Http::post("month");
+    if (!is_string($month_post)) {
+        $month_post = '';
+    }
     //SQL Injection attack possible -> kill it off after 7 letters as format is i.e. "2000-05"
     $month_post = substr($month_post, 0, 7);
     if (preg_match("/[0-9][0-9][0-9][0-9]-[0-9][0-9]/", $month_post) !== 1) {


### PR DESCRIPTION
## Summary
- avoid calling `rawurldecode` with a false value when the mercenary name query parameter is missing
- ensure the MoTD month filter treats missing submissions as an empty string before truncating

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d3afc6f9688329b998dabb21d974e7