### PR TITLE
refactor: guard Http input values

### DIFF
--- a/about.php
+++ b/about.php
@@ -31,7 +31,8 @@ Header::pageHeader("About Legend of the Green Dragon Core Engine");
 $details = gametimedetails();
 
 DateTime::checkDay();
-$op = Http::get('op');
+$opRequest = Http::get('op');
+$op = is_string($opRequest) ? $opRequest : '';
 
 switch ($op) {
     case "setup":

--- a/armor.php
+++ b/armor.php
@@ -67,7 +67,8 @@ $translator->setSchema($schemas['title']);
 Header::pageHeader($texts['title']);
 $output->output("`c`b`%" . $texts['title'] . "`0`b`c");
 $translator->setSchema();
-$op = Http::get('op');
+$opRequest = Http::get('op');
+$op = is_string($opRequest) ? $opRequest : '';
 if ($op == "") {
     $translator->setSchema($schemas['desc']);
     if (is_array($texts['desc'])) {
@@ -150,7 +151,8 @@ if ($op == "") {
     $output->rawOutput("</table>", true);
     VillageNav::render();
 } elseif ($op == "buy") {
-    $id = Http::get('id');
+    $idRequest = Http::get('id');
+    $id = is_string($idRequest) ? $idRequest : '';
     $sql = "SELECT * FROM " . Database::prefix("armor") . " WHERE armorid='$id'";
     $result = Database::query($sql);
     if (Database::numRows($result) == 0) {

--- a/armoreditor.php
+++ b/armoreditor.php
@@ -33,7 +33,8 @@ SuAccess::check(SU_EDIT_EQUIPMENT);
 Translator::getInstance()->setSchema("armor");
 
 Header::pageHeader("Armor Editor");
-$armorlevel = (int)Http::get('level');
+$armorLevelRequest = Http::get('level');
+$armorlevel = is_numeric($armorLevelRequest) ? (int)$armorLevelRequest : 0;
 SuperuserNav::render();
 Nav::add("Armor Editor");
 Nav::add("Armor Editor Home", "armoreditor.php?level=$armorlevel");
@@ -47,8 +48,10 @@ $armorarray = array(
     "armorid" => "Armor ID,hidden",
     "armorname" => "Armor Name",
     "defense" => "Defense,range,1,15,1");
-$op = Http::get('op');
-$id = Http::get('id');
+$opRequest = Http::get('op');
+$op = is_string($opRequest) ? $opRequest : '';
+$idRequest = Http::get('id');
+$id = is_string($idRequest) ? $idRequest : '';
 if ($op == "edit" || $op == "add") {
     if ($op == "edit") {
         $sql = "SELECT * FROM " . Database::prefix("armor") . " WHERE armorid='$id'";
@@ -70,9 +73,12 @@ if ($op == "edit" || $op == "add") {
     $op = "";
     Http::set('op', $op);
 } elseif ($op == "save") {
-    $armorid = Http::post('armorid');
-    $armorname = Http::post('armorname');
-    $defense = Http::post('defense');
+    $armorIdRequest = Http::post('armorid');
+    $armorid = is_numeric($armorIdRequest) ? (int)$armorIdRequest : 0;
+    $armorNameRequest = Http::post('armorname');
+    $armorname = is_string($armorNameRequest) ? $armorNameRequest : '';
+    $defenseRequest = Http::post('defense');
+    $defense = is_numeric($defenseRequest) ? (int)$defenseRequest : 0;
     if ($armorid > 0) {
         $sql = "UPDATE " . Database::prefix("armor") . " SET armorname=\"$armorname\",defense=\"$defense\",value=" . $values[$defense] . " WHERE armorid='$armorid'";
     } else {

--- a/badword.php
+++ b/badword.php
@@ -32,7 +32,8 @@ SuAccess::check(SU_EDIT_COMMENTS);
 
 Translator::getInstance()->setSchema("badword");
 
-$op = Http::get('op');
+$opRequest = Http::get('op');
+$op = is_string($opRequest) ? $opRequest : '';
 //yuck, this page is a mess, but it gets the job done.
 Header::pageHeader("Bad word editor");
 
@@ -48,7 +49,8 @@ Nav::add("", "badword.php?op=test");
 $output->output("`7Test a word:`0");
 $output->rawOutput("<input name='word'><input type='submit' class='button' value='$test'></form>");
 if ($op == "test") {
-    $word = Http::post("word");
+    $wordPost = Http::post('word');
+    $word = is_string($wordPost) ? $wordPost : '';
     $return = soap($word, true);
     if ($return == $word) {
         $output->output("`7\"%s\" does not trip any filters.`0`n`n", $word);
@@ -79,7 +81,8 @@ $result = Database::query($sql);
 $row = Database::fetchAssoc($result);
 $words = explode(" ", $row['words']);
 if ($op == "addgood") {
-    $newregexp = stripslashes(Http::post('word'));
+    $newRegexpPost = Http::post('word');
+    $newregexp = is_string($newRegexpPost) ? stripslashes($newRegexpPost) : '';
 
     // not sure if the line below should appear, as the strings in the good
     // word list have different behaviour than those in the nasty word list,
@@ -102,7 +105,9 @@ if ($op == "addgood") {
 }
 if ($op == "removegood") {
     // false if not found
-    $removekey = array_search(stripslashes(Http::post('word')), $words);
+    $removeWordPost = Http::post('word');
+    $removeWord = is_string($removeWordPost) ? stripslashes($removeWordPost) : '';
+    $removekey = array_search($removeWord, $words);
     // $removekey can be 0
     if ($removekey !== false) {
         unset($words[$removekey]);
@@ -143,7 +148,8 @@ $words = explode(" ", $row['words']);
 reset($words);
 
 if ($op == "add") {
-    $newregexp = stripslashes(Http::post('word'));
+    $newRegexpPost = Http::post('word');
+    $newregexp = is_string($newRegexpPost) ? stripslashes($newRegexpPost) : '';
 
     // automagically escapes all unescaped single quote characters
     $newregexp = preg_replace('/(?<!\\\\)\'/', '\\\'', $newregexp);
@@ -162,7 +168,9 @@ if ($op == "add") {
 }
 if ($op == "remove") {
     // false if not found
-    $removekey = array_search(stripslashes(Http::post('word')), $words);
+    $removeWordPost = Http::post('word');
+    $removeWord = is_string($removeWordPost) ? stripslashes($removeWordPost) : '';
+    $removekey = array_search($removeWord, $words);
     // $removekey can be 0
     if ($removekey !== false) {
         unset($words[$removekey]);

--- a/bank.php
+++ b/bank.php
@@ -28,7 +28,8 @@ Translator::getInstance()->setSchema("bank");
 
 Header::pageHeader("Ye Olde Bank");
 $output->output("`^`c`bYe Olde Bank`b`c");
-$op = Http::get('op');
+$opRequest = Http::get('op');
+$op = is_string($opRequest) ? $opRequest : '';
 $point = $settings->getSetting('moneydecimalpoint', ".");
 $sep = $settings->getSetting('moneythousandssep', ",");
 if ($op == "") {
@@ -74,13 +75,15 @@ if ($op == "") {
 } elseif ($op == "transfer2") {
     $output->output("`6`bConfirm Transfer`b:`n");
     $string = "%";
-    $to = Http::post('to');
+    $toPost = Http::post('to');
+    $to = is_string($toPost) ? $toPost : '';
     for ($x = 0; $x < strlen($to); $x++) {
         $string .= substr($to, $x, 1) . "%";
     }
     $sql = "SELECT name,login FROM " . Database::prefix("accounts") . " WHERE name LIKE '" . addslashes($string) . "' AND locked=0 ORDER by login='$to' DESC, name='$to' DESC, login";
     $result = Database::query($sql);
-    $amt = abs((int)Http::post('amount'));
+    $amountPost = Http::post('amount');
+    $amt = abs(is_numeric($amountPost) ? (int)$amountPost : 0);
     if (Database::numRows($result) == 1) {
         $row = Database::fetchAssoc($result);
         $msg = Translator::translateInline("Complete Transfer");
@@ -116,8 +119,10 @@ if ($op == "") {
         $output->output("`@Elessa`6 blinks at you from behind her spectacles, \"`@I'm sorry, but I can find no one matching that name who does business with our bank!  Please try again.`6\"");
     }
 } elseif ($op == "transfer3") {
-    $amt = abs((int)Http::post('amount'));
-    $to = Http::post('to');
+    $amountPost = Http::post('amount');
+    $amt = abs(is_numeric($amountPost) ? (int)$amountPost : 0);
+    $toPost = Http::post('to');
+    $to = is_string($toPost) ? $toPost : '';
     $output->output("`6`bTransfer Completion`b`n");
     if ($session['user']['gold'] + $session['user']['goldinbank'] < $amt) {
         $output->output("`@Elessa`6 stands up to her full, but still diminutive height and glares at you, \"`@How can you transfer `^%s`@ gold when you only possess `^%s`@?`6\"", number_format($amt, 0, $point, $sep), number_format($session['user']['gold'] + $session['user']['goldinbank'], 0, $point, $sep));
@@ -175,7 +180,8 @@ if ($op == "") {
     $output->rawOutput("<script language='javascript'>document.getElementById('input').focus();</script>", true);
     Nav::add("", "bank.php?op=depositfinish");
 } elseif ($op == "depositfinish") {
-    $amount = abs((int)Http::post('amount'));
+    $amountPost = Http::post('amount');
+    $amount = abs(is_numeric($amountPost) ? (int)$amountPost : 0);
     if ($amount == 0) {
         $amount = $session['user']['gold'];
     }
@@ -216,11 +222,14 @@ if ($op == "") {
     $output->rawOutput("<script language='javascript'>document.getElementById('input').focus();</script>");
     Nav::add("", "bank.php?op=withdrawfinish");
 } elseif ($op == "withdrawfinish") {
-    $amount = abs((int)Http::post('amount'));
+    $amountPost = Http::post('amount');
+    $amount = abs(is_numeric($amountPost) ? (int)$amountPost : 0);
     if ($amount == 0) {
         $amount = abs($session['user']['goldinbank']);
     }
-    if ($amount > $session['user']['goldinbank'] && Http::post('borrow') == "") {
+    $borrowPost = Http::post('borrow');
+    $borrow = is_string($borrowPost) ? $borrowPost : '';
+    if ($amount > $session['user']['goldinbank'] && $borrow === "") {
         $output->output("`\$ERROR: Not enough gold in the bank to withdraw.`^`n`n");
         $output->output("`6Having been informed that you have `^%s`6 gold in your account, you declare that you would like to withdraw all `^%s`6 of it.`n`n", number_format($session['user']['goldinbank'], 0, $point, $sep), number_format($amount, 0, $point, $sep));
         $output->output("`@Elessa`6 looks at you for a few moments without blinking, then advises you to take basic arithmetic.  You realize your folly and think you should try again.");

--- a/clan.php
+++ b/clan.php
@@ -73,9 +73,13 @@ function clanform()
     Nav::add("", "clan.php?op=new&apply=1");
     $output->output("`b`cNew Clan Application Form`c`b");
     $output->output("Clan Name: ");
-    $output->rawOutput("<input name='clanname' maxlength='50' value=\"" . htmlentities(stripslashes(Http::post('clanname')), ENT_COMPAT, $settings->getSetting('charset', 'UTF-8')) . "\">");
+    $clanNamePost = Http::post('clanname');
+    $clanName = is_string($clanNamePost) ? stripslashes($clanNamePost) : '';
+    $output->rawOutput("<input name='clanname' maxlength='50' value=\"" . htmlentities($clanName, ENT_COMPAT, $settings->getSetting('charset', 'UTF-8')) . "\">");
     $output->output("`nShort Name: ");
-    $output->rawOutput("<input name='clanshort' maxlength='5' size='5' value=\"" . htmlentities(stripslashes(Http::post('clanshort')), ENT_COMPAT, $settings->getSetting('charset', 'UTF-8')) . "\">");
+    $clanShortPost = Http::post('clanshort');
+    $clanShort = is_string($clanShortPost) ? stripslashes($clanShortPost) : '';
+    $output->rawOutput("<input name='clanshort' maxlength='5' size='5' value=\"" . htmlentities($clanShort, ENT_COMPAT, $settings->getSetting('charset', 'UTF-8')) . "\">");
     $output->output("`nNote, color codes are permitted in neither clan names nor short names.");
     $output->output("The clan name is shown on player bios and on clan overview pages while the short name is displayed next to players' names in comment areas and such.`n");
     $apply = Translator::translateInline("Apply");

--- a/creatures.php
+++ b/creatures.php
@@ -296,7 +296,8 @@ if ($op == "" || $op == "search") {
                 $row = $creaturestats[$level];
                 $posted = array('level','category','weapon','name','win','lose','aiscript','id');
                 foreach ($posted as $field) {
-                    $row['creature' . $field] = stripslashes(Http::post('creature' . $field));
+                    $creatureFieldPost = Http::post('creature' . $field);
+                    $row['creature' . $field] = is_string($creatureFieldPost) ? stripslashes($creatureFieldPost) : '';
                 }
                 if (!$row['creatureid']) {
                     $row['creatureid'] = 0;

--- a/healer.php
+++ b/healer.php
@@ -90,7 +90,8 @@ if ($op == "") {
         $output->output("You recall that the creature had asked for `b`\$%s`3`b gold.", $newcost);
     }
 } elseif ($op == "companion") {
-    $compcost = Http::get('compcost');
+    $compCostRequest = Http::get('compcost');
+    $compcost = is_numeric($compCostRequest) ? (int)$compCostRequest : 0;
 
     if ($session['user']['gold'] < $compcost) {
         $output->output("`3The old creature pierces you with a gaze hard and cruel.`n");
@@ -98,7 +99,8 @@ if ($op == "") {
         $output->output("Perhaps you should get some more money before you attempt to engage in local commerce.`n`n");
         $output->output("You recall that the creature had asked for `b`\$%s`3`b gold.", $compcost);
     } else {
-        $name = stripslashes(rawurldecode(Http::get('name')));
+        $nameRequest = Http::get('name');
+        $name = is_string($nameRequest) ? stripslashes(rawurldecode($nameRequest)) : '';
         $session['user']['gold'] -= $compcost;
         $companions[$name]['hitpoints'] = $companions[$name]['maxhitpoints'];
         $session['user']['companions'] = serialize($companions);

--- a/login.php
+++ b/login.php
@@ -28,9 +28,10 @@ $settings = Settings::getInstance();
 
 Translator::getInstance()->setSchema("login");
 Translator::translatorSetup();
-$op = Http::get('op');
-$name = Http::post('name');
-$name = $name !== false ? (string)$name : '';
+$opRequest = Http::get('op');
+$op = is_string($opRequest) ? $opRequest : '';
+$nameRequest = Http::post('name');
+$name = is_string($nameRequest) ? $nameRequest : '';
 $iname = $settings->getSetting("innname", LOCATION_INN);
 $vname = $settings->getSetting("villagename", LOCATION_FIELDS);
 
@@ -38,9 +39,10 @@ if ($name != "") {
     if (isset($session['loggedin']) && $session['loggedin']) {
         Redirect::redirect("badnav.php");
     } else {
-        $password = Http::post('password');
-        $password = $password !== false ? stripslashes((string)$password) : '';
-        $force = Http::post('force');
+        $passwordRequest = Http::post('password');
+        $password = is_string($passwordRequest) ? stripslashes($passwordRequest) : '';
+        $forceRequest = Http::post('force');
+        $force = is_string($forceRequest) ? $forceRequest : '';
         if (substr($password, 0, 5) == "!md5!") {
             $password = md5(substr($password, 5));
         } elseif (substr($password, 0, 6) == "!md52!" && strlen($password) == 38) {

--- a/mercenarycamp.php
+++ b/mercenarycamp.php
@@ -28,11 +28,7 @@ $translator->setSchema("mercenarycamp");
 
 DateTime::checkDay();
 $nameParam = Http::get('name');
-if ($nameParam !== false) {
-    $name = stripslashes(rawurldecode($nameParam));
-} else {
-    $name = '';
-}
+$name = is_string($nameParam) ? stripslashes(rawurldecode($nameParam)) : '';
 if (isset($companions[$name])) {
     $displayname = $companions[$name]['name'];
 } else {
@@ -113,7 +109,8 @@ Header::pageHeader($texts['title']);
 $output->output("`c`b`&" . $texts['title'] . "`0`b`c");
 $translator->setSchema();
 
-$op = Http::get("op");
+$opRequest = Http::get('op');
+$op = is_string($opRequest) ? $opRequest : '';
 
 if ($op == "") {
     if (Http::get('skip') != 1) {

--- a/pages/clan/clan_motd.php
+++ b/pages/clan/clan_motd.php
@@ -26,7 +26,8 @@ if ($session['user']['clanrank'] >= CLAN_OFFICER) {
         $output->output("Updating MoTD`n");
         $claninfo['motdauthor'] = $session['user']['acctid'];
     }
-    $clandesc = Http::post('clandesc');
+    $clanDescPost = Http::post('clandesc');
+    $clandesc = is_string($clanDescPost) ? $clanDescPost : '';
     if (
         Http::postIsset('clandesc') &&
             stripslashes($clandesc) != $claninfo['clandesc'] &&
@@ -39,7 +40,8 @@ if ($session['user']['clanrank'] >= CLAN_OFFICER) {
         $claninfo['clandesc'] = stripslashes($clandesc);
         $claninfo['descauthor'] = $session['user']['acctid'];
     }
-    $customsay = Http::post('customsay');
+    $customSayPost = Http::post('customsay');
+    $customsay = is_string($customSayPost) ? $customSayPost : '';
     if (Http::postIsset('customsay') && $customsay != $claninfo['customsay'] && $session['user']['clanrank'] >= CLAN_LEADER) {
         $sql = "UPDATE " . Database::prefix("clans") . " SET customsay='$customsay' WHERE clanid={$claninfo['clanid']}";
         Database::query($sql);

--- a/prefs.php
+++ b/prefs.php
@@ -173,7 +173,8 @@ if ($op == "suicide" && $settings->getSetting('selfdelete', 0) != 0) {
             }
             $session['user']['prefs'][$key] = Http::post($key);
         }
-        $bio = stripslashes(Http::post('bio'));
+        $bioPost = Http::post('bio');
+        $bio = is_string($bioPost) ? stripslashes($bioPost) : '';
         $bio = Sanitize::commentSanitize($bio);
         if ($bio != Sanitize::commentSanitize($session['user']['bio'])) {
             if ($session['user']['biotime'] > "9000-01-01") {
@@ -184,7 +185,8 @@ if ($op == "suicide" && $settings->getSetting('selfdelete', 0) != 0) {
                 $session['user']['biotime'] = date("Y-m-d H:i:s");
             }
         }
-        $email = Http::post('email');
+        $emailPost = Http::post('email');
+        $email = is_string($emailPost) ? $emailPost : '';
         if ($email != $session['user']['emailaddress']) {
             if ($settings->getSetting('playerchangeemail', 0)) {
                 if (EmailValidator::isValid($email)) {

--- a/translatortool.php
+++ b/translatortool.php
@@ -23,11 +23,14 @@ $output = Output::getInstance();
 Translator::getInstance()->setSchema("translatortool");
 
 SuAccess::check(SU_IS_TRANSLATOR);
-$op = (string) Http::get('op');
+$opRequest = Http::get('op');
+$op = is_string($opRequest) ? $opRequest : '';
 if ($op == "") {
     popup_header("Translator Tool");
-    $uri = rawurldecode((string) Http::get('u'));
-    $text = stripslashes(rawurldecode((string) Http::get('t')));
+    $uriRequest = Http::get('u');
+    $uri = is_string($uriRequest) ? rawurldecode($uriRequest) : '';
+    $textRequest = Http::get('t');
+    $text = is_string($textRequest) ? stripslashes(rawurldecode($textRequest)) : '';
     $translation = translate_loadnamespace($uri);
     if (isset($translation[$text])) {
         $trans = $translation[$text];
@@ -50,9 +53,12 @@ if ($op == "") {
     $output->rawOutput("</form>");
     popup_footer();
 } elseif ($op == 'save') {
-    $uri = (string) Http::post('uri');
-    $text = (string) Http::post('text');
-    $trans = (string) Http::post('trans');
+    $uriPost = Http::post('uri');
+    $uri = is_string($uriPost) ? $uriPost : '';
+    $textPost = Http::post('text');
+    $text = is_string($textPost) ? $textPost : '';
+    $transPost = Http::post('trans');
+    $trans = is_string($transPost) ? $transPost : '';
 
     $page = $uri;
     if (strpos($page, "?") !== false) {
@@ -101,7 +107,8 @@ if ($op == "") {
         }
     }
     Database::query($sql);
-    if ((string) Http::post('savenotclose') > "") {
+    $saveNotClosePost = Http::post('savenotclose');
+    if (is_string($saveNotClosePost) && $saveNotClosePost > "") {
         header("Location: translatortool.php?op=list&u=$page");
         exit();
     } else {

--- a/untranslated.php
+++ b/untranslated.php
@@ -86,7 +86,9 @@ if ($op == "list") {
 
     if ($mode == "edit") {
         $output->rawOutput(Translator::translate("Text:") . "<br>");
-        $output->rawOutput("<textarea name='intext' cols='60' rows='5' readonly>" . htmlentities(stripslashes(Http::get('intext')), ENT_COMPAT, $settings->getSetting('charset', 'UTF-8')) . "</textarea><br/>");
+        $intextRequest = Http::get('intext');
+        $intext = is_string($intextRequest) ? stripslashes($intextRequest) : '';
+        $output->rawOutput("<textarea name='intext' cols='60' rows='5' readonly>" . htmlentities($intext, ENT_COMPAT, $settings->getSetting('charset', 'UTF-8')) . "</textarea><br/>");
         $output->rawOutput(Translator::translate("Translation:") . "<br>");
         $output->rawOutput("<textarea name='outtext' cols='60' rows='5'></textarea><br/>");
         $output->rawOutput("<input type='submit' value='" . Translator::translate("Save") . "' class='button'>");


### PR DESCRIPTION
## Summary
- add explicit string and numeric checks when reading request parameters in core entry points
- unwrap nested stripslashes/rawurldecode usage to avoid passing non-strings to PHP string functions
- ensure administrative tools validate optional form input before using it in SQL updates

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d3bd9796208329886556545e61955e