### PR TITLE
Fix Doctrine parameter usage in example forest reward module

### DIFF
--- a/modules/example_forestreward.php
+++ b/modules/example_forestreward.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Doctrine\DBAL\ParameterType;
 use Lotgd\MySQL\Database;
 use Lotgd\Nav;
 use Lotgd\Output;
@@ -118,7 +117,7 @@ function example_forestreward_run(): void
                 $table = Database::prefix('mounts');
                 $sql = "SELECT mountname FROM {$table} WHERE mountid = :mountId";
                 $statement = $connection->prepare($sql);
-                $statement->bindValue('mountId', (int) $session['user']['hashorse'], ParameterType::INTEGER);
+                $statement->bindValue('mountId', (int) $session['user']['hashorse'], \Doctrine\DBAL\ParameterType::INTEGER);
                 $result = $statement->executeQuery();
                 $foundName = $result->fetchOne();
 


### PR DESCRIPTION
## Summary
- stop exporting Doctrine\DBAL\ParameterType alias from the module
- reference the integer parameter type via its fully qualified name when binding values

## Testing
- php -l modules/example_forestreward.php

------
https://chatgpt.com/codex/tasks/task_e_68e00d31941083299be38f3d4aa9f1c3