### PR TITLE
feat: add severity metadata to gamelog

### DIFF
--- a/gamelog.php
+++ b/gamelog.php
@@ -34,15 +34,35 @@ SuperuserNav::render();
 
 $step = 500; // hardcoded stepping
 $category = Http::get('cat');
-$start = (int)Http::get('start'); //starting
+$category = is_string($category) ? $category : '';
+$start = (int) Http::get('start'); //starting
 $sortorder = (int) Http::get('sortorder'); // 0 = DESC 1= ASC
 $sortby = Http::get('sortby');
-if ($category > "") {
-    $cat = "&cat=$category";
-    $sqlcat = "AND " . Database::prefix("gamelog") . ".category = '$category'";
+$sortby = is_string($sortby) ? $sortby : '';
+$encodedSort = urlencode($sortby);
+
+$allowedSeverities = ['info', 'warning', 'error', 'debug'];
+$severity = Http::get('severity');
+$severity = is_string($severity) ? strtolower($severity) : '';
+if (! in_array($severity, $allowedSeverities, true)) {
+    $severity = '';
+}
+
+if ($category !== '') {
+    $encodedCategory = urlencode($category);
+    $cat = "&cat=$encodedCategory";
+    $sqlcat = "AND " . Database::prefix("gamelog") . ".category = '" . addslashes($category) . "'";
 } else {
     $cat = '';
     $sqlcat = '';
+}
+
+if ($severity !== '') {
+    $sev = '&severity=' . urlencode($severity);
+    $sqlseverity = "AND " . Database::prefix("gamelog") . ".severity = '" . addslashes($severity) . "'";
+} else {
+    $sev = '';
+    $sqlseverity = '';
 }
 
 $asc_desc = ($sortorder == 0 ? "DESC" : "ASC");
@@ -52,30 +72,43 @@ if ($sortby != '') {
     $sqlsort = " ORDER BY " . $sortby . " " . $asc_desc;
 }
 
-$sql = "SELECT count(logid) AS c FROM " . Database::prefix("gamelog") . " WHERE 1 $sqlcat";
+$sql = "SELECT count(logid) AS c FROM " . Database::prefix("gamelog") . " WHERE 1 $sqlcat $sqlseverity";
 $result = Database::query($sql);
 $row = Database::fetchAssoc($result);
 $max = $row['c'];
 
 
-$sql = "SELECT " . Database::prefix("gamelog") . ".*, " . Database::prefix("accounts") . ".name AS name FROM " . Database::prefix("gamelog") . " LEFT JOIN " . Database::prefix("accounts") . " ON " . Database::prefix("gamelog") . ".who = " . Database::prefix("accounts") . ".acctid WHERE 1 $sqlcat $sqlsort LIMIT $start,$step";
+$sql = "SELECT " . Database::prefix("gamelog") . ".*, " . Database::prefix("accounts") . ".name AS name FROM " . Database::prefix("gamelog") . " LEFT JOIN " . Database::prefix("accounts") . " ON " . Database::prefix("gamelog") . ".who = " . Database::prefix("accounts") . ".acctid WHERE 1 $sqlcat $sqlseverity $sqlsort LIMIT $start,$step";
 $next = $start + $step;
 $prev = $start - $step;
 Nav::add("Operations");
-Nav::add("Refresh", "gamelog.php?start=$start$cat&sortorder=$sortorder&sortby=$sortby");
-if ($category > "") {
+Nav::add("Refresh", "gamelog.php?start=$start$cat$sev&sortorder=$sortorder&sortby=$encodedSort");
+if ($category !== '') {
     Nav::add("View all", "gamelog.php");
 }
 Nav::add("Game Log");
 if ($next < $max) {
-    Nav::add("Next page", "gamelog.php?start=$next$cat&sortorder=$sortorder&sortby=$sortby");
+    Nav::add("Next page", "gamelog.php?start=$next$cat$sev&sortorder=$sortorder&sortby=$encodedSort");
 }
 if ($start > 0) {
-    Nav::add("Previous page", "gamelog.php?start=$prev$cat&sortorder=$sortorder&sortby=$sortby");
+    Nav::add("Previous page", "gamelog.php?start=$prev$cat$sev&sortorder=$sortorder&sortby=$encodedSort");
+}
+$sortParams = "&sortorder=$sortorder&sortby=$encodedSort";
+Nav::add("Severity");
+Nav::add("All severities", "gamelog.php?start=0$cat$sortParams");
+foreach ($allowedSeverities as $severityOption) {
+    $label = ucfirst($severityOption);
+    Nav::add("Severity: $label", "gamelog.php?start=0$cat&severity=" . urlencode($severityOption) . "$sortParams");
 }
 $result = Database::query($sql);
 $odate = "";
 $categories = array();
+$severityColors = [
+    'info' => '`@',
+    'warning' => '`$',
+    'error' => '`4',
+    'debug' => '`#',
+];
 
 $i = 0;
 while ($row = Database::fetchAssoc($result)) {
@@ -85,28 +118,44 @@ while ($row = Database::fetchAssoc($result)) {
         $odate = $dom;
     }
     $time = date("H:i:s", strtotime($row['date'])) . " (" . reltime(strtotime($row['date'])) . ")";
+    $severityValue = strtolower($row['severity'] ?? '');
+    if (! isset($severityColors[$severityValue])) {
+        $severityValue = 'info';
+    }
+    $severityLabel = sprintf('`7[%s%s`7]`0', $severityColors[$severityValue], strtoupper($severityValue));
     if ($row['name'] != '' && (int) ($row['who'] ?? 0) !== 0) {
-        $output->outputNotl("`7(`\$%s`7) %s `7(`&%s`7) (`v%s`7)", $row['category'], $row['message'], $row['name'], $time);
+        $output->outputNotl(
+            "`7(`\$%s`7) %s %s `7(`&%s`7) (`v%s`7)",
+            $row['category'],
+            $severityLabel,
+            $row['message'],
+            $row['name'],
+            $time
+        );
     } else {
         $output->outputNotl(
-            "`7(`\$%s`7) %s: %s `7(`v%s`7)",
+            "`7(`\$%s`7) %s System: %s `7(`v%s`7)",
             $row['category'],
-            'System',
+            $severityLabel,
             $row['message'],
             $time
         );
     }
-    if (!isset($categories[$row['category']]) && $category == "") {
+    if (!isset($categories[$row['category']]) && $category === '') {
         Nav::add("Operations");
-        Nav::add(array("View by `i%s`i", $row['category']), "gamelog.php?cat=" . $row['category']);
+        $categoryLink = "gamelog.php?cat=" . urlencode($row['category']);
+        if ($severity !== '') {
+            $categoryLink .= '&severity=' . urlencode($severity);
+        }
+        Nav::add(array("View by `i%s`i", $row['category']), $categoryLink);
         $categories[$row['category']] = 1;
     }
     $output->outputNotl("`n");
 }
 Nav::add("Sorting");
-Nav::add("Sort by date ascending", "gamelog.php?start=$start$cat&sortorder=1&sortby=date");
-Nav::add("Sort by date descending", "gamelog.php?start=$start$cat&sortorder=0&sortby=date");
-Nav::add("Sort by category ascending", "gamelog.php?start=$start$cat&sortorder=1&sortby=category");
-Nav::add("Sort by category descending", "gamelog.php?start=$start$cat&sortorder=0&sortby=category");
+Nav::add("Sort by date ascending", "gamelog.php?start=$start$cat$sev&sortorder=1&sortby=date");
+Nav::add("Sort by date descending", "gamelog.php?start=$start$cat$sev&sortorder=0&sortby=date");
+Nav::add("Sort by category ascending", "gamelog.php?start=$start$cat$sev&sortorder=1&sortby=category");
+Nav::add("Sort by category descending", "gamelog.php?start=$start$cat$sev&sortorder=0&sortby=category");
 
 Footer::pageFooter();

--- a/install/data/tables.php
+++ b/install/data/tables.php
@@ -905,6 +905,11 @@ function get_all_tables()
             'name' => 'category',
             'type' => 'varchar(50)',
             ),
+        'severity' => array(
+            'name' => 'severity',
+            'type' => 'varchar(16)',
+            'default' => 'info',
+            ),
         'filed' => array(
             'name' => 'filed',
             'type' => 'tinyint(4)',

--- a/lib/gamelog.php
+++ b/lib/gamelog.php
@@ -2,7 +2,7 @@
 
 use Lotgd\GameLog;
 
-function gamelog($message, $category = "general", $filed = false, $acctId = null)
+function gamelog($message, $category = "general", $filed = false, $acctId = null, $severity = 'info')
 {
-    GameLog::log($message, $category, $filed, $acctId);
+    GameLog::log($message, $category, $filed, $acctId, $severity);
 }

--- a/migrations/Version20250724000020.php
+++ b/migrations/Version20250724000020.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Lotgd\MySQL\Database;
+
+final class Version20250724000020 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add severity column to gamelog table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+        $table = Database::prefix('gamelog');
+        $columns = $schemaManager->listTableColumns($table);
+
+        if (! isset($columns['severity'])) {
+            $this->addSql("ALTER TABLE $table ADD severity VARCHAR(16) NOT NULL DEFAULT 'info' AFTER category");
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+        $table = Database::prefix('gamelog');
+        $columns = $schemaManager->listTableColumns($table);
+
+        if (isset($columns['severity'])) {
+            $this->addSql("ALTER TABLE $table DROP COLUMN severity");
+        }
+    }
+}

--- a/src/Lotgd/Battle.php
+++ b/src/Lotgd/Battle.php
@@ -1128,7 +1128,10 @@ class Battle
                 \Lotgd\GameLog::log(
                     "AI script error for {$badguy['creaturename']} ({$badguy['creatureid']}): "
                     . $e->getMessage() . ' Script: ' . $script,
-                    'battle'
+                    'battle',
+                    false,
+                    null,
+                    'error'
                 );
 
                 if (isset($badguy)) {

--- a/src/Lotgd/DataCache.php
+++ b/src/Lotgd/DataCache.php
@@ -139,7 +139,8 @@ class DataCache
                     'Failed to remove cache file ' . $fullname,
                     'cache',
                     false,
-                    $session['user']['acctid'] ?? 0
+                    $session['user']['acctid'] ?? 0,
+                    'warning'
                 );
             }
             if (! $withpath) {

--- a/src/Lotgd/ExpireChars.php
+++ b/src/Lotgd/ExpireChars.php
@@ -103,7 +103,8 @@ class ExpireChars
                     'Failed to delete account ' . $row['acctid'] . ': ' . $error->getMessage(),
                     'char deletion failure',
                     false,
-                    $session['user']['acctid'] ?? 0
+                    $session['user']['acctid'] ?? 0,
+                    'error'
                 );
             } elseif ($cleanupPerformed) {
                 GameLog::log(
@@ -117,7 +118,8 @@ class ExpireChars
                     'Cleanup skipped for account ' . (int) $row['acctid'] . ' (prevented by hook)',
                     'char expiration',
                     false,
-                    $session['user']['acctid'] ?? 0
+                    $session['user']['acctid'] ?? 0,
+                    'warning'
                 );
             }
         }

