### PR TITLE
fix: populate gameoffsetseconds enum in configuration form

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -426,6 +426,7 @@ switch ($type_setting) {
                     );
                     $enum .= ",$i,$str";
                 }
+                $setup['gameoffsetseconds'] = "Real time to offset new day,{$enum}";
                 $output->rawOutput(Translator::clearButton());
 
                 $secstonewday = secondstonextgameday($details);


### PR DESCRIPTION
### Motivation
- The configuration form was missing selectable options for `gameoffsetseconds` because the constructed enum string wasn't being assigned back into the form `setup`.

### Description
- After building the `$enum` string the code now assigns it to `$setup['gameoffsetseconds']` as `Real time to offset new day,{$enum}` so `Forms::showForm()` receives the dropdown options.
- This ensures the offset dropdown renders and the selected value can be saved by the settings form.
- The change is a single-line addition in `configuration.php` placed after the loop that builds `$enum`.

### Testing
- Ran `php -l configuration.php` to verify there are no syntax errors and it passed.
- No other automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69600d1f654c8329bf017c5615ef2ac8)