### PR TITLE
fix: guard donor link item number placeholder

### DIFF
--- a/paylog.php
+++ b/paylog.php
@@ -175,7 +175,12 @@ if ($op == "") {
                 $memo = $info['memo'];
             }
             $link = "donators.php?op=add1&name=" . rawurlencode($memo) . "&amt=$amt&txnid={$row['txnid']}";
-            $output->rawOutput("-=( <a href='$link' title=\"" . htmlentities($info['item_number'], ENT_COMPAT, $settings->getSetting('charset', 'UTF-8')) . "\" alt=\"" . htmlentities($info['item_number'], ENT_COMPAT, $settings->getSetting('charset', 'UTF-8')) . "\">[" . htmlentities($memo, ENT_COMPAT, $settings->getSetting('charset', 'UTF-8')) . "]</a> )=-");
+            $itemNumberRaw = isset($info['item_number']) && $info['item_number'] !== ''
+                ? $info['item_number']
+                : Translator::translate('Unknown');
+            $itemNumber = htmlentities($itemNumberRaw, ENT_COMPAT, $settings->getSetting('charset', 'UTF-8'));
+            $memoSafe = htmlentities($memo, ENT_COMPAT, $settings->getSetting('charset', 'UTF-8'));
+            $output->rawOutput("-=( <a href='$link' title=\"{$itemNumber}\" alt=\"{$itemNumber}\">[{$memoSafe}]</a> )=-");
             Nav::add('', $link);
         }
         $output->rawOutput("</td></tr>");


### PR DESCRIPTION
## Summary
- sanitize the donor link item number before rendering paylog donor actions
- reuse the sanitized value for both attributes and fall back to a translated placeholder when data is missing

## Testing
- php -l paylog.php

------
https://chatgpt.com/codex/tasks/task_e_68e25a5a25748329a1aa33d501d72237