### PR TITLE
Modernize legacy page controllers to use service singletons

### DIFF
--- a/pages/about/about_default.php
+++ b/pages/about/about_default.php
@@ -5,6 +5,13 @@ declare(strict_types=1);
 use Lotgd\Nav;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Nltoappon;
+use Lotgd\Output;
+use Lotgd\Settings;
+
+$output = Output::getInstance();
+$settings = Settings::getInstance();
+
+global $logd_version;
 
 $order = array("2","3","1"); //arbitrary, this order the following hooks and whatnot
 

--- a/pages/about/about_license.php
+++ b/pages/about/about_license.php
@@ -3,6 +3,9 @@
 declare(strict_types=1);
 
 use Lotgd\Nav;
+use Lotgd\Output;
+
+$output = Output::getInstance();
 
 Nav::add("About LoGD");
 Nav::add("About LoGD", "about.php");

--- a/pages/about/about_listmodules.php
+++ b/pages/about/about_listmodules.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 use Lotgd\Nav;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
+use Lotgd\Output;
+
+$output = Output::getInstance();
 
 Nav::add("About LoGD");
 Nav::add("About LoGD", "about.php");

--- a/pages/about/about_setup.php
+++ b/pages/about/about_setup.php
@@ -6,6 +6,11 @@ use Lotgd\Forms;
 use Lotgd\Nav;
 use Lotgd\Modules\HookHandler;
 use Lotgd\DateTime;
+use Lotgd\Output;
+use Lotgd\Settings;
+
+$output = Output::getInstance();
+$settings = Settings::getInstance();
 
 Nav::add("About LoGD");
 Nav::add("About LoGD", "about.php");