--- a/src/Lotgd/GameLog.php
+++ b/src/Lotgd/GameLog.php
@@ -12,16 +12,29 @@ use Lotgd\MySQL\Database;
 
 class GameLog
 {
+    private const ALLOWED_SEVERITIES = ['info', 'warning', 'error', 'debug'];
+
     /**
      * Insert a log message into the database.
      */
-    public static function log(string $message, string $category = 'general', bool $filed = false, ?int $acctId = null): void
+    public static function log(
+        string $message,
+        string $category = 'general',
+        bool $filed = false,
+        ?int $acctId = null,
+        string $severity = 'info'
+    ): void
     {
         global $session;
         $who = $acctId ?? (int) ($session['user']['acctid'] ?? 0);
+        $severity = strtolower($severity);
+        if (! in_array($severity, self::ALLOWED_SEVERITIES, true)) {
+            $severity = 'info';
+        }
+
         $sql = 'INSERT INTO ' . Database::prefix('gamelog') .
-            ' (message,category,filed,date,who) VALUES (' .
-            "'" . addslashes($message) . "','" . addslashes($category) . "','" . ($filed ? "1" : "0") . "','" . date('Y-m-d H:i:s') . "','" . $who . "')";
+            ' (message,category,severity,filed,date,who) VALUES (' .
+            "'" . addslashes($message) . "','" . addslashes($category) . "','" . addslashes($severity) . "','" . ($filed ? "1" : "0") . "','" . date('Y-m-d H:i:s') . "','" . $who . "')";
         Database::query($sql);
     }
 }

