### PR TITLE
fix(mail): bind recipient lookup in mail send page

### DIFF
--- a/tests/Mail/MailSendParameterBindingTest.php
+++ b/tests/Mail/MailSendParameterBindingTest.php
@@ -101,6 +101,18 @@ final class MailSendParameterBindingTest extends TestCase
         fixtureMailSend();
     }
 
+    private function assertMailInsertIssued(): void
+    {
+        $inserted = array_filter(
+            $this->connection->executeStatements,
+            static fn (array $entry): bool => isset($entry['sql'])
+                && stripos($entry['sql'], 'INSERT INTO') === 0
+                && strpos($entry['sql'], 'mail') !== false
+        );
+
+        $this->assertNotEmpty($inserted, 'Expected mail insert query to be executed.');
+    }
+
     public function testMailSendBindsQuotedLogin(): void
     {
         $login = "O'Brien";
@@ -121,12 +133,7 @@ final class MailSendParameterBindingTest extends TestCase
         $this->assertSame(['login' => $login], $this->connection->lastFetchAssociativeParams);
         $this->assertSame(['login' => ParameterType::STRING], $this->connection->lastFetchAssociativeTypes);
 
-        $inserted = array_filter(
-            Database::$queries,
-            static fn (string $sql): bool => strpos($sql, 'INSERT INTO mail') !== false
-        );
-
-        $this->assertNotEmpty($inserted, 'Expected mail insert query to be executed.');
+        $this->assertMailInsertIssued();
     }
 
     public function testMailSendBindsMultibyteLogin(): void
@@ -149,12 +156,7 @@ final class MailSendParameterBindingTest extends TestCase
         $this->assertSame(['login' => $login], $this->connection->lastFetchAssociativeParams);
         $this->assertSame(['login' => ParameterType::STRING], $this->connection->lastFetchAssociativeTypes);
 
-        $inserted = array_filter(
-            Database::$queries,
-            static fn (string $sql): bool => strpos($sql, 'INSERT INTO mail') !== false
-        );
-
-        $this->assertNotEmpty($inserted, 'Expected mail insert query to be executed.');
+        $this->assertMailInsertIssued();
     }
 }
 }

--- a/tests/Mail/MailSendParameterBindingTest.php
+++ b/tests/Mail/MailSendParameterBindingTest.php
@@ -1,8 +1,12 @@
 <?php
-
 declare(strict_types=1);
 
