### PR TITLE
fix: ensure email input is string for validator

### DIFF
--- a/create.php
+++ b/create.php
@@ -237,6 +237,9 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
         } else {
             $blockaccount = false;
             $email = Http::post('email');
+            if ($email === false || is_array($email)) {
+                $email = '';
+            }
             $pass1 = Http::post('pass1');
             if ($pass1 === false || is_array($pass1)) {
                 $pass1 = '';


### PR DESCRIPTION
## Summary
- normalize the posted email address to an empty string when the request parameter is missing or malformed
- prevent Lotgd\EmailValidator::isValid from receiving non-string values during account creation

## Testing
- composer test
- composer static

------
https://chatgpt.com/codex/tasks/task_e_68d51f6648048329925e3d6f6f9ae14e