### PR TITLE
fix: default gamelog sorting by date desc

### DIFF
--- a/gamelog.php
+++ b/gamelog.php
@@ -35,8 +35,14 @@ SuperuserNav::render();
 $step = 500; // hardcoded stepping
 $category = Http::get('cat');
 $start = (int)Http::get('start'); //starting
-$sortorder = (int) Http::get('sortorder'); // 0 = DESC 1= ASC
-$sortby = Http::get('sortby');
+$sortorderParam = Http::get('sortorder'); // 0 = DESC 1 = ASC
+$sortorder = ($sortorderParam === false || $sortorderParam === null || $sortorderParam === '')
+    ? 0
+    : (int) $sortorderParam;
+$sortbyParam = Http::get('sortby');
+$sortby = ($sortbyParam === false || $sortbyParam === null || $sortbyParam === '')
+    ? 'date'
+    : $sortbyParam;
 if ($category > "") {
     $cat = "&cat=$category";
     $sqlcat = "AND " . Database::prefix("gamelog") . ".category = '$category'";
@@ -47,10 +53,7 @@ if ($category > "") {
 
 $asc_desc = ($sortorder == 0 ? "DESC" : "ASC");
 
-$sqlsort = "";
-if ($sortby != '') {
-    $sqlsort = " ORDER BY " . $sortby . " " . $asc_desc;
-}
+$sqlsort = " ORDER BY " . $sortby . " " . $asc_desc;
 
 $sql = "SELECT count(logid) AS c FROM " . Database::prefix("gamelog") . " WHERE 1 $sqlcat";
 $result = Database::query($sql);

--- a/tests/GameLogSystemLabelTest.php
+++ b/tests/GameLogSystemLabelTest.php
@@ -62,6 +62,7 @@ final class GameLogSystemLabelTest extends TestCase
                 'who' => 0,
             ]],
         ];
+        Database::$queries = [];
         if (!defined('DB_CHOSEN')) {
             define('DB_CHOSEN', false);
         }
@@ -76,5 +77,23 @@ final class GameLogSystemLabelTest extends TestCase
         require __DIR__ . '/../gamelog.php';
         global $forms_output;
         $this->assertStringContainsString('System: Something happened', $forms_output);
+    }
+
+    public function testDefaultSortOrdersByDateDescending(): void
+    {
+        if (!defined('GAMELOG_TEST')) {
+            define('GAMELOG_TEST', true);
+        }
+
+        Database::$mockResults = [
+            [['c' => 0]],
+            [],
+        ];
+        Database::$queries = [];
+
+        require __DIR__ . '/../gamelog.php';
+
+        $this->assertGreaterThanOrEqual(2, count(Database::$queries));
+        $this->assertStringContainsString('ORDER BY date DESC', Database::$queries[1]);
     }
 }


### PR DESCRIPTION
## Summary
- default the game log listing to order by date descending when no sort parameters are provided
- preserve existing navigation query parameters and add regression coverage for the default order

## Testing
- vendor/bin/phpunit tests/GameLogSystemLabelTest.php

------
https://chatgpt.com/codex/tasks/task_e_68df987e9d508329b2a69c7ef7fdee91