### PR TITLE
Widen settings.setting to VARCHAR(50) to support twofactorauth_key_material

### DIFF
--- a/install/data/tables.php
+++ b/install/data/tables.php
@@ -1575,7 +1575,7 @@ function get_all_tables()
         'charset' => 'utf8mb4',
         'collation' => 'utf8mb4_unicode_ci',
         'setting' => array(
-            'name' => 'setting', 'type' => 'varchar(25)'
+            'name' => 'setting', 'type' => 'varchar(50)'
             ),
         'value' => array(
             'name' => 'value', 'type' => 'varchar(255)'

--- a/migrations/Version20250724000023.php
+++ b/migrations/Version20250724000023.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Lotgd\MySQL\Database;
+
+/**
+ * Widen the main settings identifier column for longer core setting keys.
+ */
+final class Version20250724000023 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Increase settings.setting to VARCHAR(50) for new secret-backed 2FA key material storage in the main settings table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        Database::setDoctrineConnection($this->connection);
+
+        $table = Database::prefix('settings');
+
+        if (! Database::tableExists($table)) {
+            return;
+        }
+
+        $this->addSql("ALTER TABLE {$table} MODIFY setting VARCHAR(50) NOT NULL DEFAULT ''");
+    }
+
+    public function down(Schema $schema): void
+    {
+        Database::setDoctrineConnection($this->connection);
+
+        $table = Database::prefix('settings');
+
+        if (! Database::tableExists($table)) {
+            return;
+        }
+
+        $this->addSql("ALTER TABLE {$table} MODIFY setting VARCHAR(25) NOT NULL DEFAULT ''");
+    }
+}

