### PR TITLE
fix: guard module pref keys before regex checks

### DIFF
--- a/prefs.php
+++ b/prefs.php
@@ -392,8 +392,13 @@ if ($op == "suicide" && $settings->getSetting('selfdelete', 0) != 0) {
         $tempdata = array();
         $found = 0;
         foreach ($info['prefs'] as $key => $val) {
-            $isuser = preg_match("/^user_/", $key);
-            $ischeck = preg_match("/^check_/", $key);
+            if (!is_string($key)) {
+                $isuser = false;
+                $ischeck = false;
+            } else {
+                $isuser = preg_match("/^user_/", $key);
+                $ischeck = preg_match("/^check_/", $key);
+            }
 
             if (is_array($val)) {
                 $v = $val[0];


### PR DESCRIPTION
## Summary
- skip regex detection for module preference keys that are not strings to avoid runtime warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db945599788329b66e565692c9df40