### PR TITLE
fix: support stubbed PlayerSearch lookups

### DIFF
--- a/lib/playersearch.php
+++ b/lib/playersearch.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Lotgd\PlayerSearch;
+
+function playersearch_service(): PlayerSearch
+{
+    static $service = null;
+
+    if (! $service instanceof PlayerSearch) {
+        $service = new PlayerSearch();
+    }
+
+    return $service;
+}
+
+/**
+ * @param array<int|string, string>|null $columns
+ */
+function playersearch_find_exact_login(string $login, ?array $columns = null): array
+{
+    return playersearch_service()->findExactLogin($login, $columns);
+}
+
+/**
+ * @param array<int|string, string>|null $columns
+ */
+function playersearch_find_by_display_name_pattern(
+    string $pattern,
+    ?array $columns = null,
+    ?int $limit = null,
+    ?string $exactName = null
+ ): array {
+    return playersearch_service()->findByDisplayNamePattern($pattern, $columns, $limit, $exactName);
+}
+
+/**
+ * @param array<int|string, string>|null $columns
+ */
+function playersearch_find_by_display_name_fuzzy(
+    string $search,
+    ?array $columns = null,
+    ?int $limit = null,
+    ?string $exactName = null
+): array {
+    return playersearch_service()->findByDisplayNameFuzzy($search, $columns, $limit, $exactName);
+}
+
+/**
+ * @param array<int|string, string>|null $columns
+ */
+function playersearch_find_for_transfer(string $search, ?array $columns = null, ?int $limit = null): array
+{
+    return playersearch_service()->findForTransfer($search, $columns, $limit);
+}

