### PR TITLE
fix: ensure extended settings save message passes string for saved flag

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -67,7 +67,12 @@ switch ($type_setting) {
                             $old[$key] = "";
                         }
                         $hasSaved = $settings_extended->saveSetting($key, $value);
-                        $output->output("Setting %s to %s (Saved: %s)`n", $key, $value, $hasSaved);
+                        $output->output(
+                            "Setting %s to %s (Saved: %s)`n",
+                            $key,
+                            $value,
+                            $hasSaved ? "`2Yes`0" : "`$No`0"
+                        );
                         gamelog("`@Changed core setting (extended)`^$key`@ from `#" . substr($old[$key], 25) . "...`@ to `&" . substr($value, 25) . "...`0", "settings");
                         // Notify every module
                         HookHandler::hook(


### PR DESCRIPTION
### Motivation
- The extended settings save path passed the raw boolean `$hasSaved` into `Output::output`, which could be interpreted as a private-output flag by output routines and caused a `vsprintf` argument mismatch.
- The standard settings branch already formats the saved indicator as a string, so the extended branch should match to ensure consistent messaging.

### Description
- Update `configuration.php` in the `case "extended"` → `case "save"` block to format the saved indicator as a string instead of passing the raw boolean.
- Replace the single-line `output` call with a multi-argument call that uses `$hasSaved ? "`2Yes`0" : "`$No`0"` for the third parameter.
- This mirrors the behavior used in the default settings `save` branch and prevents boolean values from being misinterpreted by output handlers.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696064d3dba88329bfcb08bcc105f499)