### PR TITLE
fix: harden 2FA key derivation and add passkey rpId fallback diagnostics

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -143,6 +143,10 @@ modules.
   - Table prefix subscribers need to prefix both primary tables and join tables using the new mapping object structures.
 - **PHP 8.3**: Old PHP 7.x-style code (e.g., deprecated array/string operations) will break.
 - **Async**: All Ajax endpoints rewritten to use Jaxon.
+- **Two-factor auth key derivation**:
+  - The `twofactorauth` module now derives its crypto key from installation-secret material stored in the main settings table (`twofactorauth_key_material`) instead of only `serverurl` and `gameadminemail`.
+  - Existing installs keep a compatibility window: encrypted TOTP secrets and signed disable links are still accepted with the legacy key and TOTP secrets are re-encrypted with the new key after a successful verification.
+  - Rotating or deleting `twofactorauth_key_material` invalidates any TOTP secrets already re-encrypted with the new key and any disable links signed with it. Plan rotations carefully and keep backups if you must replace the secret.
 
 ### DBAL 4 Migration Inventory (2.x)
 

--- a/modules/TwoFactorAuth/TwoFactorAuth.md
+++ b/modules/TwoFactorAuth/TwoFactorAuth.md
@@ -132,5 +132,7 @@ If passkey registration or verification fails, verify the relying party/domain s
 - **HTTPS is required** for passkeys in normal environments.
   - Local development can use `http://localhost`, but production/staging passkey flows should use valid TLS.
 - If you run behind a reverse proxy, ensure the external host players see is consistent with `serverurl`; host mismatches can cause browser-side `NotAllowedError` / RP mismatch failures.
+- When `serverurl` is malformed and the passkey service must fall back to `HTTP_HOST` for the RP ID, the server now emits an explicit diagnostic to the PHP/web server error log so admins can correct the configuration instead of debugging silent WebAuthn mismatches.
+- The module now stores dedicated installation secret material in the main settings table (`twofactorauth_key_material`) to derive 2FA encryption/signing keys. Changing that value impacts already re-encrypted TOTP secrets and newly signed disable links, so treat it like any other installation secret.
 - If the browser shows **"Unexpected end of JSON input"** during passkey begin/finish, the backend likely returned empty content, HTML, or another non-JSON response. Inspect the raw begin/finish endpoint response body first to identify redirects/login pages/PHP errors quickly.
 - If begin-response **Raw start is empty**, treat it as backend exception/empty output. Check the Two Factor Auth module debug log and your web server/PHP error log for the root cause.

--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -15,6 +15,7 @@ use Lotgd\GameLog;
 use Lotgd\DebugLog;
 use Lotgd\Redirect;
 use Lotgd\Serialization;
