### PR TITLE
fix: correct schema argument for comment moderation

### DIFF
--- a/moderate.php
+++ b/moderate.php
@@ -142,7 +142,7 @@ if ($op == "") {
     if ($area == "") {
         Commentary::talkForm("X", "says");
         //commentdisplay("", "' or '1'='1","X",100); //sure, encourage hacking...
-        Moderate::commentmoderate('', '', 'X', 100, 'says', false, true);
+        Moderate::commentmoderate('', '', 'X', 100, 'says', null, true);
     } else {
         Moderate::commentmoderate("", $area, "X", 100);
         Commentary::talkForm($area, "says");


### PR DESCRIPTION
## Summary
- pass a null schema to `Moderate::commentmoderate` when no area is selected to satisfy the method signature

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d424888b948329ba253bf650cb3952