### PR TITLE
fix: sanitize module reinstall query

### DIFF
--- a/tests/Modules/Prefs/ModuleObjPrefsTest.php
+++ b/tests/Modules/Prefs/ModuleObjPrefsTest.php
@@ -57,9 +57,16 @@ namespace Lotgd\Tests\Modules\Prefs {
                     return new DoctrineResult([]);
                 }
 
-                public function executeStatement(string $sql, array $params = []): int
+                public function executeStatement(string $sql, array $params = [], array $types = []): int
                 {
                     $this->queries[] = $sql;
+                    $this->executeStatements[] = [
+                        'sql'    => $sql,
+                        'params' => $params,
+                        'types'  => $types,
+                    ];
+                    $this->lastExecuteStatementParams = $params;
+                    $this->lastExecuteStatementTypes  = $types;
 
                     if (preg_match("/REPLACE INTO module_objprefs\\(modulename,objtype,setting,objid,value\\) VALUES \\('(.*?)', '(.*?)', '(.*?)', '(.*?)', '(.*?)'\\)/", $sql, $m)) {
                         $key = "objpref-{$m[2]}-{$m[4]}-{$m[3]}-{$m[1]}";

--- a/tests/Modules/SpecialtyMigrationTest.php
+++ b/tests/Modules/SpecialtyMigrationTest.php
@@ -252,9 +252,16 @@ final class SpecialtyMigrationConnection extends DoctrineConnection
         return new DoctrineResult();
     }
 
-    public function executeStatement(string $sql, array $params = []): int
+    public function executeStatement(string $sql, array $params = [], array $types = []): int
     {
         $this->queries[] = $sql;
+        $this->executeStatements[] = [
+            'sql'    => $sql,
+            'params' => $params,
+            'types'  => $types,
+        ];
+        $this->lastExecuteStatementParams = $params;
+        $this->lastExecuteStatementTypes = $types;
 
         if (preg_match('/INSERT INTO\s+module_userprefs.*SELECT\s+\?,\s+\?,\s+acctid,\s+([a-z0-9_]+)\s+FROM\s+accounts/i', $sql, $matches)) {
             $column = $matches[1];

--- a/tests/Stubs/DoctrineBootstrap.php
+++ b/tests/Stubs/DoctrineBootstrap.php
@@ -39,6 +39,9 @@ class DoctrineConnection
     public array $fetchAllResults = [];
     public array $lastFetchAllParams = [];
     public array $lastFetchAllTypes = [];
+    public array $executeStatements = [];
+    public array $lastExecuteStatementParams = [];
+    public array $lastExecuteStatementTypes = [];
 
     public function executeQuery(string $sql): DoctrineResult
     {
@@ -72,9 +75,16 @@ class DoctrineConnection
         return [];
     }
 
-    public function executeStatement(string $sql, array $params = []): int
+    public function executeStatement(string $sql, array $params = [], array $types = []): int
     {
         $this->queries[] = $sql;
+        $this->executeStatements[] = [
+            'sql'    => $sql,
+            'params' => $params,
+            'types'  => $types,
+        ];
+        $this->lastExecuteStatementParams = $params;
+        $this->lastExecuteStatementTypes = $types;
         $table = null;
         if (preg_match('/^INSERT INTO\s+`?([^`\s(]+)`?/i', $sql, $matches)) {
             $table = strtolower($matches[1]);

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -454,9 +454,16 @@ final class TableDescriptorTest extends TestCase
                 return new DoctrineResult([['c' => 0]]);
             }
 
-            public function executeStatement(string $sql, array $params = []): int
+            public function executeStatement(string $sql, array $params = [], array $types = []): int
             {
                 $this->queries[] = $sql;
+                $this->executeStatements[] = [
+                    'sql'    => $sql,
+                    'params' => $params,
+                    'types'  => $types,
+                ];
+                $this->lastExecuteStatementParams = $params;
+                $this->lastExecuteStatementTypes  = $types;
                 if (
                     preg_match(
                         "/UPDATE dummy SET created = :DATETIME_DATEMIN WHERE created < :DATETIME_DATEMIN OR created = :zeroDate/",


### PR DESCRIPTION
## Summary
- sanitize module reinstall inputs and run the update through Doctrine with bound parameters
- extend ModuleManager coverage for tainted names and parameter assertions
- update Doctrine testing stubs to capture execute statement parameters

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e16c455e888329996ba40ddf9f664b