### PR TITLE
fix: guard template validation in prefs

### DIFF
--- a/prefs.php
+++ b/prefs.php
@@ -31,7 +31,7 @@ use Lotgd\PlayerFunctions;
 require_once __DIR__ . "/common.php";
 
 $skin = Http::post('template');
-if ($skin !== '' && Template::isValidTemplate($skin)) {
+if (is_string($skin) && $skin !== '' && Template::isValidTemplate($skin)) {
         Template::setTemplateCookie($skin);
         Template::prepareTemplate(true);
 }


### PR DESCRIPTION
## Summary
- ensure the template validation runs only when the POSTed value is a string

## Testing
- php -l prefs.php

------
https://chatgpt.com/codex/tasks/task_e_68da848073608329af321338a4d6a6e5