--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -84,7 +84,8 @@ class Newday
                 'ERROR, problems with moving the debuglog to the archive',
                 'maintenance',
                 false,
-                $session['user']['acctid'] ?? 0
+                $session['user']['acctid'] ?? 0,
+                'error'
             );
         }
 

--- a/tests/CharCleanupDeletesAccountTest.php
+++ b/tests/CharCleanupDeletesAccountTest.php
@@ -28,7 +28,7 @@ final class CharCleanupDeletesAccountTest extends TestCase
             eval('namespace Lotgd; class PlayerFunctions { public static function charCleanup(int $id, int $type): bool { return true; } }');
         }
         if (! class_exists('Lotgd\\GameLog', false)) {
-            eval('namespace Lotgd; class GameLog { public static function log(string $m, string $c): void {} }');
+            eval('namespace Lotgd; class GameLog { public static function log(string $m, string $c, bool $f = false, ?int $a = null, string $s = "info"): void {} }');
         }
 
         Database::$mockResults = [

--- a/tests/CharCleanupFailurePreventsDeletionTest.php
+++ b/tests/CharCleanupFailurePreventsDeletionTest.php
@@ -28,7 +28,7 @@ final class CharCleanupFailurePreventsDeletionTest extends TestCase
             eval('namespace Lotgd; class PlayerFunctions { public static function charCleanup(int $id, int $type): bool { return false; } }');
         }
         if (! class_exists('Lotgd\\GameLog', false)) {
-            eval('namespace Lotgd; class GameLog { public static function log(string $m, string $c, bool $f = false, ?int $a = null): void {} }');
+            eval('namespace Lotgd; class GameLog { public static function log(string $m, string $c, bool $f = false, ?int $a = null, string $s = "info"): void {} }');
         }
 
         Database::$mockResults = [

--- a/tests/CleanupExpiredAccountsLogsFailureTest.php
+++ b/tests/CleanupExpiredAccountsLogsFailureTest.php
@@ -29,7 +29,7 @@ final class CleanupExpiredAccountsLogsFailureTest extends TestCase
         }
 
         if (! class_exists('Lotgd\\GameLog', false)) {
-            eval('namespace Lotgd; class GameLog { public static array $entries = []; public static function log(string $m, string $c, bool $f = false, ?int $a = null): void { self::$entries[] = [$c, $m]; } }');
+            eval('namespace Lotgd; class GameLog { public static array $entries = []; public static function log(string $m, string $c, bool $f = false, ?int $a = null, string $s = "info"): void { self::$entries[] = [$c, $m, $s]; } }');
         } else {
             \Lotgd\GameLog::$entries = [];
         }
