### PR TITLE
fix: parameterize settings persistence

### DIFF
--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -101,6 +101,22 @@ class Database
     }
 
     /**
+     * Determine if the Doctrine connection has been initialised.
+     */
+    public static function hasDoctrineConnection(): bool
+    {
+        return self::$doctrine !== null;
+    }
+
+    /**
+     * Reset the Doctrine connection instance.
+     */
+    public static function resetDoctrineConnection(): void
+    {
+        self::$doctrine = null;
+    }
+
+    /**
      * Assign the Doctrine DBAL connection.
      */
     public static function setDoctrineConnection(Connection $conn): void
@@ -295,6 +311,14 @@ class Database
             return 0;
         }
         return self::getInstance()->affectedRows();
+    }
+
+    /**
+     * Manually update the last affected rows counter.
+     */
+    public static function setAffectedRows(int $affected): void
+    {
+        self::$dbinfo['affected_rows'] = $affected;
     }
 
     /**

--- a/tests/ModeratedCommentaryFallbackTest.php
+++ b/tests/ModeratedCommentaryFallbackTest.php
@@ -69,7 +69,7 @@ final class ModeratedCommentaryFallbackTest extends TestCase
             'value' => 'UTF-8',
         ]];
 
-        Database::$mockResults = [$settingsRows, true, $commentRows];
+        Database::$mockResults = [$settingsRows, $commentRows];
         Settings::getInstance();
 
         set_error_handler(static function (int $errno, string $errstr): void {

--- a/tests/Stubs/Database.php
+++ b/tests/Stubs/Database.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Lotgd\Tests\Stubs;
 
+require_once __DIR__ . '/DoctrineBootstrap.php';
+
 /**
  * Fake database used for tests.
  */
@@ -422,6 +424,11 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
             return self::$affected_rows;
         }
 
+        public static function setAffectedRows(int $affected): void
+        {
+            self::$affected_rows = $affected;
+        }
+
         public static function insertId(): string
         {
             return '1';
@@ -458,6 +465,19 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
             }
 
             return self::$doctrineConnection;
+        }
+
+        public static function hasDoctrineConnection(): bool
+        {
+            return self::$doctrineConnection !== null;
+        }
+
+        public static function resetDoctrineConnection(): void
+        {
+            self::$doctrineConnection = null;
+            if (class_exists('Lotgd\\Doctrine\\Bootstrap', false) && property_exists('Lotgd\\Doctrine\\Bootstrap', 'conn')) {
+                \Lotgd\Doctrine\Bootstrap::$conn = null;
+            }
         }
 
         public static function getInstance()


### PR DESCRIPTION
## Summary
- update `Settings::saveSetting` to persist values via a parameterized Doctrine query and reset transient connections
- expose helpers on the database wrapper for tracking affected rows and clearing the shared Doctrine connection
- extend test doubles and unit coverage to cover quoted/multibyte settings values and Doctrine-backed writes

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68e159adba508329b6840c6fd66df82e