### PR TITLE
fix: guard missing mount fields in newday

### DIFF
--- a/newday.php
+++ b/newday.php
@@ -326,6 +326,10 @@ if ($dp < $dkills) {
     $session['user']['lasthit'] = gmdate("Y-m-d H:i:s");
     if ($session['user']['hashorse']) {
         $mount = Mounts::getInstance()->getPlayerMount();
+        if (!isset($mount['newday'], $mount['mountforestfights'])) {
+            $mount['newday'] = '';
+            $mount['mountforestfights'] = 0;
+        }
         $msg   = $mount['newday'];
         $msg   = Substitute::applyArray("`n`&" . $msg . "`0`n");
         $output->output('%s', $msg);


### PR DESCRIPTION
### Motivation
- Prevent undefined index notices when `Mounts::getPlayerMount()` returns an incomplete or empty array.
- Keep `newday.php` output stable when mount data is invalid and avoid runtime warnings.
- Ensure the guard is limited to `newday.php` so legacy modules and other code paths are unaffected.

### Description
- After `$mount = Mounts::getInstance()->getPlayerMount();` add an `isset` check for `newday` and `mountforestfights`.
- When those keys are missing, set safe defaults with `$mount['newday'] = ''` and `$mount['mountforestfights'] = 0` before use.
- Change is confined to `newday.php` and does not alter other mount handling logic.

### Testing
- Ran `php -l newday.php` to verify there are no syntax errors and it succeeded.
- No additional automated test suite was run as part of this small defensive fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69552ba3a5388329a04dd536ea7805e1)