### PR TITLE
fix: bind both identifiers when saving bans

### DIFF
--- a/pages/bans/case_saveban.php
+++ b/pages/bans/case_saveban.php
@@ -27,10 +27,14 @@ if ($durationInput === 0) {
 if ($type === 'ip') {
     $column = 'ipfilter';
     $key = 'lastip';
+    $ipValue = $targetIdentifier;
+    $uniqueIdValue = '';
     $isSelfBan = substr($_SERVER['REMOTE_ADDR'], 0, strlen($targetIdentifier)) === $targetIdentifier;
 } else {
     $column = 'uniqueid';
     $key = 'uniqueid';
+    $ipValue = '';
+    $uniqueIdValue = $targetIdentifier;
     $isSelfBan = Cookies::getLgi() === $targetIdentifier;
 }
 
@@ -41,8 +45,9 @@ if ($isSelfBan) {
     return;
 }
 
-$sql = 'INSERT INTO ' . Database::prefix('bans') . " (banner, {$column}, banexpire, banreason) VALUES (?, ?, ?, ?)";
-$affected = $conn->executeStatement($sql, [$banner, $targetIdentifier, $duration, $reason]);
+$sql = 'INSERT INTO ' . Database::prefix('bans') . ' (banner, ipfilter, uniqueid, banexpire, banreason) VALUES (?, ?, ?, ?, ?)';
+$parameters = [$banner, $ipValue, $uniqueIdValue, $duration, $reason];
+$affected = $conn->executeStatement($sql, $parameters);
 Database::setAffectedRows($affected);
 
 $output->output("%s ban rows entered.`n`n", Database::affectedRows());

--- a/tests/Bans/SaveBanParameterBindingTest.php
+++ b/tests/Bans/SaveBanParameterBindingTest.php
@@ -14,6 +14,24 @@ namespace Lotgd {
     if (! class_exists(__NAMESPACE__ . '\\Translator', false)) {
         class Translator
         {
+            public static function getInstance(): self
+            {
+                return new self();
+            }
+
+            public static function enableTranslation(bool $enabled): void
+            {
+            }
+
+            public static function getNamespace(): string
+            {
+                return '';
+            }
+
+            public function setSchema(string|false|null $schema = false): void
+            {
+            }
+
             public static function translate(string $text, string|false|null $schema = false): string
             {
                 return $text;
@@ -30,6 +48,11 @@ namespace Lotgd {
             }
 
             public static function tlbuttonPop(): string
+            {
+                return '';
+            }
+
+            public static function tlbuttonClear(): string
             {
                 return '';
             }
@@ -134,7 +157,7 @@ namespace Lotgd\Tests\Bans {
             $insert = $statements[0] ?? null;
             $this->assertNotNull($insert, 'Insert statement should be recorded.');
             $this->assertSame(
-                ['Admin "Ω"', $ip, $expectedExpiry, $reason],
+                ['Admin "Ω"', $ip, '', $expectedExpiry, $reason],
                 array_values($insert['params'] ?? [])
             );
             $this->assertStringNotContainsString($ip, $insert['sql'] ?? '');


### PR DESCRIPTION
## Summary
- ensure save-ban inserts both ipfilter and uniqueid columns with parameterised values
- update ban parameter binding test doubles and assertions for the new parameter order

## Testing
- `composer test -- tests/Bans`

------
https://chatgpt.com/codex/tasks/task_e_68e28db1f3148329954aa20ccfe845da