### PR TITLE
fix: parameterize async commentary refresh

### DIFF
--- a/tests/Stubs/DoctrineBootstrap.php
+++ b/tests/Stubs/DoctrineBootstrap.php
@@ -36,6 +36,9 @@ class DoctrineConnection
     public array $countResults = [];
     public array $lastInsert = [];
     public array $lastDelete = [];
+    public array $fetchAllResults = [];
+    public array $lastFetchAllParams = [];
+    public array $lastFetchAllTypes = [];
 
     public function executeQuery(string $sql): DoctrineResult
     {
@@ -52,9 +55,20 @@ class DoctrineConnection
         return new DoctrineResult([["ok" => true]]);
     }
 
-    public function fetchAllAssociative(string $sql, array $params = []): array
+    public function fetchAllAssociative(string $sql, array $params = [], array $types = []): array
     {
         $this->queries[] = $sql;
+        $this->lastFetchAllParams = $params;
+        $this->lastFetchAllTypes = $types;
+
+        if (!empty(Database::$mockResults)) {
+            return array_shift(Database::$mockResults);
+        }
+
+        if (!empty($this->fetchAllResults)) {
+            return array_shift($this->fetchAllResults);
+        }
+
         return [];
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/Stubs/DbMysqli.php';
 require_once __DIR__ . '/Stubs/Database.php';
 require_once __DIR__ . '/Stubs/ArrayCache.php';
 require_once __DIR__ . '/Stubs/Functions.php';
+require_once __DIR__ . '/Stubs/DoctrineBootstrap.php';
 // Preload repository classes to avoid redeclaration when Doctrine loads them
 require_once realpath(__DIR__ . '/../src/Lotgd/Repository/AccountRepository.php');
 require_once realpath(__DIR__ . '/../src/Lotgd/Repository/SettingRepository.php');


### PR DESCRIPTION
## Summary
- use Doctrine DBAL prepared statements for async commentary refresh queries
- extend Doctrine stubs to capture bound parameters and expose helper data in tests
- add an async handler test covering quoted sections and verifying bound parameter types

## Testing
- vendor/bin/phpunit tests/Async/HandlerResponseTest.php
- vendor/bin/phpunit tests/Ajax/CommentaryTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e159abbf78832986a7230fb49d929d