-namespace Lotgd\Tests\Mail;
+namespace {
+    require_once __DIR__ . '/../bootstrap.php';
+    require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
+}
+
+namespace Lotgd\Tests\Mail {
 
 use Doctrine\DBAL\ParameterType;
 use Lotgd\DataCache;
@@ -12,25 +16,22 @@ use Lotgd\Tests\Stubs\DoctrineBootstrap;
 use Lotgd\Tests\Stubs\DoctrineConnection;
 use Lotgd\Tests\Stubs\MailDummySettings;
 use PHPUnit\Framework\TestCase;
+use function Lotgd\Tests\Mail\Fixture\mailSend as fixtureMailSend;
 
-/**
- * @runClassInSeparateProcess
- */
 final class MailSendParameterBindingTest extends TestCase
 {
     private DoctrineConnection $connection;
 
     protected function setUp(): void
     {
-        require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
-
         Database::$doctrineConnection = null;
         Database::$instance = null;
         Database::$mockResults = [];
         Database::$queries = [];
         DoctrineBootstrap::$conn = null;
 
-        $this->connection = Database::getDoctrineConnection();
+        $this->connection = new DoctrineConnection();
+        Database::setDoctrineConnection($this->connection);
         $this->connection->fetchAssociativeResults = [];
         $this->connection->lastFetchAssociativeParams = [];
         $this->connection->lastFetchAssociativeTypes = [];
@@ -75,6 +76,7 @@ final class MailSendParameterBindingTest extends TestCase
 
     protected function tearDown(): void
     {
+        Database::resetDoctrineConnection();
         Settings::setInstance(null);
         unset($GLOBALS['settings']);
     }
@@ -92,13 +94,11 @@ final class MailSendParameterBindingTest extends TestCase
 
     private function executeMailSend(): void
     {
-        if (! function_exists('mailSend')) {
+        if (! function_exists('Lotgd\\Tests\\Mail\\Fixture\\mailSend')) {
             require __DIR__ . '/case_send_fixture.php';
-
-            return;
         }
 
-        mailSend();
+        fixtureMailSend();
     }
 
     public function testMailSendBindsQuotedLogin(): void
@@ -156,4 +156,5 @@ final class MailSendParameterBindingTest extends TestCase
 
         $this->assertNotEmpty($inserted, 'Expected mail insert query to be executed.');
     }
+}
 }

--- a/tests/Mail/MailSendParameterBindingTest.php
+++ b/tests/Mail/MailSendParameterBindingTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Mail;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\DataCache;
+use Lotgd\MySQL\Database;
+use Lotgd\Settings;
+use Lotgd\Tests\Stubs\DoctrineBootstrap;
+use Lotgd\Tests\Stubs\DoctrineConnection;
+use Lotgd\Tests\Stubs\MailDummySettings;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runClassInSeparateProcess
+ */
+final class MailSendParameterBindingTest extends TestCase
+{
+    private DoctrineConnection $connection;
+
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
+
+        Database::$doctrineConnection = null;
+        Database::$instance = null;
+        Database::$mockResults = [];
+        Database::$queries = [];
+        DoctrineBootstrap::$conn = null;
+
+        $this->connection = Database::getDoctrineConnection();
+        $this->connection->fetchAssociativeResults = [];
+        $this->connection->lastFetchAssociativeParams = [];
+        $this->connection->lastFetchAssociativeTypes = [];
+        $this->connection->executeQueryParams = [];
+        $this->connection->executeQueryTypes = [];
+        $this->connection->queries = [];
+
+        global $session, $mail_table, $accounts_table, $mail_sent_count, $op, $id;
+        $session = ['user' => ['acctid' => 123]];
+        $op = '';
+        $id = 0;
+        $mail_table = [];
+        $mail_sent_count = 0;
+        $accounts_table = [];
+
+        Database::setPrefix('');
+
+        $settings = new MailDummySettings([
+            'mailsizelimit' => 1024,
+            'charset' => 'UTF-8',
+            'inboxlimit' => 50,
+            'onlyunreadmails' => true,
+            'soap' => 0,
+            'usedatacache' => 0,
+            'datacachepath' => sys_get_temp_dir(),
+            'serverurl' => 'http://example.com',
+            'gameadminemail' => 'admin@example.com',
+            'notificationmailsubject' => '{subject}',
+            'notificationmailtext' => '{body}',
+        ]);
+
+        Settings::setInstance($settings);
+        $GLOBALS['settings'] = $settings;
+
+        DataCache::getInstance();
+
+        $_POST = [];
+        $_GET = [];
+
+        $this->addAccount(123, 'Sender');
+    }
+
+    protected function tearDown(): void
+    {
+        Settings::setInstance(null);
+        unset($GLOBALS['settings']);
+    }
+
+    private function addAccount(int $acctid, string $name): void
+    {
+        global $accounts_table;
+
+        $accounts_table[$acctid] = [
+            'prefs' => serialize([]),
+            'emailaddress' => '',
+            'name' => $name,
+        ];
+    }
+
+    private function executeMailSend(): void
+    {
+        if (! function_exists('mailSend')) {
+            require __DIR__ . '/case_send_fixture.php';
+
+            return;
+        }
+
+        mailSend();
+    }
+
+    public function testMailSendBindsQuotedLogin(): void
+    {
+        $login = "O'Brien";
+        $acctid = 2001;
+
+        $this->addAccount($acctid, 'Quoted Recipient');
+        $this->connection->fetchAssociativeResults[] = ['acctid' => $acctid];
+
+        $_POST = [
+            'to' => $login,
+            'subject' => 'Hello',
+            'body' => 'Greetings',
+            'returnto' => '0',
+        ];
+
+        $this->executeMailSend();
+
+        $this->assertSame(['login' => $login], $this->connection->lastFetchAssociativeParams);
+        $this->assertSame(['login' => ParameterType::STRING], $this->connection->lastFetchAssociativeTypes);
+
+        $inserted = array_filter(
+            Database::$queries,
+            static fn (string $sql): bool => strpos($sql, 'INSERT INTO mail') !== false
+        );
+
+        $this->assertNotEmpty($inserted, 'Expected mail insert query to be executed.');
+    }
+
+    public function testMailSendBindsMultibyteLogin(): void
+    {
+        $login = '受信者';
+        $acctid = 2002;
+
+        $this->addAccount($acctid, '受信者');
+        $this->connection->fetchAssociativeResults[] = ['acctid' => $acctid];
+
+        $_POST = [
+            'to' => $login,
+            'subject' => 'こんにちは',
+            'body' => '世界🌟',
+            'returnto' => '0',
+        ];
+
+        $this->executeMailSend();
+
+        $this->assertSame(['login' => $login], $this->connection->lastFetchAssociativeParams);
+        $this->assertSame(['login' => ParameterType::STRING], $this->connection->lastFetchAssociativeTypes);
+
+        $inserted = array_filter(
+            Database::$queries,
+            static fn (string $sql): bool => strpos($sql, 'INSERT INTO mail') !== false
+        );
+
+        $this->assertNotEmpty($inserted, 'Expected mail insert query to be executed.');
+    }
+}

