### PR TITLE
fix: keep installer upgrade dropdown aligned with detected version

### DIFF
--- a/install/data/installer_sqlstatements.php
+++ b/install/data/installer_sqlstatements.php
@@ -964,4 +964,13 @@ $sql_upgrade_statements = array(
     ),
 "1.3.2.+nb Edition" => array(
     ),
+    // Placeholders for releases managed exclusively by Doctrine migrations.
+    "2.0.0" => array(
+    ),
+    "2.0.1" => array(
+    ),
+    "2.0.2" => array(
+    ),
+    "2.1.0" => array(
+    ),
 );

--- a/install/data/installer_sqlstatements.php
+++ b/install/data/installer_sqlstatements.php
@@ -967,10 +967,8 @@ $sql_upgrade_statements = array(
     // Placeholders for releases managed exclusively by Doctrine migrations.
     "2.0.0" => array(
     ),
-    "2.0.1" => array(
-    ),
-    "2.0.2" => array(
-    ),
-    "2.1.0" => array(
-    ),
 );
+
+$sql_upgrade_version_labels = [
+    '2.0.0' => '2.0.0+ (automatic migrations)',
+];

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1128,17 +1128,21 @@ class Installer
                     $sql_upgrade_statements,
                     $detectedDatabaseVersion
                 );
+                $versionLabels = $sql_upgrade_version_labels ?? [];
                 $charset = (string) $this->getSetting('charset', 'UTF-8');
 
                 $this->output->rawOutput("<select name='version'>");
                 foreach ($versionOptions as $version) {
                     $escapedVersion = htmlspecialchars($version, ENT_QUOTES, $charset);
+                    $label = $versionLabels[$version] ?? $version;
+                    $escapedLabel = htmlspecialchars($label, ENT_QUOTES, $charset);
                     $isSelected = $detectedDatabaseVersion === $version ? ' selected' : '';
                     $this->output->rawOutput(
                         sprintf(
-                            '<option value="%1$s"%2$s>%1$s</option>',
+                            '<option value="%1$s"%2$s>%3$s</option>',
                             $escapedVersion,
-                            $isSelected
+                            $isSelected,
+                            $escapedLabel
                         )
                     );
                 }

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1123,12 +1123,24 @@ class Installer
                 if (! isset($sql_upgrade_statements)) {
                     require __DIR__ . '/../data/installer_sqlstatements.php';
                 }
-                reset($sql_upgrade_statements);
+
+                $versionOptions = $this->getUpgradeVersionOptions(
+                    $sql_upgrade_statements,
+                    $detectedDatabaseVersion
+                );
+                $charset = (string) $this->getSetting('charset', 'UTF-8');
+
                 $this->output->rawOutput("<select name='version'>");
-                foreach ($sql_upgrade_statements as $key => $val) {
-                    if ($key != '-1') {
-                        $this->output->rawOutput("<option value='$key'" . ($detectedDatabaseVersion == $key ? ' selected' : '') . ">$key</option>");
-                    }
+                foreach ($versionOptions as $version) {
+                    $escapedVersion = htmlspecialchars($version, ENT_QUOTES, $charset);
+                    $isSelected = $detectedDatabaseVersion === $version ? ' selected' : '';
+                    $this->output->rawOutput(
+                        sprintf(
+                            '<option value="%1$s"%2$s>%1$s</option>',
+                            $escapedVersion,
+                            $isSelected
+                        )
+                    );
                 }
                 $this->output->rawOutput("</select>");
             }
@@ -1603,6 +1615,35 @@ class Installer
     private function saveSetting(string $name, $value): void
     {
         Settings::getInstance()->saveSetting($name, $value);
+    }
+
+    /**
+     * Compile the list of legacy upgrade versions shown in stage 7.
+     *
+     * @param array<string|int, mixed> $sqlUpgradeStatements
+     *
+     * @return list<string>
+     */
+    private function getUpgradeVersionOptions(array $sqlUpgradeStatements, string $detectedDatabaseVersion): array
+    {
+        $options = [];
+
+        foreach (array_keys($sqlUpgradeStatements) as $version) {
+            $stringVersion = (string) $version;
+            if ($stringVersion === '-1') {
+                continue;
+            }
+            $options[] = $stringVersion;
+        }
+
+        if ($detectedDatabaseVersion !== ''
+            && $detectedDatabaseVersion !== '-1'
+            && ! in_array($detectedDatabaseVersion, $options, true)
+        ) {
+            array_unshift($options, $detectedDatabaseVersion);
+        }
+
+        return array_values(array_unique($options));
     }
 
     /**

--- a/tests/Installer/Stage7Test.php
+++ b/tests/Installer/Stage7Test.php
@@ -152,6 +152,7 @@ namespace Lotgd\Tests\Installer {
             $this->assertTrue($_SESSION['dbinfo']['upgrade']);
             $this->assertStringContainsString("value='upgrade' name='type' checked", $output);
             $this->assertStringContainsString("<select name='version'>", $output);
+            $this->assertStringContainsString('<option value="2.0.0">2.0.0+ (automatic migrations)</option>', $output);
         }
 
         public function testStage7DefaultsToUpgradeWhenLogdTablesDetected(): void

--- a/tests/Installer/Stage7Test.php
+++ b/tests/Installer/Stage7Test.php
@@ -25,6 +25,7 @@ namespace Lotgd\Tests\Installer {
 
     use Lotgd\Installer\Installer;
     use Lotgd\Output;
+    use Lotgd\Settings;
     use Lotgd\Tests\Stubs\Database;
     use PHPUnit\Framework\TestCase;
 
@@ -44,6 +45,10 @@ namespace Lotgd\Tests\Installer {
             $_SESSION = &$session;
             $output   = Output::getInstance();
             $settings = null;
+
+            Database::$settings_table = [];
+            Database::$settings_extended_table = [];
+            Settings::setInstance(null);
 
             $_POST = [];
             $_SERVER['SCRIPT_NAME'] = 'test.php';
@@ -185,6 +190,27 @@ namespace Lotgd\Tests\Installer {
             $this->assertFalse($_SESSION['dbinfo']['upgrade']);
             $this->assertStringContainsString("value='install' name='type' checked", $output);
             $this->assertStringNotContainsString("<select name='version'>", $output);
+        }
+
+        public function testStage7IncludesDetectedVersionEvenWhenMissingFromLegacyMap(): void
+        {
+            $settings = Settings::getInstance();
+            $settings->saveSetting('installer_version', '2.0.1');
+
+            $_SESSION['dbinfo'] = [
+                'upgrade' => false,
+                'existing_tables' => ['logd_accounts'],
+                'existing_logd_tables' => ['logd_accounts'],
+            ];
+
+            $installer = new Installer();
+
+            $installer->stage7();
+
+            $output = Output::getInstance()->getRawOutput();
+
+            $this->assertTrue($_SESSION['dbinfo']['upgrade']);
+            $this->assertStringContainsString('<option value="2.0.1" selected>2.0.1</option>', $output);
         }
 
         /**


### PR DESCRIPTION
## Summary
- ensure the stage 7 upgrade selector includes and selects the detected database version even when it is not in the legacy SQL map
- add placeholder Doctrine-managed release entries to the installer SQL statement catalog to expose post-1.3.2 options
- cover future installer_version values with a regression test for stage 7

## Testing
- ./vendor/bin/phpunit tests/Installer/Stage7Test.php

------
https://chatgpt.com/codex/tasks/task_e_68d93d647f408329a680423e622e9e36