### PR TITLE
Fix ban search iteration handling

### DIFF
--- a/pages/bans/case_searchban.php
+++ b/pages/bans/case_searchban.php
@@ -40,8 +40,7 @@ if ($target == '') {
                 $output->output("Search banned user by name: ");
                 $output->rawOutput("</label>");
                 $output->rawOutput("<select name='target' id='target'>");
-        $resultRows = $names['rows'];
-        while ($row = Database::fetchAssoc($resultRows)) {
+        foreach ($names['rows'] as $row) {
             $output->rawOutput("<option value='" . $row['acctid'] . "'>" . $row['login'] . "</option>");
         }
         $output->rawOutput("</select>");

--- a/pages/user/user_searchban.php
+++ b/pages/user/user_searchban.php
@@ -35,8 +35,7 @@ if ($target == '') {
                 $output->output("Search banned user by name: ");
                 $output->rawOutput("</label>");
                 $output->rawOutput("<select name='target' id='target'>");
-        $resultRows = $names['rows'];
-        while ($row = Database::fetchAssoc($resultRows)) {
+        foreach ($names['rows'] as $row) {
             $output->rawOutput("<option value='" . $row['acctid'] . "'>" . $row['login'] . "</option>");
         }
         $output->rawOutput("</select>");

--- a/tests/Bans/LegacyLookupIntegrationTest.php
+++ b/tests/Bans/LegacyLookupIntegrationTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (! function_exists('URLEncode')) {
+        function URLEncode(string $str): string
+        {
+            return urlencode($str);
+        }
+    }
+
+    if (! function_exists('relativedate')) {
+        function relativedate(string $date): string
+        {
+            return $date;
+        }
+    }
+}
+
+namespace Lotgd\Tests\Bans {
+
+    use Lotgd\MySQL\Database;
+    use Lotgd\Nav;
+    use Lotgd\Output;
+    use Lotgd\Settings;
+    use Lotgd\Template;
+    use Lotgd\Tests\Stubs\DummySettings;
+    use Lotgd\Translator;
+    use PHPUnit\Framework\TestCase;
+    use ReflectionClass;
+
+    final class LegacyLookupIntegrationTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            global $session, $_POST, $_GET;
+
+            $session = ['user' => ['prefs' => []], 'allowednavs' => [], 'loggedin' => false];
+            $_POST = [];
+            $_GET = [];
+
+            Database::$mockResults = [];
+            Database::resetDoctrineConnection();
+
+            Translator::enableTranslation(false);
+
+            $settings = new DummySettings([
+                'charset'            => 'UTF-8',
+                'enabletranslation'  => false,
+                'defaultlanguage'    => 'en',
+                'cachetranslations'  => 0,
+                'defaultskin'        => 'jade',
+            ]);
+            Settings::setInstance($settings);
+            $GLOBALS['settings'] = $settings;
+
+            $this->resetOutputSingleton();
+
+            Template::getInstance()->setTemplate([
+                'navhead'     => '<span>{title}</span>',
+                'navhelp'     => '<span>{text}</span>',
+                'navheadsub'  => '<span>{title}</span>',
+                'navitem'     => '<a href="{link}">{text}</a>',
+            ]);
+            Nav::clearNav();
+        }
+
+        protected function tearDown(): void
+        {
+            Translator::enableTranslation(true);
+            Settings::setInstance(null);
+            unset($GLOBALS['settings']);
+            Template::getInstance()->setTemplate([]);
+            Nav::clearNav();
+            Database::$mockResults = [];
+            Database::resetDoctrineConnection();
+            $this->resetOutputSingleton();
+        }
+
+        private function resetOutputSingleton(): void
+        {
+            $reflection = new ReflectionClass(Output::class);
+            $instanceProp = $reflection->getProperty('instance');
+            $instanceProp->setAccessible(true);
+            $instanceProp->setValue(null, null);
+        }
+
+        public function testBanSearchRendersOptionsWithoutTypeErrors(): void
+        {
+            $_POST['target'] = 'ja';
+
+            Database::$mockResults = [
+                [],
+                [
+                    ['acctid' => 101, 'login' => 'jane', 'name' => 'Jane'],
+                    ['acctid' => 102, 'login' => 'jack', 'name' => 'Jack'],
+                ],
+                [
+                    [
+                        'ipfilter'  => '192.0.2.*',
+                        'uniqueid'  => 'abc123',
+                        'banner'    => 'Admin',
+                        'banexpire' => DATETIME_DATEMAX,
+                        'banreason' => 'Testing',
+                        'lasthit'   => '2024-01-01 00:00:00',
+                    ],
+                ],
+            ];
+
+            $include = static function (): void {
+                require __DIR__ . '/../../pages/bans/case_searchban.php';
+            };
+            $include();
+
+            $buffer = Output::getInstance()->getOutput();
+
+            $this->assertStringContainsString("<select name='target' id='target'>", $buffer);
+            $this->assertStringContainsString("<option value='101'>jane</option>", $buffer);
+            $this->assertStringContainsString("<option value='102'>jack</option>", $buffer);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- iterate ban search result arrays directly in the ban and user search pages
- cover the ban search path with an integration test to ensure the dropdown renders without type errors

## Testing
- vendor/bin/phpunit tests/Bans/LegacyLookupIntegrationTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e271b345408329a9344c0b918888a5