### PR TITLE
Refactor ban search queries to use parameterized Doctrine calls

### DIFF
--- a/pages/user/user_searchban.php
+++ b/pages/user/user_searchban.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Doctrine\DBAL\ParameterType;
 use Lotgd\PlayerSearch;
 use Lotgd\Nav;
 use Lotgd\MySQL\Database;
@@ -9,10 +10,14 @@ use Lotgd\Translator;
 
 $operator = "<=";
 $playerSearch = new PlayerSearch();
+$conn = Database::getDoctrineConnection();
+$banTable = Database::prefix('bans');
+$banConditions = 'WHERE 0';
+$banParameters = [];
+$banTypes = [];
 
 
 $target = httppost('target');
-$since = 'WHERE 0';
 $submit = Translator::translateInline("Search");
 if ($target == '') {
     $output->rawOutput("<form action='user.php?op=searchban' method='POST'>");
@@ -21,11 +26,30 @@ if ($target == '') {
     $output->rawOutput("<input name='target' value='$target'>");
     $output->rawOutput("<input type='submit' class='button' value='$submit'></form><br><br>");
 } elseif (is_numeric($target)) {
-    //none
-    $sql = "SELECT lastip,uniqueid FROM accounts WHERE acctid=" . $target;
-    $result = Database::query($sql);
-    $row = Database::fetchAssoc($result);
-    $since = "WHERE ipfilter LIKE '%" . $row['lastip'] . "%' OR uniqueid LIKE '%" . $row['uniqueid'] . "%'";
+    $accountTable = Database::prefix('accounts');
+    $account = $conn->fetchAssociative(
+        "SELECT lastip, uniqueid FROM $accountTable WHERE acctid = :acctid",
+        ['acctid' => (int) $target],
+        ['acctid' => ParameterType::INTEGER]
+    ) ?: [];
+
+    $filters = [];
+
+    if (($account['lastip'] ?? '') !== '') {
+        $filters[] = 'ipfilter LIKE :ipfilter';
+        $banParameters['ipfilter'] = '%' . $account['lastip'] . '%';
+        $banTypes['ipfilter'] = ParameterType::STRING;
+    }
+
+    if (($account['uniqueid'] ?? '') !== '') {
+        $filters[] = 'uniqueid LIKE :uniqueid';
+        $banParameters['uniqueid'] = '%' . $account['uniqueid'] . '%';
+        $banTypes['uniqueid'] = ParameterType::STRING;
+    }
+
+    if ($filters !== []) {
+        $banConditions = 'WHERE ' . implode(' OR ', $filters);
+    }
 } else {
     $names = $playerSearch->legacyLookup((string) $target, ['acctid', 'login', 'name'], 'login');
     if ($names['rows'] !== []) {
@@ -44,8 +68,11 @@ if ($target == '') {
     }
 }
 
-$sql = "SELECT * FROM " . Database::prefix("bans") . " $since ORDER BY banexpire ASC";
-$result = Database::query($sql);
+$bans = $conn->fetchAllAssociative(
+    "SELECT * FROM $banTable $banConditions ORDER BY banexpire ASC",
+    $banParameters,
+    $banTypes
+);
 $output->rawOutput("<script>
 (function () {
     function lotgdLoadAffectedUsers(ip, id, index) {
@@ -78,7 +105,7 @@ $aff = Translator::translateInline("Affects");
 $l = Translator::translateInline("Last");
     $output->rawOutput("<tr class='trhead'><td>$ops</td><td>$bauth</td><td>$ipd</td><td>$dur</td><td>$mssg</td><td>$aff</td><td>$l</td></tr>");
 $i = 0;
-while ($row = Database::fetchAssoc($result)) {
+foreach ($bans as $row) {
     $liftban = Translator::translateInline("Lift&nbsp;ban");
     $showuser = Translator::translateInline("Click&nbsp;to&nbsp;show&nbsp;users");
     $output->rawOutput("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'>");

--- a/tests/Bans/SearchBanParameterBindingTest.php
+++ b/tests/Bans/SearchBanParameterBindingTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (!function_exists('URLEncode')) {
+        function URLEncode(string $str): string
+        {
+            return urlencode($str);
+        }
+    }
+
+    if (!function_exists('relativedate')) {
+        function relativedate(string $date): string
+        {
+            return $date;
+        }
+    }
+
+    if (!function_exists('httppost')) {
+        function httppost(string $name): string
+        {
+            return $_POST[$name] ?? '';
+        }
+    }
+}
+
+namespace Lotgd {
+    if (!class_exists(__NAMESPACE__ . '\\Nav')) {
+        class Nav
+        {
+            public static function add(mixed ...$args): void
+            {
+            }
+        }
+    }
+
+    if (!class_exists(__NAMESPACE__ . '\\Translator')) {
+        class Translator
+        {
+            public static function getInstance(): self
+            {
+                return new self();
+            }
+
+            public static function translateInline(string $text): string
+            {
+                return $text;
+            }
+
+            public function sprintfTranslate(string $format, ...$args): string
+            {
+                return vsprintf($format, $args);
+            }
+
+            public function setSchema(mixed $schema = null): void
+            {
+            }
+        }
+    }
+
+    if (!class_exists(__NAMESPACE__ . '\\Output')) {
+        class Output
+        {
+            private static ?self $instance = null;
+
+            public static function getInstance(): self
+            {
+                return self::$instance ??= new self();
+            }
+
+            public function rawOutput(string $text): void
+            {
+            }
+
+            public function output(string $format, mixed ...$args): void
+            {
+            }
+
+            public function outputNotl(string $format, mixed ...$args): void
+            {
+            }
+
+            public function getRawOutput(): string
+            {
+                return '';
+            }
+        }
+    }
+
+    if (!class_exists(__NAMESPACE__ . '\\DateTime')) {
+        class DateTime
+        {
+            public static function relativeDate(string $date): string
+            {
+                return $date;
+            }
+        }
+    }
+
+    if (!class_exists(__NAMESPACE__ . '\\PlayerSearch')) {
+        class PlayerSearch
+        {
+            public function legacyLookup(
+                string $search,
+                ?array $columns = null,
+                ?string $order = null,
+                int $exactLimit = 2,
+                int $fuzzyLimit = 301
+            ): array {
+                return ['rows' => [], 'error' => ''];
+            }
+        }
+    }
+}
+
+namespace Lotgd\Tests\Bans {
+    use Doctrine\DBAL\ParameterType;
+    use Lotgd\MySQL\Database;
+    use Lotgd\Tests\Stubs\DoctrineBootstrap;
+    use Lotgd\Tests\Stubs\DoctrineConnection;
+    use PHPUnit\Framework\TestCase;
+
+    final class SearchBanParameterBindingTest extends TestCase
+    {
+        private DoctrineConnection $connection;
+
+        protected function setUp(): void
+        {
+            require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
+            Database::$doctrineConnection = null;
+            Database::$instance = null;
+            DoctrineBootstrap::$conn = null;
+            Database::$mockResults = [];
+            $this->connection = Database::getDoctrineConnection();
+            $this->connection->queries = [];
+            $this->connection->executeQueryParams = [];
+            $this->connection->lastFetchAllParams = [];
+            $this->connection->lastFetchAllTypes = [];
+            $this->connection->lastFetchAssociativeParams = [];
+            $this->connection->lastFetchAssociativeTypes = [];
+            $this->connection->fetchAssociativeResults = [];
+            $this->connection->fetchAllResults = [];
+            $this->connection->executeStatements = [];
+            $this->connection->lastExecuteStatementParams = [];
+            $this->connection->lastExecuteStatementTypes = [];
+            if (!defined('DATETIME_DATEMAX')) {
+                define('DATETIME_DATEMAX', '2159-01-01 00:00:00');
+            }
+            if (!defined('DATETIME_DATEMIN')) {
+                define('DATETIME_DATEMIN', '2000-01-01 00:00:00');
+            }
+            global $_POST, $_GET;
+            $_POST = [];
+            $_GET = [];
+            $GLOBALS['output'] = \Lotgd\Output::getInstance();
+        }
+
+        public function testCaseSearchBanBindsIpAndId(): void
+        {
+            $ip = "10.0.0.1'; DROP TABLE accounts; --";
+            $id = "abc\" OR \"1\"=\"1";
+            $this->connection->fetchAssociativeResults[] = [
+                'lastip' => $ip,
+                'uniqueid' => $id,
+            ];
+            $this->connection->fetchAllResults[] = [[
+                'ipfilter' => '10.0.0.1',
+                'uniqueid' => 'abc',
+                'banner' => 'Admin',
+                'banexpire' => DATETIME_DATEMAX,
+                'banreason' => 'Testing',
+                'lasthit' => '2024-01-01 00:00:00',
+            ]];
+            $_POST['target'] = '42';
+
+            $include = static function (): void {
+                require __DIR__ . '/../../pages/bans/case_searchban.php';
+            };
+            \Closure::bind($include, null, null)();
+
+            $this->assertSame(['acctid' => 42], $this->connection->lastFetchAssociativeParams);
+            $this->assertSame(
+                ParameterType::INTEGER,
+                $this->connection->lastFetchAssociativeTypes['acctid'] ?? null
+            );
+
+            $params = $this->connection->lastFetchAllParams;
+            $this->assertSame('%' . $ip . '%', $params['ipfilter'] ?? null);
+            $this->assertSame('%' . $id . '%', $params['uniqueid'] ?? null);
+            $types = $this->connection->lastFetchAllTypes;
+            $this->assertSame(ParameterType::STRING, $types['ipfilter'] ?? null);
+            $this->assertSame(ParameterType::STRING, $types['uniqueid'] ?? null);
+
+            $selectSql = $this->connection->queries[1] ?? '';
+            $this->assertStringNotContainsString($ip, $selectSql);
+            $this->assertStringNotContainsString($id, $selectSql);
+        }
+
+        public function testUserSearchBanBindsIpAndId(): void
+        {
+            $ip = "192.168.0.1' --";
+            $id = "xyz\"; DROP";
+            $this->connection->fetchAssociativeResults[] = [
+                'lastip' => $ip,
+                'uniqueid' => $id,
+            ];
+            $this->connection->fetchAllResults[] = [[
+                'ipfilter' => '192.168.0.1',
+                'uniqueid' => 'xyz',
+                'banner' => 'Admin',
+                'banexpire' => DATETIME_DATEMAX,
+                'banreason' => 'Testing',
+                'lasthit' => '2024-01-01 00:00:00',
+            ]];
+            $_POST['target'] = '99';
+
+            $include = static function (): void {
+                $output = \Lotgd\Output::getInstance();
+                require __DIR__ . '/../../pages/user/user_searchban.php';
+            };
+            \Closure::bind($include, null, null)();
+
+            $this->assertSame(['acctid' => 99], $this->connection->lastFetchAssociativeParams);
+            $this->assertSame(
+                ParameterType::INTEGER,
+                $this->connection->lastFetchAssociativeTypes['acctid'] ?? null
+            );
+
+            $params = $this->connection->lastFetchAllParams;
+            $this->assertSame('%' . $ip . '%', $params['ipfilter'] ?? null);
+            $this->assertSame('%' . $id . '%', $params['uniqueid'] ?? null);
+
+            $types = $this->connection->lastFetchAllTypes;
+            $this->assertSame(ParameterType::STRING, $types['ipfilter'] ?? null);
+            $this->assertSame(ParameterType::STRING, $types['uniqueid'] ?? null);
+
+            $selectSql = $this->connection->queries[1] ?? '';
+            $this->assertStringNotContainsString($ip, $selectSql);
+            $this->assertStringNotContainsString($id, $selectSql);
+        }
+
+        public function testRemoveBanUsesDateParameters(): void
+        {
+            $this->connection->fetchAllResults[] = [[
+                'ipfilter' => '10.0.0.2',
+                'uniqueid' => 'def',
+                'banner' => 'Admin',
+                'banexpire' => DATETIME_DATEMAX,
+                'banreason' => 'Testing',
+                'lasthit' => '2024-01-01 00:00:00',
+            ]];
+
+            $include = static function (): void {
+                $output = \Lotgd\Output::getInstance();
+                require __DIR__ . '/../../pages/bans/case_removeban.php';
+            };
+            \Closure::bind($include, null, null)();
+
+            $delete = $this->connection->executeStatements[0] ?? null;
+            $this->assertNotNull($delete);
+            $this->assertArrayHasKey('now', $delete['params']);
+            $this->assertArrayHasKey('max', $delete['params']);
+            $this->assertMatchesRegularExpression(
+                '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/',
+                $delete['params']['now']
+            );
+            $this->assertSame(DATETIME_DATEMAX, $delete['params']['max']);
+            $this->assertSame(ParameterType::STRING, $delete['types']['now'] ?? null);
+            $this->assertSame(ParameterType::STRING, $delete['types']['max'] ?? null);
+
+            $params = $this->connection->lastFetchAllParams;
+            $this->assertArrayHasKey('max', $params);
+            $this->assertArrayHasKey('limit', $params);
+            $this->assertSame(DATETIME_DATEMAX, $params['max']);
+
+            $types = $this->connection->lastFetchAllTypes;
+            $this->assertSame(ParameterType::STRING, $types['limit'] ?? null);
+            $this->assertSame(ParameterType::STRING, $types['max'] ?? null);
+        }
+    }
+}

--- a/tests/Stubs/DoctrineBootstrap.php
+++ b/tests/Stubs/DoctrineBootstrap.php
@@ -49,6 +49,9 @@ class DoctrineConnection
     public array $fetchAllResults = [];
     public array $lastFetchAllParams = [];
     public array $lastFetchAllTypes = [];
+    public array $fetchAssociativeResults = [];
+    public array $lastFetchAssociativeParams = [];
+    public array $lastFetchAssociativeTypes = [];
     public array $executeStatements = [];
     public array $lastExecuteStatementParams = [];
     public array $lastExecuteStatementTypes = [];
@@ -106,6 +109,28 @@ class DoctrineConnection
         }
 
         return [];
+    }
+
+    public function fetchAssociative(string $sql, array $params = [], array $types = []): array|false
+    {
+        $this->queries[] = $sql;
+        $this->lastFetchAssociativeParams = $params;
+        $this->lastFetchAssociativeTypes = $types;
+
+        if (!empty($this->fetchAssociativeResults)) {
+            $row = array_shift($this->fetchAssociativeResults);
+
+            return is_array($row) ? $row : false;
+        }
+
+        if (!empty(Database::$mockResults)) {
+            $rows = array_shift(Database::$mockResults);
+            if (is_array($rows)) {
+                return array_is_list($rows) ? ($rows[0] ?? false) : $rows;
+            }
+        }
+
+        return false;
     }
 
     public function executeStatement(string $sql, array $params = [], array $types = []): int


### PR DESCRIPTION
## Summary
- Parameterize ban search and removal pages to use Doctrine connections with bound placeholders
- Ensure expired bans are deleted and listed via prepared statements with bound date limits
- Extend the Doctrine stub and add Bans test coverage to confirm tainted values stay in parameter lists

## Testing
- composer test -- tests/Bans

------
https://chatgpt.com/codex/tasks/task_e_68e271bc1148832980fe13d2ec77615e