+use Lotgd\Settings;
 use Lotgd\Translator;
 
 /**
@@ -592,7 +593,8 @@ function twofactorauth_handle_challenge_verification(Output $output): void
         return;
     }
 
-    $secret = TwoFactorAuthService::decryptSecret((string) get_module_pref('secret_encrypted'), twofactorauth_signing_key());
+    $secretState = twofactorauth_decrypt_secret_with_compat((string) get_module_pref('secret_encrypted'));
+    $secret = $secretState['secret'];
     $digits = (int) get_module_setting('token_digits');
     $period = (int) get_module_setting('period_seconds');
     $window = (int) get_module_setting('window');
@@ -600,6 +602,7 @@ function twofactorauth_handle_challenge_verification(Output $output): void
 
     $result = TwoFactorAuthService::verifyTotp($secret, $token, $digits, $period, $window, $lastStep, $now);
     if ($result['valid']) {
+        twofactorauth_migrate_secret_after_success($secretState);
         set_module_pref('last_used_timestep', $result['timestep']);
         twofactorauth_clear_pending_state();
         twofactorauth_log_challenge_outcome($acctId, 'success');
@@ -708,7 +711,7 @@ function twofactorauth_handle_disable_via_email(Output $output): void
     }
 
     $expires = time() + ((int) get_module_setting('disable_link_ttl_minutes') * 60);
-    $token = TwoFactorAuthService::signDisableToken($acctId, $email, $expires, twofactorauth_signing_key());
+    $token = TwoFactorAuthService::signDisableToken($acctId, $email, $expires, twofactorauth_current_signing_key());
     $confirmUri = 'runmodule.php?module=twofactorauth&op=confirm_disable&token=' . rawurlencode($token);
 
     set_module_pref('disable_token_hash', hash('sha256', $token));
@@ -735,7 +738,7 @@ function twofactorauth_handle_disable_confirmation(Output $output): void
     global $session;
 
     $token = (string) Http::get('token');
-    $validation = TwoFactorAuthService::verifyDisableToken($token, twofactorauth_signing_key());
+    $validation = twofactorauth_verify_disable_token_with_compat($token);
     $expectedHash = (string) get_module_pref('disable_token_hash');
     $expires = (int) get_module_pref('disable_token_expires');
 
@@ -1526,9 +1529,173 @@ function twofactorauth_handle_passkey_verification(): void
 }
 
 /**
- * Return the shared signing/encryption key material for this module.
+ * Return the preferred signing/encryption key material for this module.
+ *
+ * The current key is derived from installation-scoped secret material instead of only public
+ * configuration. Existing installs may still hold data encrypted/signed with the legacy key, so
+ * read/verify paths should call the compatibility helpers below during the transition window.
  */
 function twofactorauth_signing_key(): string
 {
+    return twofactorauth_current_signing_key();
+}
+
+/**
+ * Resolve the installation secret that anchors 2FA key derivation.
+ *
+ * The value is stored outside module settings so it is not exposed as routine public config. A
+ * generated secret must stay stable across requests; rotating it invalidates encrypted TOTP
+ * secrets and outstanding signed disable links unless the legacy fallback path can still read them.
+ */
+function twofactorauth_secret_material(): string
+{
+    if (isset($GLOBALS['twofactorauth_test_install_secret']) && is_string($GLOBALS['twofactorauth_test_install_secret'])) {
+        $testSecret = trim($GLOBALS['twofactorauth_test_install_secret']);
+        if ($testSecret !== '') {
+            return $testSecret;
+        }
+    }
+
+    $settings = Settings::getInstance();
+    $settingName = 'twofactorauth_key_material';
+    $existing = trim((string) $settings->getSetting($settingName, ''));
+    if ($existing !== '') {
+        return $existing;
+    }
+
+    try {
+        $generated = bin2hex(random_bytes(32));
+    } catch (\Throwable) {
+        $generated = hash('sha256', uniqid('twofactorauth-key-', true) . '|' . microtime(true));
+    }
+
+    if ($settings->saveSetting($settingName, $generated)) {
+        return $generated;
+    }
+
+    // Re-read in case another request populated the setting first.
+    $reloaded = trim((string) $settings->getSetting($settingName, ''));
+    if ($reloaded !== '') {
+        return $reloaded;
+    }
+
+    // Last-resort fallback preserves availability in misconfigured environments, but this path
+    // should be treated as degraded because it cannot provide secret-backed key material.
+    return twofactorauth_legacy_signing_key();
+}
+
+/**
+ * Derive the current 2FA key from installation-secret material.
+ */
+function twofactorauth_current_signing_key(): string
+{
+    return hash_hmac('sha256', 'lotgd|twofactorauth|v2', twofactorauth_secret_material());
+}
+
+/**
+ * Derive the legacy 2FA key used before secret-backed key material existed.
+ *
+ * This path exists only for backward compatibility while existing encrypted TOTP secrets and
+ * disable-link tokens are migrated forward.
+ */
+function twofactorauth_legacy_signing_key(): string
+{
     return hash('sha256', getsetting('serverurl', 'lotgd') . '|' . getsetting('gameadminemail', 'admin@example.com'));
+}
+
+/**
+ * Return the ordered list of keys accepted for compatibility reads/verifications.
+ *
+ * @return array<int, string>
+ */
+function twofactorauth_compatible_signing_keys(): array
+{
+    $keys = [twofactorauth_current_signing_key(), twofactorauth_legacy_signing_key()];
+
+    return array_values(array_unique(array_filter($keys, static fn(string $key): bool => $key !== '')));
+}
+
+/**
+ * Decrypt a stored TOTP secret using the current key first, then the legacy key if needed.
+ *
+ * @return array{secret:string,key:string,used_legacy:bool,needs_reencrypt:bool,stored_secret:string}
+ */
+function twofactorauth_decrypt_secret_with_compat(string $storedSecret): array
+{
+    $storedSecret = trim($storedSecret);
+    if ($storedSecret === '') {
+        return [
+            'secret' => '',
+            'key' => '',
+            'used_legacy' => false,
+            'needs_reencrypt' => false,
+            'stored_secret' => $storedSecret,
+        ];
+    }
+
+    $currentKey = twofactorauth_current_signing_key();
+    foreach (twofactorauth_compatible_signing_keys() as $candidateKey) {
+        $secret = TwoFactorAuthService::decryptSecret($storedSecret, $candidateKey);
+        if ($secret === '') {
+            continue;
+        }
+
+        $usedLegacy = $candidateKey !== $currentKey;
+        $needsReencrypt = $usedLegacy || !str_starts_with($storedSecret, 'enc:');
+
+        return [
+            'secret' => $secret,
+            'key' => $candidateKey,
+            'used_legacy' => $usedLegacy,
+            'needs_reencrypt' => $needsReencrypt,
+            'stored_secret' => $storedSecret,
+        ];
+    }
+
+    return [
+        'secret' => '',
+        'key' => '',
+        'used_legacy' => false,
+        'needs_reencrypt' => false,
+        'stored_secret' => $storedSecret,
+    ];
+}
+
+/**
+ * Re-encrypt a TOTP secret with the current key after a successful compatibility read.
+ *
+ * This keeps existing installs working while gradually moving accounts off the legacy key or
+ * plaintext-at-rest fallback format during normal successful verification.
+ *
+ * @param array{secret:string,key:string,used_legacy:bool,needs_reencrypt:bool,stored_secret:string} $secretState
+ */
+function twofactorauth_migrate_secret_after_success(array $secretState): void
+{
+    if (($secretState['secret'] ?? '') === '' || !($secretState['needs_reencrypt'] ?? false)) {
+        return;
+    }
+
+    $reencrypted = TwoFactorAuthService::encryptSecret((string) $secretState['secret'], twofactorauth_current_signing_key());
+    if ($reencrypted === '') {
+        return;
+    }
+
+    set_module_pref('secret_encrypted', $reencrypted);
+}
+
+/**
+ * Verify disable-link tokens against both current and legacy signing keys.
+ *
+ * @return array{valid:bool,acctid:int,email:string,exp:int}
+ */
+function twofactorauth_verify_disable_token_with_compat(string $token): array
+{
+    foreach (twofactorauth_compatible_signing_keys() as $candidateKey) {
+        $validation = TwoFactorAuthService::verifyDisableToken($token, $candidateKey);
+        if ($validation['valid']) {
+            return $validation;
+        }
+    }
+
+    return TwoFactorAuthService::verifyDisableToken($token, twofactorauth_current_signing_key());
 }

