### PR TITLE
Harden installer upgrade path handling

### DIFF
--- a/tests/Installer/Stage9Test.php
+++ b/tests/Installer/Stage9Test.php
@@ -137,6 +137,7 @@ namespace Lotgd\Tests\Installer {
             global $session, $logd_version, $recommended_modules, $noinstallnavs,
             $DB_USEDATACACHE, $settings;
 
+            unset($_ENV['LOTGD_BASE_VERSION']);
             \Lotgd\PhpGenericEnvironment::setRequestUri('/installer.php');
             \Doctrine\Migrations\DependencyFactory::$instance = null;
             $session            = [
@@ -277,6 +278,19 @@ namespace Lotgd\Tests\Installer {
                 $configData['table_storage']['table_name'] ?? null,
                 'Installer did not request prefixed metadata table'
             );
+        }
+
+        public function testStage9NormalizesNonStringFromVersionBeforeMigrations(): void
+        {
+            global $session;
+
+            $session['fromversion'] = ['unexpected'];
+
+            $installer = new Installer();
+            $installer->runStage(9);
+
+            $this->assertSame('-1', $session['fromversion']);
+            $this->assertArrayNotHasKey('LOTGD_BASE_VERSION', $_ENV);
         }
 
 


### PR DESCRIPTION
## Summary
- normalize the version selected during upgrades and preserve upgrade detection when tables already exist
- guard `runMigrations()` against non-string session data and clear stale base-version environment values
- extend Stage7 and Stage9 installer tests to cover the new safeguards

## Testing
- ./vendor/bin/phpunit tests/Installer/Stage7Test.php tests/Installer/Stage9Test.php

------
https://chatgpt.com/codex/tasks/task_e_68d7b0a565c48329b0767770e1909a62