### PR TITLE
fix: normalize array inputs for color sanitize

### DIFF
--- a/src/Lotgd/Sanitize.php
+++ b/src/Lotgd/Sanitize.php
@@ -45,17 +45,45 @@ class Sanitize
     /**
      * Remove colour codes except text formatting.
      *
-     * @param string|null $in Input value
+     * @param string|array|null $in Input value
      *
-     * @return string Sanitized value
+     * @return string|array Sanitized value
      */
-    public static function colorSanitize(?string $in): string
+    public static function colorSanitize(string|array|null $in): string|array
     {
-        if ($in == '' || $in === null) {
+        if (is_array($in)) {
+            $sanitized = [];
+
+            foreach ($in as $key => $value) {
+                if (is_array($value)) {
+                    $sanitized[$key] = self::colorSanitize($value);
+                    continue;
+                }
+
+                if ($value === null) {
+                    $sanitized[$key] = '';
+                    continue;
+                }
+
+                $sanitized[$key] = self::colorSanitize((string) $value);
+            }
+
+            return $sanitized;
+        }
+
+        if ($in === null) {
             return '';
         }
-        $out = preg_replace('/[`][0' . Output::getInstance()->getColormapEscaped() . 'cbi]/', '', $in);
-        return $out;
+
+        $value = (string) $in;
+
+        if ($value === '') {
+            return '';
+        }
+
+        $out = preg_replace('/[`][0' . Output::getInstance()->getColormapEscaped() . 'cbi]/', '', $value);
+
+        return $out ?? '';
     }
 
     /**

--- a/tests/Stubs/Functions.php
+++ b/tests/Stubs/Functions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace {
     use Lotgd\Output;
     use Lotgd\Modules\ModuleManager;
+    use Lotgd\Sanitize;
     if (!function_exists('translate_inline')) {
         function translate_inline($text, $ns = false)
         {
@@ -131,6 +132,13 @@ namespace {
         function sanitize($in)
         {
             return $in;
+        }
+    }
+
+    if (!function_exists('color_sanitize')) {
+        function color_sanitize($in)
+        {
+            return Sanitize::colorSanitize($in);
         }
     }
 

--- a/tests/UtilityTest.php
+++ b/tests/UtilityTest.php
@@ -59,6 +59,39 @@ final class UtilityTest extends TestCase
         $this->assertSame('Hello `nWorld', Sanitize::colorSanitize('Hello `n`&World'));
     }
 
+    public function testColorSanitizeLegacyWrapperHandlesString(): void
+    {
+        $this->assertSame('Hello `nWorld', \color_sanitize('Hello `n`&World'));
+    }
+
+    public function testColorSanitizeLegacyWrapperHandlesArrays(): void
+    {
+        $input = [
+            'greeting' => 'Hello `n`&World',
+            'styles' => ['`bBold', 'Plain'],
+            'empty' => null,
+            'count' => 42,
+        ];
+
+        $expected = [
+            'greeting' => 'Hello `nWorld',
+            'styles' => ['Bold', 'Plain'],
+            'empty' => '',
+            'count' => '42',
+        ];
+
+        $this->assertSame($expected, \color_sanitize($input));
+    }
+
+    public function testColorSanitizeLegacyWrapperDelegatesToSanitizeClass(): void
+    {
+        $contents = file_get_contents(__DIR__ . '/../lib/sanitize.php');
+
+        $this->assertNotFalse($contents);
+        $this->assertStringContainsString('function color_sanitize($in)', $contents);
+        $this->assertStringContainsString('return Sanitize::colorSanitize($in);', $contents);
+    }
+
     public function testCommentSanitize(): void
     {
         $this->assertSame('Look ``here', Sanitize::commentSanitize('Look `here'));


### PR DESCRIPTION
## Summary
- limit `Sanitize::colorSanitize` to string and array inputs while coercing array members to strings before sanitizing
- continue recursive handling for nested arrays and ensure null elements normalize to empty strings
- extend the regression test to cover numeric array values via the legacy `color_sanitize` wrapper

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e2cc674c7c8329b0d5315f2903639c