@@ -51,7 +51,7 @@ final class CleanupExpiredAccountsLogsFailureTest extends TestCase
         $method->invoke(null);
 
         $this->assertSame([
-            ['char deletion failure', 'Failed to delete account 1: deletion failed'],
+            ['char deletion failure', 'Failed to delete account 1: deletion failed', 'error'],
         ], \Lotgd\GameLog::$entries);
 
         $this->assertStringContainsString('ROLLBACK', Database::$queries[3] ?? '');
@@ -74,7 +74,9 @@ final class CleanupExpiredAccountsLogsFailureTest extends TestCase
 
         $this->assertSame('char expiration', \Lotgd\GameLog::$entries[0][0] ?? null);
         $this->assertSame('Deleted account 1 (test)', \Lotgd\GameLog::$entries[0][1] ?? null);
+        $this->assertSame('info', \Lotgd\GameLog::$entries[0][2] ?? null);
         $this->assertCount(2, \Lotgd\GameLog::$entries);
+        $this->assertSame('info', \Lotgd\GameLog::$entries[1][2] ?? null);
 
         $this->assertStringContainsString('COMMIT', Database::$queries[3] ?? '');
     }

--- a/tests/GameLogSeverityTest.php
+++ b/tests/GameLogSeverityTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\GameLog;
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
+
+final class GameLogSeverityTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        class_exists(Database::class);
+        Database::$queries = [];
+        Database::$tablePrefix = '';
+        global $session;
+        $session['user']['acctid'] = 99;
+    }
+
+    protected function tearDown(): void
+    {
+        Database::$queries = [];
+        unset($GLOBALS['session']);
+    }
+
+    public function testInvalidSeverityFallsBackToInfo(): void
+    {
+        GameLog::log('Default severity', 'test', false, null, 'invalid');
+        $query = Database::$queries[0] ?? '';
+        $this->assertStringContainsString("INSERT INTO gamelog (message,category,severity,filed,date,who) VALUES ('Default severity','test','info'", $query);
+        $this->assertStringContainsString("'99')", $query);
+    }
+
+    public function testExplicitSeverityIsRecorded(): void
+    {
+        Database::$queries = [];
+        GameLog::log('Error severity', 'test', false, 5, 'error');
+        $query = Database::$queries[0] ?? '';
+        $this->assertStringContainsString("'Error severity','test','error'", $query);
+        $this->assertStringContainsString("'5')", $query);
+    }
+}

