### PR TITLE
fix: preserve installer table prefix detection

### DIFF
--- a/tests/Installer/Stage7Test.php
+++ b/tests/Installer/Stage7Test.php
@@ -174,6 +174,27 @@ namespace Lotgd\Tests\Installer {
             $this->assertStringContainsString("<select name='version'>", $output);
         }
 
+        public function testStage7DefaultsToUpgradeWithPrefixedTables(): void
+        {
+            $_SESSION['dbinfo'] = [
+                'upgrade' => false,
+                'existing_tables' => ['lotgd_accounts'],
+                'existing_logd_tables' => ['lotgd_accounts'],
+                'has_migration_metadata' => false,
+                'DB_PREFIX' => 'lotgd_',
+            ];
+
+            $installer = new Installer();
+
+            $installer->stage7();
+
+            $output = Output::getInstance()->getRawOutput();
+
+            $this->assertTrue($_SESSION['dbinfo']['upgrade']);
+            $this->assertStringContainsString("value='upgrade' name='type' checked", $output);
+            $this->assertStringContainsString("<select name='version'>", $output);
+        }
+
         public function testStage7KeepsCleanInstallDefaultWhenOnlyUnrelatedTablesDetected(): void
         {
             $_SESSION['dbinfo'] = [


### PR DESCRIPTION
## Summary
- reuse previously discovered installer table prefixes, reading dbconnect.php when needed and normalising them with a trailing underscore
- rescan installer table metadata after the prefix is resolved so prefixed tables and migration metadata are detected
- expand Stage 5 and Stage 7 installer tests to cover prefixed tables and dbconnect.php seeding

## Testing
- ./vendor/bin/phpunit tests/Installer/Stage5Test.php tests/Installer/Stage7Test.php

------
https://chatgpt.com/codex/tasks/task_e_68d94e8b83488329ab4e1ca8a5ef93a4