--- a/pages/bans/case_.php
+++ b/pages/bans/case_.php
@@ -5,6 +5,12 @@ declare(strict_types=1);
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Nav;
+use Lotgd\Output;
+use Lotgd\Settings;
+use Lotgd\DateTime;
+
+$output = Output::getInstance();
+$settings = Settings::getInstance();
 
 if ($display == 1) {
     $q = "";
@@ -34,7 +40,7 @@ if ($display == 1) {
     $rn = 0;
     $oorder = "";
     while ($row = Database::fetchAssoc($searchresult)) {
-        $laston = relativedate($row['laston']);
+        $laston = DateTime::relativeDate($row['laston']);
         $loggedin =
             (date("U") - strtotime($row['laston']) <
              $settings->getSetting("LOGINTIMEOUT", 900) && $row['loggedin']);

--- a/pages/bans/case_removeban.php
+++ b/pages/bans/case_removeban.php
@@ -6,6 +6,10 @@ use Lotgd\MySQL\Database;
 use Lotgd\Nav;
 use Lotgd\Http;
 use Lotgd\Translator;
+use Lotgd\Output;
+use Lotgd\DateTime;
+
+$output = Output::getInstance();
 
 $subop = Http::get('subop');
 $none = Translator::translateInline('NONE');
@@ -164,7 +168,7 @@ while ($row = Database::fetchAssoc($result)) {
     $output->rawOutput("</a></div>");
     Nav::add("", $file);
     $output->rawOutput("</td><td>");
-    $output->outputNotl("%s", relativedate($row['lasthit']));
+    $output->outputNotl("%s", DateTime::relativeDate($row['lasthit']));
     $output->rawOutput("</td></tr>");
     $i++;
 }

--- a/pages/bans/case_searchban.php
+++ b/pages/bans/case_searchban.php
@@ -7,6 +7,10 @@ use Lotgd\Nav;
 use Lotgd\Http;
 use Lotgd\UserLookup;
 use Lotgd\Translator;
+use Lotgd\Output;
+use Lotgd\DateTime;
+
+$output = Output::getInstance();
 
 $subop = Http::get('subop');
 $none = Translator::translateInline('NONE');
@@ -147,7 +151,7 @@ while ($row = Database::fetchAssoc($result)) {
     $output->rawOutput("</a></div>");
     Nav::add("", $file);
     $output->rawOutput("</td><td>");
-    $output->outputNotl("%s", relativedate($row['lasthit']));
+    $output->outputNotl("%s", DateTime::relativeDate($row['lasthit']));
     $output->rawOutput("</td></tr>");
     $i++;
 }

--- a/pages/bans/case_setupban.php
+++ b/pages/bans/case_setupban.php
@@ -6,6 +6,12 @@ use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Nav;
 use Lotgd\Http;
+use Lotgd\Output;
+use Lotgd\Settings;
+use Lotgd\DateTime;
+
+$output = Output::getInstance();
+$settings = Settings::getInstance();
 
 $sql = 'SELECT name,lastip,uniqueid FROM ' . Database::prefix('accounts') . ' WHERE acctid=' . (int) $userid;
 $result = Database::query($sql);
@@ -54,7 +60,7 @@ if (isset($row['name']) && !empty($row['name'])) {
             $row['lastip'],
             $row['name'],
             $row['gentimecount'],
-            reltime(strtotime($row['laston']))
+            DateTime::relTime(strtotime($row['laston']))
         );
     }
     $output->outputNotl("`n");
@@ -83,7 +89,7 @@ if (isset($row['name']) && !empty($row['name'])) {
                     $row['uniqueid'],
                     $row['name'],
                     $row['gentimecount'],
-                    reltime(strtotime($row['laston']))
+                    DateTime::relTime(strtotime($row['laston']))
                 );
             }
             $output->outputNotl("`n");

--- a/pages/graveyard/case_battle_search.php
+++ b/pages/graveyard/case_battle_search.php
@@ -11,6 +11,11 @@ use Lotgd\Http;
 use Lotgd\Page\Footer;
 use Lotgd\MySQL\Database;
 use Lotgd\Random;
+use Lotgd\Output;
+use Lotgd\Settings;
+
+$output = Output::getInstance();
+$settings = Settings::getInstance();
 
 if ($session['user']['gravefights'] <= 0) {
     $output->output("`\$`bYour soul can bear no more torment in this afterlife.`b`0");
@@ -18,7 +23,8 @@ if ($session['user']['gravefights'] <= 0) {
     Http::set('op', '');
 } else {
     Battle::suspendCompanions('allowinshades', true);
-    if (HookHandler::moduleEvents('graveyard', (int) getsetting('gravechance', 0)) != 0) {
+    $graveChance = (int) $settings->getSetting('gravechance', 0);
+    if (HookHandler::moduleEvents('graveyard', $graveChance) != 0) {
         if (! Nav::checkNavs()) {
             // If we're going back to the graveyard, make sure to reset
             // the special and the specialmisc

--- a/pages/graveyard/case_default.php
+++ b/pages/graveyard/case_default.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 use Lotgd\Nav;
 use Lotgd\Modules\HookHandler;
+use Lotgd\Output;
+
+$output = Output::getInstance();
 
 if (! $skipgraveyardtext) {
     $output->output("`)`c`bThe Graveyard`b`c");

--- a/pages/graveyard/case_enter.php
+++ b/pages/graveyard/case_enter.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 use Lotgd\Nav;
 use Lotgd\Modules\HookHandler;
+use Lotgd\Output;
+
+$output = Output::getInstance();
 
 $output->output('`)`b`cThe Mausoleum`c`b');
 

--- a/pages/graveyard/case_question.php
+++ b/pages/graveyard/case_question.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 use Lotgd\Nav;
 use Lotgd\Modules\HookHandler;
+use Lotgd\Output;
+use Lotgd\Settings;
+use Lotgd\Translator;
+use Lotgd\Sanitize;
+
+$output = Output::getInstance();
+$settings = Settings::getInstance();
 
 Nav::add('G?Return to the Graveyard', 'graveyard.php');
 Nav::add('Places');
@@ -14,15 +21,15 @@ if ($favortoheal > 0) {
 }
 
 
-$hauntcost = getsetting('hauntcost', 25);
-$resurrectioncost = getsetting('resurrectioncost', 100);
+$hauntcost = $settings->getSetting('hauntcost', 25);
+$resurrectioncost = $settings->getSetting('resurrectioncost', 100);
 
 $default_actions = array();
 $default_actions[] = array(
     "link" => "graveyard.php?op=resurrection",
     "linktext" => "Resurrection",
     "linkhardcoded" => 1,
-    "favor" => getsetting('resurrectioncost', 100),
+    "favor" => $resurrectioncost,
     "text" => "",
     "titletext" => "`\${deathoverlord}`) speaks, \"`7You have impressed me indeed.  I shall grant you the ability to visit your foes in the mortal world.`)\""
     );
@@ -60,7 +67,7 @@ if ($length > 0) {
     array_multisort($favorcostlist, SORT_ASC, $linklist, $textlist, $overlord, $linktext);
 }
 
-$highest = translate_inline("`\${deathoverlord}`) speaks, \"`7I am not yet impressed with your efforts.  Continue my work, and we may speak further.`)");
+$highest = Translator::translateInline("`\${deathoverlord}`) speaks, \"`7I am not yet impressed with your efforts.  Continue my work, and we may speak further.`)");
 
 if ($length > 0) {
     $reverse = array_reverse($overlord);
@@ -76,7 +83,7 @@ $highest = str_replace("{deathoverlord}", $deathoverlord, $highest);
 $output->outputNotl($highest . "`n`n");
 
 
-Nav::add(["%s Favors", sanitize($deathoverlord)]);
+Nav::add(["%s Favors", Sanitize::sanitize($deathoverlord)]);
 for ($i = 0; $i < $length; $i++) {
     $linktext[$i] = str_replace("{deathoverlord}", $deathoverlord, $linktext[$i]);
     Nav::add(["%s`) (%s favors)", $linktext[$i], $favorcostlist[$i]], $linklist[$i]);

--- a/pages/graveyard/case_restore.php
+++ b/pages/graveyard/case_restore.php
@@ -3,6 +3,9 @@
 declare(strict_types=1);
 
 use Lotgd\Nav;
+use Lotgd\Output;
+
+$output = Output::getInstance();
 
 $output->output('`)`b`cThe Mausoleum`c`b');
 if ($session['user']['soulpoints'] < $max) {

--- a/pages/graveyard/case_resurrection.php
+++ b/pages/graveyard/case_resurrection.php
@@ -3,6 +3,9 @@
 declare(strict_types=1);
 
 use Lotgd\Nav;
+use Lotgd\Output;
+
+$output = Output::getInstance();
 
 $output->output("`\$%s`0 waves his skeletal arms as he begins to command the very fabric of life.`n`n", $deathoverlord);
 // Note to translators.  The text spoken by Ramius here is backwards

--- a/pages/inn/inn_default.php
+++ b/pages/inn/inn_default.php
@@ -5,11 +5,21 @@ declare(strict_types=1);
 use Lotgd\Http;
 use Lotgd\Nav;
 use Lotgd\Random;
+use Lotgd\Modules\HookHandler;
+use Lotgd\Output;
+use Lotgd\Settings;
+use Lotgd\Translator;
+use Lotgd\DateTime;
+use Lotgd\Page\Footer;
+
+$output = Output::getInstance();
+$settings = Settings::getInstance();
 
 if ($com == "" && !$comment && $op != "fleedragon") {
-    if (module_events("inn", (int)getsetting("innchance", 0)) != 0) {
-        if (checknavs()) {
-            page_footer();
+    $innChance = (int) $settings->getSetting('innchance', 0);
+    if (HookHandler::moduleEvents('inn', $innChance) != 0) {
+        if (Nav::checkNavs()) {
+            Footer::pageFooter();
         } else {
             $skipinndesc = true;
             $session['user']['specialinc'] = "";
@@ -21,11 +31,11 @@ if ($com == "" && !$comment && $op != "fleedragon") {
 }
 
 Nav::add("Things to do");
-$args = modulehook("blockcommentarea", array("section" => "inn"));
+$args = HookHandler::hook('blockcommentarea', array('section' => 'inn'));
 if (!isset($args['block']) || $args['block'] != 'yes') {
     Nav::add("Converse with patrons", "inn.php?op=converse");
 }
-Nav::add(array("B?Talk to %s`0 the Barkeep",$barkeep), "inn.php?op=bartender");
+Nav::add(["B?Talk to %s`0 the Barkeep", $barkeep], "inn.php?op=bartender");
 
 Nav::add("Other");
 Nav::add("Get a room (log out)", "inn.php?op=room");
@@ -55,18 +65,18 @@ if (!$skipinndesc) {
     $output->output("%s`0 the innkeep stands behind his counter, chatting with someone.", $barkeep);
 
     $chats = array(
-        translate_inline("dragons"),
-        translate_inline(getsetting("bard", "`^Seth")),
-        translate_inline(getsetting("barmaid", "`%Violet")),
-        translate_inline("`#MightyE"),
-        translate_inline("fine drinks"),
+        Translator::translateInline("dragons"),
+        Translator::translateInline($settings->getSetting('bard', '`^Seth')),
+        Translator::translateInline($settings->getSetting('barmaid', '`%Violet')),
+        Translator::translateInline("`#MightyE"),
+        Translator::translateInline("fine drinks"),
         $partner,
     );
-    $chats = modulehook("innchatter", $chats);
+    $chats = HookHandler::hook('innchatter', $chats);
     $talk = $chats[Random::eRand(0, count($chats) - 1)];
     $output->output("You can't quite make out what he is saying, but it's something about %s`0.`n`n", $talk);
-    $output->output("The clock on the mantle reads `6%s`0.`n", getgametime());
-    modulehook("inn-desc", array());
+    $output->output("The clock on the mantle reads `6%s`0.`n", DateTime::getGameTime());
+    HookHandler::hook('inn-desc', array());
 }
-modulehook("inn", array());
-module_display_events("inn", "inn.php");
+HookHandler::hook('inn', array());
+HookHandler::displayEvents('inn', 'inn.php');

--- a/pages/mail/case_address.php
+++ b/pages/mail/case_address.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Lotgd\Translator;
 use Lotgd\Http;
 use Lotgd\Output;
+use Lotgd\Settings;
 
 $id = (int) Http::get('id');
 $preop = (string) Http::get('preop');
@@ -18,12 +19,14 @@ $preop = (string) Http::get('preop');
 function mailAddress(int $id, string $preop): void
 {
     $output = Output::getInstance();
+    $settings = Settings::getInstance();
+    $charset = $settings->getSetting('charset', 'UTF-8');
 
     $output->outputNotl("<form action='mail.php?op=write' method='post'>", true);
     $output->output("`b`2Address:`b`n");
     $to = Translator::translateInline("To: ");
     $forwardto = Translator::translateInline("Forward To: ");
-    $search = htmlentities(Translator::translateInline("Search"), ENT_COMPAT, getsetting("charset", "UTF-8"));
+    $search = htmlentities(Translator::translateInline("Search"), ENT_COMPAT, $charset);
     $forwardlink = '';
 
     if ($id > 0) {
@@ -33,7 +36,7 @@ function mailAddress(int $id, string $preop): void
 
     $output->outputNotl(
         "`2$to <input name='to' id='to' value=\""
-        . htmlentities($preop, ENT_COMPAT, getsetting("charset", "UTF-8"))
+        . htmlentities($preop, ENT_COMPAT, $charset)
         . "\">",
         true
     );


### PR DESCRIPTION
## Summary
- replace lingering global `$output`/`$settings` dependencies in the about and bans page controllers with the shared Output and Settings singletons
- migrate graveyard and inn flows to HookHandler/DateTime helpers instead of legacy module helpers and utility functions
- refresh core mail actions to rely on Http/Output/Settings services and tidy cache invalidation

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d3c27273148329abf784fac298fa95