### PR TITLE
fix: harden installer upgrade version handling

### DIFF
--- a/tests/Installer/Stage7Test.php
+++ b/tests/Installer/Stage7Test.php
@@ -95,6 +95,21 @@ namespace Lotgd\Tests\Installer {
             $this->assertContains('Location: installer.php?stage=8', $this->getRedirectHeaders());
         }
 
+        public function testStage7FallsBackToDefaultVersionWhenPostValueIsInvalid(): void
+        {
+            $_POST['type']    = 'upgrade';
+            $_POST['version'] = ['1.0.0'];
+
+            $installer = new Installer();
+
+            $installer->stage7();
+
+            $this->assertTrue($_SESSION['dbinfo']['upgrade']);
+            $this->assertSame('2.0.0', $_SESSION['fromversion']);
+            $this->assertSame(7, $_SESSION['stagecompleted']);
+            $this->assertContains('Location: installer.php?stage=8', $this->getRedirectHeaders());
+        }
+
         public function testStage7SkipsLegacyDropdownWhenDoctrineMetadataExists(): void
         {
             $_SESSION['dbinfo'] = [


### PR DESCRIPTION
## Summary
- coerce installer upgrade version selection to a safe default and always render the selector when upgrades are implied
- harden migration bootstrap to ignore invalid or missing source versions
- extend installer stage tests to cover the new guards

## Testing
- vendor/bin/phpunit tests/Installer/Stage7Test.php tests/Installer/Stage9Test.php

------
https://chatgpt.com/codex/tasks/task_e_68d92ed97e9c8329b6788a15711fc39e