### PR TITLE
docs: clarify cron job configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,16 @@ as the `tests/` directory.
 
 `cron.php` handles automated tasks such as daily resets. Run it from the command line with `php cron.php` and schedule it in your system's crontab. The script automatically determines its installation directory, so no manual configuration or `$GAME_DIR` value is required.
 
-Enable the `newdaycron` flag in the admin settings (or set `newdaycron` to `1` in the `settings` table) to process new days exclusively through the cron job instead of when the first player logs in.
+| Constant               | Bit value | Routine              | Notes |
+| ---------------------- | --------- | -------------------- | ----- |
+| `CRON_NEWDAY`          | `1`       | Daily reset          | Calls `Newday::runOnce()` to process turns, buffs, and cache maintenance. |
+| `CRON_DBCLEANUP`       | `2`       | Database maintenance | Runs `Newday::dbCleanup()` to optimize all tables. Accepts an optional second CLI argument to force an optimization even if the daily timer has not elapsed. |
+| `CRON_COMMENTCLEANUP`  | `4`       | Content cleanup      | Purges old commentary, news, referers, mail, fail logs, and archives via `Newday::commentCleanup()`. |
+| `CRON_CHARCLEANUP`     | `8`       | Character expiration | Invokes `Newday::charCleanup()` and `ExpireChars::expire()` to remove inactive characters. |
+
+Invoke `php cron.php` with no arguments for the full maintenance run (`1|2|4|8 = 15`). Supply a bitmask to limit the routines—for example, `php cron.php 5` (`1|4`) runs the newday reset and content cleanup while skipping database/character cleanup. Leave off the second argument unless you need to force database optimization.
+
+Enable the `newdaycron` flag in the admin settings (or set `newdaycron` to `1` in the `settings` table) to process new days exclusively through the cron job instead of when the first player logs in. Each maintenance step records its work in the Game Log (Superuser ➜ Game Log or `gamelog.php`), letting administrators confirm that the cron run completed successfully.
 
 ## SMTP Mail Setup
 

--- a/docs/AdminGuide.md
+++ b/docs/AdminGuide.md
@@ -35,6 +35,23 @@ email. Run `cron.php` regularly via your system's scheduler:
 */5 * * * * php /path/to/lotgd/cron.php >/dev/null 2>&1
 ```
 
+`cron.php` accepts an optional bitmask that selects which routines to execute:
+
+| Constant              | Bit value | Routine              | Notes |
+| --------------------- | --------- | -------------------- | ----- |
+| `CRON_NEWDAY`         | `1`       | Daily reset          | Calls `Newday::runOnce()` for turns, buffs, and cache cleanup. |
+| `CRON_DBCLEANUP`      | `2`       | Database maintenance | Runs `Newday::dbCleanup()` (pass a second CLI argument of `1` to force optimization even if it was run less than a day ago). |
+| `CRON_COMMENTCLEANUP` | `4`       | Content cleanup      | Executes `Newday::commentCleanup()` to purge aged commentary, news, mail, and logs. |
+| `CRON_CHARCLEANUP`    | `8`       | Character expiration | Invokes `Newday::charCleanup()` / `ExpireChars::expire()` to remove inactive characters. |
+
+Omit the argument for the full run (`1|2|4|8 = 15`). To customize, combine bit values: for example,
+`php cron.php 13 1` runs the daily reset (`1`), database optimization (`2`, forced by the second
+`1`), and character expiration (`8`) while skipping the comment cleanup (`4`).
+
+Every routine writes its activity to the Game Log (`gamelog.php`, available from the Superuser
+navigation). Review that log after a cron run to confirm each maintenance step completed; bootstrap
+failures are additionally written to `logs/bootstrap.log`.
+
 ## SMTP and Email
 
 Configure SMTP credentials in `config/configuration.php` or your environment to send reliable


### PR DESCRIPTION
## Summary
- document the cron.php bitmask constants and default behavior in the README
- expand the admin guide with bitmask usage, force optimization details, and logging references

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dc3b2f8cfc8329ac691e392e345875