### PR TITLE
Add legacy global alias `LotgdServerFunctions` in lib wrapper

### DIFF
--- a/lib/serverfunctions.class.php
+++ b/lib/serverfunctions.class.php
@@ -5,3 +5,5 @@ namespace Lotgd;
 class ServerFunctions extends \Lotgd\ServerFunctions
 {
 }
+
+\class_alias(ServerFunctions::class, 'LotgdServerFunctions');


### PR DESCRIPTION
### Motivation
- Legacy modules expect a global `LotgdServerFunctions` class name for compatibility with the namespaced implementation.  
- `lib/serverfunctions.class.php` did not expose a global alias while `lib/settings.class.php` follows that pattern.  
- Providing the alias prevents runtime errors in older modules that reference the legacy class name.  
- Keep `src/Lotgd/ServerFunctions.php` as the canonical implementation and avoid breaking autoloading expectations.

### Description
- Added `\class_alias(ServerFunctions::class, 'LotgdServerFunctions');` to `lib/serverfunctions.class.php` to create the global legacy alias.  
- Kept the namespaced wrapper `class ServerFunctions extends \Lotgd\ServerFunctions` intact.  
- Followed the same aliasing pattern used in `lib/settings.class.php`.  
- No other files were modified.

### Testing
- Ran a PHP syntax check with `php -l lib/serverfunctions.class.php`, which succeeded.  
- No new unit tests were added for this alias-only change.  
- Recommend running `composer test` and `composer static` locally as part of further QA (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bed30bea883299eaba5fd40a74bd3)