### PR TITLE
fix: restore title_help output renderer

### DIFF
--- a/titleedit.php
+++ b/titleedit.php
@@ -209,8 +209,12 @@ switch ($op) {
         break;
 }
 
-function title_help()
+function title_help(?Output $output = null): void
 {
+    if (null === $output) {
+        $output = Output::getInstance();
+    }
+
     $output->output("`#You can have multiple titles for a given dragon kill rank.");
     $output->output("If you do, one of those titles will be chosen at random to give to the player when a title is assigned.`n`n");
     $output->output("You can have gaps in the title order.");


### PR DESCRIPTION
## Summary
- ensure `title_help` obtains an `Output` renderer before using it
- add an optional parameter and explicit `void` return type for clarity

## Testing
- php -l titleedit.php

------
https://chatgpt.com/codex/tasks/task_e_68e2c8333a1883299254f711ae0e901a