### PR TITLE
test: guard database stub alias

### DIFF
--- a/tests/Stubs/Database.php
+++ b/tests/Stubs/Database.php
@@ -490,5 +490,11 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
         }
     }
 
-    class_alias(Database::class, 'Lotgd\\MySQL\\Database');
+    $productionClass = 'Lotgd\\MySQL\\Database';
+
+    if (!class_exists($productionClass, false)) {
+        class_alias(Database::class, $productionClass);
+    } elseif (!is_a($productionClass, Database::class, true)) {
+        class_alias($productionClass, __NAMESPACE__ . '\\ProductionDatabase');
+    }
 }


### PR DESCRIPTION
## Summary
- guard the database stub alias so the tests only claim the Lotgd\\MySQL\\Database name when it is still undefined
- preserve a reference to the production Lotgd\\MySQL\\Database implementation when it was already loaded so the stub can fall back safely

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e16c39f9a88329b8ca8aad5ed26c2c