### PR TITLE
fix: harden referer tracking

### DIFF
--- a/src/Lotgd/RefererLogger.php
+++ b/src/Lotgd/RefererLogger.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\MySQL\Database;
+
+final class RefererLogger
+{
+    private const CONTROL_PATTERN = '/[\x00-\x1F\x7F]/';
+
+    /**
+     * @param array<string,mixed> $server
+     */
+    public static function log(array $server, string $requestUri, string $remoteAddr): void
+    {
+        $refererValue = isset($server['HTTP_REFERER']) && is_string($server['HTTP_REFERER'])
+            ? $server['HTTP_REFERER']
+            : '';
+        $hostValue = isset($server['HTTP_HOST']) && is_string($server['HTTP_HOST'])
+            ? $server['HTTP_HOST']
+            : '';
+
+        if ($refererValue === '' || $hostValue === '') {
+            return;
+        }
+
+        if (preg_match(self::CONTROL_PATTERN, $refererValue) === 1 || preg_match(self::CONTROL_PATTERN, $hostValue) === 1) {
+            return;
+        }
+
+        $rawReferer = trim($refererValue);
+        $rawHostHeader = trim($hostValue);
+
+        if ($rawReferer === '' || $rawHostHeader === '') {
+            return;
+        }
+
+        $scheme = strtolower((string) parse_url($rawReferer, PHP_URL_SCHEME));
+        if ($scheme !== 'http' && $scheme !== 'https') {
+            return;
+        }
+
+        $refererHost = parse_url($rawReferer, PHP_URL_HOST);
+        if (!is_string($refererHost) || $refererHost === '') {
+            return;
+        }
+
+        $refererPort = parse_url($rawReferer, PHP_URL_PORT);
+        $site = strtolower($refererHost);
+        if (
+            $refererPort !== null
+            && !($refererPort === 80 && $scheme === 'http')
+            && !($refererPort === 443 && $scheme === 'https')
+        ) {
+            $site .= ':' . $refererPort;
+        }
+
+        $hostHeader = strtolower($rawHostHeader);
+        $hostHeader = preg_replace('/:(80|443)$/', '', $hostHeader) ?? '';
+        $siteForComparison = preg_replace('/:(80|443)$/', '', $site) ?? '';
+
+        if ($siteForComparison === $hostHeader) {
+            return;
+        }
+
+        $requestUri = trim($requestUri);
+        if ($requestUri !== '' && preg_match(self::CONTROL_PATTERN, $requestUri) === 1) {
+            $requestUri = '';
+        }
+        if ($requestUri !== '' && $requestUri[0] !== '/') {
+            $requestUri = '/' . $requestUri;
+        }
+
+        $dest = $hostHeader;
+        if ($requestUri !== '') {
+            $dest .= $requestUri;
+        }
+
+        $remoteValue = $remoteAddr;
+        if (preg_match(self::CONTROL_PATTERN, $remoteValue) === 1) {
+            $remoteValue = '';
+        }
+
+        $remoteAddr = trim($remoteValue);
+        if ($remoteAddr !== '' && preg_match(self::CONTROL_PATTERN, $remoteAddr) === 1) {
+            $remoteAddr = '';
+        }
+
+        $conn = Database::getDoctrineConnection();
+        $table = Database::prefix('referers');
+        $now = date('Y-m-d H:i:s');
+
+        $existing = $conn->fetchAllAssociative(
+            "SELECT refererid FROM {$table} WHERE uri = :uri",
+            [
+                'uri' => $rawReferer,
+            ],
+            [
+                'uri' => ParameterType::STRING,
+            ]
+        );
+
+        $row = $existing[0] ?? null;
+
+        if (isset($row['refererid'])) {
+            $conn->executeStatement(
+                "UPDATE {$table} SET count = count + 1, last = :last, site = :site, dest = :dest, ip = :ip WHERE refererid = :id",
+                [
+                    'last' => $now,
+                    'site' => $site,
+                    'dest' => $dest,
+                    'ip'   => $remoteAddr,
+                    'id'   => (int) $row['refererid'],
+                ],
+                [
+                    'last' => ParameterType::STRING,
+                    'site' => ParameterType::STRING,
+                    'dest' => ParameterType::STRING,
+                    'ip'   => ParameterType::STRING,
+                    'id'   => ParameterType::INTEGER,
+                ]
+            );
+
+            return;
+        }
+
+        $conn->executeStatement(
+            "INSERT INTO {$table} (uri, count, last, site, dest, ip) VALUES (:uri, :count, :last, :site, :dest, :ip)",
+            [
+                'uri'   => $rawReferer,
+                'count' => 1,
+                'last'  => $now,
+                'site'  => $site,
+                'dest'  => $dest,
+                'ip'    => $remoteAddr,
+            ],
+            [
+                'uri'   => ParameterType::STRING,
+                'count' => ParameterType::INTEGER,
+                'last'  => ParameterType::STRING,
+                'site'  => ParameterType::STRING,
+                'dest'  => ParameterType::STRING,
+                'ip'    => ParameterType::STRING,
+            ]
+        );
+    }
+}

