### PR TITLE
fix: correct optional chaining in ajax polling notifications

### DIFF
--- a/async/js/ajax_polling.js
+++ b/async/js/ajax_polling.js
@@ -27,7 +27,7 @@ function lotgdShowNotification(title, message)
     if (!('Notification' in window)) {
         return;
     }
-    const icon = document.querySelector('link[rel="icon"][sizes="32x32"]') ? .href || '/images/favicon/favicon-32x32.png';
+    const icon = document.querySelector('link[rel="icon"][sizes="32x32"]')?.href || '/images/favicon/favicon-32x32.png';
     if (Notification.permission === 'granted') {
         new Notification(title, {body: message, icon: icon});
     } else if (Notification.permission !== 'denied') {


### PR DESCRIPTION
## Summary
- fix the favicon lookup in the async notification helper to use valid optional chaining syntax

## Testing
- node --check async/js/ajax_polling.js

------
https://chatgpt.com/codex/tasks/task_e_68e1801adb8c8329aae0460e8b6db1a8