### PR TITLE
fix: defer cron Settings bootstrap

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -17,10 +17,6 @@ define('CRON_CHARCLEANUP', 8);
 
 define("ALLOW_ANONYMOUS", true);
 
-if (!($settings instanceof Settings)) {
-    $settings = new Settings('settings');
-}
-
 BootstrapErrorHandler::register();
 
 $result = chdir(__DIR__);


### PR DESCRIPTION
## Summary
- remove the manual Settings bootstrap in cron.php so the entry point waits for common.php to initialise the singleton

## Testing
- php cron.php (with common.php temporarily renamed to trigger the failure path)
- php cron.php


------
https://chatgpt.com/codex/tasks/task_e_68dc17f1d2b88329bbd804766e1fa1ad