--- a/tests/Common/RefererLoggerTest.php
+++ b/tests/Common/RefererLoggerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Common;
+
+use PHPUnit\Framework\TestCase;
+
+final class RefererLoggerTest extends TestCase
+{
+    /**
+     * @return array{statements:array<int,array{sql:string,params:array,types:array}>}
+     */
+    private function runLogger(string $referer, string $host = 'example.com'): array
+    {
+        \Lotgd\MySQL\Database::resetDoctrineConnection();
+        $conn = \Lotgd\MySQL\Database::getDoctrineConnection();
+        $conn->executeStatements = [];
+
+        $server = [
+            'HTTP_REFERER' => $referer,
+            'HTTP_HOST'    => $host,
+        ];
+
+        \Lotgd\RefererLogger::log($server, '/village.php', '203.0.113.7');
+
+        return [
+            'statements' => $conn->executeStatements,
+        ];
+    }
+
+    public function testBinaryRefererIsIgnored(): void
+    {
+        $result = $this->runLogger("\0http://evil.test/path");
+
+        $this->assertSame([], $result['statements']);
+    }
+
+    public function testMaliciousRefererUsesBoundParameters(): void
+    {
+        $payload = "http://evil.test/path?x='\"><script>alert(1)</script>";
+        $result = $this->runLogger($payload);
+
+        $this->assertCount(1, $result['statements']);
+        $statement = $result['statements'][0];
+
+        $this->assertStringNotContainsString($payload, $statement['sql']);
+        $this->assertSame($payload, $statement['params']['uri']);
+        $this->assertSame('evil.test', $statement['params']['site']);
+        $this->assertSame('example.com/village.php', $statement['params']['dest']);
+        $this->assertSame('203.0.113.7', $statement['params']['ip']);
+    }
+}

--- a/tests/Common/RefererLoggerTest.php
+++ b/tests/Common/RefererLoggerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Lotgd\Tests\Common;
 
+use Lotgd\Doctrine\Bootstrap;
+use Lotgd\Tests\Stubs\DoctrineConnection;
 use PHPUnit\Framework\TestCase;
 
 final class RefererLoggerTest extends TestCase
@@ -14,6 +16,7 @@ final class RefererLoggerTest extends TestCase
     private function runLogger(string $referer, string $host = 'example.com'): array
     {
         \Lotgd\MySQL\Database::resetDoctrineConnection();
+        Bootstrap::$conn = new DoctrineConnection();
         $conn = \Lotgd\MySQL\Database::getDoctrineConnection();
         $conn->executeStatements = [];
 


### PR DESCRIPTION
## Summary
- route referer logging through a dedicated `RefererLogger` that normalizes inputs, rejects binary payloads, and uses Doctrine prepared statements
- replace the legacy SQL assembly in `common.php` with a call to the new logger while keeping the referer prefix helpers intact for existing readers
- add regression tests covering binary and malicious referers to ensure the logger ignores unsafe values and binds parameters

## Testing
- ./vendor/bin/phpunit tests/Common/RefererLoggerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e17708ca6883299e05b6a33a8288f3