### PR TITLE
Fix enum form rendering for empty values

### DIFF
--- a/src/Lotgd/Forms.php
+++ b/src/Lotgd/Forms.php
@@ -528,9 +528,9 @@ JS;
                 array_shift($inf_list);
                 $select = '';
                 $select .= "<select id='$entityId' name='$keyout'>";
-                $optval = '';
+                $optval = null;
                 foreach ($inf_list as $optdis) {
-                    if ($optval == '') {
+                    if ($optval === null) {
                         $optval = $optdis;
                         continue;
                     }
@@ -539,7 +539,7 @@ JS;
                     }
                     $selected = isset($row[$key]) && $row[$key] == $optval ? 1 : 0;
                     $select .= "<option value='$optval'" . ($selected ? ' selected' : '') . '>' . HTMLEntities("$optdis", ENT_COMPAT, $charset) . '</option>';
-                    $optval = '';
+                    $optval = null;
                 }
                 $select .= '</select>';
                 $output->rawOutput($select);


### PR DESCRIPTION
## Summary
- replace the enum field sentinel with null so empty string options are preserved
- reset the sentinel after each option to maintain value/label pairing

## Testing
- not run (environment not configured)


------
https://chatgpt.com/codex/tasks/task_e_68e2ca54dcc88329ae970aa95c58f81b