### PR TITLE
fix: restore public passkey handler test-injection setters

### DIFF
--- a/src/Lotgd/Async/Handler/TwoFactorAuthPasskey.php
+++ b/src/Lotgd/Async/Handler/TwoFactorAuthPasskey.php
@@ -52,18 +52,34 @@ class TwoFactorAuthPasskey
     }
 
     /**
-     * Test seam: override the passkey service without constructor injection.
+     * Test-only seam to override the passkey service without constructor injection.
+     *
+     * This is intentionally public so async handler tests can inject stubs.
+     * It is not part of the runtime API surface and should not be used by
+     * production call sites.
      */
-    protected function setService(PasskeyService $service): void
+    public function setService(PasskeyService $service): void
     {
+        // Jaxon only invokes explicitly registered handler methods
+        // (beginRegistration, finishRegistration, beginAuthentication,
+        // verifyAuthentication), so widening this setter does not create an
+        // additional remote-call surface.
         $this->service = $service;
     }
 
     /**
-     * Test seam: override the passkey repository without constructor injection.
+     * Test-only seam to override the passkey repository without constructor injection.
+     *
+     * This is intentionally public so async handler tests can inject stubs.
+     * It is not part of the runtime API surface and should not be used by
+     * production call sites.
      */
-    protected function setRepository(PasskeyCredentialRepository $repository): void
+    public function setRepository(PasskeyCredentialRepository $repository): void
     {
+        // Jaxon only invokes explicitly registered handler methods
+        // (beginRegistration, finishRegistration, beginAuthentication,
+        // verifyAuthentication), so widening this setter does not create an
+        // additional remote-call surface.
         $this->repository = $repository;
     }
 


### PR DESCRIPTION
### Motivation

- Tests for the async Jaxon handler need a way to inject stubbed dependencies because the async bootstrap instantiates the handler without DI, so setter injection must remain accessible. 
- The change aims to restore testability while keeping the runtime remote-call surface unchanged. 

### Description

- Changed `TwoFactorAuthPasskey::setService()` visibility to `public` and added a PHPDoc noting it is a test-only seam and not part of the runtime API. 
- Changed `TwoFactorAuthPasskey::setRepository()` visibility to `public` and added matching PHPDoc indicating test-only usage. 
- Added inline comments to both setters clarifying that Jaxon only calls explicitly registered handler methods (`beginRegistration`, `finishRegistration`, `beginAuthentication`, `verifyAuthentication`), so widening these setters does not expose new remote-call surface. 
- Left all Jaxon-callable business methods unchanged in visibility and behavior. 

### Testing

- Ran a syntax check with `php -l src/Lotgd/Async/Handler/TwoFactorAuthPasskey.php` and it reported no syntax errors. 
- Executed the focused suite with `php -d detect_unicode=0 vendor/bin/phpunit tests/Async/TwoFactorAuthPasskeyHandlerTest.php`, which completed successfully (9 tests, 58 assertions) with PHPUnit notices but no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7c297c37c8329bd597714f36b97dd)