### PR TITLE
fix: refresh focus state before sending notifications

### DIFF
--- a/async/js/ajax_polling.js
+++ b/async/js/ajax_polling.js
@@ -31,7 +31,7 @@ function lotgdUpdateWindowFocusState()
 }
 
 window.addEventListener('focus', function () {
-    lotgd_windowHasFocus = true;
+    lotgdUpdateWindowFocusState();
 });
 
 window.addEventListener('blur', function () {
@@ -49,6 +49,7 @@ document.addEventListener('visibilitychange', function () {
 
 function lotgdShouldNotify()
 {
+    lotgdUpdateWindowFocusState();
     return !lotgd_windowHasFocus || document.visibilityState === 'hidden';
 }
 

--- a/async/setup.php
+++ b/async/setup.php
@@ -94,10 +94,10 @@ $polling_script .= "console.log('AJAX polling initialized:', {interval: lotgd_po
 // Track window focus/visibility state for consistent notification behaviour
 $polling_script .= "var lotgd_windowHasFocus = document.hasFocus();";
 $polling_script .= "function lotgdUpdateWindowFocusState() { lotgd_windowHasFocus = document.visibilityState === 'visible' && document.hasFocus(); }";
-$polling_script .= "window.addEventListener('focus', function () { lotgd_windowHasFocus = true; });";
+$polling_script .= "window.addEventListener('focus', function () { lotgdUpdateWindowFocusState(); });";
 $polling_script .= "window.addEventListener('blur', function () { lotgd_windowHasFocus = false; });";
 $polling_script .= "document.addEventListener('visibilitychange', function () { if (document.visibilityState === 'hidden') { lotgd_windowHasFocus = false; } else { lotgdUpdateWindowFocusState(); } });";
-$polling_script .= "function lotgdShouldNotify() { return !lotgd_windowHasFocus || document.visibilityState === 'hidden'; }";
+$polling_script .= "function lotgdShouldNotify() { lotgdUpdateWindowFocusState(); return !lotgd_windowHasFocus || document.visibilityState === 'hidden'; }";
 
 // Add missing notification functions and clean AJAX polling implementation
 $polling_script .= "


### PR DESCRIPTION
## Summary
- refresh the tracked window focus flag before evaluating notification eligibility in the async setup script
- update the legacy ajax polling helper to recompute focus state on demand so both paths stay in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e21d54f6ac8329911c1b8da7bbdb3d