--- a/src/Lotgd/Security/PasskeyService.php
+++ b/src/Lotgd/Security/PasskeyService.php
@@ -19,6 +19,9 @@ class PasskeyService
     private const SESSION_KEY_PREFIX = 'twofactorauth_passkey_challenge_';
     private const CHALLENGE_TTL_SECONDS = 300;
 
+    /** @var array<int, string> */
+    private static array $diagnostics = [];
+
     public function __construct(private readonly PasskeyCredentialRepository $credentials)
     {
     }
@@ -188,6 +191,24 @@ class PasskeyService
         return ['ok' => true, 'error' => '', 'clone' => false];
     }
 
+    /**
+     * Clear captured diagnostics between requests/tests.
+     */
+    public static function clearDiagnostics(): void
+    {
+        self::$diagnostics = [];
+    }
+
+    /**
+     * Return captured diagnostics emitted while resolving passkey configuration.
+     *
+     * @return array<int, string>
+     */
+    public static function getDiagnostics(): array
+    {
+        return self::$diagnostics;
+    }
+
     private function createWebAuthn(): WebAuthn
     {
         $rpId = $this->resolveRpId();
@@ -207,11 +228,32 @@ class PasskeyService
         if ($host === '') {
             $requestHost = trim((string) ($_SERVER['HTTP_HOST'] ?? ''));
             if ($requestHost !== '') {
-                $host = explode(':', $requestHost, 2)[0];
+                $fallbackHost = explode(':', $requestHost, 2)[0];
+                $this->emitRpIdDiagnostic(sprintf(
+                    'Passkey rpId fallback: configured serverurl "%s" did not yield a valid host; using HTTP_HOST "%s" (rpId "%s").',
+                    $serverUrl !== '' ? $serverUrl : '[empty]',
+                    $requestHost,
+                    $fallbackHost
+                ));
+                $host = $fallbackHost;
+            } else {
+                $this->emitRpIdDiagnostic(sprintf(
+                    'Passkey rpId fallback: configured serverurl "%s" did not yield a valid host and HTTP_HOST is unavailable; using localhost.',
+                    $serverUrl !== '' ? $serverUrl : '[empty]'
+                ));
             }
         }
 
         return $host !== '' ? $host : 'localhost';
+    }
+
+    /**
+     * Emit an observable diagnostic when passkey rpId resolution has to fall back.
+     */
+    private function emitRpIdDiagnostic(string $message): void
+    {
+        self::$diagnostics[] = $message;
+        error_log($message);
     }
 
     private function resolveRpName(): string

