### PR TITLE
fix: clamp news timestamp offsets

### DIFF
--- a/news.php
+++ b/news.php
@@ -36,8 +36,12 @@ if ($session['user']['loggedin']) {
 }
 $newsperpage = (int) $settings->getSetting('newsperpage', 50);
 
-$offset = (int)Http::get('offset');
-$timestamp = strtotime((0 - $offset) . " days");
+$offsetInput = Http::get('offset');
+$offset = filter_var($offsetInput, FILTER_VALIDATE_INT);
+if ($offset === false) {
+    $offset = 0;
+}
+$timestamp = DateTime::newsTimestampFromOffset($offset);
 $sql = "SELECT count(newsid) AS c FROM " . Database::prefix("news") . " WHERE newsdate='" . date("Y-m-d", $timestamp) . "'";
 $result = Database::query($sql);
 $row = Database::fetchAssoc($result);

--- a/src/Lotgd/DateTime.php
+++ b/src/Lotgd/DateTime.php
@@ -210,4 +210,46 @@ class DateTime
 
         return $abs ? abs($d_return) : $d_return;
     }
+
+    /**
+     * Clamp a timestamp to the supported MySQL date range.
+     */
+    public static function normalizeTimestamp(int $timestamp, ?int $minTimestamp = null, ?int $maxTimestamp = null): int
+    {
+        $minTimestamp = $minTimestamp ?? strtotime(DATETIME_DATEMIN);
+        $maxTimestamp = $maxTimestamp ?? strtotime(DATETIME_DATEMAX);
+
+        if ($timestamp < $minTimestamp) {
+            return $minTimestamp;
+        }
+
+        if ($timestamp > $maxTimestamp) {
+            return $maxTimestamp;
+        }
+
+        return $timestamp;
+    }
+
+    /**
+     * Convert a news offset (days) into a safe timestamp.
+     */
+    public static function newsTimestampFromOffset(int $offset, ?int $baseTime = null): int
+    {
+        $baseTime = $baseTime ?? time();
+        $minTimestamp = strtotime(DATETIME_DATEMIN);
+        $maxTimestamp = strtotime(DATETIME_DATEMAX);
+
+        $minOffset = (int) ceil(($baseTime - $maxTimestamp) / 86400);
+        $maxOffset = (int) floor(($baseTime - $minTimestamp) / 86400);
+
+        if ($offset < $minOffset) {
+            $offset = $minOffset;
+        } elseif ($offset > $maxOffset) {
+            $offset = $maxOffset;
+        }
+
+        $timestamp = $baseTime - ($offset * 86400);
+
+        return self::normalizeTimestamp($timestamp, $minTimestamp, $maxTimestamp);
+    }
 }

--- a/tests/DateTimeTest.php
+++ b/tests/DateTimeTest.php
@@ -11,6 +11,16 @@ use PHPUnit\Framework\TestCase;
 
 final class DateTimeTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (!defined('DATETIME_DATEMIN')) {
+            define('DATETIME_DATEMIN', '1970-01-01 00:00:00');
+        }
+        if (!defined('DATETIME_DATEMAX')) {
+            define('DATETIME_DATEMAX', '2159-01-01 00:00:00');
+        }
+    }
+
     public function testReadableTimeShortFormat(): void
     {
         $seconds = 2 * 86400 + 3 * 3600 + 5;
@@ -70,5 +80,21 @@ final class DateTimeTest extends TestCase
     {
         $this->assertSame('1d1h1m1s', Dhms::format(90061));
         $this->assertSame('0d1h1m1.5s', Dhms::format(3661.5, true));
+    }
+
+    public function testNewsTimestampFromOffsetClampsPast(): void
+    {
+        $baseTime = strtotime('2000-01-10 00:00:00');
+        $timestamp = DateTime::newsTimestampFromOffset(1000000, $baseTime);
+
+        $this->assertSame(strtotime(DATETIME_DATEMIN), $timestamp);
+    }
+
+    public function testNewsTimestampFromOffsetClampsFuture(): void
+    {
+        $baseTime = strtotime('2000-01-10 00:00:00');
+        $timestamp = DateTime::newsTimestampFromOffset(-1000000, $baseTime);
+
+        $this->assertSame(strtotime(DATETIME_DATEMAX), $timestamp);
     }
 }


### PR DESCRIPTION
### Motivation

- Prevent invalid or out-of-range timestamps being produced from the `news.php` `offset` parameter which can underflow/overflow MySQL `DATETIME` values.
- Ensure non-numeric `offset` inputs are handled safely and do not cause unexpected date computations.
- Provide a reusable helper to normalize timestamps to the supported MySQL date range.

### Description

- Validate the `offset` input in `news.php` using `filter_var` and default to `0` for invalid values and replace raw `strtotime` usage with `DateTime::newsTimestampFromOffset`.
- Add `DateTime::normalizeTimestamp` to clamp timestamps to `DATETIME_DATEMIN`/`DATETIME_DATEMAX` and `DateTime::newsTimestampFromOffset` to compute bounded day offsets safely.
- Add PHPUnit tests in `tests/DateTimeTest.php` that cover extreme positive and negative offsets (`testNewsTimestampFromOffsetClampsPast` and `testNewsTimestampFromOffsetClampsFuture`).
- Add test setup guards to define `DATETIME_DATEMIN`/`DATETIME_DATEMAX` when running tests.

### Testing

- Ran `php -l news.php` to check syntax and it succeeded.
- Ran `php -l src/Lotgd/DateTime.php` to check syntax and it succeeded.
- Ran `php -l tests/DateTimeTest.php` to check syntax and it succeeded.
- Added PHPUnit tests for the new behavior (`DateTimeTest::testNewsTimestampFromOffsetClampsPast` and `...ClampsFuture`) which are present in the suite and should be executed with `composer test` (not executed in this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf1bbe30c8329b4616e805aedf5cd)