--- a/tests/Mail/case_send_fixture.php
+++ b/tests/Mail/case_send_fixture.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Mail\Fixture;
+
+require_once dirname(__DIR__, 2) . '/pages/mail/case_send.php';

--- a/tests/Mail/case_send_fixture.php
+++ b/tests/Mail/case_send_fixture.php
@@ -4,4 +4,14 @@ declare(strict_types=1);
 
 namespace Lotgd\Tests\Mail\Fixture;
 
-require_once dirname(__DIR__, 2) . '/pages/mail/case_send.php';
+$source = file_get_contents(dirname(__DIR__, 2) . '/pages/mail/case_send.php');
+
+if ($source === false) {
+    throw new \RuntimeException('Unable to load case_send.php for mail fixture.');
+}
+
+$source = preg_replace('/^\s*<\?php/', '', $source, 1);
+$source = preg_replace('/^\s*declare\s*\(\s*strict_types\s*=\s*1\s*\)\s*;\s*/', '', $source, 1);
+$source = preg_replace('/mailSend\s*\(\s*\)\s*;\s*$/', '', $source, 1);
+
+eval('namespace ' . __NAMESPACE__ . ' {' . $source . '}');

--- a/tests/Stubs/Database.php
+++ b/tests/Stubs/Database.php
@@ -467,6 +467,15 @@ if (!class_exists(__NAMESPACE__ . '\\Database', false)) {
             return self::$doctrineConnection;
         }
 
+        public static function setDoctrineConnection(object $connection): void
+        {
+            self::$doctrineConnection = $connection;
+
+            if (class_exists('Lotgd\\Doctrine\\Bootstrap', false) && property_exists('Lotgd\\Doctrine\\Bootstrap', 'conn')) {
+                \Lotgd\Doctrine\Bootstrap::$conn = $connection;
+            }
+        }
+
         public static function hasDoctrineConnection(): bool
         {
             return self::$doctrineConnection !== null;

--- a/tests/Stubs/MailSendStubs.php
+++ b/tests/Stubs/MailSendStubs.php
@@ -25,31 +25,41 @@ if (! function_exists('mailSend')) {
     }
 }
 
-function sanitizeSubject(string $subject): string
-{
-    return str_replace('`n', '', $subject);
+if (! function_exists('sanitizeSubject')) {
+    function sanitizeSubject(string $subject): string
+    {
+        return str_replace('`n', '', $subject);
+    }
 }
 
-function sanitizeBody(string $body): string
-{
-    $body = replaceGameNewlines($body);
-    $body = normalizeLineEndings($body);
-    return escapeAndTruncateBody($body);
+if (! function_exists('sanitizeBody')) {
+    function sanitizeBody(string $body): string
+    {
+        $body = replaceGameNewlines($body);
+        $body = normalizeLineEndings($body);
+        return escapeAndTruncateBody($body);
+    }
 }
 
-function replaceGameNewlines(string $body): string
-{
-    return str_replace('`n', "\n", $body);
+if (! function_exists('replaceGameNewlines')) {
+    function replaceGameNewlines(string $body): string
+    {
+        return str_replace('`n', "\n", $body);
+    }
 }
 
-function normalizeLineEndings(string $body): string
-{
-    $body = str_replace("\r\n", "\n", $body);
-    return str_replace("\r", "\n", $body);
+if (! function_exists('normalizeLineEndings')) {
+    function normalizeLineEndings(string $body): string
+    {
+        $body = str_replace("\r\n", "\n", $body);
+        return str_replace("\r", "\n", $body);
+    }
 }
 
-function escapeAndTruncateBody(string $body): string
-{
-    $limit = (int) getsetting('mailsizelimit', 1024);
-    return addslashes(substr(stripslashes($body), 0, $limit));
+if (! function_exists('escapeAndTruncateBody')) {
+    function escapeAndTruncateBody(string $body): string
+    {
+        $limit = (int) getsetting('mailsizelimit', 1024);
+        return addslashes(substr(stripslashes($body), 0, $limit));
+    }
 }


### PR DESCRIPTION
## Summary
- use a Doctrine-bound query to locate the mail recipient in `case_send.php`
- consume the associative result when checking inbox limits and delivering mail
- add PHPUnit coverage for quoted and multibyte logins to ensure bound parameters are used

## Testing
- vendor/bin/phpunit tests/Mail/MailSendParameterBindingTest.php
- vendor/bin/phpunit tests/MailUtf8Test.php

------
https://chatgpt.com/codex/tasks/task_e_68e2d6d7caec8329859b3404fa4d5363