### PR TITLE
Fix ban deletion to use parameterized Doctrine statement

### DIFF
--- a/pages/bans/case_delban.php
+++ b/pages/bans/case_delban.php
@@ -2,10 +2,21 @@
 
 declare(strict_types=1);
 
+use Doctrine\DBAL\ParameterType;
 use Lotgd\Http;
 use Lotgd\MySQL\Database;
 use Lotgd\Redirect;
 
-$sql = 'DELETE FROM ' . Database::prefix('bans') . " WHERE ipfilter = '" . Http::get('ipfilter') . "' AND uniqueid = '" . Http::get('uniqueid') . "'";
-Database::query($sql);
+$conn = Database::getDoctrineConnection();
+$conn->executeStatement(
+    'DELETE FROM ' . Database::prefix('bans') . ' WHERE ipfilter = :ip AND uniqueid = :id',
+    [
+        'ip' => Http::get('ipfilter'),
+        'id' => Http::get('uniqueid'),
+    ],
+    [
+        'ip' => ParameterType::STRING,
+        'id' => ParameterType::STRING,
+    ]
+);
 Redirect::redirect('bans.php?op=removeban');


### PR DESCRIPTION
## Summary
- update the ban deletion handler to use the shared Doctrine connection with bound parameters
- extend the ban parameter binding test to cover the deletion path and capture redirect behavior

## Testing
- ./vendor/bin/phpunit tests/Bans/SearchBanParameterBindingTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e2823c4a3483299bd386448b82a49f