### PR TITLE
Harden mail compose recipient lookups

### DIFF
--- a/tests/MailWriteComposeTest.php
+++ b/tests/MailWriteComposeTest.php
@@ -46,6 +46,16 @@ namespace Lotgd\Tests {
             $_GET = [];
             $_POST = [];
             Database::$mockResults = [];
+            Database::resetDoctrineConnection();
+            if (! defined('LOTGD_MAIL_WRITE_AUTORUN')) {
+                define('LOTGD_MAIL_WRITE_AUTORUN', false);
+            }
+            static $loaded = false;
+            if (! $loaded) {
+                require_once __DIR__ . '/../pages/mail/case_write.php';
+                $loaded = true;
+            }
+            $forms_output = '';
         }
 
         public function testRecipientDropdownShownForPartialNames(): void
@@ -53,15 +63,95 @@ namespace Lotgd\Tests {
             global $forms_output;
             $_POST['to'] = 'ja';
             $test_accounts_query_result = [
-                ['login' => 'john', 'name' => 'John', 'superuser' => 0],
-                ['login' => 'jane', 'name' => 'Jane', 'superuser' => 0],
+                ['acctid' => 10, 'login' => 'john', 'name' => 'John', 'superuser' => 0],
+                ['acctid' => 11, 'login' => 'jane', 'name' => 'Jane', 'superuser' => 0],
             ];
-            Database::$mockResults = [
-                [],                         // exact login search
-                $test_accounts_query_result, // fallback name search
+            $conn = Database::getDoctrineConnection();
+            $conn->fetchAllResults = [$test_accounts_query_result];
+            Database::$mockResults = array_fill(0, 4, []);
+            \mailWrite();
+            $this->assertGreaterThanOrEqual(2, count($conn->executeQueryParams));
+            $expectedPattern = $this->buildWildcardPattern('ja', 'UTF-8');
+            $this->assertSame($expectedPattern, $conn->executeQueryParams[1]['pattern']);
+        }
+
+        public function testFallbackSearchHandlesQuotedNames(): void
+        {
+            global $forms_output;
+
+            $_POST['to'] = "O'";
+            $test_accounts_query_result = [
+                [
+                    'acctid'    => 20,
+                    'login'     => 'oconnor',
+                    'name'      => "Shaun \"Quote\" O'Connor",
+                    'superuser' => 0,
+                ],
             ];
-            require __DIR__ . '/../pages/mail/case_write.php';
-            $this->assertStringContainsString("<select name='to'", $forms_output);
+
+            $conn = Database::getDoctrineConnection();
+            $conn->fetchAllResults = [$test_accounts_query_result];
+            Database::$mockResults = array_fill(0, 4, []);
+
+            \mailWrite();
+
+            $this->assertGreaterThanOrEqual(2, count($conn->executeQueryParams));
+
+            $expectedPattern = $this->buildWildcardPattern("O'", 'UTF-8');
+            $this->assertSame($expectedPattern, $conn->executeQueryParams[1]['pattern']);
+        }
+
+        public function testFallbackSearchHandlesMultibyteNames(): void
+        {
+            global $forms_output;
+
+            $_POST['to'] = 'さく';
+            $test_accounts_query_result = [
+                [
+                    'acctid'    => 30,
+                    'login'     => 'sakura',
+                    'name'      => 'さくら"🌸"',
+                    'superuser' => 0,
+                ],
+            ];
+
+            $conn = Database::getDoctrineConnection();
+            $conn->fetchAllResults = [$test_accounts_query_result];
+            Database::$mockResults = [[], []];
+
+            \mailWrite();
+
+            $this->assertGreaterThanOrEqual(2, count($conn->executeQueryParams));
+
+            $expectedPattern = $this->buildWildcardPattern('さく', 'UTF-8');
+            $this->assertSame($expectedPattern, $conn->executeQueryParams[1]['pattern']);
+        }
+
+        private function buildWildcardPattern(string $value, string $charset): string
+        {
+            $pattern = '%';
+
+            if (function_exists('mb_strlen')) {
+                $length = mb_strlen($value, $charset);
+
+                if ($length === false) {
+                    $length = strlen($value);
+                    for ($i = 0; $i < $length; ++$i) {
+                        $pattern .= $value[$i] . '%';
+                    }
+                } else {
+                    for ($i = 0; $i < $length; ++$i) {
+                        $pattern .= mb_substr($value, $i, 1, $charset) . '%';
+                    }
+                }
+            } else {
+                $length = strlen($value);
+                for ($i = 0; $i < $length; ++$i) {
+                    $pattern .= $value[$i] . '%';
+                }
+            }
+
+            return $pattern;
         }
     }
 