--- a/tests/Security/PasskeyServiceTest.php
+++ b/tests/Security/PasskeyServiceTest.php
@@ -85,6 +85,7 @@ class PasskeyServiceTest extends TestCase
     {
         $this->repo = new InMemoryPasskeyCredentialRepository();
         $GLOBALS['session'] = [];
+        PasskeyService::clearDiagnostics();
 
         $settings = $this->createMock(Settings::class);
         $settings->method('getSetting')->willReturnCallback(static function (string $name, mixed $default = false): mixed {
@@ -101,6 +102,7 @@ class PasskeyServiceTest extends TestCase
 
     protected function tearDown(): void
     {
+        PasskeyService::clearDiagnostics();
         Settings::setInstance(null);
         unset($GLOBALS['settings']);
         unset($_SERVER['HTTP_HOST']);
@@ -310,6 +312,9 @@ class PasskeyServiceTest extends TestCase
         $service = new PasskeyService($this->repo);
 
         self::assertSame('fallback.example.test', $this->invokeResolveRpId($service));
+        self::assertSame([
+            'Passkey rpId fallback: configured serverurl "example.test/no-scheme" did not yield a valid host; using HTTP_HOST "fallback.example.test:8080" (rpId "fallback.example.test").',
+        ], PasskeyService::getDiagnostics());
     }
 
     public function testResolveRpIdFallsBackToLocalhostWhenNoConfiguredOrRequestHostExists(): void
@@ -330,6 +335,9 @@ class PasskeyServiceTest extends TestCase
         $service = new PasskeyService($this->repo);
 
         self::assertSame('localhost', $this->invokeResolveRpId($service));
+        self::assertSame([
+            'Passkey rpId fallback: configured serverurl "[empty]" did not yield a valid host and HTTP_HOST is unavailable; using localhost.',
+        ], PasskeyService::getDiagnostics());
     }
 
     private function invokeResolveRpId(PasskeyService $service): string

--- a/tests/Security/TwoFactorAuthModuleFlowTest.php
+++ b/tests/Security/TwoFactorAuthModuleFlowTest.php
@@ -73,12 +73,20 @@ namespace Lotgd\Tests\Security {
                 'max_attempts' => 5,
                 'lock_seconds' => 120,
             ];
+            $GLOBALS['twofactorauth_test_install_secret'] = 'test-install-secret-material';
             $_GET = [];
             $_POST = [];
             $GLOBALS['forms_output'] = '';
             unset($GLOBALS['twofactorauth_test_request_body']);
             $_SERVER['REQUEST_URI'] = 'runmodule.php?module=twofactorauth&op=challenge';
             $_SERVER['REQUEST_METHOD'] = 'POST';
+        }
+
+        protected function tearDown(): void
+        {
+            unset($GLOBALS['twofactorauth_test_install_secret']);
+
+            parent::tearDown();
         }
 
         public function testLoginStagesSessionSnapshotAndEveryhitPersistsIt(): void
@@ -252,6 +260,54 @@ namespace Lotgd\Tests\Security {
             self::assertSame(0, (int) ($GLOBALS['twofactorauth_test_prefs']['locked_until'] ?? 0));
 
             $this->assertDebugLogContains('2FA token verification failure for account 7 (reason: mismatch).', '2fa_verify');
+        }
+
+        public function testVerifyAcceptsLegacyEncryptedSecretAndReencryptsWithCurrentKey(): void
+        {
+            $secret = \TwoFactorAuthService::generateSecret();
+            $legacyStoredSecret = \TwoFactorAuthService::encryptSecret($secret, twofactorauth_legacy_signing_key());
+
+            $GLOBALS['twofactorauth_test_prefs']['pending_challenge'] = 1;
+            $GLOBALS['twofactorauth_test_prefs']['secret_encrypted'] = $legacyStoredSecret;
+            $GLOBALS['twofactorauth_test_prefs']['last_used_timestep'] = 0;
+            $_POST['token'] = \TwoFactorAuthService::generateTokenAtTime($secret, 6, 30, time());
+
+            twofactorauth_handle_challenge_verification(Output::getInstance());
+
+            self::assertSame(0, $GLOBALS['twofactorauth_test_prefs']['pending_challenge']);
+            self::assertNotSame($legacyStoredSecret, $GLOBALS['twofactorauth_test_prefs']['secret_encrypted']);
+            self::assertSame(
+                $secret,
+                \TwoFactorAuthService::decryptSecret(
+                    (string) $GLOBALS['twofactorauth_test_prefs']['secret_encrypted'],
+                    twofactorauth_current_signing_key()
+                )
+            );
+        }
+
+        public function testDisableConfirmationAcceptsLegacySignedToken(): void
+        {
+            global $session;
+
+            $legacyToken = \TwoFactorAuthService::signDisableToken(
+                7,
+                'player@example.test',
+                time() + 300,
+                twofactorauth_legacy_signing_key()
+            );
+
+            $session['user']['emailaddress'] = 'player@example.test';
+            $_GET['token'] = $legacyToken;
+            $GLOBALS['twofactorauth_test_prefs']['enabled'] = 1;
+            $GLOBALS['twofactorauth_test_prefs']['secret_encrypted'] = $this->encodePlainStoredSecret(\TwoFactorAuthService::generateSecret());
+            $GLOBALS['twofactorauth_test_prefs']['disable_token_hash'] = hash('sha256', $legacyToken);
+            $GLOBALS['twofactorauth_test_prefs']['disable_token_expires'] = time() + 300;
+
+            twofactorauth_handle_disable_confirmation(Output::getInstance());
+
+            self::assertSame(0, $GLOBALS['twofactorauth_test_prefs']['enabled']);
+            self::assertSame('', $GLOBALS['twofactorauth_test_prefs']['secret_encrypted']);
+            self::assertSame('', $GLOBALS['twofactorauth_test_prefs']['disable_token_hash']);
         }
 
         public function testVerifyLockoutStillAppliesAfterThreshold(): void


### PR DESCRIPTION
### Motivation
- Replace a weak, public-config-only 2FA key derivation with a secret-backed, installation-scoped derivation so stored TOTP secrets and signing tokens are anchored to true secret material. 
- Preserve existing installs by accepting legacy keys during a transition window and re-encrypting secrets after successful verification to avoid silent lockouts. 
- Make passkey RP ID fallbacks observable so misconfigured `serverurl` values (which can cause WebAuthn rpId mismatches) produce clear server-side diagnostics instead of silent failures. 

### Description
- Derive the active 2FA key from installation secret material stored in the settings entry `twofactorauth_key_material` (with a test hook `twofactorauth_test_install_secret` for tests) and expose `twofactorauth_current_signing_key()` / `twofactorauth_legacy_signing_key()` helpers. 
- Add compatibility helpers: `twofactorauth_compatible_signing_keys()`, `twofactorauth_decrypt_secret_with_compat()` (tries current key then legacy), `twofactorauth_migrate_secret_after_success()` (re-encrypts with current key after a successful verification), and `twofactorauth_verify_disable_token_with_compat()` (accept both legacy and new signed tokens). 
- Use the new compatibility helpers in the module flow (decrypt during verification, re-encrypt on success, sign disable links with the current key, and verify disable tokens with compatibility). 
- In `PasskeyService` add observable diagnostics (captured in a static diagnostics array and sent to `error_log`) when `resolveRpId()` must fall back from a malformed `serverurl` to `HTTP_HOST` or to `localhost`, and provide test-accessors (`clearDiagnostics()` / `getDiagnostics()`). 
- Update unit tests to cover legacy-key compatibility and rpId-fallback diagnostics, and update documentation (`UPGRADING.md` and module README) to explain the compatibility/migration impact and admin guidance. 
- Behavior remains permissive by default: legacy data is accepted during the transition and re-encrypted opportunistically after successful verification rather than hard-failing. 

### Testing
- Ran syntax checks with `php -l` on modified files and they reported no syntax errors. 
- Executed targeted unit tests with `vendor/bin/phpunit tests/Security/PasskeyServiceTest.php tests/Security/TwoFactorAuthModuleFlowTest.php` and they passed. 
- Ran the full test suite with `composer test` and observed all tests passing (606 tests; some warnings/deprecations/notices were reported but no failures). 
- Ran static analysis `phpstan` with increased memory (`php -d memory_limit=512M vendor/bin/phpstan analyse --configuration phpstan.neon`) after an initial run that hit the default 128M limit, and the analysis completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba991fcee88329acef567fe4bb27a7)