### PR TITLE
fix: keep mount buff rounds field string-safe

### DIFF
--- a/mounts.php
+++ b/mounts.php
@@ -475,7 +475,7 @@ function mountform($mount)
     $output->output("(message replacements: {badguy}, {goodguy}, {weapon}, {armor}, {creatureweapon}, and where applicable {damage}.)`n");
     $output->output("`n`bEffects:`b`n");
     $output->output("Rounds to last (from new day):");
-    $output->rawOutput("<input name='mount[mountbuff][rounds]' value=\"" . htmlentities((int)$mount['mountbuff']['rounds'], ENT_COMPAT, $settings->getSetting('charset', 'UTF-8')) . "\" size='50'><br/>");
+    $output->rawOutput("<input name='mount[mountbuff][rounds]' value=\"" . htmlentities((string)($mount['mountbuff']['rounds'] ?? ''), ENT_COMPAT, $settings->getSetting('charset', 'UTF-8')) . "\" size='50'><br/>");
     $output->output("Player Atk mod:");
     $output->rawOutput("<input name='mount[mountbuff][atkmod]' value=\"" . htmlentities($mount['mountbuff']['atkmod'], ENT_COMPAT, $settings->getSetting('charset', 'UTF-8')) . "\" size='50'>");
     $output->output("(multiplier)`n");


### PR DESCRIPTION
## Summary
- stop casting the mount buff rounds value to int before escaping it for the form field
- ensure the rounds input safely handles missing or non-numeric values using string casting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db983eec7c8329ad603b3ee9fd2a72