--- a/tests/GameLogSystemLabelTest.php
+++ b/tests/GameLogSystemLabelTest.php
@@ -60,6 +60,7 @@ final class GameLogSystemLabelTest extends TestCase
                 'message' => 'Something happened',
                 'name' => '',
                 'who' => 0,
+                'severity' => 'warning',
             ]],
         ];
         if (!defined('DB_CHOSEN')) {
@@ -75,6 +76,6 @@ final class GameLogSystemLabelTest extends TestCase
         }
         require __DIR__ . '/../gamelog.php';
         global $forms_output;
-        $this->assertStringContainsString('System: Something happened', $forms_output);
+        $this->assertStringContainsString('`7[`$WARNING`7]`0 System: Something happened', $forms_output);
     }
 }

--- a/tests/LogExpiredAccountStatsUsesDeletedAccountsTest.php
+++ b/tests/LogExpiredAccountStatsUsesDeletedAccountsTest.php
@@ -29,7 +29,7 @@ final class LogExpiredAccountStatsUsesDeletedAccountsTest extends TestCase
         }
 
         if (! class_exists('Lotgd\\GameLog', false)) {
-            eval('namespace Lotgd; class GameLog { public static array $entries = []; public static function log(string $m, string $c, bool $f = false, ?int $a = null): void { self::$entries[] = [$c, $m]; } }');
+            eval('namespace Lotgd; class GameLog { public static array $entries = []; public static function log(string $m, string $c, bool $f = false, ?int $a = null, string $s = "info"): void { self::$entries[] = [$c, $m, $s]; } }');
         } else {
             \Lotgd\GameLog::$entries = [];
         }
@@ -53,5 +53,6 @@ final class LogExpiredAccountStatsUsesDeletedAccountsTest extends TestCase
         $this->assertStringContainsString('Deleted 1 accounts:', $summary[0][1]);
         $this->assertStringContainsString('foo:dk0-lv1', $summary[0][1]);
         $this->assertStringNotContainsString('bar:dk1-lv2', $summary[0][1]);
+        $this->assertSame('info', $summary[0][2]);
     }
 }

--- a/tests/ModuleManagerTest.php
+++ b/tests/ModuleManagerTest.php
@@ -215,7 +215,7 @@ namespace Lotgd\Tests {
 
             $this->assertSame($expectedPaths, $this->listCacheFiles());
 
-            $needle = "INSERT INTO gamelog (message,category,filed,date,who) VALUES ('Module mod force-uninstalled','modules','0'";
+            $needle = "INSERT INTO gamelog (message,category,severity,filed,date,who) VALUES ('Module mod force-uninstalled','modules','info','0'";
             $matches = array_filter(
                 \Lotgd\MySQL\Database::$queries,
                 static fn (string $query): bool => str_contains($query, $needle)
@@ -276,7 +276,7 @@ namespace Lotgd\Tests {
 
         private function assertGamelogEntryContains(string $message): void
         {
-            $needle = "INSERT INTO gamelog (message,category,filed,date,who) VALUES ('{$message}','modules','0'";
+            $needle = "INSERT INTO gamelog (message,category,severity,filed,date,who) VALUES ('{$message}','modules','info','0'";
             $matches = array_filter(
                 \Lotgd\MySQL\Database::$queries,
                 static fn (string $query): bool => str_contains($query, $needle)


### PR DESCRIPTION
## Summary
- add a migration and installer schema updates that introduce a severity column to the gamelog table
- extend the GameLog helpers and core usages to accept optional severities and surface them in the superuser gamelog UI with filtering
- add and update test coverage for severity persistence and presentation

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68df98972e048329bca6cc901f19cca7