### PR TITLE
docs: reference DragonPrime Reborn resource hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ See `CHANGELOG.txt` for a list of changes up until version 1.3.2.
 
 If you need **modules**, [go there](https://github.com/NB-Core/modules) and fetch the ones you like.
 There may be more out there, in the original dragonprime resources or other people's work.
+Modern DragonPrime resources, templates, and community support now live at [DragonPrime Reborn](https://dragonprime-reborn.ca/), the successor to the legacy DragonPrime site.
 
 If you need more legacy **templates** / skins for the game, [go there](https://github.com/NB-Core/lotgd-templates).
 


### PR DESCRIPTION
## Summary
- add a link to DragonPrime Reborn as the modern successor to the legacy DragonPrime resources in the README

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6f16dc0ac83299efc4c0d568ccae9