### PR TITLE
Allow installer stage 5 to run with existing dbconnect.php

### DIFF
--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1090,6 +1090,28 @@ class Installer
             $session['dbinfo']['upgrade'] = true;
         }
 
+        $sessionFromVersion = $session['fromversion'] ?? null;
+        $hasValidFromVersion = is_string($sessionFromVersion)
+            && $sessionFromVersion !== ''
+            && $sessionFromVersion !== '-1';
+
+        if (($session['dbinfo']['upgrade'] ?? false)) {
+            if (! $hasValidFromVersion || $sessionFromVersion === false) {
+                $fallbackVersion = $detectedDatabaseVersion;
+                if (! is_string($fallbackVersion) || $fallbackVersion === '' || $fallbackVersion === '-1') {
+                    $fallbackVersion = $doctrineDefaultVersion;
+                }
+
+                $sessionFromVersion = $fallbackVersion;
+                $session['fromversion'] = $sessionFromVersion;
+                $hasValidFromVersion = true;
+            }
+
+            if ($hasValidFromVersion) {
+                $detectedDatabaseVersion = $sessionFromVersion;
+            }
+        }
+
         if ($detectedDatabaseVersion != '-1') {
             $this->output->output("`n`2Detected database version: `^%s`2.`n", $detectedDatabaseVersion);
             if ($session['dbinfo']['upgrade']) {


### PR DESCRIPTION
## Summary
- hydrate the installer session from dbconnect.php so stage 5 can probe existing databases
- ensure stage 7 selects a concrete upgrade version when an upgrade is implied
- add coverage for the stage 5/7 flow when dbconnect.php is present and update related expectations

## Testing
- vendor/bin/phpunit tests/Installer/Stage7Test.php
- vendor/bin/phpunit tests/Installer/Stage5Test.php

------
https://chatgpt.com/codex/tasks/task_e_68d95449081883298c0893e93671c9e5