### PR TITLE
fix: normalize bartender color practice input

### DIFF
--- a/pages/inn/inn_bartender.php
+++ b/pages/inn/inn_bartender.php
@@ -113,6 +113,9 @@ if ($act == "") {
     $output->output("`% Got it?`0\"  You can practice below:");
     $output->rawOutput("<form action=\"" . PhpGenericEnvironment::getRequestUri() . "\" method='POST'>", true);
     $testtext = Http::post('testtext');
+    if ($testtext === false) {
+        $testtext = '';
+    }
     $output->output("You entered %s`n", Sanitize::preventColors(HTMLEntities($testtext, ENT_COMPAT, $settings->getSetting('charset', 'UTF-8'))), true);
     $output->output("It looks like %s`n", $testtext);
     $try = Translator::translateInline("Try");


### PR DESCRIPTION
## Summary
- normalize the bartender color practice input so it defaults to an empty string when no POST data is available
- continue to use the normalized value for both sanitized and raw outputs to avoid type errors on the initial render

## Testing
- php -l pages/inn/inn_bartender.php

------
https://chatgpt.com/codex/tasks/task_e_68d6ef396ef4832997ca90c439b46ed9