### PR TITLE
docs: reference spiritual successor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ If you need **modules**, [go there](https://github.com/NB-Core/modules) and fetc
 There may be more out there, in the original dragonprime resources or other people's work.
 Modern DragonPrime resources, templates, and community support now live at [DragonPrime Reborn](https://dragonprime-reborn.ca/), the successor to the legacy DragonPrime site.
 
+To follow the actively maintained spiritual successor of the main core this fork extends, visit [StephenKise's Legend of the Green Dragon](https://github.com/stephenKise/Legend-of-the-Green-Dragon), which carries forward ongoing development and releases.
+
 If you need more legacy **templates** / skins for the game, [go there](https://github.com/NB-Core/lotgd-templates).
 
 ## System Requirements


### PR DESCRIPTION
## Summary
- add a reference in the Read Me First section to the StephenKise spiritual successor repository
- clarify the relationship between this fork and the actively maintained mainline core

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6f26981688329a01dbe0e59214fe9