### PR TITLE
refactor: parameterize gamelog inserts

### DIFF
--- a/src/Lotgd/GameLog.php
+++ b/src/Lotgd/GameLog.php
@@ -32,9 +32,19 @@ class GameLog
             $severity = 'info';
         }
 
-        $sql = 'INSERT INTO ' . Database::prefix('gamelog') .
-            ' (message,category,severity,filed,date,who) VALUES (' .
-            "'" . addslashes($message) . "','" . addslashes($category) . "','" . addslashes($severity) . "','" . ($filed ? "1" : "0") . "','" . date('Y-m-d H:i:s') . "','" . $who . "')";
-        Database::query($sql);
+        $conn = Database::getDoctrineConnection();
+        $sql  = sprintf(
+            'INSERT INTO %s (message,category,severity,filed,date,who) VALUES (:message, :category, :severity, :filed, :date, :who)',
+            Database::prefix('gamelog')
+        );
+
+        $conn->executeStatement($sql, [
+            'message'  => $message,
+            'category' => $category,
+            'severity' => $severity,
+            'filed'    => $filed ? 1 : 0,
+            'date'     => date('Y-m-d H:i:s'),
+            'who'      => $who,
+        ]);
     }
 }

--- a/tests/GameLogSeverityTest.php
+++ b/tests/GameLogSeverityTest.php
@@ -15,6 +15,7 @@ final class GameLogSeverityTest extends TestCase
         class_exists(Database::class);
         Database::$queries = [];
         Database::$tablePrefix = '';
+        Database::resetDoctrineConnection();
         global $session;
         $session['user']['acctid'] = 99;
     }
@@ -22,23 +23,48 @@ final class GameLogSeverityTest extends TestCase
     protected function tearDown(): void
     {
         Database::$queries = [];
+        Database::resetDoctrineConnection();
         unset($GLOBALS['session']);
     }
 
     public function testInvalidSeverityFallsBackToInfo(): void
     {
         GameLog::log('Default severity', 'test', false, null, 'invalid');
-        $query = Database::$queries[0] ?? '';
-        $this->assertStringContainsString("INSERT INTO gamelog (message,category,severity,filed,date,who) VALUES ('Default severity','test','info'", $query);
-        $this->assertStringContainsString("'99')", $query);
+        $conn   = Database::getDoctrineConnection();
+        $record = $conn->executeStatements[0] ?? null;
+
+        $this->assertNotNull($record);
+        $this->assertStringContainsString('INSERT INTO gamelog (message,category,severity,filed,date,who) VALUES (:message, :category, :severity, :filed, :date, :who)', $record['sql']);
+        $this->assertSame('info', $record['params']['severity']);
+        $this->assertSame(99, $record['params']['who']);
     }
 
     public function testExplicitSeverityIsRecorded(): void
     {
         Database::$queries = [];
         GameLog::log('Error severity', 'test', false, 5, 'error');
-        $query = Database::$queries[0] ?? '';
-        $this->assertStringContainsString("'Error severity','test','error'", $query);
-        $this->assertStringContainsString("'5')", $query);
+        $conn   = Database::getDoctrineConnection();
+        $record = $conn->executeStatements[0] ?? null;
+
+        $this->assertNotNull($record);
+        $this->assertSame('error', $record['params']['severity']);
+        $this->assertSame(5, $record['params']['who']);
+        $this->assertSame('Error severity', $record['params']['message']);
+    }
+
+    public function testQuotedAndMultibyteMessageIsPersisted(): void
+    {
+        $message = 'Quotes "double" and \'single\' with emoji 😃 and kanji 漢字';
+        GameLog::log($message, 'special', true, 7, 'warning');
+
+        $conn   = Database::getDoctrineConnection();
+        $record = $conn->executeStatements[0] ?? null;
+
+        $this->assertNotNull($record);
+        $this->assertSame($message, $record['params']['message']);
+        $this->assertSame('special', $record['params']['category']);
+        $this->assertSame(1, $record['params']['filed']);
+        $this->assertSame(7, $record['params']['who']);
+        $this->assertSame('warning', $record['params']['severity']);
     }
 }


### PR DESCRIPTION
## Summary
- refactor `GameLog::log` to use the shared Doctrine connection with a parameterized insert
- update game log severity tests to cover the Doctrine execution path and quoted/multibyte messages

## Testing
- composer test -- tests/GameLogSeverityTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e2213fcf4c832994b8656e4967e3ee