--- a/src/Lotgd/PlayerSearch.php
+++ b/src/Lotgd/PlayerSearch.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd;
+
+use Doctrine\DBAL\Connection;
+use InvalidArgumentException;
+use Lotgd\MySQL\Database;
+use Throwable;
+
+final class PlayerSearch
+{
+    private const DEFAULT_LIMIT = 100;
+    private const MAX_LIMIT = 250;
+    private const LIKE_ESCAPE = '!';
+
+    /**
+     * @var array<int|string, string>
+     */
+    private const DEFAULT_COLUMNS = ['acctid', 'login', 'name'];
+
+    /**
+     * @var Connection|object
+     */
+    private $connection;
+
+    public function __construct(?Connection $connection = null)
+    {
+        $this->connection = $connection ?? Database::getDoctrineConnection();
+    }
+
+    /**
+     * Find players that exactly match a login name.
+     *
+     * @param array<int|string, string>|null $columns
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function findExactLogin(string $login, ?array $columns = null): array
+    {
+        return $this->executeSearch([
+            'columns' => $columns,
+            'limit'   => 1,
+            'loginExact' => $login,
+            'alphabeticalColumn' => 'a.login',
+        ]);
+    }
+
+    /**
+     * Find players by a display name pattern. The pattern may include SQL LIKE wildcards.
+     *
+     * @param array<int|string, string>|null $columns
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function findByDisplayNamePattern(
+        string $pattern,
+        ?array $columns = null,
+        ?int $limit = null,
+        ?string $exactName = null
+    ): array {
+        return $this->executeSearch([
+            'columns' => $columns,
+            'limit'   => $limit,
+            'namePattern' => $pattern,
+            'nameExact'   => $exactName,
+        ]);
+    }
+
+    /**
+     * Find players by a display name using a character-spaced wildcard search (e.g. %N%A%M%E%).
+     *
+     * @param array<int|string, string>|null $columns
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function findByDisplayNameFuzzy(
+        string $search,
+        ?array $columns = null,
+        ?int $limit = null,
+        ?string $exactName = null
+    ): array {
+        return $this->executeSearch([
+            'columns' => $columns,
+            'limit'   => $limit,
+            'namePattern' => '%' . $this->escapeLikeWildcards($search) . '%',
+            'nameCharacterPattern' => $this->buildCharacterWildcardPattern($search),
+            'nameExact'   => $exactName,
+        ]);
+    }
+
+    /**
+     * Find potential transfer targets by combining an exact login match with a display name search.
+     *
+     * @param array<int|string, string>|null $columns
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function findForTransfer(string $search, ?array $columns = null, ?int $limit = null): array
+    {
+        $escaped = $this->escapeLikeWildcards($search);
+
+        return $this->executeSearch([
+            'columns' => $columns,
+            'limit'   => $limit,
+            'loginExact'  => $search,
+            'namePattern' => '%' . $escaped . '%',
+            'nameCharacterPattern' => $this->buildCharacterWildcardPattern($search),
+            'nameExact'   => $search,
+        ]);
+    }
+
+    /**
+     * @param array{
+     *     columns?: array<int|string, string>|null,
+     *     limit?: int|null,
+     *     loginExact?: string|null,
+     *     namePattern?: string|null,
+     *     nameExact?: string|null,
+     *     nameCharacterPattern?: string|null,
+     *     alphabeticalColumn?: string|null
+     * } $options
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function executeSearch(array $options): array
+    {
+        $columns = $this->normaliseColumns($options['columns'] ?? null);
+        $limit   = $this->normaliseLimit($options['limit'] ?? null);
+        $alphabetical = $this->normaliseAlphabeticalColumn($options['alphabeticalColumn'] ?? 'a.name');
+        $conditions = [];
+        $orderPriorities = [];
+        $parameters = [];
+
+        if (isset($options['loginExact'])) {
+            $conditions[] = 'a.login = :loginExact';
+            $parameters['loginExact'] = $options['loginExact'];
+            $orderPriorities[] = ['column' => 'a.login', 'parameter' => 'loginExact'];
+        }
+
+        if (isset($options['namePattern'])) {
+            $conditions[] = sprintf("a.name LIKE :namePattern ESCAPE '%s'", self::LIKE_ESCAPE);
+            $parameters['namePattern'] = $options['namePattern'];
+        }
+
+        if (isset($options['nameCharacterPattern'])) {
+            $conditions[] = sprintf("a.name LIKE :nameCharacterPattern ESCAPE '%s'", self::LIKE_ESCAPE);
+            $parameters['nameCharacterPattern'] = $options['nameCharacterPattern'];
+        }
+
+        if (isset($options['nameExact'])) {
+            $parameters['nameExact'] = $options['nameExact'];
+            $orderPriorities[] = ['column' => 'a.name', 'parameter' => 'nameExact'];
+        }
+
+        if ($conditions === []) {
+            throw new InvalidArgumentException('At least one search criterion must be provided.');
+        }
+
+        $wrapped = array_map(
+            static fn(string $condition): string => '(' . $condition . ')',
+            $conditions
+        );
+
+        $sql = sprintf(
+            'SELECT %s FROM accounts a WHERE %s ORDER BY %s LIMIT %d',
+            implode(', ', $columns),
+            implode(' OR ', $wrapped),
+            $this->buildOrderByClause($orderPriorities, $alphabetical),
+            $limit
+        );
+
+        return $this->connection->executeQuery($sql, $parameters)->fetchAllAssociative();
+    }
+
+    /**
+     * @param array<int|string, string>|null $columns
+     *
+     * @return array<int, string>
+     */
+    private function normaliseColumns(?array $columns): array
+    {
+        $columns ??= self::DEFAULT_COLUMNS;
+        $selects = [];
+
+        foreach ($columns as $key => $value) {
+            if (is_int($key)) {
+                $column = $value;
+                $alias  = $value;
+            } else {
+                $column = (string) $key;
+                $alias  = (string) $value;
+            }
+
+            if (!preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $column)) {
+                throw new InvalidArgumentException(sprintf('Invalid column name "%s" supplied.', $column));
+            }
+
+            if ($alias !== null && !preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $alias)) {
+                throw new InvalidArgumentException(sprintf('Invalid column alias "%s" supplied.', $alias));
+            }
+
+            $qualified = 'a.' . $column;
+            if ($alias !== null && $alias !== $column) {
+                $selects[] = sprintf('%s AS %s', $qualified, $alias);
+            } else {
+                $selects[] = $qualified;
+            }
+        }
+
+        return $selects;
+    }
+
+    private function normaliseLimit(?int $limit): int
+    {
+        $limit = $limit ?? self::DEFAULT_LIMIT;
+        if ($limit <= 0) {
+            $limit = self::DEFAULT_LIMIT;
+        }
+
+        return min($limit, self::MAX_LIMIT);
+    }
+
+    private function normaliseAlphabeticalColumn(string $column): string
+    {
+        if (!preg_match('/^a\.[A-Za-z_][A-Za-z0-9_]*$/', $column)) {
+            throw new InvalidArgumentException('Alphabetical column must reference the accounts table alias.');
+        }
+
+        return $column;
+    }
+
+    private function escapeLikeWildcards(string $value): string
+    {
+        try {
+            if (method_exists($this->connection, 'getDatabasePlatform')) {
+                $platform = $this->connection->getDatabasePlatform();
+                if ($platform && method_exists($platform, 'escapeStringForLike')) {
+                    return $platform->escapeStringForLike($value, self::LIKE_ESCAPE);
+                }
+            }
+        } catch (Throwable $exception) {
+            // Ignore and fall back to manual escaping below.
+        }
+
+        return str_replace(
+            [self::LIKE_ESCAPE, '%', '_'],
+            [self::LIKE_ESCAPE . self::LIKE_ESCAPE, self::LIKE_ESCAPE . '%', self::LIKE_ESCAPE . '_'],
+            $value
+        );
+    }
+
+    private function buildCharacterWildcardPattern(string $search): string
+    {
+        if ($search === '') {
+            return '%%';
+        }
+
+        $characters = preg_split('//u', $search, -1, PREG_SPLIT_NO_EMPTY);
+        $escaped = array_map(fn(string $char): string => $this->escapeLikeWildcards($char), $characters);
+
+        return '%' . implode('%', $escaped) . '%';
+    }
+
+    /**
+     * @param array<int, array{column: string, parameter: string}> $orderPriorities
+     */
+    private function buildOrderByClause(array $orderPriorities, string $alphabetical): string
+    {
+        $orderParts = [];
+
+        foreach ($orderPriorities as $priority) {
+            $orderParts[] = sprintf(
+                'CASE WHEN %s = :%s THEN 0 ELSE 1 END ASC',
+                $priority['column'],
+                $priority['parameter']
+            );
+        }
+
+        $orderParts[] = sprintf('LOWER(%s) ASC', $alphabetical);
+        $orderParts[] = 'a.acctid ASC';
+
+        return implode(', ', $orderParts);
+    }
+}

