### PR TITLE
Guard mount buff handling during new day

### DIFF
--- a/newday.php
+++ b/newday.php
@@ -219,11 +219,19 @@ if ($dp < $dkills) {
     }
     if ($session['user']['hashorse']) {
         $mount = Mounts::getInstance()->getPlayerMount();
-        $buff  = unserialize($mount['mountbuff']);
-        if (!isset($buff['schema']) || $buff['schema'] == "") {
-            $buff['schema'] = "mounts";
+        $mountBuff = $mount['mountbuff'] ?? null;
+
+        if (is_string($mountBuff) && $mountBuff !== '') {
+            $buff = unserialize($mountBuff);
+
+            if (is_array($buff)) {
+                if (empty($buff['schema'])) {
+                    $buff['schema'] = "mounts";
+                }
+
+                Buffs::applyBuff('mount', $buff);
+            }
         }
-        Buffs::applyBuff('mount', $buff);
     }
     if ($dkff > 0) {
         $output->output(


### PR DESCRIPTION
## Summary
- guard mount buff handling when no mount buff data is available
- ensure mount buff strings are safely unserialized and schema defaults are applied before use

## Testing
- php -l newday.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927585425748329922e706460c81ed1)