### PR TITLE
Ensure dynamic output strings use explicit formats

### DIFF
--- a/armor.php
+++ b/armor.php
@@ -75,7 +75,7 @@ if ($op == "") {
             $output->outputNotl($translator->sprintfTranslate($description));
         }
     } else {
-        $output->output($basetext['desc']);
+        $output->output('%s', $basetext['desc']);
     }
     $translator->setSchema();
 
@@ -92,7 +92,7 @@ if ($op == "") {
             $output->outputNotl($translator->sprintfTranslate($description));
         }
     } else {
-        $output->output($texts['tradein']);
+        $output->output('%s', $texts['tradein']);
     }
     $translator->setSchema();
 
@@ -155,7 +155,7 @@ if ($op == "") {
     $result = Database::query($sql);
     if (Database::numRows($result) == 0) {
         $translator->setSchema($schemas['nosuchweapon']);
-        $output->output($texts['nosuchweapon']);
+        $output->output('%s', $texts['nosuchweapon']);
         $translator->setSchema();
         $translator->setSchema($schemas['tryagain']);
         Nav::add($texts['tryagain'], "armor.php");

--- a/bans.php
+++ b/bans.php
@@ -46,14 +46,14 @@ if (!$query && $sort) {
     $query = "%";
 }
 
-if ($op == "search" || $op == "") {
-    list($searchresult, $err) = UserLookup::lookup($query, $order);
-    $op = "";
-    if ($err) {
-        $output->output($err);
-    } else {
-        if ($searchresult) {
-            $display = 1;
+    if ($op == "search" || $op == "") {
+        list($searchresult, $err) = UserLookup::lookup($query, $order);
+        $op = "";
+        if ($err) {
+            $output->output('%s', $err);
+        } else {
+            if ($searchresult) {
+                $display = 1;
         }
     }
 }

--- a/battle.php
+++ b/battle.php
@@ -105,7 +105,7 @@ if ($op == "fight") {
                         $msg = $badguy['cannotbetarget'];
                     }
                     $msg = Substitute::applyArray("`5" . $msg . "`0`n");
-                    $output->output($msg);
+                    $output->output('%s', $msg);
                 }
             }
         } else {
@@ -501,7 +501,7 @@ if ($op != "newtarget") {
                             $msg = $badguy['fleesifalone'];
                         }
                         $msg = Substitute::applyArray("`5" . $msg . "`0`n");
-                        $output->output($msg);
+                        $output->output('%s', $msg);
                     }
                 } else {
                     $newenemies[$index] = $badguy;
@@ -519,7 +519,7 @@ if ($op != "newtarget") {
                     $msg = $badguy['essentialleader'];
                 }
                 $msg = Substitute::applyArray("`5" . $msg . "`0`n");
-                $output->output($msg);
+                $output->output('%s', $msg);
             }
         }
         if (is_array($newenemies)) {
@@ -561,7 +561,7 @@ if ($victory || $defeat) {
     foreach ($companions as $index => $companion) {
         if (isset($companion['expireafterfight']) && $companion['expireafterfight']) {
             if (isset($companion['dyingtext'])) {
-                $output->output($companion['dyingtext']);
+                $output->output('%s', $companion['dyingtext']);
             }
             unset($companions[$index]);
         }

--- a/inn.php
+++ b/inn.php
@@ -49,7 +49,7 @@ if (!$skipinndesc) {
     DateTime::checkDay();
     $output->rawOutput("<span style='color: #9900FF'>");
     $output->outputNotl("`c`b");
-    $output->output($iname);
+    $output->output('%s', $iname);
     $output->outputNotl("`b`c");
 }
 

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1271,7 +1271,7 @@ class Installer
                     if (isset($moduleinfo['invalid']) && $moduleinfo['invalid'] == true) {
                         $this->output->rawOutput($moduleinfo['formalname']);
                     } else {
-                        $this->output->output($moduleinfo['formalname']);
+                    $this->output->output('%s', $moduleinfo['formalname']);
                     }
                     $this->output->outputNotl(" [`%$modulename`@]`0");
                     $this->output->rawOutput("</span></td><td>");

--- a/list.php
+++ b/list.php
@@ -222,7 +222,7 @@ foreach ($rows as $i => $row) {
         $row['race'] = RACE_UNKNOWN;
     }
     Translator::getInstance()->setSchema("race");
-    $output->output($row['race']);
+    $output->output('%s', $row['race']);
     Translator::getInstance()->setSchema();
     $output->rawOutput("</td><td>");
     $sex = Translator::translate($row['sex'] ? "`%Female`0" : "`!Male`0");

--- a/mercenarycamp.php
+++ b/mercenarycamp.php
@@ -123,7 +123,7 @@ if ($op == "") {
                 $output->outputNotl($translator->sprintfTranslate($description));
             }
         } else {
-            $output->output($texts['desc']);
+            $output->output('%s', $texts['desc']);
         }
         $translator->setSchema();
     }
@@ -171,7 +171,7 @@ if ($op == "") {
                 $output->outputNotl($translator->sprintfTranslate($healnotenough));
             }
         } else {
-            $output->output($texts['healnotenough']);
+            $output->output('%s', $texts['healnotenough']);
         }
         $translator->setSchema();
     } else {
@@ -185,7 +185,7 @@ if ($op == "") {
                 $output->outputNotl($translator->sprintfTranslate($healpaid));
             }
         } else {
-            $output->output($texts['healpaid']);
+            $output->output('%s', $texts['healpaid']);
         }
         $translator->setSchema();
     }