--- a/tests/Modules/Prefs/ModuleObjPrefsTest.php
+++ b/tests/Modules/Prefs/ModuleObjPrefsTest.php
@@ -51,7 +51,7 @@ namespace Lotgd\Tests\Modules\Prefs {
             $conn = new class extends DoctrineConnection {
                 public array $objprefs = [];
 
-                public function executeQuery(string $sql): DoctrineResult
+                public function executeQuery(string $sql, array $params = [], array $types = []): DoctrineResult
                 {
                     $this->queries[] = $sql;
                     return new DoctrineResult([]);

--- a/tests/Modules/Prefs/ModulePrefsTest.php
+++ b/tests/Modules/Prefs/ModulePrefsTest.php
@@ -58,7 +58,7 @@ namespace Lotgd\Tests\Modules\Prefs {
             Database::$queryCacheResults = [];
             Database::$lastSql           = '';
             $conn                        = new class extends DoctrineConnection {
-                public function executeQuery(string $sql): DoctrineResult
+                public function executeQuery(string $sql, array $params = [], array $types = []): DoctrineResult
                 {
                     $this->queries[] = $sql;
                     return new DoctrineResult([]);

--- a/tests/Modules/Settings/ModuleLoadSettingsPrefsTest.php
+++ b/tests/Modules/Settings/ModuleLoadSettingsPrefsTest.php
@@ -79,7 +79,7 @@ namespace Lotgd\Tests\Modules\Settings {
 
             $conn = new class extends DoctrineConnection {
                 public array $data = [];
-                public function executeQuery(string $sql): DoctrineResult
+                public function executeQuery(string $sql, array $params = [], array $types = []): DoctrineResult
                 {
                     $this->queries[] = $sql;
                     return new DoctrineResult($this->data[$sql] ?? []);
@@ -111,7 +111,7 @@ namespace Lotgd\Tests\Modules\Settings {
 
             $conn = new class extends DoctrineConnection {
                 public array $data = [];
-                public function executeQuery(string $sql): DoctrineResult
+                public function executeQuery(string $sql, array $params = [], array $types = []): DoctrineResult
                 {
                     $this->queries[] = $sql;
                     return new DoctrineResult($this->data[$sql] ?? []);

--- a/tests/Modules/SpecialtyMigrationTest.php
+++ b/tests/Modules/SpecialtyMigrationTest.php
@@ -241,7 +241,7 @@ final class SpecialtyMigrationConnection extends DoctrineConnection
         $this->describeRows = $describeRows;
     }
 
-    public function executeQuery(string $sql): DoctrineResult
+    public function executeQuery(string $sql, array $params = [], array $types = []): DoctrineResult
     {
         $this->queries[] = $sql;
 

--- a/tests/TableDescriptorTest.php
+++ b/tests/TableDescriptorTest.php
@@ -435,7 +435,7 @@ final class TableDescriptorTest extends TestCase
         $mockConn = new class extends DoctrineConnection {
             public array $table = [['id' => 1, 'created' => '0000-00-00 00:00:00']];
 
-            public function executeQuery(string $sql): DoctrineResult
+            public function executeQuery(string $sql, array $params = [], array $types = []): DoctrineResult
             {
                 $this->queries[] = $sql;
                 if (str_starts_with($sql, 'SHOW FULL COLUMNS FROM dummy')) {
@@ -501,7 +501,7 @@ final class TableDescriptorTest extends TestCase
     public function testSynctableConvertsZeroDatesWithoutException(): void
     {
         $conn = new class extends DoctrineConnection {
-            public function executeQuery(string $sql): DoctrineResult
+            public function executeQuery(string $sql, array $params = [], array $types = []): DoctrineResult
             {
                 $this->queries[] = $sql;
                 if (str_starts_with($sql, 'SHOW FULL COLUMNS FROM dummy')) {


### PR DESCRIPTION
## Summary
- refactor the mail compose helpers to use the Doctrine connection with bound parameters and JSON-escaped superuser metadata
- build the fallback LIKE pattern in PHP before binding and keep ordering logic intact
- extend the Doctrine stub and mail compose tests to cover quoted and multibyte recipient names while updating other Doctrine test doubles to the new signature

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e176fdc5f083298752942c39bb3cc8