### PR TITLE
fix: address strict type mismatches in user input flows

### DIFF
--- a/create.php
+++ b/create.php
@@ -224,7 +224,12 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
 } else {
     if ($op == "create") {
         $emailverification = "";
-        $shortname = Sanitize::sanitizeName((int) $settings->getSetting('spaceinname', 0), Http::post('name'));
+        $name = Http::post('name');
+        if ($name === false || is_array($name)) {
+            $name = '';
+        }
+        $allowSpacesInName = (bool) $settings->getSetting('spaceinname', 0);
+        $shortname = Sanitize::sanitizeName($allowSpacesInName, (string) $name);
 
         if (soap($shortname) != $shortname) {
             $output->output("`\$Error`^: Bad language was found in your name, please consider revising it.`n");

--- a/forest.php
+++ b/forest.php
@@ -84,7 +84,7 @@ if ($op == "search") {
             'sobermsg' => "`&Faced with the prospect of death, you sober up a little.`n",
             'schema' => 'forest');
         HookHandler::hook("soberup", $args);
-        if (HookHandler::moduleEvents("forest", $settings->getSetting("forestchance", 15)) != 0) {
+        if (HookHandler::moduleEvents('forest', (int) $settings->getSetting('forestchance', 15)) != 0) {
             if (!Nav::checkNavs()) {
                 // If we're showing the forest, make sure to reset the special
                 // and the specialmisc

--- a/gardens.php
+++ b/gardens.php
@@ -37,7 +37,7 @@ $comment = Http::post('insertcommentary');
 // Don't give people a chance at a special event if they are just browsing
 // the commentary (or talking) or dealing with any of the hooks in the village.
 if (!$op && $com == "" && !$comment && !$refresh && !$commenting) {
-    if (HookHandler::moduleEvents("gardens", $settings->getSetting("gardenchance", 0)) != 0) {
+    if (HookHandler::moduleEvents('gardens', (int) $settings->getSetting('gardenchance', 0)) != 0) {
         if (Nav::checkNavs()) {
             Footer::pageFooter();
         } else {


### PR DESCRIPTION
## Summary
- ensure the account creation flow casts the incoming name and space-in-name setting to the expected sanitizeName types
- cast module event chance settings to integers before invoking HookHandler in the forest and gardens entry points

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d3b85f855c83298ff88a594f4e986f