### PR TITLE
docs: warn administrators to secure cron.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,16 @@ as the `tests/` directory.
 
 `cron.php` handles automated tasks such as daily resets. Run it from the command line with `php cron.php` and schedule it in your system's crontab. The script automatically determines its installation directory, so no manual configuration or `$GAME_DIR` value is required.
 
+> ⚠️ **Do not leave `cron.php` publicly reachable.** Remove it from the web root or block direct requests. When using Apache, add the following rule to the project’s root [`.htaccess`](./.htaccess):
+>
+> ```apache
+> <Files "cron.php">
+>     Require all denied
+> </Files>
+> ```
+>
+> Apply the equivalent protection in other servers (for example, an Nginx `location` block that returns `403`) or move the script outside the document root so it can only be executed from the CLI.
+
 | Constant               | Bit value | Routine              | Notes |
 | ---------------------- | --------- | -------------------- | ----- |
 | `CRON_NEWDAY`          | `1`       | Daily reset          | Calls `Newday::runOnce()` to process turns, buffs, and cache maintenance. |

--- a/docs/AdminGuide.md
+++ b/docs/AdminGuide.md
@@ -28,7 +28,9 @@ See the [Hooks guide](Hooks.md) for details on how modules integrate with the en
 ## Cron and Background Tasks
 
 LotGD relies on scheduled jobs for housekeeping tasks like resetting daily turns or sending queued
-email. Run `cron.php` regularly via your system's scheduler:
+email. Run `cron.php` regularly via your system's scheduler, but ensure it cannot be accessed directly
+over HTTP. Follow the [Cron Job Setup guidance](../README.md#cron-job-setup) and confirm your web
+server denies requests to the script:
 
 ```bash
 # Example: run every 5 minutes
@@ -51,6 +53,21 @@ Omit the argument for the full run (`1|2|4|8 = 15`). To customize, combine bit v
 Every routine writes its activity to the Game Log (`gamelog.php`, available from the Superuser
 navigation). Review that log after a cron run to confirm each maintenance step completed; bootstrap
 failures are additionally written to `logs/bootstrap.log`.
+
+> ⚠️ **Security reminder:** Keep `cron.php` outside the document root or restrict it in your web
+> server configuration. On Apache, add the rule below to the root [`.htaccess`](../.htaccess) file to
+> deny direct access:
+>
+> ```apache
+> <Files "cron.php">
+>     Require all denied
+> </Files>
+> ```
+>
+> Apply the same protection in other servers (for example, returning `403` from an Nginx `location`
+> block) or remove the script from the public directory so that only CLI cron jobs can invoke it.
+> After deploying the rule, test that your web server responds with `403 Forbidden` (or equivalent)
+> when requesting `/cron.php` directly.
 
 ## SMTP and Email
 


### PR DESCRIPTION
## Summary
- document that cron.php must not remain publicly accessible and provide an Apache `.htaccess` example in the README
- repeat the cron security warning in the Admin Guide with reminders for Apache and other servers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f28f4b47108329976b31ce8a867a8a