### PR TITLE
fix: narrow passkey Jaxon registration surface

### DIFF
--- a/async/common/jaxon.php
+++ b/async/common/jaxon.php
@@ -38,9 +38,31 @@ $jaxon->setOption('core.debug.verbose', false);
  * Register async handlers from the directory to keep the historical Jaxon
  * client export shape (Lotgd.Async.Handler.*) stable for runtime bridge code.
  *
- * Security note: passkey method allowlisting is enforced server-side in
- * async/process.php so hardening does not alter this client namespace contract.
+ * Security note: async/process.php still enforces its allowlist before Jaxon
+ * dispatch. The passkey class options below narrow Jaxon's callable surface as
+ * defense in depth so helper/test seams are never exported or invokable.
+ *
+ * @var array<int, string> $passkeyRuntimeMethods
  */
+$passkeyRuntimeMethods = [
+    'beginRegistration',
+    'finishRegistration',
+    'beginAuthentication',
+    'verifyAuthentication',
+];
+
 $jaxon->register(Jaxon::CALLABLE_DIR, __DIR__ . '/../../src/Lotgd/Async/Handler', [
     'namespace' => 'Lotgd\\Async\\Handler',
+    'classes' => [
+        'Lotgd\\Async\\Handler\\TwoFactorAuthPasskey' => [
+            'export' => [
+                'only' => $passkeyRuntimeMethods,
+            ],
+            'functions' => [
+                'setService,setRepository' => [
+                    'excluded' => true,
+                ],
+            ],
+        ],
+    ],
 ]);

--- a/src/Lotgd/Async/Handler/TwoFactorAuthPasskey.php
+++ b/src/Lotgd/Async/Handler/TwoFactorAuthPasskey.php
@@ -55,32 +55,28 @@ class TwoFactorAuthPasskey
     /**
      * Test-only seam to override the passkey service without constructor injection.
      *
-     * This is intentionally public so async handler tests can inject stubs.
-     * It is not part of the runtime API surface and should not be used by
-     * production call sites.
+     * This remains public only so async handler tests can inject stubs.
+     * Jaxon registration explicitly excludes it from the remote callable
+     * surface, so production async requests cannot invoke this helper seam.
      */
     public function setService(PasskeyService $service): void
     {
-        // Jaxon only invokes explicitly registered handler methods
-        // (beginRegistration, finishRegistration, beginAuthentication,
-        // verifyAuthentication), so widening this setter does not create an
-        // additional remote-call surface.
+        // Keep test wiring local to the object instance. Runtime requests are
+        // blocked earlier because async/common/jaxon.php excludes this helper.
         $this->service = $service;
     }
 
     /**
      * Test-only seam to override the passkey repository without constructor injection.
      *
-     * This is intentionally public so async handler tests can inject stubs.
-     * It is not part of the runtime API surface and should not be used by
-     * production call sites.
+     * This remains public only so async handler tests can inject stubs.
+     * Jaxon registration explicitly excludes it from the remote callable
+     * surface, so production async requests cannot invoke this helper seam.
      */
     public function setRepository(PasskeyCredentialRepository $repository): void
     {
-        // Jaxon only invokes explicitly registered handler methods
-        // (beginRegistration, finishRegistration, beginAuthentication,
-        // verifyAuthentication), so widening this setter does not create an
-        // additional remote-call surface.
+        // Keep test wiring local to the object instance. Runtime requests are
+        // blocked earlier because async/common/jaxon.php excludes this helper.
         $this->repository = $repository;
     }
 