@@ -206,7 +206,7 @@ if ($op == "") {
         if (Buffs::applyCompanion($row['name'], $row)) {
             $output->output("`QYou hand over `^%s gold`Q and `%%s %s`Q.`n`n", (int)$row['companioncostgold'], (int)$row['companioncostgems'], Translator::translate($row['companioncostgems'] == 1 ? "gem" : "gems"));
             if (isset($row['jointext']) && $row['jointext'] > "") {
-                $output->output($row['jointext']);
+                $output->output('%s', $row['jointext']);
             }
             $session['user']['gold'] -= $row['companioncostgold'];
             $session['user']['gems'] -= $row['companioncostgems'];
@@ -219,7 +219,7 @@ if ($op == "") {
                     $output->outputNotl($translator->sprintfTranslate($toomanycompanions));
                 }
             } else {
-                $output->output($texts['toomanycompanions']);
+                $output->output('%s', $texts['toomanycompanions']);
             }
             $translator->setSchema();
         }
@@ -261,7 +261,7 @@ function healnav($companions, $texts, $schemas)
                 $output->outputNotl($translator->sprintfTranslate($healtext));
             }
         } else {
-            $output->output($texts['healtext']);
+            $output->output('%s', $texts['healtext']);
         }
         $translator->setSchema();
     }

