### PR TITLE
Refactor admin user lookup to PlayerSearch service

### DIFF
--- a/bans.php
+++ b/bans.php
@@ -11,7 +11,7 @@ use Lotgd\Page\Header;
 use Lotgd\Settings;
 use Lotgd\SuAccess;
 use Lotgd\Translator;
-use Lotgd\UserLookup;
+use Lotgd\PlayerSearch;
 
 //addnews ready
 // mail ready
@@ -45,15 +45,33 @@ if ($query === false) {
 if (!$query && $sort) {
     $query = "%";
 }
-
-    if ($op == "search" || $op == "") {
-        list($searchresult, $err) = UserLookup::lookup($query, $order);
-        $op = "";
-        if ($err) {
-            $output->output('%s', $err);
-        } else {
-            if ($searchresult) {
-                $display = 1;
+ 
+$playerSearch = new PlayerSearch();
+$columns = [
+    'acctid',
+    'login',
+    'name',
+    'level',
+    'laston',
+    'loggedin',
+    'gentimecount',
+    'gentime',
+    'lastip',
+    'uniqueid',
+    'emailaddress',
+];
+$searchresult = [];
+$err = '';
+if ($op == "search" || $op == "") {
+    $lookup = $playerSearch->legacyLookup((string) $query, $columns, $order);
+    $searchresult = $lookup['rows'];
+    $err = $lookup['error'];
+    $op = "";
+    if ($err) {
+        $output->output('%s', $err);
+    } else {
+        if ($searchresult) {
+            $display = 1;
         }
     }
 }

--- a/docs/Deprecations.md
+++ b/docs/Deprecations.md
@@ -24,10 +24,14 @@ This project aims to preserve legacy compatibility while moving to a modern stac
   - Replacement: Doctrine ORM/DBAL repositories and migrations  
   - Migration: Move writes/reads into services or repositories; create migrations instead of ad‑hoc SQL.
 
-- Custom Ajax endpoints not using Jaxon  
-  - Status: Deprecated  
-  - Replacement: Jaxon-based async calls under `async/`  
+- Custom Ajax endpoints not using Jaxon
+  - Status: Deprecated
+  - Replacement: Jaxon-based async calls under `async/`
   - Migration: Wrap Ajax actions with Jaxon controllers; adhere to rate limiting.
+- `Lotgd\UserLookup::lookup()`
+  - Status: Deprecated in 2.9.0
+  - Replacement: `Lotgd\PlayerSearch::legacyLookup()` and other `PlayerSearch` helpers
+  - Migration: Inject or instantiate `PlayerSearch` directly and call `legacyLookup()` (or a more specific finder), removing usage of the legacy array/SQL wrapper.
 
 ### Upgrade Guidance (1.3.x → 2.0)
 

--- a/pages/bans/case_searchban.php
+++ b/pages/bans/case_searchban.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Lotgd\MySQL\Database;
 use Lotgd\Nav;
 use Lotgd\Http;
-use Lotgd\UserLookup;
+use Lotgd\PlayerSearch;
 use Lotgd\Translator;
 use Lotgd\Output;
 use Lotgd\DateTime;
@@ -37,6 +37,7 @@ if ($subop == "xml") {
     exit();
 }
 $operator = "<=";
+$playerSearch = new PlayerSearch();
 
 
 $target = Http::post('target');
@@ -55,15 +56,16 @@ if ($target == '') {
     $row = Database::fetchAssoc($result);
     $since = "WHERE ipfilter LIKE '%" . $row['lastip'] . "%' OR uniqueid LIKE '%" . $row['uniqueid'] . "%'";
 } else {
-    $names = UserLookup::lookup($target);
-    if ($names[0] !== false) {
+    $names = $playerSearch->legacyLookup((string) $target, ['acctid', 'login', 'name'], 'login');
+    if ($names['rows'] !== []) {
         $output->rawOutput("<form action='bans.php?op=searchban' method='POST'>");
         Nav::add("", "bans.php?op=searchban");
                 $output->rawOutput("<label for='target'>");
                 $output->output("Search banned user by name: ");
                 $output->rawOutput("</label>");
                 $output->rawOutput("<select name='target' id='target'>");
-        while ($row = Database::fetchAssoc($names[0])) {
+        $resultRows = $names['rows'];
+        while ($row = Database::fetchAssoc($resultRows)) {
             $output->rawOutput("<option value='" . $row['acctid'] . "'>" . $row['login'] . "</option>");
         }
         $output->rawOutput("</select>");

--- a/pages/user/user_searchban.php
+++ b/pages/user/user_searchban.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Lotgd\UserLookup;
+use Lotgd\PlayerSearch;
 use Lotgd\Nav;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
@@ -30,6 +30,7 @@ if ($subop == "xml") {
     exit();
 }
 $operator = "<=";
+$playerSearch = new PlayerSearch();
 
 
 $target = httppost('target');
@@ -48,15 +49,16 @@ if ($target == '') {
     $row = Database::fetchAssoc($result);
     $since = "WHERE ipfilter LIKE '%" . $row['lastip'] . "%' OR uniqueid LIKE '%" . $row['uniqueid'] . "%'";
 } else {
-    $names = UserLookup::lookup($target);
-    if ($names[0] !== false) {
+    $names = $playerSearch->legacyLookup((string) $target, ['acctid', 'login', 'name'], 'login');
+    if ($names['rows'] !== []) {
         $output->rawOutput("<form action='user.php?op=searchban' method='POST'>");
         Nav::add("", "user.php?op=searchban");
                 $output->rawOutput("<label for='target'>");
                 $output->output("Search banned user by name: ");
                 $output->rawOutput("</label>");
                 $output->rawOutput("<select name='target' id='target'>");
-        while ($row = Database::fetchAssoc($names[0])) {
+        $resultRows = $names['rows'];
+        while ($row = Database::fetchAssoc($resultRows)) {
             $output->rawOutput("<option value='" . $row['acctid'] . "'>" . $row['login'] . "</option>");
         }
         $output->rawOutput("</select>");

--- a/src/Lotgd/UserLookup.php
+++ b/src/Lotgd/UserLookup.php
@@ -5,9 +5,26 @@ declare(strict_types=1);
 namespace Lotgd;
 
 use Lotgd\MySQL\Database;
+use Lotgd\PlayerSearch;
+
+use function trigger_deprecation;
 
 class UserLookup
 {
+    private const DEFAULT_FIELDS = [
+        'acctid',
+        'login',
+        'name',
+        'level',
+        'laston',
+        'loggedin',
+        'gentimecount',
+        'gentime',
+        'lastip',
+        'uniqueid',
+        'emailaddress',
+    ];
+
     /**
      * Search for users matching the given criteria.
      *
@@ -17,51 +34,108 @@ class UserLookup
      * @param string|false $where  Optional where clause
      *
      * @return array{0:mixed,1:string} Database result resource and error message
+     *
+     * @deprecated since 2.9.0. Use {@see PlayerSearch::legacyLookup()} or dedicated
+     *             PlayerSearch helpers directly.
      */
     public static function lookup(string|false $query = false, string|false $order = false, string|false $fields = false, string|false $where = false): array
     {
-        $err = '';
-        $searchresult = false;
-        if ($order !== false) {
-            $order = "ORDER BY $order";
+        trigger_deprecation('lotgd/core', '2.9.0', 'Lotgd\\UserLookup::lookup() is deprecated. Use Lotgd\\PlayerSearch::legacyLookup() instead.');
+
+        if ($query === false) {
+            return [false, ''];
         }
+
+        $fieldsInfo = self::normaliseFields($fields);
+
+        if ($where !== false) {
+            return self::runWhereQuery($fieldsInfo['sql'], $order, $where);
+        }
+
+        $search = trim((string) $query);
+
+        if ($search === '') {
+            return [[], ''];
+        }
+
+        $playerSearch = new PlayerSearch();
+        $result = $playerSearch->legacyLookup(
+            $search,
+            $fieldsInfo['columns'],
+            is_string($order) && $order !== '' ? $order : null
+        );
+
+        return [$result['rows'], $result['error']];
+    }
+
+    /**
+     * @return array{columns: array<int|string, string>, sql: string}
+     */
+    private static function normaliseFields(string|false $fields): array
+    {
         if ($fields === false) {
-            $fields = 'acctid,login,name,level,laston,loggedin,gentimecount,gentime,lastip,uniqueid,emailaddress';
+            return [
+                'columns' => self::DEFAULT_FIELDS,
+                'sql'      => implode(',', self::DEFAULT_FIELDS),
+            ];
         }
-        $sql = 'SELECT ' . $fields . ' FROM ' . Database::prefix('accounts');
-        if ($query != '') {
-            if ($where === false) {
-                $query = Database::escape($query);
-                $sql_where = "WHERE login LIKE '$query' OR name LIKE '$query' OR acctid = '$query' OR emailaddress LIKE '$query' OR lastip LIKE '$query' OR uniqueid LIKE '$query'";
+
+        $columns = [];
+        $sqlParts = [];
+
+        foreach (explode(',', $fields) as $piece) {
+            $piece = trim($piece);
+            if ($piece === '') {
+                continue;
+            }
+
+            $sqlParts[] = $piece;
+
+            if (stripos($piece, ' as ') !== false) {
+                [$column, $alias] = preg_split('/\s+as\s+/i', $piece, 2);
+                $columns[$column] = $alias;
             } else {
-                $sql_where = "WHERE $where";
-            }
-            $searchresult = Database::query($sql . " $sql_where $order LIMIT 2");
-        }
-        if ($query !== false || $searchresult) {
-            if (Database::numRows($searchresult) != 1) {
-                $name_query = '%';
-                for ($x = 0; $x < strlen($query); $x++) {
-                    $char = substr($query, $x, 1);
-                    if ($char != '\\') {
-                        $name_query .= $char . '%';
-                    } else {
-                        $name_query .= $char;
-                    }
-                }
-                if ($where === false) {
-                    $sql_where = "WHERE login LIKE '%$query%' OR acctid LIKE '%$query%' OR name LIKE '%$name_query%' OR emailaddress LIKE '%$query%' OR lastip LIKE '%$query%' OR uniqueid LIKE '%$query%' OR gentimecount LIKE '%$query%' OR level LIKE '%$query%'";
-                } else {
-                    $sql_where = "WHERE $where";
-                }
-                $searchresult = Database::query($sql . " $sql_where $order LIMIT 301");
-            }
-            if (Database::numRows($searchresult) <= 0) {
-                $err = "`\$No results found`0";
-            } elseif (Database::numRows($searchresult) > 300) {
-                $err = "`\$Too many results found, narrow your search please.`0";
+                $columns[] = $piece;
             }
         }
-        return [$searchresult, $err];
+
+        if ($columns === []) {
+            $columns = self::DEFAULT_FIELDS;
+            $sqlParts = self::DEFAULT_FIELDS;
+        }
+
+        return [
+            'columns' => $columns,
+            'sql'      => implode(', ', $sqlParts),
+        ];
+    }
+
+    private static function runWhereQuery(string $fieldsSql, string|false $order, string $where): array
+    {
+        $orderSql = '';
+        if (is_string($order) && trim($order) !== '') {
+            $orderSql = ' ORDER BY ' . trim($order);
+        }
+
+        $sql = sprintf(
+            'SELECT %s FROM %s WHERE %s%s',
+            $fieldsSql,
+            Database::prefix('accounts'),
+            $where,
+            $orderSql
+        );
+
+        $result = Database::query($sql);
+        $rows = [];
+
+        if ($result !== false) {
+            while (($row = Database::fetchAssoc($result)) !== false && $row !== null) {
+                $rows[] = $row;
+            }
+        }
+
+        $error = $rows === [] ? "`\$No results found`0" : '';
+
+        return [$rows, $error];
     }
 }

--- a/tests/PlayerSearch/PlayerSearchTest.php
+++ b/tests/PlayerSearch/PlayerSearchTest.php
@@ -210,6 +210,27 @@ final class PlayerSearchTest extends TestCase
         $this->assertStringContainsString('LIMIT 1', $sql);
     }
 
+    public function testLegacyLookupReturnsExactMatch(): void
+    {
+        \Lotgd\MySQL\Database::$mockResults = [[
+            [
+                'acctid' => 1,
+                'login' => 'alpha',
+                'name' => 'Alpha',
+                'emailaddress' => 'alpha@example.com',
+            ],
+        ]];
+
+        $result = $this->search->legacyLookup('alpha', ['acctid', 'login', 'name', 'emailaddress'], 'login');
+
+        $this->assertSame('', $result['error']);
+        $this->assertCount(1, $result['rows']);
+        $this->assertSame('alpha@example.com', $result['rows'][0]['emailaddress']);
+        $this->assertCount(1, $this->connection->queries);
+        $this->assertStringContainsString('legacyExactPattern', $this->connection->queries[0]);
+        $this->assertArrayHasKey('legacyExactPattern', $this->connection->executeQueryParams[0]);
+    }
+
     public function testInvalidColumnNameThrows(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/UserLookup/LookupTest.php
+++ b/tests/UserLookup/LookupTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\UserLookup;
+
+use Lotgd\MySQL\Database;
+use Lotgd\Tests\Stubs\Database as DatabaseStub;
+use Lotgd\Tests\Stubs\DoctrineBootstrap;
+use Lotgd\UserLookup;
+use PHPUnit\Framework\TestCase;
+
+final class LookupTest extends TestCase
+{
+    /**
+     * @var \Lotgd\Tests\Stubs\DoctrineConnection
+     */
+    private $connection;
+
+    protected function setUp(): void
+    {
+        class_exists(DatabaseStub::class);
+
+        Database::resetDoctrineConnection();
+        if (class_exists(DoctrineBootstrap::class, false)) {
+            DoctrineBootstrap::$conn = null;
+        }
+
+        \Lotgd\MySQL\Database::$mockResults = [];
+
+        // Prime the fake Doctrine connection that PlayerSearch will use.
+        $this->connection = Database::getDoctrineConnection();
+        $this->connection->queries = [];
+        $this->connection->executeQueryParams = [];
+    }
+
+    protected function tearDown(): void
+    {
+        Database::resetDoctrineConnection();
+        if (class_exists(DoctrineBootstrap::class, false)) {
+            DoctrineBootstrap::$conn = null;
+        }
+
+        \Lotgd\MySQL\Database::$mockResults = [];
+    }
+
+    public function testLookupDelegatesToPlayerSearch(): void
+    {
+        \Lotgd\MySQL\Database::$mockResults = [[
+            [
+                'acctid' => 1,
+                'login' => 'alpha',
+                'name' => 'Alpha',
+                'level' => 1,
+                'laston' => '2024-01-01 00:00:00',
+                'loggedin' => 0,
+                'gentimecount' => 10,
+                'gentime' => 1.23,
+                'lastip' => '127.0.0.1',
+                'uniqueid' => 'abc',
+                'emailaddress' => 'alpha@example.com',
+            ],
+        ]];
+
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $message) use (&$deprecations): bool {
+            if ($errno === E_USER_DEPRECATED) {
+                $deprecations[] = $message;
+                return true;
+            }
+
+            return false;
+        });
+
+        [$rows, $error] = UserLookup::lookup('alpha');
+
+        restore_error_handler();
+
+        $this->assertSame('', $error);
+        $this->assertCount(1, $rows);
+        $this->assertSame('alpha', $rows[0]['login']);
+        $this->assertSame('alpha@example.com', $rows[0]['emailaddress']);
+
+        $this->assertNotEmpty($deprecations);
+        $this->assertStringContainsString('Lotgd\\UserLookup::lookup()', $deprecations[0]);
+
+        $this->assertNotEmpty($this->connection->queries);
+        $this->assertStringContainsString('FROM accounts a', $this->connection->queries[0]);
+        $this->assertArrayHasKey('legacyExactPattern', $this->connection->executeQueryParams[0]);
+    }
+
+    public function testLookupFallsBackToFuzzySearch(): void
+    {
+        $firstPass = [
+            [
+                'acctid' => 1,
+                'login' => 'alpha',
+                'name' => 'Alpha',
+                'level' => 10,
+                'laston' => '2024-01-01 00:00:00',
+                'loggedin' => 0,
+                'gentimecount' => 5,
+                'gentime' => 0.5,
+                'lastip' => '192.168.0.1',
+                'uniqueid' => 'first',
+                'emailaddress' => 'alpha@example.com',
+            ],
+            [
+                'acctid' => 2,
+                'login' => 'alphonse',
+                'name' => 'Alphonse',
+                'level' => 4,
+                'laston' => '2024-01-02 00:00:00',
+                'loggedin' => 0,
+                'gentimecount' => 6,
+                'gentime' => 0.4,
+                'lastip' => '192.168.0.2',
+                'uniqueid' => 'second',
+                'emailaddress' => 'alphonse@example.com',
+            ],
+        ];
+
+        $fuzzyRows = [];
+        for ($i = 0; $i < 301; $i++) {
+            $fuzzyRows[] = [
+                'acctid' => 100 + $i,
+                'login' => 'alpha' . $i,
+                'name' => 'Alpha ' . $i,
+                'level' => 1,
+                'laston' => '2024-01-03 00:00:00',
+                'loggedin' => 0,
+                'gentimecount' => 1,
+                'gentime' => 0.1,
+                'lastip' => '10.0.0.' . $i,
+                'uniqueid' => 'u' . $i,
+                'emailaddress' => 'alpha' . $i . '@example.com',
+            ];
+        }
+
+        \Lotgd\MySQL\Database::$mockResults = [$firstPass, $fuzzyRows];
+
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $message) use (&$deprecations): bool {
+            if ($errno === E_USER_DEPRECATED) {
+                $deprecations[] = $message;
+                return true;
+            }
+
+            return false;
+        });
+
+        [$rows, $error] = UserLookup::lookup('alpha');
+
+        restore_error_handler();
+
+        $this->assertSame("`\$Too many results found, narrow your search please.`0", $error);
+        $this->assertCount(301, $rows);
+        $this->assertNotEmpty($deprecations);
+        $this->assertGreaterThanOrEqual(2, count($this->connection->queries));
+        $this->assertStringContainsString('LIKE :legacyFuzzyPattern', end($this->connection->queries));
+    }
+}

--- a/user.php
+++ b/user.php
@@ -15,7 +15,7 @@ use Lotgd\Page\Footer;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Sanitize;
-use Lotgd\UserLookup;
+use Lotgd\PlayerSearch;
 
 //addnews ready
 // mail ready
@@ -61,14 +61,32 @@ if (!$query && $sort) {
     $query = "%";
 }
 
-    if ($op == "search" || $op == "") {
-        [$searchresult, $err] = UserLookup::lookup($query, $order);
-        $op = "";
-        if ($err) {
-            $output->output('%s', $err);
-        } else {
-            if ($searchresult) {
-                $display = 1;
+$playerSearch = new PlayerSearch();
+$columns = [
+    'acctid',
+    'login',
+    'name',
+    'level',
+    'laston',
+    'loggedin',
+    'gentimecount',
+    'gentime',
+    'lastip',
+    'uniqueid',
+    'emailaddress',
+];
+$searchresult = [];
+$err = '';
+if ($op == "search" || $op == "") {
+    $lookup = $playerSearch->legacyLookup((string) $query, $columns, $order);
+    $searchresult = $lookup['rows'];
+    $err = $lookup['error'];
+    $op = "";
+    if ($err) {
+        $output->output('%s', $err);
+    } else {
+        if ($searchresult) {
+            $display = 1;
         }
     }
 }


### PR DESCRIPTION
## Summary
- deprecate `Lotgd\UserLookup::lookup()` and route it through the new `PlayerSearch::legacyLookup()` helper
- update admin user and ban pages to use PlayerSearch directly while keeping compatibility for legacy modules
- document the deprecation and add regression tests covering both the wrapper and the new service path

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e24c68de208329a7b1272920e202d3