### PR TITLE
fix: guard fightbar legacy alias

### DIFF
--- a/lib/battle-functions.php
+++ b/lib/battle-functions.php
@@ -2,11 +2,15 @@
 
 namespace Lotgd {
 
-    class Fightbar extends \FightBar
-    {
+    if (! class_exists(__NAMESPACE__ . '\\Fightbar', false)) {
+        class Fightbar extends FightBar
+        {
+        }
     }
 
-    \class_alias(Fightbar::class, 'fightbar');
+    if (! class_exists('fightbar', false)) {
+        \class_alias(Fightbar::class, 'fightbar');
+    }
 }
 
 namespace {


### PR DESCRIPTION
## Summary
- wrap the legacy Fightbar shim in class_exists checks to avoid redeclaration
- update the shim to extend the namespaced Lotgd\FightBar implementation and guard the alias definition

## Testing
- php -l lib/battle-functions.php

------
https://chatgpt.com/codex/tasks/task_e_68edff4bdf14832993cb1294915b1f9e