### PR TITLE
fix: refine installer upgrade detection

### DIFF
--- a/tests/Installer/Stage7Test.php
+++ b/tests/Installer/Stage7Test.php
@@ -135,6 +135,7 @@ namespace Lotgd\Tests\Installer {
             $_SESSION['dbinfo'] = [
                 'upgrade' => true,
                 'existing_tables' => [],
+                'existing_logd_tables' => [],
             ];
 
             $installer = new Installer();
@@ -148,11 +149,12 @@ namespace Lotgd\Tests\Installer {
             $this->assertStringContainsString("<select name='version'>", $output);
         }
 
-        public function testStage7DefaultsToUpgradeWhenExistingTablesDetected(): void
+        public function testStage7DefaultsToUpgradeWhenLogdTablesDetected(): void
         {
             $_SESSION['dbinfo'] = [
                 'upgrade' => false,
                 'existing_tables' => ['logd_accounts'],
+                'existing_logd_tables' => ['logd_accounts'],
             ];
 
             $installer = new Installer();
@@ -164,6 +166,25 @@ namespace Lotgd\Tests\Installer {
             $this->assertTrue($_SESSION['dbinfo']['upgrade']);
             $this->assertStringContainsString("value='upgrade' name='type' checked", $output);
             $this->assertStringContainsString("<select name='version'>", $output);
+        }
+
+        public function testStage7KeepsCleanInstallDefaultWhenOnlyUnrelatedTablesDetected(): void
+        {
+            $_SESSION['dbinfo'] = [
+                'upgrade' => false,
+                'existing_tables' => ['something_else'],
+                'existing_logd_tables' => [],
+            ];
+
+            $installer = new Installer();
+
+            $installer->stage7();
+
+            $output = Output::getInstance()->getRawOutput();
+
+            $this->assertFalse($_SESSION['dbinfo']['upgrade']);
+            $this->assertStringContainsString("value='install' name='type' checked", $output);
+            $this->assertStringNotContainsString("<select name='version'>", $output);
         }
 
         /**


### PR DESCRIPTION
## Summary
- persist the list of detected LoGD tables during Stage 5 so it can inform later stages
- update Stage 7 to default to upgrades only when Stage 5 or LoGD table detection indicates they are needed
- extend the Stage 7 PHPUnit coverage to verify both clean-install and upgrade defaults

## Testing
- vendor/bin/phpunit tests/Installer/Stage7Test.php

------
https://chatgpt.com/codex/tasks/task_e_68d935db232c8329b86352853cf7e7bc