### PR TITLE
fix: cast motd id to integer

### DIFF
--- a/motd.php
+++ b/motd.php
@@ -30,7 +30,7 @@ Translator::getInstance()->setSchema("motd");
 $settings = Settings::getInstance();
 
 $op = Http::get('op');
-$id = Http::get('id');
+$id = (int) Http::get('id');
 
 Commentary::addCommentary();
 Header::popupHeader("LoGD Message of the Day (MoTD)");


### PR DESCRIPTION
## Summary
- ensure the MoTD id query parameter is cast to an integer before use

## Testing
- php -l motd.php

------
https://chatgpt.com/codex/tasks/task_e_68e93c11083883298f83acf443e05751