### PR TITLE
fix: preserve installer upgrade selection

### DIFF
--- a/tests/Installer/Stage7Test.php
+++ b/tests/Installer/Stage7Test.php
@@ -115,6 +115,42 @@ namespace Lotgd\Tests\Installer {
             $this->assertStringNotContainsString("<select name='version'>", $output);
         }
 
+        public function testStage7RespectsUpgradeFlagFromStage5(): void
+        {
+            $_SESSION['dbinfo'] = [
+                'upgrade' => true,
+                'existing_tables' => [],
+            ];
+
+            $installer = new Installer();
+
+            $installer->stage7();
+
+            $output = Output::getInstance()->getRawOutput();
+
+            $this->assertTrue($_SESSION['dbinfo']['upgrade']);
+            $this->assertStringContainsString("value='upgrade' name='type' checked", $output);
+            $this->assertStringContainsString("<select name='version'>", $output);
+        }
+
+        public function testStage7DefaultsToUpgradeWhenExistingTablesDetected(): void
+        {
+            $_SESSION['dbinfo'] = [
+                'upgrade' => false,
+                'existing_tables' => ['logd_accounts'],
+            ];
+
+            $installer = new Installer();
+
+            $installer->stage7();
+
+            $output = Output::getInstance()->getRawOutput();
+
+            $this->assertTrue($_SESSION['dbinfo']['upgrade']);
+            $this->assertStringContainsString("value='upgrade' name='type' checked", $output);
+            $this->assertStringContainsString("<select name='version'>", $output);
+        }
+
         /**
          * @return list<string>
          */


### PR DESCRIPTION
## Summary
- keep Stage 7 from resetting the upgrade flag when Stage 5 has already determined an upgrade or Doctrine metadata is present
- default the Stage 7 UI to upgrade mode when Stage 5 found existing tables and cover the behaviour with installer tests

## Testing
- vendor/bin/phpunit tests/Installer/Stage7Test.php

------
https://chatgpt.com/codex/tasks/task_e_68d7b0a4a3dc832994e6ad9d8f5e1036