### PR TITLE
fix: sanitize referral nav parameter

### DIFF
--- a/referral.php
+++ b/referral.php
@@ -86,7 +86,10 @@ if ($session['user']['loggedin']) {
     Header::pageHeader("Welcome to Legend of the Green Dragon");
     $output->output("`@Legend of the Green Dragon is a remake of the classic BBS Door Game Legend of the Red Dragon.");
     $output->output("Adventure into the classic realm that was one of the world's very first multiplayer roleplaying games!");
-    Nav::add("Create a character", "create.php?r=" . HTMLEntities(Http::get('r'), ENT_COMPAT, $settings->getSetting("charset", "UTF-8")));
+    $referrer = Http::get('r') ?: '';
+    $sanitizedReferrer = HTMLEntities($referrer, ENT_COMPAT, $settings->getSetting("charset", "UTF-8"));
+
+    Nav::add("Create a character", "create.php?r=" . $sanitizedReferrer);
     Nav::add("Login Page", "index.php");
     Footer::pageFooter();
 }


### PR DESCRIPTION
## Summary
- guard the referral query parameter before sanitizing it in referral.php
- reuse the sanitized referral value when building the create link

## Testing
- php -l referral.php
- curl -s -o /tmp/referral_no_param.html -w '%{http_code}' http://127.0.0.1:8000/referral.php
- curl -s -o /tmp/referral_with_param.html -w '%{http_code}' 'http://127.0.0.1:8000/referral.php?r=test'

------
https://chatgpt.com/codex/tasks/task_e_68d668bf7f6883298bf82c7948161755