### PR TITLE
fix: guard password inputs during account creation

### DIFF
--- a/create.php
+++ b/create.php
@@ -238,7 +238,14 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
             $blockaccount = false;
             $email = Http::post('email');
             $pass1 = Http::post('pass1');
+            if ($pass1 === false || is_array($pass1)) {
+                $pass1 = '';
+            }
+
             $pass2 = Http::post('pass2');
+            if ($pass2 === false || is_array($pass2)) {
+                $pass2 = '';
+            }
             if ((int) $settings->getSetting('blockdupeemail', 0) === 1 && (int) $settings->getSetting('requireemail', 0) === 1) {
                 $sql = "SELECT login FROM " . Database::prefix("accounts") . " WHERE emailaddress='" . Database::escape($email) . "'";
                 $result = Database::query($sql);


### PR DESCRIPTION
## Summary
- normalize password POST values during character creation to ensure string handling
- prevent substr calls from receiving non-string values when passwords are missing or malformed

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d5105b26008329aecc4b564a6a7fd8