### PR TITLE
Fix timeout notify banner when session expires

### DIFF
--- a/src/Lotgd/Async/Handler/Timeout.php
+++ b/src/Lotgd/Async/Handler/Timeout.php
@@ -94,7 +94,25 @@ class Timeout
         }
 
         if (!isset($session['user'])) {
-            return jaxon()->newResponse();
+            $hasTimedOut = false;
+
+            if (isset($session['loggedin']) && $session['loggedin'] === false) {
+                $hasTimedOut = true;
+            }
+
+            if (!$hasTimedOut && isset($session['message']) && stripos($session['message'], 'Your session has expired!') !== false) {
+                $hasTimedOut = true;
+            }
+
+            if (!$hasTimedOut) {
+                return jaxon()->newResponse();
+            }
+
+            $objResponse = jaxon()->newResponse();
+            $warning = $output->appoencode('`$`b') . 'TIMEOUT: Your session has timed out!' . $output->appoencode('`b');
+            $objResponse->assign('notify', 'innerHTML', $warning);
+
+            return $objResponse;
         }
 
         $warning = '';

--- a/tests/Ajax/TimeoutStatusTest.php
+++ b/tests/Ajax/TimeoutStatusTest.php
@@ -74,13 +74,30 @@ namespace Lotgd\Tests\Ajax {
             $this->assertStringContainsString('TIMEOUT', $commands[0]['data'] ?? '');
         }
 
-        public function testNoWarningWhenSessionUserAbsent(): void
+        public function testNoWarningWhenSessionUserAbsentWithoutTimeoutIndicators(): void
         {
             global $session;
             $session = [];
 
             $response = Timeout::getInstance()->timeoutStatus(true);
             $this->assertEmpty($response->getCommands());
+        }
+
+        public function testTimeoutWarningWhenSessionExpiredAndSessionUserAbsent(): void
+        {
+            global $session;
+
+            $session = [
+                'loggedin' => false,
+                'message' => "`nYour session has expired!`n",
+            ];
+
+            $response = Timeout::getInstance()->timeoutStatus(true);
+            $commands = $response->getCommands();
+
+            $this->assertNotEmpty($commands);
+            $this->assertSame('notify', $commands[0]['id'] ?? null);
+            $this->assertStringContainsString('TIMEOUT', $commands[0]['data'] ?? '');
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure the timeout handler shows the TIMEOUT banner even when the session user data is missing but the session has expired
- add regression coverage for the expired session scenario while keeping existing behaviour for active users

## Testing
- composer test -- tests/Ajax/TimeoutStatusTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e410d614a08329b3fcc74b22888474