### PR TITLE
fix: ensure motd pollitem uses default voting controls

### DIFF
--- a/motd.php
+++ b/motd.php
@@ -149,8 +149,7 @@ if ($op == "") {
                             $row['motdtitle'],
                             $row['motdbody'],
                             $row['motdauthorname'],
-                            $row['motddate'],
-                            $row['motditem']
+                            $row['motddate']
                         );
         }
     }


### PR DESCRIPTION
## Summary
- stop passing the motd item id as the showpoll flag so the MOTD page uses the default voting controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f93a5ec3488329b696677adba88b9c