--- a/tests/PlayerSearch/PlayerSearchTest.php
+++ b/tests/PlayerSearch/PlayerSearchTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\PlayerSearch;
+
+use InvalidArgumentException;
+use Lotgd\MySQL\Database;
+use Lotgd\PlayerSearch;
+use Lotgd\Tests\Stubs\Database as DatabaseStub;
+use Lotgd\Tests\Stubs\DoctrineBootstrap;
+use PHPUnit\Framework\TestCase;
+
+final class PlayerSearchTest extends TestCase
+{
+    private PlayerSearch $search;
+
+    /**
+     * @var \Lotgd\Tests\Stubs\DoctrineConnection
+     */
+    private $connection;
+
+    protected function setUp(): void
+    {
+        // Ensure the stub classes are loaded so Doctrine resolves to the in-memory fake connection.
+        class_exists(DatabaseStub::class);
+
+        Database::resetDoctrineConnection();
+        if (class_exists(DoctrineBootstrap::class, false)) {
+            DoctrineBootstrap::$conn = null;
+        }
+
+        \Lotgd\MySQL\Database::$mockResults = [];
+
+        $this->search = new PlayerSearch();
+        $this->connection = Database::getDoctrineConnection();
+        $this->connection->queries = [];
+        $this->connection->executeQueryParams = [];
+    }
+
+    protected function tearDown(): void
+    {
+        Database::resetDoctrineConnection();
+        if (class_exists(DoctrineBootstrap::class, false)) {
+            DoctrineBootstrap::$conn = null;
+        }
+
+        \Lotgd\MySQL\Database::$mockResults = [];
+    }
+
+    public function testFindExactLoginReturnsSingleRow(): void
+    {
+        \Lotgd\MySQL\Database::$mockResults = [[
+            ['acctid' => 1, 'login' => 'alpha', 'name' => 'Alpha'],
+        ]];
+
+        $result = $this->search->findExactLogin('alpha');
+
+        $this->assertSame('alpha', $result[0]['login']);
+        $this->assertSame('Alpha', $result[0]['name']);
+
+        $sql = end($this->connection->queries);
+        $this->assertStringContainsString('a.login = :loginExact', $sql);
+        $this->assertStringContainsString('LIMIT 1', $sql);
+
+        $params = end($this->connection->executeQueryParams);
+        $this->assertSame(['loginExact' => 'alpha'], $params);
+    }
+
+    public function testFindByDisplayNamePatternHonoursOrdering(): void
+    {
+        \Lotgd\MySQL\Database::$mockResults = [[
+            ['login' => 'bravo', 'name' => 'Bravo'],
+            ['login' => 'bravo_team', 'name' => 'Bravocado'],
+        ]];
+
+        $result = $this->search->findByDisplayNamePattern('Brav%', ['login', 'name'], null, 'Bravo');
+
+        $this->assertCount(2, $result);
+        $this->assertSame('bravo', $result[0]['login']);
+        $this->assertSame('Bravo', $result[0]['name']);
+
+        $sql = end($this->connection->queries);
+        $this->assertStringContainsString('a.name LIKE :namePattern', $sql);
+        $this->assertStringContainsString('CASE WHEN a.name = :nameExact THEN 0 ELSE 1 END', $sql);
+
+        $params = end($this->connection->executeQueryParams);
+        $this->assertSame([
+            'namePattern' => 'Brav%',
+            'nameExact'   => 'Bravo',
+        ], $params);
+    }
+
+    public function testFindByDisplayNameFuzzyBuildsCharacterPattern(): void
+    {
+        \Lotgd\MySQL\Database::$mockResults = [[
+            ['login' => 'charlie', 'name' => 'Char L.'],
+        ]];
+
+        $result = $this->search->findByDisplayNameFuzzy('Ch', ['login', 'name'], 10, 'Char L.');
+
+        $this->assertSame('charlie', $result[0]['login']);
+
+        $sql = end($this->connection->queries);
+        $this->assertStringContainsString('a.name LIKE :nameCharacterPattern', $sql);
+
+        $params = end($this->connection->executeQueryParams);
+        $this->assertSame([
+            'namePattern' => '%Ch%',
+            'nameCharacterPattern' => '%C%h%',
+            'nameExact'   => 'Char L.',
+        ], $params);
+        $this->assertStringContainsString('LIMIT 10', $sql);
+    }
+
+    public function testFindForTransferCombinesExactAndFuzzyPatterns(): void
+    {
+        \Lotgd\MySQL\Database::$mockResults = [[
+            ['login' => 'bravo', 'name' => 'Bravo'],
+            ['login' => 'bravo_team', 'name' => 'Bravocado'],
+        ]];
+
+        $result = $this->search->findForTransfer('bravo', ['login', 'name'], 15);
+
+        $this->assertSame('bravo', $result[0]['login']);
+
+        $sql = end($this->connection->queries);
+        $this->assertStringContainsString('a.login = :loginExact', $sql);
+        $this->assertStringContainsString('a.name LIKE :namePattern', $sql);
+        $this->assertStringContainsString('a.name LIKE :nameCharacterPattern', $sql);
+
+        $params = end($this->connection->executeQueryParams);
+        $this->assertSame([
+            'loginExact'           => 'bravo',
+            'namePattern'          => '%bravo%',
+            'nameCharacterPattern' => '%b%r%a%v%o%',
+            'nameExact'            => 'bravo',
+        ], $params);
+        $this->assertStringContainsString('LIMIT 15', $sql);
+    }
+
+    public function testWildcardCharactersAreEscaped(): void
+    {
+        \Lotgd\MySQL\Database::$mockResults = [[
+            ['login' => 'symbols', 'name' => '%Weird_'],
+        ]];
+
+        $this->search->findForTransfer('%_');
+
+        $params = end($this->connection->executeQueryParams);
+        $this->assertSame('%_', $params['loginExact']);
+        $this->assertSame('%!%!_%', $params['namePattern']);
+        $this->assertSame('%!%%!_%', $params['nameCharacterPattern']);
+        $this->assertSame('%_', $params['nameExact']);
+    }
+
+    public function testPatternsPreserveQuotesAndMultibyteCharacters(): void
+    {
+        \Lotgd\MySQL\Database::$mockResults = [[
+            ['login' => 'quote', 'name' => "O'Reilly"],
+        ]];
+
+        $this->search->findByDisplayNamePattern("%O'Reilly%", null, null, "O'Reilly");
+
+        $params = end($this->connection->executeQueryParams);
+        $this->assertSame("%O'Reilly%", $params['namePattern']);
+        $this->assertSame("O'Reilly", $params['nameExact']);
+
+        \Lotgd\MySQL\Database::$mockResults = [[
+            ['login' => 'unicode', 'name' => '漢字'],
+        ]];
+
+        $this->search->findByDisplayNameFuzzy('漢字');
+
+        $params = end($this->connection->executeQueryParams);
+        $this->assertSame('%漢字%', $params['namePattern']);
+        $this->assertSame('%漢%字%', $params['nameCharacterPattern']);
+    }
+
+    public function testLimitDefaultsAndCaps(): void
+    {
+        \Lotgd\MySQL\Database::$mockResults = [[['login' => 'alpha', 'name' => 'Alpha']]];
+        $this->search->findByDisplayNamePattern('%');
+        $sql = end($this->connection->queries);
+        $this->assertStringContainsString('LIMIT 100', $sql);
+
+        \Lotgd\MySQL\Database::$mockResults = [[['login' => 'alpha', 'name' => 'Alpha']]];
+        $this->search->findByDisplayNamePattern('%', null, 999);
+        $sql = end($this->connection->queries);
+        $this->assertStringContainsString('LIMIT 250', $sql);
+
+        \Lotgd\MySQL\Database::$mockResults = [[['login' => 'alpha', 'name' => 'Alpha']]];
+        $this->search->findByDisplayNamePattern('%', null, 0);
+        $sql = end($this->connection->queries);
+        $this->assertStringContainsString('LIMIT 100', $sql);
+    }
+
+    public function testCustomColumnsAreRespected(): void
+    {
+        \Lotgd\MySQL\Database::$mockResults = [[
+            ['acctid' => 1, 'player_login' => 'alpha'],
+        ]];
+
+        $result = $this->search->findForTransfer('alpha', ['acctid', 'login' => 'player_login'], 1);
+
+        $this->assertSame(['acctid' => 1, 'player_login' => 'alpha'], $result[0]);
+
+        $sql = end($this->connection->queries);
+        $this->assertStringContainsString('SELECT a.acctid, a.login AS player_login', $sql);
+        $this->assertStringContainsString('LIMIT 1', $sql);
+    }
+
+    public function testInvalidColumnNameThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->search->findExactLogin('alpha', ['invalid column']);
+    }
+}


### PR DESCRIPTION
## Summary
- rework PlayerSearch to build parameterised SQL that works with stubbed Doctrine connections
- add a fuzzy display-name search helper and expose it via the legacy wrapper
- rewrite PlayerSearch tests to exercise stub-driven queries, wildcard escaping, and limit handling

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e22932a0908329a99eb1844253e68a