### PR TITLE
Fix mercenary camp heal navigation output initialization

### DIFF
--- a/mercenarycamp.php
+++ b/mercenarycamp.php
@@ -232,6 +232,8 @@ Footer::pageFooter();
 function healnav($companions, $texts, $schemas)
 {
     global $session, $translator;
+
+    $output = Output::getInstance();
     $translator->setSchema($schemas['healnav']);
     Nav::add($texts['healnav']);
     $translator->setSchema();


### PR DESCRIPTION
## Summary
- ensure mercenary camp heal navigation initializes the Output singleton before use

## Testing
- php -l mercenarycamp.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69289f769b1c832987ab35a1ffa19a99)