--- a/modules/cities.php
+++ b/modules/cities.php
@@ -132,20 +132,20 @@ function cities_dohook(string $hookname, array $args): array
             if ($info['used'] < $info['available']) {
                 set_module_pref("traveltoday", get_module_pref("traveltoday") + 1);
                 if (isset($args['traveltext'])) {
-                    output($args['traveltext']);
+                    output('%s', $args['traveltext']);
                 }
                 $args['success'] = true;
                 $args['type'] = 'travel';
             } elseif ($session['user']['turns'] > 0) {
                 $session['user']['turns']--;
                 if (isset($args['foresttext'])) {
-                    output($args['foresttext']);
+                    output('%s', $args['foresttext']);
                 }
                 $args['success'] = true;
                 $args['type'] = 'forest';
             } else {
                 if (isset($args['nonetext'])) {
-                    output($args['nonetext']);
+                    output('%s', $args['nonetext']);
                 }
                 $args['success'] = false;
                 $args['type'] = 'none';

--- a/modules/lovers.php
+++ b/modules/lovers.php
@@ -144,7 +144,7 @@ function lovers_run(): void
     page_header($iname);
     rawoutput("<span style='color: #9900FF'>");
     output_notl("`c`b");
-    output($iname);
+    output('%s', $iname);
     output_notl("`b`c");
     switch (httpget('op')) {
         case "flirt":

--- a/newday.php
+++ b/newday.php
@@ -195,7 +195,7 @@ if ($dp < $dkills) {
                     array_key_exists('newdaymessage', $val) &&
                         $val['newdaymessage']
                 ) {
-                    $output->output($val['newdaymessage']);
+                    $output->output('%s', $val['newdaymessage']);
                     $output->outputNotl("`n");
                 }
                 if (array_key_exists('schema', $val) && $val['schema']) {
@@ -320,7 +320,7 @@ if ($dp < $dkills) {
         $mount = Mounts::getInstance()->getPlayerMount();
         $msg   = $mount['newday'];
         $msg   = Substitute::applyArray("`n`&" . $msg . "`0`n");
-        $output->output($msg);
+        $output->output('%s', $msg);
                 list($name, $lcname) = MountName::getmountname();
 
         $mff = (int) $mount['mountforestfights'];

--- a/pages/about/about_listmodules.php
+++ b/pages/about/about_listmodules.php
@@ -29,7 +29,7 @@ while ($row = Database::fetchAssoc($result)) {
     $i++;
     if ($cat != $row['category']) {
         $output->rawOutput("<tr class='trhead'><td colspan='4' align='left'>");
-        $output->output($row['category']);
+        $output->output('%s', $row['category']);
         $output->rawOutput(":</td></tr>");
         $cat = $row['category'];
     }

--- a/pages/mail/case_default.php
+++ b/pages/mail/case_default.php
@@ -16,7 +16,7 @@ function mailDefault(): void
 
     output('`b`iMail Box`i`b');
     if (isset($session['message'])) {
-        output($session['message']);
+        output('%s', $session['message']);
     }
     $session['message'] = '';
 
@@ -122,10 +122,10 @@ function renderMailRows(array $rows, array $userStatusList, string $noSubject): 
         }
 
         rawoutput("<a href='mail.php?op=read&id={$row['messageid']}'>");
-        output_notl((trim($row['subject']) ? $row['subject'] : $noSubject));
+        output_notl('%s', trim($row['subject']) ? $row['subject'] : $noSubject);
         rawoutput('</a>');
         rawoutput("</td><td><a href='mail.php?op=read&id={$row['messageid']}'>");
-        output_notl($row['name']);
+        output_notl('%s', $row['name']);
         rawoutput("</a>$statusImage</td><td><a href='mail.php?op=read&id={$row['messageid']}'>" . date('M d, h:i a', strtotime($row['sent'])) . '</a></td>');
         rawoutput('</tr>');
     }

--- a/pages/mail/case_read.php
+++ b/pages/mail/case_read.php
@@ -114,7 +114,7 @@ function mailRead(): void
 
     // Message headers
     output('`b`2From:`b `^%s', $message['name']);
-    output_notl($statusImage . '`n', true);
+    output_notl('%s', ($statusImage ?? '') . '`n', true);
     output('`b`2Subject:`b `^%s`n', $message['subject']);
     output('`b`2Sent:`b `^%s`n', $message['sent']);
 
@@ -127,7 +127,7 @@ function mailRead(): void
     rawoutput('</tr></table><br/>');
 
     // Message body
-    output_notl(Sanitize::sanitizeMb(str_replace("\n", '`n', $message['body'])));
+    output_notl('%s', Sanitize::sanitizeMb(str_replace("\n", '`n', $message['body'])));
 
     // Mark as read
     Mail::markRead($session['user']['acctid'], $messageId);

--- a/pages/petition/petition_default.php
+++ b/pages/petition/petition_default.php
@@ -73,7 +73,7 @@ if (count($post) > 0 && (string) Http::post('abuse') !== 'yes') {
             $output->output("`\$There was a problem with your petition!`n");
             $output->output("`@Please read the information below carefully; there was a problem with your petition, and it was not submitted.\n");
             $output->rawOutput("<blockquote>");
-            $output->output($post['cancelreason']);
+            $output->output('%s', $post['cancelreason']);
             $output->rawOutput("</blockquote>");
         }
     } else {

--- a/src/Lotgd/Battle.php
+++ b/src/Lotgd/Battle.php
@@ -124,7 +124,7 @@ class Battle
             }
             if ($power) {
                 Translator::getInstance()->setSchema('battle');
-                Output::getInstance()->output($msg);
+                Output::getInstance()->output('%s', $msg);
                 Translator::getInstance()->setSchema();
 
                 $dmg += random_int((int)($crit / 4), (int)($crit / 2));
@@ -159,7 +159,7 @@ class Battle
             if ($schema) {
                 Translator::getInstance()->setSchema($schema);
             }
-            Output::getInstance()->output(Sanitize::sanitizeMb($msg));
+                Output::getInstance()->output('%s', Sanitize::sanitizeMb($msg));
             if ($schema) {
                 Translator::getInstance()->setSchema();
             }
@@ -184,7 +184,7 @@ class Battle
             if ($schema) {
                 Translator::getInstance()->setSchema($schema);
             }
-            Output::getInstance()->output($msg);
+            Output::getInstance()->output('%s', $msg);
             if ($schema) {
                 Translator::getInstance()->setSchema();
             }
@@ -205,7 +205,7 @@ class Battle
             if ($schema) {
                 Translator::getInstance()->setSchema($schema);
             }
-            Output::getInstance()->output($msg);
+            Output::getInstance()->output('%s', $msg);
             if ($schema) {
                 Translator::getInstance()->setSchema();
             }
@@ -241,7 +241,7 @@ class Battle
             if ($schema) {
                 Translator::getInstance()->setSchema($schema);
             }
-            Output::getInstance()->output($msg);
+            Output::getInstance()->output('%s', $msg);
             if ($schema) {
                 Translator::getInstance()->setSchema();
             }
@@ -645,7 +645,7 @@ class Battle
                 if ($schema) {
                     Translator::getInstance()->setSchema($schema);
                 }
-                Output::getInstance()->output($nomsg);
+                Output::getInstance()->output('%s', $nomsg);
                 if ($schema) {
                     Translator::getInstance()->setSchema();
                 }
@@ -685,7 +685,7 @@ class Battle
                 if ($schema) {
                     Translator::getInstance()->setSchema($schema);
                 }
-                Output::getInstance()->output($nomsg);
+                Output::getInstance()->output('%s', $nomsg);
                 if ($schema) {
                     Translator::getInstance()->setSchema();
                 }
@@ -786,7 +786,7 @@ class Battle
                 }
                     $msg = Substitute::applyArray("`)" . $msg . "`0`n", array("{companion}","{damage}"), array($companion['name'],$hptoheal));
                     Translator::getInstance()->setSchema(isset($companion['schema']) ? $companion['schema'] : "battle");
-                    $output->output($msg);
+                    $output->output('%s', $msg);
                     Translator::getInstance()->setSchema();
             } else {
                     // Okay. We really have to do this :(
@@ -809,7 +809,7 @@ class Battle
                         }
                         $msg = Substitute::applyArray("`)" . $msg . "`0`n", array("{companion}","{damage}","{target}"), array($companion['name'],$hptoheal,$mycompanion['name']));
                         Translator::getInstance()->setSchema(isset($companion['schema']) ? $companion['schema'] : "battle");
-                        $output->output($msg);
+                        $output->output('%s', $msg);
                         Translator::getInstance()->setSchema();
                         $healed = true;
                         $newcompanions[$myname] = $mycompanion;
@@ -840,7 +840,7 @@ class Battle
                                     }
                                     $msg = Substitute::applyArray("`)" . $msg . "`0`n", array("{companion}","{damage}","{target}"), array($companion['name'],$hptoheal,$mycompanion['name']));
                                     Translator::getInstance()->setSchema(isset($companion['schema']) ? $companion['schema'] : "battle");
