### PR TITLE
fix: realign legacy entry points

### DIFF
--- a/about.php
+++ b/about.php
@@ -38,10 +38,10 @@ switch ($op) {
     case "setup":
     case "listmodules":
     case "license":
-            require __DIR__ . "/pages/about/about_$op.php";
+        require __DIR__ . "/pages/about/about_$op.php";
         break;
     default:
-            require __DIR__ . "/pages/about/about_default.php";
+        require __DIR__ . "/pages/about/about_default.php";
         break;
 }
 if ($session['user']['loggedin']) {

--- a/battle.php
+++ b/battle.php
@@ -234,7 +234,7 @@ if ($op != "newtarget") {
                                 $newcompanions = array();
                                 foreach ($companions as $name => $companion) {
                                     if (isset($companion['hitpoints']) && $companion['hitpoints'] > 0) {
-                                                                       $buffer = Battle::reportCompanionMove($badguy, $companion, "heal");
+                                        $buffer = Battle::reportCompanionMove($badguy, $companion, "heal");
                                         if ($buffer !== false) {
                                             $newcompanions[$name] = $buffer;
                                             unset($buffer);
@@ -254,19 +254,19 @@ if ($op != "newtarget") {
 
                         if ($op == "fight" || $op == "run" || $surprised) {
                             // Grab an initial roll.
-                                                    $roll = Battle::rollDamage($badguy);
+                            $roll = Battle::rollDamage($badguy);
                             if ($op == "fight" && !$surprised) {
                                 $ggchancetodouble = $session['user']['dragonkills'];
                                 $bgchancetodouble = $session['user']['dragonkills'];
 
                                 if ($badguy['creaturehealth'] > 0 && $session['user']['hitpoints'] > 0) {
-                                                                   $buffset = Buffs::activateBuffs("offense");
+                                    $buffset = Buffs::activateBuffs("offense");
                                     if ($badguy['creaturehealth'] > 0 && $session['user']['hitpoints'] > 0 && $badguy['istarget']) {
                                         if (is_array($companions)) {
                                             $newcompanions = array();
                                             foreach ($companions as $name => $companion) {
                                                 if (isset($companion['hitpoits']) && $companion['hitpoints'] > 0) {
-                                                                       $buffer = Battle::reportCompanionMove($badguy, $companion, "magic");
+                                                    $buffer = Battle::reportCompanionMove($badguy, $companion, "magic");
                                                     if ($buffer !== false) {
                                                         $newcompanions[$name] = $buffer;
                                                         unset($buffer);
@@ -310,7 +310,7 @@ if ($op != "newtarget") {
                                             if ($r < $ggchancetodouble && $badguy['creaturehealth'] > 0 && $session['user']['hitpoints'] > 0 && !$needtostopfighting) {
                                                 $additionalattack = true;
                                                 $ggchancetodouble -= ($r + 5);
-                                                                           $roll = Battle::rollDamage($badguy);
+                                                $roll = Battle::rollDamage($badguy);
                                             } else {
                                                 $additionalattack = false;
                                             }
@@ -345,7 +345,7 @@ if ($op != "newtarget") {
                                     if ($r < $bgchancetodouble && $badguy['creaturehealth'] > 0 && $session['user']['hitpoints'] > 0 && !$needtostopfighting) {
                                         $additionalattack = true;
                                         $bgchancetodouble -= ($r + 5);
-                                                                           $roll = Battle::rollDamage($badguy);
+                                        $roll = Battle::rollDamage($badguy);
                                     } else {
                                         $additionalattack = false;
                                     }
@@ -356,7 +356,7 @@ if ($op != "newtarget") {
                                 if (is_array($companions)) {
                                     foreach ($companions as $name => $companion) {
                                         if (isset($companion['hitpoints']) && $companion['hitpoints'] > 0) {
-                                                                       $buffer = Battle::reportCompanionMove($badguy, $companion, "fight");
+                                            $buffer = Battle::reportCompanionMove($badguy, $companion, "fight");
                                             if ($buffer !== false) {
                                                 $newcompanions[$name] = $buffer;
                                                 unset($buffer);
@@ -661,7 +661,7 @@ function battle_badguy_attacks(&$badguy)
             if (is_array($companions)) {
                 foreach ($companions as $name => $companion) {
                     if (isset($companion['hitpoints']) && $companion['hitpoints'] > 0) {
-                                        $buffer = Battle::reportCompanionMove($badguy, $companion, "defend");
+                        $buffer = Battle::reportCompanionMove($badguy, $companion, "defend");
                         if ($buffer !== false) {
                             $newcompanions[$name] = $buffer;
                             unset($buffer);

--- a/bio.php
+++ b/bio.php
@@ -53,7 +53,7 @@ if (is_numeric($char)) {
 $sql = "SELECT login, name, level, sex, title, specialty, hashorse, acctid, resurrections, bio, dragonkills, race, clanname, clanshort, clanrank, " . Database::prefix("accounts") . ".clanid, laston, loggedin FROM " . Database::prefix("accounts") . " LEFT JOIN " . Database::prefix("clans") . " ON " . Database::prefix("accounts") . ".clanid = " . Database::prefix("clans") . ".clanid WHERE $where";
 $result = Database::query($sql);
 if ($target = Database::fetchAssoc($result)) {
-  // Let a module get the values if necessary
+    // Let a module get the values if necessary
     $target = HookHandler::hook("biotarget", $target);
     $target['login'] = rawurlencode($target['login']);
     $id = $target['acctid'];

--- a/bios.php
+++ b/bios.php
@@ -34,14 +34,14 @@ SuAccess::check(SU_EDIT_COMMENTS);
 $op = Http::get('op');
 $userid = (int)Http::get('userid');
 if ($op == "block") {
-       $sql = "UPDATE " . Database::prefix("accounts") . " SET bio='`iBlocked for inappropriate usage`i',biotime='9999-12-31 23:59:59' WHERE acctid=$userid";
+    $sql = "UPDATE " . Database::prefix("accounts") . " SET bio='`iBlocked for inappropriate usage`i',biotime='9999-12-31 23:59:59' WHERE acctid=$userid";
     $subj = array("Your bio has been blocked");
     $msg = array("The system administrators have decided that your bio entry is inappropriate, so it has been blocked.`n`nIf you wish to appeal this decision, you may do so with the petition link.");
     Mail::systemMail($userid, $subj, $msg);
     Database::query($sql);
 }
 if ($op == "unblock") {
-       $sql = "UPDATE " . Database::prefix("accounts") . " SET bio='',biotime='" . DATETIME_DATEMIN . "' WHERE acctid=$userid";
+    $sql = "UPDATE " . Database::prefix("accounts") . " SET bio='',biotime='" . DATETIME_DATEMIN . "' WHERE acctid=$userid";
     $subj = array("Your bio has been unblocked");
     $msg = array("The system administrators have decided to unblock your bio.  You can once again enter a bio entry.");
     Mail::systemMail($userid, $subj, $msg);

--- a/create.php
+++ b/create.php
@@ -356,20 +356,20 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
                             $subj = translate_mail($settings_extended->getSetting('verificationmailsubject'), 0);
                             $msg = translate_mail($settings_extended->getSetting('verificationmailtext'), 0);
                             $replace = array(
-                                    "{login}" => $shortname,
-                                    "{acctid}" => $row['acctid'],
-                                    "{emailaddress}" => $email,
-                                    "{gameurl}" => $settings->getSetting('serverurl', 'https://lotgd.com') . "/create.php",
-                                    "{validationid}" => $emailverification,
-                                      );
+                                "{login}" => $shortname,
+                                "{acctid}" => $row['acctid'],
+                                "{emailaddress}" => $email,
+                                "{gameurl}" => $settings->getSetting('serverurl', 'https://lotgd.com') . "/create.php",
+                                "{validationid}" => $emailverification,
+                            );
 
                             $keys = array_keys($replace);
                             $values = array_values($replace);
                             $msg = str_replace($keys, $values, $msg);
                             $msg = str_replace("`n", "\n", $msg);
-                                                        $to_array = array($email => $shortname);
-                                                        $from_array = array($settings->getSetting('gameadminemail', 'postmaster@localhost') => $settings->getSetting('gameadminemail', 'postmaster@localhost'));
-                                                        \Lotgd\Mail::send($to_array, $msg, $subj, $from_array, false, "text/plain");
+                            $to_array = array($email => $shortname);
+                            $from_array = array($settings->getSetting('gameadminemail', 'postmaster@localhost') => $settings->getSetting('gameadminemail', 'postmaster@localhost'));
+                            \Lotgd\Mail::send($to_array, $msg, $subj, $from_array, false, "text/plain");
                             $output->output("`4An email was sent to `\$%s`4 to validate your address.  Click the link in the email to activate your account.`0`n`n", $email);
                         } else {
                             $output->rawOutput("<form action='login.php' method='POST'>");
@@ -441,13 +441,13 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
                 $r1 = Translator::translate("`^(optional -- however, if you choose not to enter one, there will be no way that you can reset your password if you forget it!)`0");
                 $r2 = Translator::translate("`\$(required)`0");
                 $r3 = Translator::translate("`\$(required, an email will be sent to this address to verify it before you can log in)`0");
-        if ((int) $settings->getSetting('requireemail', 0) === 0) {
-            $req = $r1;
-        } elseif ((int) $settings->getSetting('requirevalidemail', 0) === 0) {
-            $req = $r2;
-        } else {
-            $req = $r3;
-        }
+                if ((int) $settings->getSetting('requireemail', 0) === 0) {
+                    $req = $r1;
+                } elseif ((int) $settings->getSetting('requirevalidemail', 0) === 0) {
+                    $req = $r2;
+                } else {
+                    $req = $r3;
+                }
                 $output->rawOutput("</td><td><input name='email'>");
                 $output->outputNotl("%s", $req);
                 $output->rawOutput("</td></tr></table>");
@@ -461,15 +461,15 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
                 $createbutton = Translator::translate("Create your character");
                 $output->rawOutput("<input type='submit' class='button' value='$createbutton'>");
                 $output->outputNotl("`n`n");
-        if ($trash > 0) {
-            $output->output("`^Characters that have never been logged into will be deleted after %s day(s) of no activity.`n`0", $trash);
-        }
-        if ($new > 0) {
-            $output->output("`^Characters that have never reached level 2 will be deleted after %s days of no activity.`n`0", $new);
-        }
-        if ($old > 0) {
-            $output->output("`^Characters that have reached level 2 at least once will be deleted after %s days of no activity.`n`0", $old);
-        }
+                if ($trash > 0) {
+                    $output->output("`^Characters that have never been logged into will be deleted after %s day(s) of no activity.`n`0", $trash);
+                }
+                if ($new > 0) {
+                    $output->output("`^Characters that have never reached level 2 will be deleted after %s days of no activity.`n`0", $new);
+                }
+                if ($old > 0) {
+                    $output->output("`^Characters that have reached level 2 at least once will be deleted after %s days of no activity.`n`0", $old);
+                }
                 $output->rawOutput("</form>");
     }
 }

--- a/dragon.php
+++ b/dragon.php
@@ -116,64 +116,64 @@ $badguy = array(
 
     restore_buff_fields();
     $hpgain = array(
-            'total' => $session['user']['maxhitpoints'],
-            'dkpoints' => $dkpoints,
-            'extra' => $session['user']['maxhitpoints'] - $dkpoints -
-                    ($session['user']['level'] * 10),
-            'base' => $dkpoints + ($session['user']['level'] * 10),
-            );
+        'total' => $session['user']['maxhitpoints'],
+        'dkpoints' => $dkpoints,
+        'extra' => $session['user']['maxhitpoints'] - $dkpoints - ($session['user']['level'] * 10),
+        'base' => $dkpoints + ($session['user']['level'] * 10),
+    );
     $hpgain = HookHandler::hook("hprecalc", $hpgain);
     calculate_buff_fields();
 
-    $nochange = array("acctid" => 1
-                   ,"name" => 1
-                   ,"sex" => 1
-                   ,"playername" => 1
-                   ,"strength" => 1
-                   ,"dexterity" => 1
-                   ,"intelligence" => 1
-                   ,"constitution" => 1
-                   ,"wisdom" => 1
-                   ,"password" => 1
-                   ,"marriedto" => 1
-                   ,"title" => 1
-                   ,"login" => 1
-                   ,"dragonkills" => 1
-                   ,"locked" => 1
-                   ,"loggedin" => 1
-                   ,"superuser" => 1
-                   ,"gems" => 1
-                   ,"hashorse" => 1
-                   ,"gentime" => 1
-                   ,"gentimecount" => 1
-                   ,"lastip" => 1
-                   ,"uniqueid" => 1
-                   ,"dragonpoints" => 1
-                   ,"laston" => 1
-                   ,"prefs" => 1
-                   ,"lastmotd" => 1
-                   ,"emailaddress" => 1
-                   ,"emailvalidation" => 1
-                   ,"gensize" => 1
-                   ,"bestdragonage" => 1
-                   ,"dragonage" => 1
-                   ,"donation" => 1
-                   ,"donationspent" => 1
-                   ,"donationconfig" => 1
-                   ,"bio" => 1
-                   ,"charm" => 1
-                   ,"banoverride" => 1
-                   ,"referer" => 1
-                   ,"refererawarded" => 1
-                   ,"ctitle" => 1
-                   ,"beta" => 1
-                   ,"clanid" => 1
-                   ,"clanrank" => 1
-                   ,"clanjoindate" => 1
-                   ,"translatorlanguages" => 1
-                   ,"replaceemail" => 1
-                   ,"forgottenpassword" => 1
-                   );
+    $nochange = array(
+        "acctid" => 1,
+        "name" => 1,
+        "sex" => 1,
+        "playername" => 1,
+        "strength" => 1,
+        "dexterity" => 1,
+        "intelligence" => 1,
+        "constitution" => 1,
+        "wisdom" => 1,
+        "password" => 1,
+        "marriedto" => 1,
+        "title" => 1,
+        "login" => 1,
+        "dragonkills" => 1,
+        "locked" => 1,
+        "loggedin" => 1,
+        "superuser" => 1,
+        "gems" => 1,
+        "hashorse" => 1,
+        "gentime" => 1,
+        "gentimecount" => 1,
+        "lastip" => 1,
+        "uniqueid" => 1,
+        "dragonpoints" => 1,
+        "laston" => 1,
+        "prefs" => 1,
+        "lastmotd" => 1,
+        "emailaddress" => 1,
+        "emailvalidation" => 1,
+        "gensize" => 1,
+        "bestdragonage" => 1,
+        "dragonage" => 1,
+        "donation" => 1,
+        "donationspent" => 1,
+        "donationconfig" => 1,
+        "bio" => 1,
+        "charm" => 1,
+        "banoverride" => 1,
+        "referer" => 1,
+        "refererawarded" => 1,
+        "ctitle" => 1,
+        "beta" => 1,
+        "clanid" => 1,
+        "clanrank" => 1,
+        "clanjoindate" => 1,
+        "translatorlanguages" => 1,
+        "replaceemail" => 1,
+        "forgottenpassword" => 1,
+    );
 
     $nochange = HookHandler::hook("dk-preserve", $nochange);
 

--- a/forest.php
+++ b/forest.php
@@ -218,7 +218,7 @@ if ($op == "search") {
                     $prefixs = array("Elite","Dangerous","Lethal","Savage","Deadly","Malevolent","Malignant");
                     for ($i = 0; $i < $multi; $i++) {
                         $initialbadguy['creaturelevel'] = Random::eRand($mintargetlevel, $targetlevel);
-                                               $badguy = Outcomes::buffBadguy($initialbadguy);
+                        $badguy = Outcomes::buffBadguy($initialbadguy);
                         if ($type == "thrill") {
                             // 10% more experience
                             $badguy['creatureexp'] = round($badguy['creatureexp'] * 1.1, 0);
@@ -261,7 +261,7 @@ if ($op == "search") {
                             $badguy['creatureaiscript'] = "require('" . $aiscriptfile . "');";
                         }
                         //AI setup
-                                               $badguy = Outcomes::buffBadguy($badguy);
+                        $badguy = Outcomes::buffBadguy($badguy);
                         // Okay, they are thrillseeking, let's give them a bit extra
                         // exp and gold.
                         if ($type == "thrill") {

--- a/installer.php
+++ b/installer.php
@@ -54,7 +54,7 @@ if (!$requirements_met) {
 }
 
 if (!file_exists("dbconnect.php")) {
-       define("DB_NODB", true);
+    define("DB_NODB", true);
 }
 chdir(__DIR__);
 

--- a/lodge.php
+++ b/lodge.php
@@ -96,7 +96,7 @@ if ($op == "") {
     $output->output("Donating even one %s will gain you a membership card to the Hunter's Lodge, an area reserved exclusively for contributors.", $settings->getSetting('paypalcurrency', 'USD'));
     $output->output("Donations are accepted in whole %s increments only.`n`n", $settings->getSetting('paypalcurrency', 'USD'));
     $output->output("\"`&But I don't have access to a PayPal account, or I otherwise can't donate to your very wonderful project!`7\"`n");
-           // yes, "referer" is misspelt here, but the game setting was also misspelt
+    // yes, "referer" is misspelt here, but the game setting was also misspelt
     if ($settings->getSetting('refereraward', 25)) {
         $output->output("Well, there is another way that you can obtain points: by referring other people to our site!");
         $output->output("You'll get %s points for each person whom you've referred who makes it to level %s.", $settings->getSetting('refereraward', 25), $settings->getSetting('referminlevel', 4));

--- a/logdnet.php
+++ b/logdnet.php
@@ -100,12 +100,12 @@ function lotgdsort($a, $b)
 
 $op = Http::get('op');
 if ($op == "") {
-       $addy  = Http::get('addy');
-       $desc  = Http::get('desc');
-       $vers  = Http::get('version');
-       $admin = Http::get('admin');
-       $count = (int)Http::get('c');
-       $lang  = Http::get('l');
+    $addy  = Http::get('addy');
+    $desc  = Http::get('desc');
+    $vers  = Http::get('version');
+    $admin = Http::get('admin');
+    $count = (int)Http::get('c');
+    $lang  = Http::get('l');
 
     if ($vers == "") {
         $vers = "Unknown";

--- a/moderate.php
+++ b/moderate.php
@@ -140,12 +140,12 @@ if ($op == "") {
     $output->rawOutput("</form>");
     Nav::add("", "$link");
     if ($area == "") {
-               Commentary::talkForm("X", "says");
+        Commentary::talkForm("X", "says");
         //commentdisplay("", "' or '1'='1","X",100); //sure, encourage hacking...
         Moderate::commentmoderate('', '', 'X', 100, 'says', false, true);
     } else {
         Moderate::commentmoderate("", $area, "X", 100);
-               Commentary::talkForm($area, "says");
+        Commentary::talkForm($area, "says");
     }
 } elseif ($op == "audit") {
     $subop = Http::get("subop");

--- a/modules.php
+++ b/modules.php
@@ -213,8 +213,10 @@ if ($op == "") {
             $output->rawOutput(" ]</td><td valign='top'>");
             $output->outputNotl($row['active'] ? $active : $inactive);
             $output->rawOutput("</td><td nowrap valign='top'><span title=\"" .
-            (isset($row['description']) && $row['description'] ?
-             $row['description'] : Sanitize::sanitize($row['formalname'])) . "\">");
+                (isset($row['description']) && $row['description']
+                    ? $row['description']
+                    : Sanitize::sanitize($row['formalname'])
+                ) . "\">");
             $output->outputNotl("%s", $row['formalname']);
             $output->rawOutput("<br>");
             $output->outputNotl("(%s) V%s", $row['modulename'], $row['version']);

--- a/news.php
+++ b/news.php
@@ -78,7 +78,7 @@ while ($row = Database::fetchAssoc($result2)) {
             Motd::pollitem($row['motditem'], $row['motdtitle'], $row['motdbody'], $row['motdauthorname'], $row['motddate'], false);
     }
 }
- $output->outputNotl("`n");
+$output->outputNotl("`n");
 $output->output("`c`b`!News for %s %s`0`b`c", $date, $pagestr);
 
 while ($row = Database::fetchAssoc($result)) {
@@ -108,7 +108,7 @@ if (Database::numRows($result) == 0) {
     $output->outputNotl("`c`2-=-`@=-=`2-=-`@=-=`2-=-`@=-=`2-=-`0`c");
     $output->output("`1`b`c Nothing of note happened this day.  All in all a boring day. `c`b`0");
 }
- $output->outputNotl("`c`2-=-`@=-=`2-=-`@=-=`2-=-`@=-=`2-=-`0`c");
+$output->outputNotl("`c`2-=-`@=-=`2-=-`@=-=`2-=-`@=-=`2-=-`0`c");
 if (!$session['user']['loggedin']) {
     Nav::add("Login Screen", "index.php");
 } elseif ($session['user']['alive']) {

--- a/pages/about/about_default.php
+++ b/pages/about/about_default.php
@@ -24,8 +24,8 @@ foreach ($order as $current_rank) {
             $output->output("`nBy Oliver Brendel (<a href='http://nb-core.org'>NB Core</a>) `n`n", true);
             $output->output("This version is a forked version of the pre-1.1.1 DP Edition core shortly after I stopped developing for this specific version.`n`nThe reasons were mainly that the path the leading people there wanted to go was not my path at all. Hence this version reflects mostly what *I* wanted to see different *without* having to rewrite the core using modules... and still be stuck with the old structures. Also I don't have to ask for changes with the high probability of getting no answer or a negative one.`n`n");
             $output->output("If you use this core, you need to be aware of the goals of my optimizations:`n`n<ul>", true);
-               $output->output("<li>PHP 8.3 or newer is required</li>", true);
-               $output->output("<li>MySQL 5.0 or later (MariaDB compatible) is required</li>", true);
+            $output->output("<li>PHP 8.3 or newer is required</li>", true);
+            $output->output("<li>MySQL 5.0 or later (MariaDB compatible) is required</li>", true);
             $output->output("<li>Features should be done focussed on avoiding high-load and focussing on many (MMORG) users</li>", true);
             $output->output("<li>Roleplay like in D&D should be possible</li>", true);
             $output->output("</ul>`n`n", true);

--- a/pages/bans/case_.php
+++ b/pages/bans/case_.php
@@ -43,7 +43,7 @@ if ($display == 1) {
         $laston = DateTime::relativeDate($row['laston']);
         $loggedin =
             (date("U") - strtotime($row['laston']) <
-             $settings->getSetting("LOGINTIMEOUT", 900) && $row['loggedin']);
+                $settings->getSetting("LOGINTIMEOUT", 900) && $row['loggedin']);
         if ($loggedin) {
             $laston = Translator::translateInline("`#Online`0");
         }

--- a/pages/clan/waiting.php
+++ b/pages/clan/waiting.php
@@ -12,7 +12,7 @@ use Lotgd\Commentary;
     $output->output("You stroll off to the side where there are some plush leather chairs, and take a seat.");
     $output->output("There are several other warriors sitting here talking amongst themselves.");
     $output->output("Some Ye Olde Muzak is coming from a fake rock sitting at the base of a potted bush.`n`n");
-      Commentary::commentDisplay("", "waiting", "Speak", 25);
+    Commentary::commentDisplay("", "waiting", "Speak", 25);
 if ($session['user']['clanrank'] == CLAN_APPLICANT) {
     Nav::add("Return to the Lobby", "clan.php");
 } else {

--- a/pages/user/user_.php
+++ b/pages/user/user_.php
@@ -42,7 +42,7 @@ if ($display == 1) {
         $laston = relativedate($row['laston']);
         $loggedin =
             (date("U") - strtotime($row['laston']) <
-             getsetting("LOGINTIMEOUT", 900) && $row['loggedin']);
+                getsetting("LOGINTIMEOUT", 900) && $row['loggedin']);
         if ($loggedin) {
             $laston = Translator::translateInline("`#Online`0");
         }

--- a/pages/user/user_edit.php
+++ b/pages/user/user_edit.php
@@ -103,7 +103,7 @@ if (httpget("subop") == "") {
                 $data[$key] = $x[1];
             }
         }
-               $sql = "SELECT * FROM " . Database::prefix("module_userprefs") . " WHERE modulename='" . Database::escape($module) . "' AND userid=" . (int)$userid;
+            $sql = "SELECT * FROM " . Database::prefix("module_userprefs") . " WHERE modulename='" . Database::escape($module) . "' AND userid=" . (int)$userid;
         $result = Database::query($sql);
         while ($row = Database::fetchAssoc($result)) {
             $data[$row['setting']] = $row['value'];

--- a/pages/user/user_savemodule.php
+++ b/pages/user/user_savemodule.php
@@ -20,11 +20,11 @@ if (isset($post['validation_error']) && $post['validation_error']) {
     $output->outputNotl("`n");
     foreach ($post as $key => $val) {
         $output->output("`\$Setting '`2%s`\$' to '`2%s`\$'`n", $key, htmlspecialchars($val, ENT_QUOTES, 'UTF-8'));
-               $sql = "REPLACE INTO " . Database::prefix("module_userprefs") .
-                       " (modulename,userid,setting,value) VALUES ('" .
-                       Database::escape($module) . "',$userid,'" .
-                       Database::escape($key) . "','" .
-                       Database::escape($val) . "')";
+        $sql = "REPLACE INTO " . Database::prefix("module_userprefs") .
+            " (modulename,userid,setting,value) VALUES ('" .
+            Database::escape($module) . "',$userid,'" .
+            Database::escape($key) . "','" .
+            Database::escape($val) . "')";
         Database::query($sql);
     }
     $output->output("`^Preferences for module %s saved.`n", $module);

--- a/pages/user/user_special.php
+++ b/pages/user/user_special.php
@@ -8,15 +8,15 @@ if (httppost("newday") != "") {
 #   $offset = "-".(24 / (int)getsetting("daysperday",4))." hours";
 #   $newdate = date("Y-m-d H:i:s",strtotime($offset));
 #   $sql = "UPDATE " . Database::prefix("accounts") . " SET lasthit='$newdate' WHERE acctid='$userid'";
-       $sql = "UPDATE " . Database::prefix("accounts") . " SET lasthit='" . DATETIME_DATEMIN . "' WHERE acctid=" . (int)$userid;
+    $sql = "UPDATE " . Database::prefix("accounts") . " SET lasthit='" . DATETIME_DATEMIN . "' WHERE acctid=" . (int)$userid;
     Database::query($sql);
 } elseif (httppost("fixnavs") != "") {
-       $sql = "UPDATE " . Database::prefix("accounts") . " SET allowednavs='', restorepage='', specialinc='' WHERE acctid=" . (int)$userid;
+    $sql = "UPDATE " . Database::prefix("accounts") . " SET allowednavs='', restorepage='', specialinc='' WHERE acctid=" . (int)$userid;
     Database::query($sql);
-       $sql = "DELETE FROM " . Database::prefix("accounts_output") . " WHERE acctid=" . (int)$userid . ";";
+    $sql = "DELETE FROM " . Database::prefix("accounts_output") . " WHERE acctid=" . (int)$userid . ";";
     Database::query($sql);
 } elseif (httppost("clearvalidation") != "") {
-       $sql = "UPDATE " . Database::prefix("accounts") . " SET emailvalidation='' WHERE acctid=" . (int)$userid;
+    $sql = "UPDATE " . Database::prefix("accounts") . " SET emailvalidation='' WHERE acctid=" . (int)$userid;
     Database::query($sql);
 }
 $op = "edit";

--- a/prefs.php
+++ b/prefs.php
@@ -49,7 +49,7 @@ $op = Http::get('op');
 
 Nav::add("Navigation");
 if ($op == "suicide" && $settings->getSetting('selfdelete', 0) != 0) {
-       $userid = (int)Http::get('userid');
+    $userid = (int)Http::get('userid');
     if (PlayerFunctions::charCleanup($userid, CHAR_DELETE_SUICIDE)) {
         $sql = "DELETE FROM " . Database::prefix("accounts") . " WHERE acctid=$userid";
         Database::query($sql);

--- a/source.php
+++ b/source.php
@@ -193,10 +193,10 @@ if (
         ;
     }
 } else {
-       $output->output("Due to the behaviour of people in the past, access to the source code online has been restricted.");
-       $output->output("You may download the entirety of the latest publicly released stable version from <a href='http://www.dragonprime.net' target='_blank'>DragonPrime</a>.", true);
-       $output->output("For the +NB version of Legend of the Green Dragon, visit our <a href='https://github.com/NB-Core/lotgd' target='_blank'>GitHub repository</a> where you can download releases or clone the project.", true);
-       $output->output("You may then work with that code within the restrictions of its license.");
+    $output->output("Due to the behaviour of people in the past, access to the source code online has been restricted.");
+    $output->output("You may download the entirety of the latest publicly released stable version from <a href='http://www.dragonprime.net' target='_blank'>DragonPrime</a>.", true);
+    $output->output("For the +NB version of Legend of the Green Dragon, visit our <a href='https://github.com/NB-Core/lotgd' target='_blank'>GitHub repository</a> where you can download releases or clone the project.", true);
+    $output->output("You may then work with that code within the restrictions of its license.");
     $output->output("`n`nHopefully this will help put an end to actions like the following:");
     $output->rawOutput("<ul><li>");
     $output->output("Releasing code which they do not own without permission.");

--- a/stables.php
+++ b/stables.php
@@ -259,8 +259,10 @@ if ($op == 'confirmbuy') {
             $output->output(
                 $texts['mountfull'],
                 Translator::translateInline($session['user']['sex'] ? $texts['lass'] : $texts['lad']),
-                (isset($playerMount['basename']) && $playerMount['basename'] ?
-                 $playerMount['basename'] : $playerMount['mountname'])
+                (isset($playerMount['basename']) && $playerMount['basename']
+                    ? $playerMount['basename']
+                    : $playerMount['mountname']
+                )
             );
             $translator->setSchema();
         }


### PR DESCRIPTION
## Summary
- normalize indentation across root entry points and user/admin subpages to comply with PSR-12 spacing
- restyle multi-line arrays and ternary expressions for clarity in dragon.php, modules.php, stables.php, and related files
- tidy supporting comments and helper assignments to match the repository coding standard

## Testing
- php -l about.php battle.php bio.php bios.php create.php dragon.php forest.php installer.php lodge.php logdnet.php moderate.php modules.php news.php pages/about/about_default.php pages/bans/case_.php pages/clan/waiting.php pages/user/user_.php pages/user/user_edit.php pages/user/user_savemodule.php pages/user/user_special.php prefs.php source.php stables.php
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d3d359e7108329b377016fcf9bc328