### PR TITLE
Auto-detect Doctrine-managed upgrades in the installer

### DIFF
--- a/tests/Installer/Stage7Test.php
+++ b/tests/Installer/Stage7Test.php
@@ -95,6 +95,26 @@ namespace Lotgd\Tests\Installer {
             $this->assertContains('Location: installer.php?stage=8', $this->getRedirectHeaders());
         }
 
+        public function testStage7SkipsLegacyDropdownWhenDoctrineMetadataExists(): void
+        {
+            $_SESSION['dbinfo'] = [
+                'has_migration_metadata' => true,
+            ];
+
+            $installer = new Installer();
+
+            $installer->stage7();
+
+            $output = Output::getInstance()->getRawOutput();
+
+            $this->assertTrue($_SESSION['dbinfo']['upgrade']);
+            $this->assertSame('2.0.0', $_SESSION['fromversion']);
+            $this->assertSame(6, $_SESSION['stagecompleted']);
+            $this->assertStringContainsString('Doctrine migration metadata detected', $output);
+            $this->assertStringContainsString('Perform an upgrade using Doctrine migrations only.', $output);
+            $this->assertStringNotContainsString("<select name='version'>", $output);
+        }
+
         /**
          * @return list<string>
          */


### PR DESCRIPTION
## Summary
- detect Doctrine's migration metadata during stage 5 to flag migration-managed upgrades
- default stage 7 to the migrations-only path and hide the legacy snapshot selector when metadata exists
- skip legacy SQL seeding for Doctrine installs and add installer regression tests

## Testing
- ./vendor/bin/phpunit tests/Installer/Stage7Test.php tests/Installer/Stage9Test.php

------
https://chatgpt.com/codex/tasks/task_e_68d6ff7f3d788329ad94f939a5faa725