### PR TITLE
fix: validate csrf on sync passkey handlers

### DIFF
--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -1093,6 +1093,51 @@ function twofactorauth_output_json(array $payload): void
 }
 
 /**
+ * Read the raw request body for passkey endpoints.
+ *
+ * Tests can override the transport body with a fixture string because php://input is not
+ * writable in the CLI runtime used by PHPUnit.
+ */
+function twofactorauth_read_request_body(): string
+{
+    if (isset($GLOBALS['twofactorauth_test_request_body']) && is_string($GLOBALS['twofactorauth_test_request_body'])) {
+        return $GLOBALS['twofactorauth_test_request_body'];
+    }
+
+    return (string) (file_get_contents('php://input') ?: '');
+}
+
+/**
+ * Decode a JSON request body into an associative array for passkey endpoints.
+ *
+ * @return array<string, mixed>
+ */
+function twofactorauth_read_json_request_body(): array
+{
+    $requestBody = json_decode(twofactorauth_read_request_body() ?: '{}', true);
+
+    return is_array($requestBody) ? $requestBody : [];
+}
+
+/**
+ * Extract the module CSRF token from either a JSON body or classic POST fields.
+ *
+ * The legacy synchronous passkey entry point may still receive either fetch()-style JSON
+ * or a traditional POST payload. This helper normalizes both transports before the
+ * handler compares the request token against the session token.
+ */
+function twofactorauth_extract_request_csrf_token(): string
+{
+    $requestBody = twofactorauth_read_json_request_body();
+    $csrf = (string) ($requestBody['csrf_token'] ?? '');
+    if ($csrf !== '') {
+        return $csrf;
+    }
+
+    return (string) Http::post('csrf_token');
+}
+
+/**
  * Keep setup async routes explicitly in allowed navigation entries.
  *
  * Forced-nav can redirect requests before module code fully executes. These endpoints are called
@@ -1233,10 +1278,7 @@ function twofactorauth_handle_begin_passkey_registration(): void
     twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'entry', $acctId);
 
     try {
-        $requestBody = json_decode(file_get_contents('php://input') ?: '{}', true);
-        if (!is_array($requestBody)) {
-            $requestBody = [];
-        }
+        $requestBody = twofactorauth_read_json_request_body();
 
         twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'pre-csrf', $acctId);
         $csrf = (string) ($requestBody['csrf_token'] ?? '');
@@ -1302,10 +1344,7 @@ function twofactorauth_handle_finish_passkey_registration(): void
     twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'entry', $acctId);
 
     try {
-        $requestBody = json_decode(file_get_contents('php://input') ?: '{}', true);
-        if (!is_array($requestBody)) {
-            $requestBody = [];
-        }
+        $requestBody = twofactorauth_read_json_request_body();
 
         twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'pre-csrf', $acctId);
         $csrf = (string) ($requestBody['csrf_token'] ?? '');
@@ -1390,6 +1429,13 @@ function twofactorauth_handle_begin_passkey_auth(): void
         return;
     }
 
+    $csrf = twofactorauth_extract_request_csrf_token();
+    if ($csrf === '' || !hash_equals(twofactorauth_csrf_token(), $csrf)) {
+        twofactorauth_output_json(twofactorauth_challenge_async_error_payload('csrf'));
+
+        return;
+    }
+
     try {
         $acctId = (int) ($session['user']['acctid'] ?? 0);
         $existing = twofactorauth_passkey_repository()->listForAccount($acctId);
@@ -1436,9 +1482,12 @@ function twofactorauth_handle_passkey_verification(): void
             return;
         }
 
-        $requestBody = json_decode(file_get_contents('php://input') ?: '{}', true);
-        if (!is_array($requestBody)) {
-            $requestBody = [];
+        $requestBody = twofactorauth_read_json_request_body();
+        $csrf = (string) ($requestBody['csrf_token'] ?? '');
+        if ($csrf === '' || !hash_equals(twofactorauth_csrf_token(), $csrf)) {
+            twofactorauth_output_json(twofactorauth_challenge_async_error_payload('csrf'));
+
+            return;
         }
 
         $result = twofactorauth_passkey_service()->finishAuthentication($acctId, $requestBody);

--- a/tests/Security/TwoFactorAuthModuleFlowTest.php
+++ b/tests/Security/TwoFactorAuthModuleFlowTest.php
@@ -75,6 +75,8 @@ namespace Lotgd\Tests\Security {
             ];
             $_GET = [];
             $_POST = [];
+            $GLOBALS['forms_output'] = '';
+            unset($GLOBALS['twofactorauth_test_request_body']);
             $_SERVER['REQUEST_URI'] = 'runmodule.php?module=twofactorauth&op=challenge';
             $_SERVER['REQUEST_METHOD'] = 'POST';
         }
@@ -268,6 +270,52 @@ namespace Lotgd\Tests\Security {
             self::assertGreaterThan(time(), (int) $GLOBALS['twofactorauth_test_prefs']['locked_until']);
 
             $this->assertDebugLogContains('2FA token verification failure for account 7 (reason: locked).', '2fa_verify');
+        }
+
+        public function testBeginPasskeyAuthRejectsInvalidCsrfOnSynchronousRoute(): void
+        {
+            global $session;
+
+            $session['user']['twofactorauth'] = [
+                'pending_challenge' => 1,
+                'locked_until' => 0,
+            ];
+            $session['twofactorauth_csrf'] = 'csrf-test-token';
+            $_POST['csrf_token'] = 'wrong-token';
+            $GLOBALS['forms_output'] = '';
+
+            twofactorauth_handle_begin_passkey_auth();
+
+            $payload = json_decode((string) $GLOBALS['forms_output'], true);
+            self::assertSame([
+                'ok' => false,
+                'error' => 'csrf',
+                'code' => 'csrf',
+            ], $payload);
+        }
+
+        public function testVerifyPasskeyRejectsEmptyCsrfOnSynchronousRoute(): void
+        {
+            global $session;
+
+            $GLOBALS['twofactorauth_test_prefs']['pending_challenge'] = 1;
+            $GLOBALS['twofactorauth_test_prefs']['failed_attempts'] = 0;
+            $session['twofactorauth_csrf'] = 'csrf-test-token';
+            $GLOBALS['twofactorauth_test_request_body'] = json_encode([
+                'id' => 'credential-id',
+                'response' => [],
+            ]);
+            $GLOBALS['forms_output'] = '';
+
+            twofactorauth_handle_passkey_verification();
+
+            $payload = json_decode((string) $GLOBALS['forms_output'], true);
+            self::assertSame([
+                'ok' => false,
+                'error' => 'csrf',
+                'code' => 'csrf',
+            ], $payload);
+            self::assertSame(0, $GLOBALS['twofactorauth_test_prefs']['failed_attempts']);
         }
 
         #[RunInSeparateProcess]


### PR DESCRIPTION
### Motivation
- Harden the legacy synchronous passkey routes so they validate the module CSRF token before calling `PasskeyService` to prevent CSRF bypass on the synchronous transport.
- Share JSON request parsing between async setup handlers and the synchronous handlers to keep parsing consistent and make tests easier to exercise.

### Description
- Added request helpers: `twofactorauth_read_request_body()`, `twofactorauth_read_json_request_body()`, and `twofactorauth_extract_request_csrf_token()` to normalize JSON/body reading and extract the module `csrf_token` from either JSON or classic POST fields.
- Updated `twofactorauth_handle_begin_passkey_auth()` to validate the extracted CSRF token with `hash_equals()` against `twofactorauth_csrf_token()` and return the existing `csrf` JSON error payload on mismatch.
- Updated `twofactorauth_handle_passkey_verification()` to read the JSON body via the new helper, require a non-empty `csrf_token`, validate it with `hash_equals()` and reject mismatches with the same `csrf` JSON error payload before calling `PasskeyService` or incrementing failure counters.
- Switched setup async handlers (`begin_passkey_registration`, `finish_passkey_registration`) to use the shared JSON reader for consistency.
- Added two unit tests to `tests/Security/TwoFactorAuthModuleFlowTest.php` that assert CSRF rejection for the synchronous begin and verify routes, and adjusted test setup to reset the request-body fixture and raw output capture.
- Kept the synchronous routes rather than removing them after searching for `op=begin_passkey_auth` and `op=verify_passkey`, because they are still referenced in allow-list/hidden nav plumbing; hardened them to avoid changing login-flow compatibility.

### Testing
- Lint: `php -l modules/twofactorauth.php` and `php -l tests/Security/TwoFactorAuthModuleFlowTest.php` succeeded.
- Unit: `vendor/bin/phpunit tests/Security/TwoFactorAuthModuleFlowTest.php` ran and passed (11 tests, 48 assertions) and the added tests exercised the CSRF rejection paths successfully.
- Full suite: `composer test` was executed and completed (tests ran), and the change did not introduce new failures in the suite.
- Static analysis: `composer static` (PHPStan) was attempted but failed in this environment due to PHP memory limits (PHPStan worker reached the configured 128M limit), not because of the introduced code; this should be re-run in CI or with increased memory to obtain a complete static report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba8f48f41c832981a69fc2bfe00590)