### PR TITLE
fix: quote affected users onclick attributes

### DIFF
--- a/pages/bans/case_removeban.php
+++ b/pages/bans/case_removeban.php
@@ -139,7 +139,7 @@ while ($row = Database::fetchAssoc($result)) {
     $output->rawOutput("</td><td>");
     $ipArgument = json_encode($row['ipfilter'], JSON_THROW_ON_ERROR);
     $idArgument = json_encode($row['uniqueid'], JSON_THROW_ON_ERROR);
-    $output->rawOutput("<div id='user$i'><a href='#' onClick=\"return lotgdLoadAffectedUsers({$ipArgument}, {$idArgument}, $i);\">");
+    $output->rawOutput("<div id='user$i'><a href='#' onclick='return lotgdLoadAffectedUsers({$ipArgument}, {$idArgument}, $i);'>");
     $output->outputNotl("%s", $showuser, true);
     $output->rawOutput("</a></div>");
     $output->rawOutput("</td><td>");

--- a/pages/bans/case_searchban.php
+++ b/pages/bans/case_searchban.php
@@ -124,7 +124,7 @@ while ($row = Database::fetchAssoc($result)) {
     $output->rawOutput("</td><td>");
     $ipArgument = json_encode($row['ipfilter'], JSON_THROW_ON_ERROR);
     $idArgument = json_encode($row['uniqueid'], JSON_THROW_ON_ERROR);
-    $output->rawOutput("<div id='user$i'><a href='#' onClick=\"return lotgdLoadAffectedUsers({$ipArgument}, {$idArgument}, $i);\">");
+    $output->rawOutput("<div id='user$i'><a href='#' onclick='return lotgdLoadAffectedUsers({$ipArgument}, {$idArgument}, $i);'>");
     $output->outputNotl("%s", $showuser, true);
     $output->rawOutput("</a></div>");
     $output->rawOutput("</td><td>");


### PR DESCRIPTION
## Summary
- switch the affected-users toggle link to use single-quoted onclick attributes on the remove and search ban pages

## Testing
- php -l pages/bans/case_removeban.php
- php -l pages/bans/case_searchban.php

------
https://chatgpt.com/codex/tasks/task_e_68e2604ba1688329ad2cbfd63c78e415