-                                    $output->output($msg);
+                                    $output->output('%s', $msg);
                                     Translator::getInstance()->setSchema();
                                     $healed = true;
                                     $companions[$myname] = $mycompanion;
@@ -905,7 +905,7 @@ class Battle
                 }
                        $msg = Substitute::applyArray("`)" . $msg . "`0`n", array("{companion}"), array($companion['name']));
                        Translator::getInstance()->setSchema(isset($companion['schema']) ? $companion['schema'] : "battle");
-                       $output->output($msg);
+                       $output->output('%s', $msg);
                        Translator::getInstance()->setSchema();
             } else {
                 if (isset($companion['magicmsg'])) {
@@ -915,7 +915,7 @@ class Battle
                 }
                       $msg = Substitute::applyArray("`)" . $msg . "`0`n", array("{companion}","{damage}"), array($companion['name'],$damage_done));
                       Translator::getInstance()->setSchema(isset($companion['schema']) ? $companion['schema'] : "battle");
-                      $output->output($msg);
+                      $output->output('%s', $msg);
                       Translator::getInstance()->setSchema();
                       $badguy['creaturehealth'] -= $damage_done;
             }
@@ -936,7 +936,7 @@ class Battle
             }
             $msg = Substitute::applyArray("`)" . $msg . "`0`n", array("{companion}"), array($companion['name']));
             Translator::getInstance()->setSchema(isset($companion['schema']) ? $companion['schema'] : "battle");
