### PR TITLE
tests: relax PasskeyService rpId fallback diagnostic assertion

### DIFF
--- a/tests/Security/PasskeyServiceTest.php
+++ b/tests/Security/PasskeyServiceTest.php
@@ -312,9 +312,13 @@ class PasskeyServiceTest extends TestCase
         $service = new PasskeyService($this->repo);
 
         self::assertSame('fallback.example.test', $this->invokeResolveRpId($service));
-        self::assertSame([
-            'Passkey rpId fallback: configured serverurl "example.test/no-scheme" did not yield a valid host; using HTTP_HOST "fallback.example.test:8080" (rpId "fallback.example.test").',
-        ], PasskeyService::getDiagnostics());
+
+        $diagnostics = PasskeyService::getDiagnostics();
+
+        self::assertCount(1, $diagnostics);
+        self::assertStringContainsString('configured serverurl "example.test/no-scheme"', $diagnostics[0]);
+        self::assertStringContainsString('derived rpId "fallback.example.test"', $diagnostics[0]);
+        self::assertStringContainsString('from HTTP_HOST', $diagnostics[0]);
     }
 
     public function testResolveRpIdFallsBackToLocalhostWhenNoConfiguredOrRequestHostExists(): void


### PR DESCRIPTION
### Motivation
- The test for malformed `serverurl` was tightly coupled to the exact diagnostic wording emitted by `Lotgd\Security\PasskeyService::resolveRpId()` and needed to be relaxed to match the current implementation that reports a derived rpId from `HTTP_HOST`.

### Description
- Updated `tests/Security/PasskeyServiceTest.php::testResolveRpIdFallsBackToRequestHostWhenServerUrlIsMalformed()` to keep the functional assertion that `resolveRpId()` returns `fallback.example.test` and replace the exact-array diagnostic equality with a narrower set of assertions: assert there is exactly one diagnostic and assert the diagnostic contains the substrings `configured serverurl "example.test/no-scheme"`, `derived rpId "fallback.example.test"`, and `from HTTP_HOST`.

### Testing
- Ran `php -l tests/Security/PasskeyServiceTest.php` which succeeded with no syntax errors.
- Ran `vendor/bin/phpunit tests/Security/PasskeyServiceTest.php` which passed and produced the expected diagnostics output for the updated assertions.
- Ran `composer test` which completed successfully in this environment.
- Ran `composer static` which failed due to PHPStan hitting the configured 128M memory limit in this environment (this is an environment limitation, not related to the test change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bda3b4dfe88329b4a7001a018ff75b)