### PR TITLE
fix: sanitize debug sort parameter

### DIFF
--- a/debug.php
+++ b/debug.php
@@ -28,6 +28,9 @@ SuperuserNav::render();
 Nav::add("Debug Options");
 Nav::add("", $_SERVER['REQUEST_URI']);
 $sort = Http::get('sort');
+if ($sort === false) {
+    $sort = '';
+}
 Nav::add("Get Pageruntimes", "debug.php?debug=pageruntime&sort=" . URLEncode($sort));
 Nav::add("Get Modulehooktimes", "debug.php?debug=hooksort&sort=" . URLEncode($sort));
 


### PR DESCRIPTION
## Summary
- ensure the debug page treats a missing sort parameter as an empty string so URL generation remains valid

## Testing
- php -l debug.php
- php -r '$_SERVER["REQUEST_URI"]="/debug.php"; $_SERVER["HTTP_HOST"]="localhost"; $_SERVER["SERVER_NAME"]="localhost"; $_SERVER["SCRIPT_FILENAME"]=__DIR__."/debug.php"; $_SERVER["PHP_SELF"]="/debug.php"; $_GET=[]; include "debug.php";'

------
https://chatgpt.com/codex/tasks/task_e_68ee00fb9a5c83298de0fb93ce846cbf