### PR TITLE
Fix player list escape clause quoting

### DIFF
--- a/src/Lotgd/PlayerSearch.php
+++ b/src/Lotgd/PlayerSearch.php
@@ -115,7 +115,7 @@ final class PlayerSearch
         }
 
         $sql = sprintf(
-            'SELECT acctid,name,login,alive,hitpoints,location,race,sex,level,laston,loggedin,lastip,uniqueid FROM %s WHERE locked=0 AND name LIKE :namePattern ESCAPE \"!\" ORDER BY level DESC, dragonkills DESC, login ASC%s',
+            "SELECT acctid,name,login,alive,hitpoints,location,race,sex,level,laston,loggedin,lastip,uniqueid FROM %s WHERE locked=0 AND name LIKE :namePattern ESCAPE '!' ORDER BY level DESC, dragonkills DESC, login ASC%s",
             Database::prefix('accounts'),
             $limitClause
         );

--- a/tests/List/ListSearchParameterBindingTest.php
+++ b/tests/List/ListSearchParameterBindingTest.php
@@ -44,6 +44,7 @@ final class ListSearchParameterBindingTest extends TestCase
         $sql = $this->connection->queries[0];
         $this->assertStringNotContainsString($tainted, $sql, 'Tainted input leaked into the SQL string.');
         $this->assertStringNotContainsString("' OR 1=1 --", $sql, 'Dangerous substring should not appear in SQL.');
+        $this->assertStringContainsString("ESCAPE '!'", $sql, 'Expected the SQL to declare the configured escape character.');
 
         $params = $this->connection->executeQueryParams[0] ?? [];
         $this->assertArrayHasKey('namePattern', $params, 'Missing bound parameter for name pattern.');


### PR DESCRIPTION
## Summary
- emit the warrior list search ESCAPE clause with proper quoting
- extend the list search binding test to assert the escape clause

## Testing
- composer test -- --filter=ListSearchParameterBindingTest
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e2d44537c8832983c385775a438640