-            $output->output($msg);
+            $output->output('%s', $msg);
             $output->outputNotl("`0`n");
             Translator::getInstance()->setSchema();
             if (isset($companion['cannotdie']) && $companion['cannotdie'] == true) {

--- a/src/Lotgd/Buffs.php
+++ b/src/Lotgd/Buffs.php
@@ -332,7 +332,7 @@ class Buffs
                     $output->outputNotl($msg);
                 } else {
                     $msg = Substitute::applyArray("`5" . $buff['startmsg'] . "`0`n");
-                    $output->output($msg);
+                    $output->output('%s', $msg);
                 }
 
                 unset($session['bufflist'][$key]['startmsg']);
@@ -396,7 +396,7 @@ class Buffs
                         $output->outputNotl($msg);
                     } else {
                         $msg = Substitute::applyArray("`5" . $buff['roundmsg'] . "`0`n");
-                        $output->output($msg);
+                        $output->output('%s', $msg);
                     }
                 }
             }
@@ -461,7 +461,7 @@ class Buffs
                     $output->outputNotl($msg);
                 } elseif ($msg != '') {
                     $msg = Substitute::applyArray('`)' . $msg . '`0`n', ['{damage}'], [$hptoregen]);
-                    $output->output($msg);
+                    $output->output('%s', $msg);
                 }
                 if (isset($buff['aura']) && $buff['aura'] == true) {
                     global $companions;
@@ -476,11 +476,11 @@ class Buffs
                                 $hptoregen = min($auraeffect, $companion['maxhitpoints'] - $companion['hitpoints']);
                                 $companions[$name]['hitpoints'] += $hptoregen;
                                 $msg = Substitute::applyArray('`)' . $buff['auramsg'] . '`0`n', ['{damage}', '{companion}'], [$hptoregen, $companion['name']]);
-                                $output->output($msg);
+                                $output->output('%s', $msg);
                                 if ($hptoregen < 0 && $companion['hitpoints'] <= 0) {
                                     if (isset($companion['dyingtext'])) {
                                         Translator::getInstance()->setSchema('battle');
-                                        $output->output($companion['dyingtext']);
+                                        $output->output('%s', $companion['dyingtext']);
                                         Translator::getInstance()->setSchema();
                                     }
                                     if (isset($companion['cannotdie']) && $companion['cannotdie'] == true) {
@@ -554,7 +554,7 @@ class Buffs
                         $output->outputNotl($msg);
                     } elseif ($msg > '') {
                         $msg = Substitute::applyArray('`)' . $msg . '`0`n', ['{damage}'], [abs($damage)]);
-                        $output->output($msg);
+                        $output->output('%s', $msg);
                     }
                     if ($badguy['dead'] == true) {
                         break;
@@ -612,7 +612,7 @@ class Buffs
                 $output->outputNotl($msg);
             } elseif ($msg > '') {
                 $msg = Substitute::applyArray('`)' . $msg . '`0`n', ['{damage}'], [$healhp]);
-                $output->output($msg);
+                $output->output('%s', $msg);
             }
             if ($buff['schema']) {
                 Translator::getInstance()->setSchema();
@@ -663,7 +663,7 @@ class Buffs
                 $output->outputNotl($msg);
             } elseif ($msg > '') {
                 $msg = Substitute::applyArray('`)' . $msg . '`0`n', ['{damage}'], [$realdamage]);
-                $output->output($msg);
+                $output->output('%s', $msg);
             }
             if ($buff['schema']) {
                 Translator::getInstance()->setSchema();
@@ -698,7 +698,7 @@ class Buffs
                             $output->outputNotl($msg);
                         } else {
                             $msg = Substitute::applyArray('`5' . $buff['wearoff'] . '`0`n');
-                            $output->output($msg);
+                            $output->output('%s', $msg);
                         }
                     }
                     self::stripBuff($key);
@@ -734,7 +734,7 @@ class Buffs
                             $output->outputNotl($msg);
                         } else {
                             $msg = Substitute::applyArray('`5' . $buff['wearoff'] . '`0`n');
-                            $output->output($msg);
+                            $output->output('%s', $msg);
                         }
                     }
                     self::stripBuff($key);

--- a/src/Lotgd/Commentary.php
+++ b/src/Lotgd/Commentary.php
@@ -517,7 +517,7 @@ SQL;
             return;
         }
         if ($intro) {
-            $output->output($intro);
+            $output->output('%s', $intro);
         }
         self::viewCommentary($section, $message, $limit, $talkline, $schema);
     }