--- a/src/Lotgd/Entity/Setting.php
+++ b/src/Lotgd/Entity/Setting.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 class Setting
 {
     #[ORM\Id]
-    #[ORM\Column(type: 'string', length: 25, name: 'setting')]
+    #[ORM\Column(type: 'string', length: 50, name: 'setting')]
     private string $setting = '';
 
     #[ORM\Column(type: 'string', length: 255, name: 'value')]

--- a/tests/Migrations/SettingsSettingWidthMigrationTest.php
+++ b/tests/Migrations/SettingsSettingWidthMigrationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Migrations;
+
+use PHPUnit\Framework\TestCase;
+
+final class SettingsSettingWidthMigrationTest extends TestCase
+{
+    /**
+     * Ensure the migration explicitly widens the primary settings identifier
+     * column so longer keys such as the 2FA key-material setting fit without
+     * truncation on upgrade.
+     */
+    public function testMigrationWidensSettingsIdentifierColumn(): void
+    {
+        $migrationFile = dirname(__DIR__, 2) . '/migrations/Version20250724000023.php';
+        $contents = file_get_contents($migrationFile);
+
+        self::assertNotFalse($contents);
+        self::assertStringContainsString("Database::prefix('settings')", $contents);
+        self::assertStringContainsString('VARCHAR(50)', $contents);
+        self::assertStringContainsString('VARCHAR(25)', $contents);
+        self::assertStringContainsString('secret-backed 2FA key material storage', $contents);
+        self::assertStringContainsString('if (! Database::tableExists($table)) {', $contents);
+    }
+
+    /**
+     * Keep the installer schema and Doctrine metadata aligned with the new
+     * column width to prevent schema drift after fresh installs.
+     */
+    public function testSchemaDefinitionsUseFiftyCharacterSettingIdentifiers(): void
+    {
+        $installerSchema = file_get_contents(dirname(__DIR__, 2) . '/install/data/tables.php');
+        $settingEntity = file_get_contents(dirname(__DIR__, 2) . '/src/Lotgd/Entity/Setting.php');
+
+        self::assertNotFalse($installerSchema);
+        self::assertNotFalse($settingEntity);
+        self::assertStringContainsString("'name' => 'setting', 'type' => 'varchar(50)'", $installerSchema);
+        self::assertStringContainsString("length: 50, name: 'setting'", $settingEntity);
+    }
+}

--- a/tests/Security/TwoFactorAuthModuleFlowTest.php
+++ b/tests/Security/TwoFactorAuthModuleFlowTest.php
@@ -262,6 +262,56 @@ namespace Lotgd\Tests\Security {
             $this->assertDebugLogContains('2FA token verification failure for account 7 (reason: mismatch).', '2fa_verify');
         }
 
+
+        /**
+         * The 2FA bootstrap path must persist secret-backed key material in the
+         * main settings table using the longer identifier without truncation.
+         */
+        public function testSecretMaterialBootstrapPersistsLongMainSettingKey(): void
+        {
+            unset($GLOBALS['twofactorauth_test_install_secret']);
+
+            $capturedSettingName = null;
+            $capturedSettingValue = null;
+
+            $settings = new class () extends \Lotgd\Settings {
+                /** @var array<string, string> */
+                private array $values = [];
+
+                public function __construct()
+                {
+                }
+
+                public function getSetting(string|int $settingname, mixed $default = false): mixed
+                {
+                    return $this->values[(string) $settingname] ?? $default;
+                }
+
+                public function saveSetting(string|int $settingname, mixed $value): bool
+                {
+                    $this->values[(string) $settingname] = (string) $value;
+                    $GLOBALS['twofactorauth_saved_setting_name'] = (string) $settingname;
+                    $GLOBALS['twofactorauth_saved_setting_value'] = (string) $value;
+
+                    return true;
+                }
+            };
+
+            $GLOBALS['settings'] = $settings;
+            \Lotgd\Settings::setInstance($settings);
+
+            $secretMaterial = twofactorauth_secret_material();
+            $currentSigningKey = twofactorauth_current_signing_key();
+            $capturedSettingName = $GLOBALS['twofactorauth_saved_setting_name'] ?? null;
+            $capturedSettingValue = $GLOBALS['twofactorauth_saved_setting_value'] ?? null;
+
+            self::assertSame('twofactorauth_key_material', $capturedSettingName);
+            self::assertIsString($capturedSettingValue);
+            self::assertSame($capturedSettingValue, $secretMaterial);
+            self::assertSame(64, strlen($secretMaterial));
+            self::assertSame(hash_hmac('sha256', 'lotgd|twofactorauth|v2', $secretMaterial), $currentSigningKey);
+        }
+
         public function testVerifyAcceptsLegacyEncryptedSecretAndReencryptsWithCurrentKey(): void
         {
             $secret = \TwoFactorAuthService::generateSecret();


### PR DESCRIPTION
### Motivation

- The main settings identifier column was `varchar(25)` and could truncate longer identifiers such as `twofactorauth_key_material` introduced for secret-backed 2FA key material, so the schema and metadata must be widened to avoid truncation and bootstrap failures.

### Description

- Add Doctrine migration `migrations/Version20250724000023.php` that `ALTER TABLE settings MODIFY setting VARCHAR(50)` in `up()` and reverts to `VARCHAR(25)` in `down()` with a descriptive message about 2FA key material storage.
- Update the installer schema descriptor in `install/data/tables.php` so the `settings` table defines `setting` as `varchar(50)` for fresh installs.
- Update Doctrine metadata in `src/Lotgd/Entity/Setting.php` to `#[ORM\Column(... length: 50 ...)]` so ORM mappings match the DB width.
- Add `tests/Migrations/SettingsSettingWidthMigrationTest.php` and extend `tests/Security/TwoFactorAuthModuleFlowTest.php` with a targeted test that stubs `Settings` and exercises `twofactorauth_secret_material()` / `twofactorauth_current_signing_key()` to verify `twofactorauth_key_material` is persisted without truncation.

### Testing

- Per-file syntax checks with `php -l` were run on the new migration, modified entity and tests and reported no syntax errors.
- Targeted unit tests `vendor/bin/phpunit --configuration phpunit.xml tests/Migrations/SettingsSettingWidthMigrationTest.php tests/Security/TwoFactorAuthModuleFlowTest.php` passed (16 tests, 69 assertions for the subset) and the full test suite via `composer test` completed (613 tests run, overall OK with expected warnings/notices reported by tests).
- Static analysis originally hit the environment default memory ceiling when run via `composer static`, so `vendor/bin/phpstan analyse --configuration phpstan.neon --memory-limit=512M` was executed and completed with no reported errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdb93239088329b6b264f9365e2cee)