### PR TITLE
fix: guard cron bootstrap notifications

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -38,20 +38,27 @@ if (!defined('CRON_TEST')) {
         );
         error_log($message, 3, __DIR__ . '/logs/bootstrap.log');
 
-        $email = $settings->getSetting('gameadminemail', '');
-        if ($email !== '') {
-            $body = sprintf(
-                'Cronjob at %s failed to load common.php: %s',
-                $settings->getSetting('serverurl', ''),
-                $e->getMessage()
-            );
-            $mailResult = Mail::send([$email => $email], $body, 'Cronjob Error', [$email => $email], false, 'text/plain', true);
+        if (! Settings::hasInstance()) {
+            exit(1);
+        }
 
-            if (is_array($mailResult) && ! $mailResult['success']) {
-                error_log('Cron notification mail failed: ' . $mailResult['error']);
-            } elseif ($mailResult === false) {
-                error_log('Cron notification mail failed to send.');
-            }
+        $settingsInstance = Settings::getInstance();
+        $email = $settingsInstance->getSetting('gameadminemail', '');
+        if ($email === '') {
+            exit(1);
+        }
+
+        $body = sprintf(
+            'Cronjob at %s failed to load common.php: %s',
+            $settingsInstance->getSetting('serverurl', ''),
+            $e->getMessage()
+        );
+        $mailResult = Mail::send([$email => $email], $body, 'Cronjob Error', [$email => $email], false, 'text/plain', true);
+
+        if (is_array($mailResult) && ! $mailResult['success']) {
+            error_log('Cron notification mail failed: ' . $mailResult['error']);
+        } elseif ($mailResult === false) {
+            error_log('Cron notification mail failed to send.');
         }
 
         exit(1);


### PR DESCRIPTION
## Summary
- guard the cron bootstrap failure handler so it only queries settings and sends mail when a Settings instance and admin email exist
- exit immediately after logging when cron bootstrap cannot access settings to avoid premature notifications or debug output

## Testing
- php -l cron.php
- php -d auto_prepend_file=prepend.php cron.php (with common.php temporarily renamed)


------
https://chatgpt.com/codex/tasks/task_e_68dc0773929c8329924e39c3f4c0ef30