@@ -974,12 +974,12 @@ SQL;
         ) {
             if ($message != "X") {
                     $message = "`n`@$message`n";
-                    $output->output($message);
+                    $output->output('%s', $message);
                     self::talkForm($section, $talkline, $limit, $schema);
             }
         } else {
                 $message = "`n`@$message`n";
-                $output->output($message);
+                $output->output('%s', $message);
                 $output->output("Sorry, you've exhausted your posts in this section for now.`0`n");
         }
     }

--- a/src/Lotgd/Moderate.php
+++ b/src/Lotgd/Moderate.php
@@ -33,7 +33,7 @@ class Moderate
         $output = Output::getInstance();
 
         if ($intro) {
-            $output->output($intro);
+            $output->output('%s', $intro);
         }
 
         self::viewmoderatedcommentary($section, $message, $limit, $talkline, $schema, $viewall);
@@ -487,12 +487,12 @@ class Moderate
             } elseif ($counttoday < ($limit / 2) || ($session['user']['superuser'] & ~SU_DOESNT_GIVE_GROTTO) || !$settings->getSetting('postinglimit', 1)) {
                 if ($message != 'X') {
                     $message = "`n`@" . $message . '`n';
-                    $output->output($message);
+                    $output->output('%s', $message);
                     Commentary::talkForm($section, $talkline, $limit, $schema);
                 }
             } else {
                 $message = "`n`@" . $message . '`n';
-                $output->output($message);
+                $output->output('%s', $message);
                 $output->output("Sorry, you've exhausted your posts in this section for now.`0`n");
             }
         }

--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -323,7 +323,7 @@ class Newday
                 }
                 if (isset($canbuy[$type]) && $canbuy[$type]) {
                     $output->rawOutput("<tr><td nowrap>");
-                    $output->output($label);
+                    $output->output('%s', $label);
                     $output->outputNotl(":");
                     $output->rawOutput("</td><td>");
                     $output->rawOutput("<input id='$type' name='$type' size='4' maxlength='4' value='{$canbuy[$type]}' onKeyUp='pointsLeft();' onBlur='pointsLeft();' onFocus='pointsLeft();'>");
@@ -394,7 +394,7 @@ class Newday
                     continue;
                 }
                 $output->rawOutput('<tr><td nowrap>');
-                $output->output($label);
+                $output->output('%s', $label);
                 $output->outputNotl(':');
                 $output->rawOutput('</td><td>&nbsp;&nbsp;</td><td>');
                 $output->outputNotl("`@%s", $dist[$type]);

--- a/stables.php
+++ b/stables.php
@@ -121,7 +121,7 @@ if ($op == "") {
             $output->outputNotl($translator->sprintfTranslate($description));
         }
     } else {
-        $output->output($texts['desc']);
+        $output->output('%s', $texts['desc']);
     }
     $translator->setSchema();
     HookHandler::hook("stables-desc");
