### PR TITLE
feat: modernize mail navigation layout

### DIFF
--- a/mail.php
+++ b/mail.php
@@ -58,20 +58,18 @@ array_push($args, ["mail.php?op=address", $write]);
 // and "functionname" is the name of the mail function to add
 $mailfunctions = HookHandler::hook("mailfunctions", $args);
 
-$output->rawOutput("<table width='50%' border='0' cellpadding='0' cellspacing='2'>");
-$output->rawOutput("<tr>");
-$count_mailfunctions = count($mailfunctions);
-for ($i = 0; $i < $count_mailfunctions; ++$i) {
-    if (is_array($mailfunctions[$i])) {
-        if (count($mailfunctions[$i]) == 2) {
-            $page = $mailfunctions[$i][0];
-            $name = $mailfunctions[$i][1]; // already translated
-            $output->rawOutput("<td><a href='$page' class='motd'>$name</a></td>");
-            // No need for addnav since mail function pages are (or should be) outside the page nav system.
-        }
+$output->rawOutput("<div class='mail-nav'>");
+foreach ($mailfunctions as $mailfunction) {
+    if (!is_array($mailfunction) || count($mailfunction) !== 2) {
+        continue;
     }
+
+    $page = $mailfunction[0];
+    $name = $mailfunction[1]; // already translated
+    $output->rawOutput("<a href='{$page}' class='button mail-nav__link'>{$name}</a>");
+    // No need for addnav since mail function pages are (or should be) outside the page nav system.
 }
-$output->rawOutput("</tr></table>");
+$output->rawOutput('</div>');
 $output->outputNotl("`n`n");
 switch (Http::get('even')) {
     case "mailsent":

--- a/templates/modern.css
+++ b/templates/modern.css
@@ -147,6 +147,19 @@ font-family: verdana,arial,helvetica,sans-serif;
      border-right: 1px solid #403225;
      border-bottom: 1px solid #403225;
 }
+.mail-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-bottom: 4px;
+}
+
+.mail-nav__link {
+    display: inline-flex;
+    align-items: center;
+    text-decoration: none;
+    padding: 0 2px;
+}
 .input {
     background-color: #433828;
     border: 1px solid #806B4D;


### PR DESCRIPTION
## Summary
- replace the mail function table markup with a button-based navigation container
- add flex styling for the mail navigation wrapper and links so the button palette is reused

## Testing
- php -l mail.php

------
https://chatgpt.com/codex/tasks/task_e_68e262946db883298956f1e81cc71116