### PR TITLE
fix: harden 2FA async bootstrap and polling failure handling

### DIFF
--- a/async/js/ajax_polling.js
+++ b/async/js/ajax_polling.js
@@ -217,9 +217,19 @@ function set_poll_ajax()
 
         var handlers = getJaxonHandlers();
         if (handlers && handlers.Commentary && typeof handlers.Commentary.pollUpdates === 'function') {
-            console.log('DEBUG: Calling Commentary.pollUpdates');
+            // Ensure we never send an empty/undefined section, which would cause
+            // the server to fall back to the privileged "superuser" section.
+            var safeSection;
+            if (typeof lotgd_comment_section === 'string' && lotgd_comment_section.trim() !== '') {
+                safeSection = lotgd_comment_section;
+            } else {
+                safeSection = 'village'; // non-privileged default section
+                console.log('DEBUG: lotgd_comment_section not set/empty, defaulting to section:', safeSection);
+            }
+
+            console.log('DEBUG: Calling Commentary.pollUpdates for section:', safeSection);
             try {
-                var response = handlers.Commentary.pollUpdates(lotgd_comment_section, lotgd_lastCommentId);
+                var response = handlers.Commentary.pollUpdates(safeSection, lotgd_lastCommentId);
                 if (response && typeof response.then === 'function') {
                     response.catch(function (error) {
                         if (lotgdIsJsonParseError(error)) {

--- a/async/js/ajax_polling.js
+++ b/async/js/ajax_polling.js
@@ -235,7 +235,8 @@ function set_poll_ajax()
                     return;
                 }
 
-                throw error;
+                console.error('DEBUG: pollUpdates threw:', error);
+                return;
             }
         } else {
             console.log('DEBUG: pollUpdates not available, handlers:', handlers);

--- a/async/js/ajax_polling.js
+++ b/async/js/ajax_polling.js
@@ -187,19 +187,56 @@ function set_timeout_ajax()
 /**
  * Start polling for all updates using a single server call.
  */
+function lotgdPausePollingOnParseError(error)
+{
+    var message = error && error.message ? String(error.message) : 'Unknown JSON parse failure';
+    console.error('DEBUG: Polling paused due to JSON parse failure:', message);
+    window.__lotgdPollingPaused = true;
+    window.clearInterval(active_poll_interval);
+}
+
+function lotgdIsJsonParseError(error)
+{
+    var message = error && error.message ? String(error.message).toLowerCase() : '';
+    return message.indexOf('json') !== -1 || message.indexOf('parse') !== -1;
+}
+
 function set_poll_ajax()
 {
     if (typeof lotgd_poll_interval_ms === 'undefined') {
         console.log('DEBUG: lotgd_poll_interval_ms not defined, skipping combined polling');
         return;
     }
+    window.__lotgdPollingPaused = false;
     console.log('DEBUG: Starting combined polling with interval:', lotgd_poll_interval_ms);
     window.clearInterval(active_poll_interval); // Clear any existing interval
     active_poll_interval = window.setInterval(function () {
+        if (window.__lotgdPollingPaused) {
+            return;
+        }
+
         var handlers = getJaxonHandlers();
         if (handlers && handlers.Commentary && typeof handlers.Commentary.pollUpdates === 'function') {
             console.log('DEBUG: Calling Commentary.pollUpdates');
-            handlers.Commentary.pollUpdates(lotgd_comment_section, lotgd_lastCommentId);
+            try {
+                var response = handlers.Commentary.pollUpdates(lotgd_comment_section, lotgd_lastCommentId);
+                if (response && typeof response.then === 'function') {
+                    response.catch(function (error) {
+                        if (lotgdIsJsonParseError(error)) {
+                            lotgdPausePollingOnParseError(error);
+                            return;
+                        }
+                        console.error('DEBUG: pollUpdates rejected:', error);
+                    });
+                }
+            } catch (error) {
+                if (lotgdIsJsonParseError(error)) {
+                    lotgdPausePollingOnParseError(error);
+                    return;
+                }
+
+                throw error;
+            }
         } else {
             console.log('DEBUG: pollUpdates not available, handlers:', handlers);
         }

--- a/async/setup.php
+++ b/async/setup.php
@@ -180,8 +180,11 @@ function pollForUpdates() {
     var handlers = getJaxonHandlers();
     if (handlers && handlers.Commentary && typeof handlers.Commentary.pollUpdates === 'function') {
         try {
+            var section = (typeof lotgd_comment_section === 'string' && lotgd_comment_section.trim() !== '')
+                ? lotgd_comment_section
+                : 'village';
             var response = handlers.Commentary.pollUpdates(
-                lotgd_comment_section || 'superuser',
+                section,
                 lotgd_lastCommentId || 0
             );
             if (response && typeof response.then === 'function') {

--- a/async/setup.php
+++ b/async/setup.php
@@ -160,13 +160,46 @@ function getJaxonHandlers() {
     return null;
 }
 
+function pausePollingOnParseError(error) {
+    var pollingRoot = window.top || window;
+    pollingRoot.__lotgdPollingPaused = true;
+    var message = error && error.message ? String(error.message) : 'Unknown JSON parse failure';
+    console.error('AJAX: Polling paused after JSON parse failure:', message);
+}
+
 function pollForUpdates() {
+    var pollingRoot = window.top || window;
+    if (pollingRoot.__lotgdPollingPaused) {
+        return;
+    }
+
     var handlers = getJaxonHandlers();
     if (handlers && handlers.Commentary && typeof handlers.Commentary.pollUpdates === 'function') {
-        handlers.Commentary.pollUpdates(
-            lotgd_comment_section || 'superuser',
-            lotgd_lastCommentId || 0
-        );
+        try {
+            var response = handlers.Commentary.pollUpdates(
+                lotgd_comment_section || 'superuser',
+                lotgd_lastCommentId || 0
+            );
+            if (response && typeof response.then === 'function') {
+                response.catch(function(error) {
+                    var message = error && error.message ? String(error.message) : '';
+                    if (message.toLowerCase().indexOf('json') !== -1 || message.toLowerCase().indexOf('parse') !== -1) {
+                        pausePollingOnParseError(error);
+                        return;
+                    }
+
+                    console.error('AJAX: pollUpdates rejected:', error);
+                });
+            }
+        } catch (error) {
+            var message = error && error.message ? String(error.message) : '';
+            if (message.toLowerCase().indexOf('json') !== -1 || message.toLowerCase().indexOf('parse') !== -1) {
+                pausePollingOnParseError(error);
+                return;
+            }
+
+            throw error;
+        }
         return;
     }
 
@@ -180,6 +213,7 @@ function startAjaxPolling() {
         return;
     }
     pollingRoot.__lotgdPollingInitialized = true;
+    pollingRoot.__lotgdPollingPaused = false;
     console.log('AJAX: Starting polling every ' + (lotgd_poll_interval_ms / 1000) + ' seconds');
     
     // Regular polling

--- a/async/setup.php
+++ b/async/setup.php
@@ -163,6 +163,10 @@ function getJaxonHandlers() {
 function pausePollingOnParseError(error) {
     var pollingRoot = window.top || window;
     pollingRoot.__lotgdPollingPaused = true;
+    if (typeof pollingRoot.__lotgdPollingIntervalId !== 'undefined' && pollingRoot.__lotgdPollingIntervalId !== null) {
+        clearInterval(pollingRoot.__lotgdPollingIntervalId);
+        pollingRoot.__lotgdPollingIntervalId = null;
+    }
     var message = error && error.message ? String(error.message) : 'Unknown JSON parse failure';
     console.error('AJAX: Polling paused after JSON parse failure:', message);
 }
@@ -198,7 +202,8 @@ function pollForUpdates() {
                 return;
             }
 
-            throw error;
+            console.error('AJAX: pollUpdates threw:', error);
+            return;
         }
         return;
     }
@@ -216,8 +221,9 @@ function startAjaxPolling() {
     pollingRoot.__lotgdPollingPaused = false;
     console.log('AJAX: Starting polling every ' + (lotgd_poll_interval_ms / 1000) + ' seconds');
     
-    // Regular polling
-    setInterval(pollForUpdates, lotgd_poll_interval_ms);
+    // Regular polling: keep the interval handle on the shared root so parse-failure
+    // handling can cancel future ticks deterministically.
+    pollingRoot.__lotgdPollingIntervalId = setInterval(pollForUpdates, lotgd_poll_interval_ms);
 }
 
 // Initialize after page load

--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -509,33 +509,39 @@ function twofactorauth_handle_challenge_verification(Output $output): void
     global $session;
 
     $acctId = (int) ($session['user']['acctid'] ?? 0);
+    if ((int) get_module_pref('pending_challenge') !== 1) {
+        Redirect::redirect('village.php', '2FA verify without pending state');
+    }
+
     $token = trim((string) Http::post('token'));
     $hasToken = $token !== '';
     $requestMethod = strtoupper((string) ($_SERVER['REQUEST_METHOD'] ?? 'GET'));
-    DebugLog::add(
-        sprintf(
-            '2FA verify entry account %d method=%s token_present=%s token_length=%d.',
+    // Temporary diagnostics: only persist verify request-entry details for valid accounts to
+    // avoid noisy target=0 rows when unauthenticated/invalid requests hit the endpoint.
+    if ($acctId > 0) {
+        DebugLog::add(
+            sprintf(
+                '2FA verify entry account %d method=%s token_present=%s token_length=%d.',
+                $acctId,
+                $requestMethod,
+                $hasToken ? 'yes' : 'no',
+                strlen($token)
+            ),
             $acctId,
-            $requestMethod,
-            $hasToken ? 'yes' : 'no',
-            strlen($token)
-        ),
-        $acctId,
-        $acctId,
-        '2fa_verify',
-        false,
-        false
-    );
-
-    if ((int) get_module_pref('pending_challenge') !== 1) {
-        Redirect::redirect('village.php', '2FA verify without pending state');
+            $acctId,
+            '2fa_verify',
+            false,
+            false
+        );
     }
 
     $now = time();
     $lockedUntil = (int) get_module_pref('locked_until');
     if ($lockedUntil > $now) {
         twofactorauth_log_challenge_outcome($acctId, 'failure', 'locked');
-        DebugLog::add(sprintf('2FA verify exit account %d branch=locked.', $acctId), $acctId, $acctId, '2fa_verify', false, false);
+        if ($acctId > 0) {
+            DebugLog::add(sprintf('2FA verify exit account %d branch=locked.', $acctId), $acctId, $acctId, '2fa_verify', false, false);
+        }
         $output->output('Too many failures. Please wait before trying again.`n');
 
         return;
@@ -552,7 +558,9 @@ function twofactorauth_handle_challenge_verification(Output $output): void
         set_module_pref('last_used_timestep', $result['timestep']);
         twofactorauth_clear_pending_state();
         twofactorauth_log_challenge_outcome($acctId, 'success');
-        DebugLog::add(sprintf('2FA verify exit account %d branch=valid timestep=%d.', $acctId, (int) $result['timestep']), $acctId, $acctId, '2fa_verify', false, false);
+        if ($acctId > 0) {
+            DebugLog::add(sprintf('2FA verify exit account %d branch=valid timestep=%d.', $acctId, (int) $result['timestep']), $acctId, $acctId, '2fa_verify', false, false);
+        }
         $output->output('Two-factor authentication complete. Welcome back.`n');
         Nav::add('Continue', 'runmodule.php?module=twofactorauth&op=resume');
 
@@ -567,13 +575,17 @@ function twofactorauth_handle_challenge_verification(Output $output): void
         $lockSeconds = (int) get_module_setting('lock_seconds');
         set_module_pref('locked_until', $now + $lockSeconds);
         twofactorauth_log_challenge_outcome($acctId, 'failure', 'locked');
-        DebugLog::add(sprintf('2FA verify exit account %d branch=invalid_locked fails=%d.', $acctId, $fails), $acctId, $acctId, '2fa_verify', false, false);
+        if ($acctId > 0) {
+            DebugLog::add(sprintf('2FA verify exit account %d branch=invalid_locked fails=%d.', $acctId, $fails), $acctId, $acctId, '2fa_verify', false, false);
+        }
         $output->output('Too many failures. Challenge temporarily locked.`n');
     } else {
         // Slow down automated guessing while keeping the current challenge active for retries.
         sleep(2);
         twofactorauth_log_challenge_outcome($acctId, 'failure', (string) $result['reason']);
-        DebugLog::add(sprintf('2FA verify exit account %d branch=invalid_retry reason=%s fails=%d.', $acctId, (string) ($result['reason'] ?? 'unknown'), $fails), $acctId, $acctId, '2fa_verify', false, false);
+        if ($acctId > 0) {
+            DebugLog::add(sprintf('2FA verify exit account %d branch=invalid_retry reason=%s fails=%d.', $acctId, (string) ($result['reason'] ?? 'unknown'), $fails), $acctId, $acctId, '2fa_verify', false, false);
+        }
         $output->output('Invalid token. Please try again.`n');
         twofactorauth_render_challenge($output);
     }

--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -495,8 +495,9 @@ function twofactorauth_render_challenge(Output $output): void
         twofactorauth_render_passkey_js_helpers();
         twofactorauth_render_passkey_jaxon_bridge();
         $csrfJson = json_encode(twofactorauth_csrf_token()) ?: '""';
+        $showDebugJson = twofactorauth_is_megauser() ? 'true' : 'false';
         rawoutput("<div style='margin-top:12px'><button type='button' id='twofactorauth-use-passkey'>" . htmlspecialchars(translate_inline('Use passkey'), ENT_QUOTES, 'UTF-8') . "</button></div>");
-        rawoutput("<script>(function(){const btn=document.getElementById('twofactorauth-use-passkey');if(!btn){return;}const csrfToken=" . $csrfJson . ";btn.addEventListener('click',async function(){try{const beginData=await window.twofactorauthJaxonPasskeyCall('beginAuthentication',[csrfToken]);if(!beginData||!beginData.ok){alert('Passkey challenge failed.');return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const cred=await navigator.credentials.get({publicKey});if(!cred){alert('Passkey not available.');return;}const body={id:cred.id,type:cred.type,response:{authenticatorData:window.twofactorauthArrayBufferToBase64Url(cred.response.authenticatorData),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(cred.response.clientDataJSON),signature:window.twofactorauthArrayBufferToBase64Url(cred.response.signature),userHandle:cred.response.userHandle?window.twofactorauthArrayBufferToBase64Url(cred.response.userHandle):''}};const verifyData=await window.twofactorauthJaxonPasskeyCall('verifyAuthentication',[csrfToken,body]);if(verifyData&&verifyData.ok){window.location='runmodule.php?module=twofactorauth&op=resume';return;}alert('Passkey verification failed.');}catch(e){alert('Passkey operation failed.');}});})();</script>");
+        rawoutput("<script>(function(){const btn=document.getElementById('twofactorauth-use-passkey');if(!btn){return;}const csrfToken=" . $csrfJson . ";const showDebug=" . $showDebugJson . ";btn.onclick=async function(){try{const beginData=await window.twofactorauthJaxonPasskeyCall('beginAuthentication',[csrfToken]);if(!beginData||!beginData.ok){const beginCode=beginData&&beginData.error?String(beginData.error):'';alert(showDebug&&beginCode!==''?'Passkey challenge failed. Code: '+beginCode:'Passkey challenge failed.');return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const cred=await navigator.credentials.get({publicKey});if(!cred){alert('Passkey not available.');return;}const body={id:cred.id,type:cred.type,response:{authenticatorData:window.twofactorauthArrayBufferToBase64Url(cred.response.authenticatorData),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(cred.response.clientDataJSON),signature:window.twofactorauthArrayBufferToBase64Url(cred.response.signature),userHandle:cred.response.userHandle?window.twofactorauthArrayBufferToBase64Url(cred.response.userHandle):''}};const verifyData=await window.twofactorauthJaxonPasskeyCall('verifyAuthentication',[csrfToken,body]);if(verifyData&&verifyData.ok){window.location='runmodule.php?module=twofactorauth&op=resume';return;}const verifyCode=verifyData&&verifyData.error?String(verifyData.error):'';alert(showDebug&&verifyCode!==''?'Passkey verification failed. Code: '+verifyCode:'Passkey verification failed.');}catch(e){const detail=e&&e.message?String(e.message):'';alert(showDebug&&detail!==''?'Passkey operation failed: '+detail:'Passkey operation failed.');}};})();</script>");
     }
 }
 
@@ -507,22 +508,40 @@ function twofactorauth_handle_challenge_verification(Output $output): void
 {
     global $session;
 
+    $acctId = (int) ($session['user']['acctid'] ?? 0);
+    $token = trim((string) Http::post('token'));
+    $hasToken = $token !== '';
+    $requestMethod = strtoupper((string) ($_SERVER['REQUEST_METHOD'] ?? 'GET'));
+    DebugLog::add(
+        sprintf(
+            '2FA verify entry account %d method=%s token_present=%s token_length=%d.',
+            $acctId,
+            $requestMethod,
+            $hasToken ? 'yes' : 'no',
+            strlen($token)
+        ),
+        $acctId,
+        $acctId,
+        '2fa_verify',
+        false,
+        false
+    );
+
     if ((int) get_module_pref('pending_challenge') !== 1) {
         Redirect::redirect('village.php', '2FA verify without pending state');
     }
 
     $now = time();
-    $acctId = (int) ($session['user']['acctid'] ?? 0);
     $lockedUntil = (int) get_module_pref('locked_until');
     if ($lockedUntil > $now) {
         twofactorauth_log_challenge_outcome($acctId, 'failure', 'locked');
+        DebugLog::add(sprintf('2FA verify exit account %d branch=locked.', $acctId), $acctId, $acctId, '2fa_verify', false, false);
         $output->output('Too many failures. Please wait before trying again.`n');
 
         return;
     }
 
     $secret = TwoFactorAuthService::decryptSecret((string) get_module_pref('secret_encrypted'), twofactorauth_signing_key());
-    $token = (string) Http::post('token');
     $digits = (int) get_module_setting('token_digits');
     $period = (int) get_module_setting('period_seconds');
     $window = (int) get_module_setting('window');
@@ -533,6 +552,7 @@ function twofactorauth_handle_challenge_verification(Output $output): void
         set_module_pref('last_used_timestep', $result['timestep']);
         twofactorauth_clear_pending_state();
         twofactorauth_log_challenge_outcome($acctId, 'success');
+        DebugLog::add(sprintf('2FA verify exit account %d branch=valid timestep=%d.', $acctId, (int) $result['timestep']), $acctId, $acctId, '2fa_verify', false, false);
         $output->output('Two-factor authentication complete. Welcome back.`n');
         Nav::add('Continue', 'runmodule.php?module=twofactorauth&op=resume');
 
@@ -547,11 +567,13 @@ function twofactorauth_handle_challenge_verification(Output $output): void
         $lockSeconds = (int) get_module_setting('lock_seconds');
         set_module_pref('locked_until', $now + $lockSeconds);
         twofactorauth_log_challenge_outcome($acctId, 'failure', 'locked');
+        DebugLog::add(sprintf('2FA verify exit account %d branch=invalid_locked fails=%d.', $acctId, $fails), $acctId, $acctId, '2fa_verify', false, false);
         $output->output('Too many failures. Challenge temporarily locked.`n');
     } else {
         // Slow down automated guessing while keeping the current challenge active for retries.
         sleep(2);
         twofactorauth_log_challenge_outcome($acctId, 'failure', (string) $result['reason']);
+        DebugLog::add(sprintf('2FA verify exit account %d branch=invalid_retry reason=%s fails=%d.', $acctId, (string) ($result['reason'] ?? 'unknown'), $fails), $acctId, $acctId, '2fa_verify', false, false);
         $output->output('Invalid token. Please try again.`n');
         twofactorauth_render_challenge($output);
     }
@@ -904,6 +926,11 @@ function twofactorauth_render_passkey_jaxon_bridge(): void
  */
 function twofactorauth_force_async_bootstrap(): void
 {
+    static $bootstrapInjected = false;
+    if ($bootstrapInjected) {
+        return;
+    }
+
     $asyncSetupFile = dirname(__DIR__) . '/async/setup.php';
     if (!file_exists($asyncSetupFile)) {
         return;
@@ -913,7 +940,7 @@ function twofactorauth_force_async_bootstrap(): void
     global $session;
 
     /** @var string|array<int, string> $pre_headscript */
-    // Do not change to array; async/setup.php concatenates strings into this include-scope buffer.
+    // Keep string contract for async/setup.php and defensively normalize legacy array buffers.
     $pre_headscript = '';
 
     require_once $asyncSetupFile;
@@ -921,13 +948,27 @@ function twofactorauth_force_async_bootstrap(): void
     // Do not change this handling to array-only; legacy paths may still provide an array.
     if (is_string($pre_headscript) && $pre_headscript !== '') {
         Output::addHeadMarkup($pre_headscript);
+        $bootstrapInjected = true;
     } elseif (is_array($pre_headscript)) {
         foreach ($pre_headscript as $scriptMarkup) {
             if (is_string($scriptMarkup) && $scriptMarkup !== '') {
                 Output::addHeadMarkup($scriptMarkup);
+                $bootstrapInjected = true;
             }
         }
     }
+}
+
+/**
+ * Determine whether deep client/server diagnostics may be shown.
+ */
+function twofactorauth_is_megauser(): bool
+{
+    global $session;
+
+    $superuserFlags = (int) ($session['user']['superuser'] ?? 0);
+
+    return ($superuserFlags & SU_MEGAUSER) === SU_MEGAUSER;
 }
 
 /**
@@ -939,10 +980,11 @@ function twofactorauth_render_passkey_registration_script(string $csrf): void
     twofactorauth_render_passkey_jaxon_bridge();
 
     $csrfJson = json_encode($csrf) ?: '""';
+    $showDebugJson = twofactorauth_is_megauser() ? 'true' : 'false';
 
     // Assign via `onclick` so repeated script injection cannot stack multiple handlers.
     // This setup page can be re-rendered in some module flows.
-    rawoutput("<script>(function(){const button=document.getElementById('passkey-add-button');if(!button){return;}const csrfToken=" . $csrfJson . ";button.onclick=async function(){try{const labelEl=document.getElementById('passkey-label');const label=labelEl?labelEl.value:'';const beginData=await window.twofactorauthJaxonPasskeyCall('beginRegistration',[csrfToken,label]);if(!beginData||!beginData.ok){const beginCode=beginData&&beginData.error?String(beginData.error):'unknown';const beginDebug=beginData&&beginData.debug_message?String(beginData.debug_message):'';const beginDetail=beginDebug!==''?' Debug: '+beginDebug:'';alert('Unable to start passkey registration. Code: '+beginCode+'.'+beginDetail);return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const credential=await navigator.credentials.create({publicKey});if(!credential){alert('Passkey registration cancelled.');return;}const payload={id:credential.id,type:credential.type,response:{attestationObject:window.twofactorauthArrayBufferToBase64Url(credential.response.attestationObject),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(credential.response.clientDataJSON),transports:typeof credential.response.getTransports==='function'?credential.response.getTransports():[]}};const finishData=await window.twofactorauthJaxonPasskeyCall('finishRegistration',[csrfToken,label,payload]);if(finishData&&finishData.ok){window.location='runmodule.php?module=twofactorauth&op=setup';return;}const finishCode=finishData&&finishData.error?String(finishData.error):'unknown';const finishDebug=finishData&&finishData.debug_message?String(finishData.debug_message):'';const finishDetail=finishDebug!==''?' Debug: '+finishDebug:'';alert('Passkey registration failed. Code: '+finishCode+'.'+finishDetail);}catch(error){const errorName=error&&error.name?String(error.name):'Error';const errorMessage=error&&error.message?String(error.message):'No additional details.';alert('Passkey registration error ('+errorName+'): '+errorMessage);}};})();</script>");
+    rawoutput("<script>(function(){const button=document.getElementById('passkey-add-button');if(!button){return;}const csrfToken=" . $csrfJson . ";const showDebug=" . $showDebugJson . ";button.onclick=async function(){try{const labelEl=document.getElementById('passkey-label');const label=labelEl?labelEl.value:'';const beginData=await window.twofactorauthJaxonPasskeyCall('beginRegistration',[csrfToken,label]);if(!beginData||!beginData.ok){const beginCode=beginData&&beginData.error?String(beginData.error):'unknown';const beginDebug=beginData&&beginData.debug_message?String(beginData.debug_message):'';const beginDetail=showDebug&&beginDebug!==''?' Debug: '+beginDebug:'';const beginPrefix=showDebug?'Unable to start passkey registration. Code: '+beginCode+'.':'Unable to start passkey registration.';alert(beginPrefix+beginDetail);return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const credential=await navigator.credentials.create({publicKey});if(!credential){alert('Passkey registration cancelled.');return;}const payload={id:credential.id,type:credential.type,response:{attestationObject:window.twofactorauthArrayBufferToBase64Url(credential.response.attestationObject),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(credential.response.clientDataJSON),transports:typeof credential.response.getTransports==='function'?credential.response.getTransports():[]}};const finishData=await window.twofactorauthJaxonPasskeyCall('finishRegistration',[csrfToken,label,payload]);if(finishData&&finishData.ok){window.location='runmodule.php?module=twofactorauth&op=setup';return;}const finishCode=finishData&&finishData.error?String(finishData.error):'unknown';const finishDebug=finishData&&finishData.debug_message?String(finishData.debug_message):'';const finishDetail=showDebug&&finishDebug!==''?' Debug: '+finishDebug:'';const finishPrefix=showDebug?'Passkey registration failed. Code: '+finishCode+'.':'Passkey registration failed.';alert(finishPrefix+finishDetail);}catch(error){const errorName=error&&error.name?String(error.name):'Error';const errorMessage=error&&error.message?String(error.message):'No additional details.';alert(showDebug?'Passkey registration error ('+errorName+'): '+errorMessage:'Passkey registration error.');}};})();</script>");
 }
 
 /**
@@ -1026,13 +1068,10 @@ function twofactorauth_log_setup_async_checkpoint(string $handler, string $check
  */
 function twofactorauth_setup_async_error_payload(string $errorCode, ?\Throwable $exception = null): array
 {
-    global $session;
-
     // Privilege-gate deep diagnostics: only megausers get internals to avoid leaking
     // exception context to normal players while still enabling admin troubleshooting.
     $payload = ['ok' => false, 'error' => $errorCode, 'code' => $errorCode];
-    $superuserFlags = (int) ($session['user']['superuser'] ?? 0);
-    if ($exception instanceof \Throwable && ($superuserFlags & SU_MEGAUSER) === SU_MEGAUSER) {
+    if ($exception instanceof \Throwable && twofactorauth_is_megauser()) {
         $payload['debug_message'] = sprintf('%s: %s', $exception::class, $exception->getMessage());
     }
 

--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -513,7 +513,12 @@ function twofactorauth_handle_challenge_verification(Output $output): void
         Redirect::redirect('village.php', '2FA verify without pending state');
     }
 
-    $token = trim((string) Http::post('token'));
+    $rawToken = Http::post('token');
+    if (!is_string($rawToken)) {
+        $token = '';
+    } else {
+        $token = trim($rawToken);
+    }
     $hasToken = $token !== '';
     $requestMethod = strtoupper((string) ($_SERVER['REQUEST_METHOD'] ?? 'GET'));
     // Temporary diagnostics: only persist verify request-entry details for valid accounts to


### PR DESCRIPTION
### Motivation

- Prevent duplicate or mis-typed async/Jaxon bootstraps during the 2FA setup/challenge flows, which caused inconsistent client namespaces and bootstrap order.
- Avoid unhandled promise/JSON parse errors in the frontend polling path that could stop background polling or throw uncaught exceptions.
- Make it easier to verify whether `op=verify` POSTs reach the server during manual debugging without leaking internals to normal users.

### Description

- Keep the `async/setup.php` contract string-first while defensively accepting legacy array buffers and add a one-time guard (`$bootstrapInjected`) in `twofactorauth_force_async_bootstrap()` to avoid double injection of Jaxon bootstrap markup. (modules/twofactorauth.php)
- Add temporary server-side `DebugLog` entry/exit checkpoints to `twofactorauth_handle_challenge_verification()` to record request arrival, token presence/length, and the verification branch taken (valid / invalid / locked) for troubleshooting. (modules/twofactorauth.php)
- Introduce `twofactorauth_is_megauser()` and gate client-facing debug details and async error payload `debug_message` so only `SU_MEGAUSER` users see diagnostic internals. (modules/twofactorauth.php)
- Ensure passkey client handlers are assigned via `onclick` (not stacking listeners) and limit client debug alerts to megausers. (modules/twofactorauth.php)
- Harden polling: catch promise rejections and synchronous throws from `pollUpdates`, detect JSON/parse-related errors, and pause polling cleanly (flag + clear interval) instead of letting unhandled promise errors propagate; applied to both the embedded polling in `async/setup.php` and the separate `async/js/ajax_polling.js`. (async/setup.php, async/js/ajax_polling.js)

### Testing

- Ran syntax checks with `php -l modules/twofactorauth.php` and `php -l async/setup.php`, both returned no syntax errors. (success)
- Executed the full test suite with `composer test`; PHPUnit ran the suite (580 tests) and completed with expected issues reported by the suite but overall successful exit. (OK, but with the test-suite's existing notices/expected failures)
- Ran static analysis: initial `composer static` hit the environment PHPStan memory limit, then `vendor/bin/phpstan analyse --configuration phpstan.neon --memory-limit=512M` completed with no errors. (PHPStan OK with increased memory)
- Verified changes via `git diff` and committed local edits; manual inspection confirms the bootstrap guard, debug logs, gating, and polling pause behaviour are present in the modified files. (validation done)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b70d24f8488329826fd3018da72d20)