@@ -130,13 +130,13 @@ if ($op == "") {
     $result = Database::queryCached($sql, "mountdata-$id", 3600);
     if (Database::numRows($result) <= 0) {
         $translator->setSchema($schemas['nosuchbeast']);
-        $output->output($texts['nosuchbeast']);
+        $output->output('%s', $texts['nosuchbeast']);
         $translator->setSchema();
     } else {
         // Idea taken from Robert of dragonprime.cawsquad.net
         $t = Random::eRand(0, count($texts['finebeast']) - 1);
         $translator->setSchema($schemas['finebeast']);
-        $output->output($texts['finebeast'][$t]);
+        $output->output('%s', $texts['finebeast'][$t]);
         $translator->setSchema();
         $mount = Database::fetchAssoc($result);
         $mount = HookHandler::hook("mount-modifycosts", $mount);
@@ -168,7 +168,7 @@ if ($op == 'confirmbuy') {
     $result = Database::queryCached($sql, "mountdata-$id", 3600);
     if (Database::numRows($result) <= 0) {
         $translator->setSchema($schemas['nosuchbeast']);
-        $output->output($texts['nosuchbeast']);
+        $output->output('%s', $texts['nosuchbeast']);
         $translator->setSchema();
     } else {
         $mount = Database::fetchAssoc($result);

--- a/titleedit.php
+++ b/titleedit.php
@@ -62,10 +62,10 @@ switch ($op) {
         }
         Database::query($sql);
         if (Database::affectedRows() == 0) {
-            $output->output($errnote);
+            $output->output('%s', $errnote);
             $output->rawOutput(Database::error());
         } else {
-            $output->output($note);
+            $output->output('%s', $note);
         }
         $op = "";
         break;

--- a/train.php
+++ b/train.php
@@ -207,7 +207,7 @@ if (Database::numRows($result) > 0 && $session['user']['level'] < (int) $setting
             }
             $badguy['creaturelose'] = Substitute::applyArray($badguy['creaturelose']);
             $output->outputNotl("`b`&");
-            $output->output($badguy['creaturelose']);
+            $output->output('%s', $badguy['creaturelose']);
             $output->outputNotl("`0`b`n");
             $output->output("`b`\$You have defeated %s!`0`b`n", $badguy['creaturename']);
 
@@ -296,7 +296,7 @@ if (Database::numRows($result) > 0 && $session['user']['level'] < (int) $setting
             $output->output("`%%s`\$ halts just before delivering the final blow, and instead extends a hand to help you to your feet, and hands you a complementary healing potion.`n", $badguy['creaturename']);
             $badguy['creaturewin'] = Substitute::applyArray($badguy['creaturewin']);
             $output->outputNotl("`^`b");
-            $output->output($badguy['creaturewin']);
+            $output->output('%s', $badguy['creaturewin']);
             $output->outputNotl("`b`0`n");
             Nav::add("Navigation");
             VillageNav::render();

--- a/user.php
+++ b/user.php
@@ -61,14 +61,14 @@ if (!$query && $sort) {
     $query = "%";
 }
 
-if ($op == "search" || $op == "") {
-    [$searchresult, $err] = UserLookup::lookup($query, $order);
-    $op = "";
-    if ($err) {
-        $output->output($err);
-    } else {
-        if ($searchresult) {
-            $display = 1;
+    if ($op == "search" || $op == "") {
+        [$searchresult, $err] = UserLookup::lookup($query, $order);
+        $op = "";
+        if ($err) {
+            $output->output('%s', $err);
+        } else {
+            if ($searchresult) {
+                $display = 1;
         }
     }
 }

--- a/village.php
+++ b/village.php
@@ -290,7 +290,7 @@ Nav::add("", "weaponeditor.php");
 if (!$skipvillagedesc) {
     HookHandler::hook("collapse{", array("name" => "villagedesc-" . $session['user']['location']));
     $translator->setSchema($schemas['text']);
-    $output->output($texts['text']);
+    $output->output('%s', $texts['text']);
     $translator->setSchema();
     HookHandler::hook("}collapse");
     HookHandler::hook("collapse{", array("name" => "villageclock-" . $session['user']['location']));
@@ -327,7 +327,7 @@ if ($skipvillagedesc) {
 $args = HookHandler::hook("blockcommentarea", array("section" => $texts['section']));
 if (!isset($args['block']) || $args['block'] != 'yes') {
         $translator->setSchema($schemas['talk']);
-        $output->output($texts['talk']);
+        $output->output('%s', $texts['talk']);
         $translator->setSchema();
             Commentary::commentDisplay("", $texts['section'], "Speak", 25, $texts['sayline'], $schemas['sayline']);
 }

--- a/weapons.php
+++ b/weapons.php
@@ -75,7 +75,7 @@ if ($op == "") {
             $output->outputNotl($translator->sprintfTranslate($description));
         }
     } else {
-        $output->output($texts['desc']);
+        $output->output('%s', $texts['desc']);
     }
     $translator->setSchema();
 
@@ -93,7 +93,7 @@ if ($op == "") {
             $output->outputNotl($translator->sprintfTranslate($description));
         }
     } else {
-        $output->output($texts['tradein']);
+        $output->output('%s', $texts['tradein']);
     }
     $translator->setSchema();
 
@@ -155,7 +155,7 @@ if ($op == "") {
     $result = Database::query($sql);
     if (Database::numRows($result) == 0) {
         $translator->setSchema($schemas['nosuchweapon']);
-        $output->output($texts['nosuchweapon']);
+        $output->output('%s', $texts['nosuchweapon']);
         $translator->setSchema();
         $translator->setSchema($schemas['tryagain']);
         Nav::add($texts['tryagain'], "weapons.php");


### PR DESCRIPTION
## Summary
- update Output::output()/output_notl() callers that previously passed dynamic strings directly so they now use explicit format specifiers
- cover core pages, modules, and support classes to guard against unintended sprintf formatting on user-supplied values

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d3b402bde08329acbb4751d57a9cb6