--- a/tests/Async/ProcessAuthorizationTest.php
+++ b/tests/Async/ProcessAuthorizationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lotgd\Tests\Async {
 
+    use PHPUnit\Framework\Attributes\DataProvider;
     use PHPUnit\Framework\TestCase;
 
     /**
@@ -135,6 +136,42 @@ namespace Lotgd\Tests\Async {
             $this->assertSame(1, $jaxon->processCount);
         }
 
+
+        #[DataProvider('deniedPasskeyHelperMethodProvider')]
+        public function testPasskeyHelperCallableIsDeniedBeforeJaxonDispatch(string $methodName): void
+        {
+            global $jaxon, $ajax_rate_limit_seconds;
+
+            $ajax_rate_limit_seconds = 1.0;
+            $_POST['jxncls'] = 'Lotgd.Async.Handler.TwoFactorAuthPasskey';
+            $_POST['jxnmthd'] = $methodName;
+
+            $jaxon = new class {
+                public int $processCount = 0;
+
+                public function canProcessRequest(): bool
+                {
+                    return true;
+                }
+
+                public function processRequest(): void
+                {
+                    $this->processCount++;
+                }
+            };
+
+            ob_start();
+            lotgd_async_process_entrypoint();
+            $body = (string) ob_get_clean();
+
+            $payload = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+            $this->assertSame(403, http_response_code());
+            $this->assertSame(0, $jaxon->processCount);
+            $this->assertSame('callable_not_allowed', $payload['error'] ?? null);
+            $this->assertSame('Forbidden', $payload['message'] ?? null);
+        }
+
         public function testDeniedResponsesHaveConsistentJsonShape(): void
         {
             global $jaxon, $ajax_rate_limit_seconds;
@@ -186,6 +223,18 @@ namespace Lotgd\Tests\Async {
             $_SESSION = [];
 
             $this->assertTrue(lotgd_async_denied_request_is_throttled($start + 0.2, 2.0));
+        }
+
+
+        /**
+         * @return array<string, array{0:string}>
+         */
+        public static function deniedPasskeyHelperMethodProvider(): array
+        {
+            return [
+                'setService helper' => ['setService'],
+                'setRepository helper' => ['setRepository'],
+            ];
         }
 
         public function testAbuseKeyIgnoresSessionIdWhenNoCookieIsPresent(): void

--- a/tests/Async/TwoFactorAuthPasskeyHandlerTest.php
+++ b/tests/Async/TwoFactorAuthPasskeyHandlerTest.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Lotgd\Tests\Async {
 
+    use Jaxon\Exception\RequestException;
     use Lotgd\Async\Handler\TwoFactorAuthPasskey;
     use Lotgd\Security\PasskeyCredentialRepository;
     use Lotgd\Security\PasskeyService;
+    use Nyholm\Psr7Server\ServerRequestCreator;
+    use Psr\Http\Message\ServerRequestInterface;
+    use PHPUnit\Framework\Attributes\DataProvider;
     use PHPUnit\Framework\Attributes\PreserveGlobalState;
     use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
     use PHPUnit\Framework\TestCase;
@@ -258,6 +262,35 @@ namespace Lotgd\Tests\Async {
             self::assertContains('finishRegistration', $exportedMethods);
             self::assertContains('beginAuthentication', $exportedMethods);
             self::assertContains('verifyAuthentication', $exportedMethods);
+            self::assertNotContains('setService', $exportedMethods);
+            self::assertNotContains('setRepository', $exportedMethods);
+        }
+
+        #[DataProvider('excludedPasskeyHelperMethodProvider')]
+        public function testJaxonBootstrapRejectsExcludedPasskeyHelperRequestsBeforeInvocation(string $methodName): void
+        {
+            require __DIR__ . '/../../async/common/jaxon.php';
+
+            global $jaxon;
+            self::assertNotNull($jaxon);
+
+            $jaxon->setOption('core.response.send', false);
+            $jaxon->di()->set(ServerRequestInterface::class, static fn($container) =>
+                $container->g(ServerRequestCreator::class)
+                    ->fromGlobals()
+                    ->withParsedBody([
+                        'jxncall' => json_encode([
+                            'type' => 'class',
+                            'name' => 'Lotgd.Async.Handler.TwoFactorAuthPasskey',
+                            'method' => $methodName,
+                            'args' => [],
+                        ], JSON_THROW_ON_ERROR),
+                    ]));
+
+            $this->expectException(RequestException::class);
+            $this->expectExceptionMessage('excluded method');
+
+            $jaxon->processRequest();
         }
 
         public function testJaxonBootstrapPreservesLegacyNamespaceExportShapeForPasskeyBridge(): void
@@ -338,6 +371,17 @@ namespace Lotgd\Tests\Async {
             return [
                 'requestId' => (string) ($first['args']['args'][0] ?? ''),
                 'data' => (array) ($first['args']['args'][1] ?? []),
+            ];
+        }
+
+        /**
+         * @return array<string, array{0:string}>
+         */
+        public static function excludedPasskeyHelperMethodProvider(): array
+        {
+            return [
+                'setService helper' => ['setService'],
+                'setRepository helper' => ['setRepository'],
             ];
         }
 


### PR DESCRIPTION
### Motivation

- Reduce reliance on `async/process.php` as the sole protection by narrowing the Jaxon registration surface so non-runtime helper/test seams are not exported or remotely callable.

### Description

- Limit Jaxon exports for `Lotgd\Async\Handler\TwoFactorAuthPasskey` in `async/common/jaxon.php` to only the runtime methods `beginRegistration`, `finishRegistration`, `beginAuthentication`, and `verifyAuthentication`, and explicitly exclude the helper setters `setService` and `setRepository` via class options. 
- Update `src/Lotgd/Async/Handler/TwoFactorAuthPasskey.php` docblocks and comments to state that `setService()` and `setRepository()` remain public only as local test seams and are not part of the remote callable surface. 
- Add regression coverage in `tests/Async/TwoFactorAuthPasskeyHandlerTest.php` to assert the helper setters are not exported and that Jaxon rejects excluded helper-method requests, and in `tests/Async/ProcessAuthorizationTest.php` to assert `async/process.php` continues to deny helper-method requests before dispatch. 
- Preserve the existing allowlist and authorization logic in `async/process.php`; this registration narrowing is treated as defense in depth.

### Testing

- Ran syntax checks with `php -l` on `async/common/jaxon.php`, `src/Lotgd/Async/Handler/TwoFactorAuthPasskey.php`, and modified tests, and they passed. 
- Executed the focused PHPUnit tests with `vendor/bin/phpunit tests/Async/TwoFactorAuthPasskeyHandlerTest.php tests/Async/ProcessAuthorizationTest.php` and the targeted assertions (export narrowing and pre-dispatch denials) passed. 
- Ran the full test suite with `composer test` which completed but surfaced a pre-existing unrelated test failure in `Lotgd\Tests\Security\PasskeyServiceTest::testResolveRpIdFallsBackToRequestHostWhenServerUrlIsMalformed` that is not caused by these changes. 
- Ran `composer static` and the static analysis run failed because a PHPStan worker hit the configured 128M memory limit; this is an environment/tooling issue and not a functional regression from this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd97e2d2bc8329a870286296df1bf7)