### PR TITLE
fix: respect button state in user special actions

### DIFF
--- a/pages/user/user_special.php
+++ b/pages/user/user_special.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 use Lotgd\MySQL\Database;
 use Lotgd\Http;
 
-if (Http::post('newday') !== '') {
+if (Http::post('newday') !== false) {
 #   $offset = '-' . (24 / (int) \Lotgd\Settings::getInstance()->getSetting('daysperday', 4)) . ' hours';
 #   $newdate = date("Y-m-d H:i:s",strtotime($offset));
 #   $sql = "UPDATE " . Database::prefix("accounts") . " SET lasthit='$newdate' WHERE acctid='$userid'";
     $sql = "UPDATE " . Database::prefix("accounts") . " SET lasthit='" . DATETIME_DATEMIN . "' WHERE acctid=" . (int)$userid;
     Database::query($sql);
-} elseif (Http::post('fixnavs') !== '') {
+} elseif (Http::post('fixnavs') !== false) {
     $sql = "UPDATE " . Database::prefix("accounts") . " SET allowednavs='', restorepage='', specialinc='' WHERE acctid=" . (int)$userid;
     Database::query($sql);
     $sql = "DELETE FROM " . Database::prefix("accounts_output") . " WHERE acctid=" . (int)$userid . ";";
     Database::query($sql);
-} elseif (Http::post('clearvalidation') !== '') {
+} elseif (Http::post('clearvalidation') !== false) {
     $sql = "UPDATE " . Database::prefix("accounts") . " SET emailvalidation='' WHERE acctid=" . (int)$userid;
     Database::query($sql);
 }


### PR DESCRIPTION
## Summary
- ensure user.php special operations only execute when their submit buttons are actually posted
- prevent the new day branch from catching other admin actions so fixing navs resets allowed navigation again

## Testing
- php -l pages/user/user_special.php

------
https://chatgpt.com/codex/tasks/task_e_68e7ec0b4e6483298dd85e1ed3bfa0e4