### PR TITLE
fix: avoid commentary warnings for non-comment scripts

### DIFF
--- a/async/setup.php
+++ b/async/setup.php
@@ -155,13 +155,15 @@ function pollForUpdates() {
                                 eval(cmd.data);
 
                                 if (window.lotgd_lastCommentId === beforeId) {
-                                    const match = cmd.data.match(/lotgd_lastCommentId\s*=\s*(\d+)/);
+                                    if (cmd.data.includes('lotgd_lastCommentId')) {
+                                        const match = cmd.data.match(/lotgd_lastCommentId\s*=\s*(\d+)/);
 
-                                    if (match) {
-                                        window.lotgd_lastCommentId = parseInt(match[1], 10);
-                                        console.log('AJAX: lastCommentId parsed to', window.lotgd_lastCommentId);
-                                    } else {
-                                        console.warn('AJAX: lastCommentId unchanged after script:', cmd.data);
+                                        if (match) {
+                                            window.lotgd_lastCommentId = parseInt(match[1], 10);
+                                            console.log('AJAX: lastCommentId parsed to', window.lotgd_lastCommentId);
+                                        } else {
+                                            console.warn('AJAX: lastCommentId unchanged after script:', cmd.data);
+                                        }
                                     }
                                 } else {
                                     console.log('AJAX: lastCommentId updated to', window.lotgd_lastCommentId);


### PR DESCRIPTION
## Summary
- restrict the fallback lotgd_lastCommentId parsing to scripts that reference the variable
- keep existing logging for genuine commentary parsing failures while skipping unrelated commands

## Testing
- php -l async/setup.php

------
https://chatgpt.com/codex/tasks/task_e_68e1900254c08329bba78a84593b058c