### PR TITLE
fix: restore default gamelog ordering

### DIFF
--- a/gamelog.php
+++ b/gamelog.php
@@ -37,9 +37,20 @@ $category = Http::get('cat');
 
 $category = is_string($category) ? $category : '';
 $start = (int) Http::get('start'); //starting
-$sortorder = (int) Http::get('sortorder'); // 0 = DESC 1= ASC
+$sortorderParam = Http::get('sortorder'); // 0 = DESC 1= ASC
+$sortorder = is_numeric($sortorderParam) ? (int) $sortorderParam : 0;
+if ($sortorder !== 0 && $sortorder !== 1) {
+    $sortorder = 0;
+}
+
 $sortby = Http::get('sortby');
-$sortby = is_string($sortby) ? $sortby : '';
+$allowedSortColumns = ['date', 'category'];
+if (! is_string($sortby) || ! in_array(strtolower($sortby), $allowedSortColumns, true)) {
+    $sortby = 'date';
+} else {
+    $sortby = strtolower($sortby);
+}
+
 $encodedSort = urlencode($sortby);
 
 $allowedSeverities = ['info', 'warning', 'error', 'debug'];
@@ -67,9 +78,9 @@ if ($severity !== '') {
     $sqlseverity = '';
 }
 
-$asc_desc = ($sortorder == 0 ? "DESC" : "ASC");
+$asc_desc = ($sortorder === 0 ? 'DESC' : 'ASC');
 
-$sqlsort = " ORDER BY " . $sortby . " " . $asc_desc;
+$sqlsort = ' ORDER BY ' . $sortby . ' ' . $asc_desc;
 
 $sql = "SELECT count(logid) AS c FROM " . Database::prefix("gamelog") . " WHERE 1 $sqlcat $sqlseverity";
 $result = Database::query($sql);

--- a/tests/GameLogSystemLabelTest.php
+++ b/tests/GameLogSystemLabelTest.php
@@ -95,6 +95,6 @@ final class GameLogSystemLabelTest extends TestCase
         require __DIR__ . '/../gamelog.php';
 
         $this->assertGreaterThanOrEqual(2, count(Database::$queries));
-        $this->assertStringContainsString('ORDER BY date DESC', Database::$queries[1]);
+        $this->assertMatchesRegularExpression('/ORDER BY\s+date\s+DESC/i', Database::$queries[1]);
     }
 }


### PR DESCRIPTION
## Summary
- default the game log listing to sort by date descending when no sort parameters are supplied
- validate incoming sort options before building the SQL clause while keeping navigation links in sync
- update the regression test to ensure the default query orders by date descending

## Testing
- ./vendor/bin/phpunit tests/GameLogSystemLabelTest.php

------
https://chatgpt.com/codex/tasks/task_e_68df9cc6c62c8329881c168daaf40552