### PR TITLE
fix: prevent mail reply from closing window by default

### DIFF
--- a/pages/mail/case_send.php
+++ b/pages/mail/case_send.php
@@ -25,8 +25,8 @@ function mailSend(): void
     $to = (string) Http::post('to');
     $subject = (string) Http::post('subject');
     $body = (string) Http::post('body');
-    $sendClose = Http::post('sendclose') !== '';
-    $sendBack = Http::post('sendback') !== '';
+    $sendClose = Http::postIsset('sendclose');
+    $sendBack = Http::postIsset('sendback');
     $return = (int) Http::post('returnto');
 
     if ($to === '' || $body === '') {


### PR DESCRIPTION
## Summary
- ensure the Send button only closes the compose popup when the explicit "Send and Close" control is used

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d45a8ebd648329907eaebdbae7f626