### PR TITLE
Add pull request template aligning with contribution checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+- [ ] Provide a clear, concise summary of the change.
+- [ ] Link related discussions or provide necessary context.
+
+## Issue Links
+
+- [ ] Resolves #[ISSUE]
+- [ ] Related to #[ISSUE]
+
+## Testing Commands
+
+Confirm you ran the required checks locally:
+
+- [ ] `composer test`
+- [ ] `php -l` (on all modified PHP files)
+- [ ] `composer static`
+
+## Documentation Updates
+
+- [ ] Documentation not required; behaviour is unchanged.
+- [ ] Documentation updated (e.g., README, in-code docs).
+- [ ] Behaviour changed and I updated `UPGRADING.md` and/or `docs/Deprecations.md` as appropriate.
+
+## Additional Notes
+
+- [ ] Tests or migrations added when needed.
+- [ ] Changes keep the diff minimal and focused.
+- [ ] I reviewed the AGENTS.md guidelines before submitting this PR.
+- [ ] I reviewed the CONTRIBUTING.md checklist before submitting this PR.


### PR DESCRIPTION
## Summary
- add a default pull request template covering summary, issue links, testing, and documentation updates
- mirror the contribution checklist from CONTRIBUTING.md and AGENTS.md so authors confirm expectations

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e9347b6dc4832981ea23aab2a88b4a