### PR TITLE
Use comment id to populate moderation ban reason

### DIFF
--- a/src/Lotgd/Moderate.php
+++ b/src/Lotgd/Moderate.php
@@ -393,8 +393,27 @@ class Moderate
             if ($moderating) {
                 if ($session['user']['superuser'] & SU_EDIT_USERS) {
                     $reason = $rawc[$i] ?? '';
-                    $out .= "`0[ <input type='checkbox' name='comment[{$commentids[$i]}]'> | <a href='user.php?op=setupban&userid=" . $auth[$i] . "&reason=" . rawurlencode((string) $reason) . "'>Ban</a> ]&nbsp;";
-                    Navigation::add('', "user.php?op=setupban&userid=" . $auth[$i] . "&reason=" . rawurlencode((string) $reason));
+                    $commentId = $commentids[$i];
+
+                    if ($reason !== '') {
+                        if (! isset($session['moderation']) || ! is_array($session['moderation'])) {
+                            $session['moderation'] = [];
+                        }
+
+                        if (! isset($session['moderation']['ban_reasons']) || ! is_array($session['moderation']['ban_reasons'])) {
+                            $session['moderation']['ban_reasons'] = [];
+                        }
+
+                        $session['moderation']['ban_reasons'][$commentId] = $reason;
+
+                        if (count($session['moderation']['ban_reasons']) > 50) {
+                            $session['moderation']['ban_reasons'] = array_slice($session['moderation']['ban_reasons'], -50, 50, true);
+                        }
+                    }
+
+                    $banLink = 'user.php?op=setupban&userid=' . $auth[$i] . '&commentid=' . $commentId;
+                    $out .= "`0[ <input type='checkbox' name='comment[{$commentId}]'> | <a href='{$banLink}'>Ban</a> ]&nbsp;";
+                    Navigation::add('', $banLink);
                 } else {
                     $out .= "`0[ <input type='checkbox' name='comment[{$commentids[$i]}]'> ]&nbsp;";
                 }

--- a/tests/UserSetupBanTest.php
+++ b/tests/UserSetupBanTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Output;
+use Lotgd\Settings;
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
+
+final class UserSetupBanTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $session, $forms_output;
+
+        $session = [];
+        $_GET = [];
+        $_POST = [];
+        $forms_output = '';
+
+        require_once __DIR__ . '/bootstrap.php';
+
+        Settings::setInstance(null);
+        unset($GLOBALS['settings']);
+
+        if (! defined('DB_NODB')) {
+            define('DB_NODB', true);
+        }
+
+        $outputObj = Output::getInstance();
+        $ref = new \ReflectionProperty(Output::class, 'output');
+        $ref->setAccessible(true);
+        $ref->setValue($outputObj, '');
+
+        Database::$mockResults = [];
+        Database::$queries = [];
+
+        if (! function_exists('reltime')) {
+            eval('function reltime(int $timestamp): string { return "ago"; }');
+        }
+    }
+
+    public function testReasonPrefilledFromSessionCache(): void
+    {
+        global $session, $userid;
+
+        $session['moderation']['ban_reasons'][5] = 'cached reason text';
+        $userid = 42;
+
+        Database::$mockResults = [[[
+            'name' => 'Victim',
+            'lastip' => '192.0.2.10',
+            'uniqueid' => 'unique-123',
+        ]]];
+
+        $_GET['commentid'] = '5';
+
+        require __DIR__ . '/../pages/user/user_setupban.php';
+
+        $output = Output::getInstance()->getRawOutput();
+        $this->assertStringContainsString('value="cached reason text"', $output);
+        $this->assertCount(1, Database::$queries);
+    }
+
+    public function testReasonFallbacksToCommentLookup(): void
+    {
+        global $session, $userid;
+
+        $userid = 77;
+        $longComment = str_repeat('Long reason ', 40);
+
+        Database::$mockResults = [[[
+            'name' => 'Poster',
+            'lastip' => '203.0.113.20',
+            'uniqueid' => 'unique-777',
+        ]], [[
+            'comment' => $longComment,
+            'name' => 'Poster',
+        ]]];
+
+        $_GET['commentid'] = '8';
+
+        require __DIR__ . '/../pages/user/user_setupban.php';
+
+        $output = Output::getInstance()->getRawOutput();
+        $this->assertStringContainsString('Long reason Long reason', $output);
+        $this->assertCount(2, Database::$queries);
+    }
+}


### PR DESCRIPTION
## Summary
- update the moderation ban link to send a comment id and cache sanitized reasons server-side
- resolve comment ids in the ban setup form, hydrating the default reason from session or a commentary lookup
- adjust commentary tests and add ban form coverage, including a long-comment regression case

## Testing
- vendor/bin/phpunit tests/ModeratedCommentaryFallbackTest.php tests/UserSetupBanTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e2bac85eb483299c2902fc69fbd1d4