### PR TITLE
fix: read 2FA passkey begin state from module prefs

### DIFF
--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -1404,15 +1404,19 @@ function twofactorauth_handle_finish_passkey_registration(): void
 
 /**
  * Begin passkey authentication challenge for the pending 2FA login.
+ *
+ * Module prefs are the canonical persisted 2FA challenge state. Legacy ad-hoc
+ * nested session data is not guaranteed to be synchronized for the synchronous
+ * challenge flow, so this handler must read the pending challenge flags from
+ * module prefs before applying the existing CSRF and ceremony begin logic.
  */
 function twofactorauth_handle_begin_passkey_auth(): void
 {
     global $session;
 
-    // Ensure there is a pending 2FA challenge and the account is not locked out
-    $twofaState        = $session['user']['twofactorauth'] ?? [];
-    $pendingChallenge  = (int) ($twofaState['pending_challenge'] ?? 0);
-    $lockedUntil       = isset($twofaState['locked_until']) ? (int) $twofaState['locked_until'] : 0;
+    // Module prefs are the persisted source of truth for pending 2FA state.
+    $pendingChallenge  = (int) get_module_pref('pending_challenge');
+    $lockedUntil       = (int) get_module_pref('locked_until');
     $now               = time();
 
     if ($pendingChallenge !== 1) {

--- a/tests/Security/TwoFactorAuthModuleFlowTest.php
+++ b/tests/Security/TwoFactorAuthModuleFlowTest.php
@@ -378,14 +378,15 @@ namespace Lotgd\Tests\Security {
             $this->assertDebugLogContains('2FA token verification failure for account 7 (reason: locked).', '2fa_verify');
         }
 
-        public function testBeginPasskeyAuthRejectsInvalidCsrfOnSynchronousRoute(): void
+        public function testBeginPasskeyAuthReadsPendingStateFromModulePrefsOnSynchronousRoute(): void
         {
             global $session;
 
-            $session['user']['twofactorauth'] = [
-                'pending_challenge' => 1,
-                'locked_until' => 0,
-            ];
+            // Module prefs are the canonical persisted 2FA challenge state for
+            // synchronous passkey routes; nested session data is intentionally
+            // not seeded here so this regression covers the persisted-path read.
+            $GLOBALS['twofactorauth_test_prefs']['pending_challenge'] = 1;
+            $GLOBALS['twofactorauth_test_prefs']['locked_until'] = 0;
             $session['twofactorauth_csrf'] = 'csrf-test-token';
             $_POST['csrf_token'] = 'wrong-token';
             $GLOBALS['forms_output'] = '';


### PR DESCRIPTION
### Motivation
- The synchronous passkey-begin handler relied on an ad-hoc nested session map for persistent challenge state, but module prefs are the canonical persisted 2FA challenge state and must be used for correctness and synchronization.

### Description
- Change `twofactorauth_handle_begin_passkey_auth()` to read `pending_challenge` and `locked_until` via `get_module_pref()` instead of from `$session['user']['twofactorauth']` and add a docblock comment explaining the rationale.
- Leave existing CSRF validation and passkey ceremony-begin logic unchanged so runtime behavior is preserved.
- Update the synchronous regression test `testBeginPasskeyAuth...` in `tests/Security/TwoFactorAuthModuleFlowTest.php` to seed `pending_challenge=1` and `locked_until=0` in module prefs instead of injecting nested session data, proving the handler now honors persisted prefs.

### Testing
- Searched for remaining ad-hoc session references with `rg -n "\$session\['user'\]\['twofactorauth'\]" modules tests src -g '!vendor'` and confirmed no remaining production usage of the nested session structure.
- Syntax-checked modified files with `php -l modules/twofactorauth.php` and `php -l tests/Security/TwoFactorAuthModuleFlowTest.php`, which reported no syntax errors.
- Ran targeted tests with `vendor/bin/phpunit tests/Security/TwoFactorAuthModuleFlowTest.php`, which passed (14 tests, 59 assertions) and verified the new regression.
- Executed the full test suite with `composer test`, which completed (613 tests) though there were non-blocking warnings and notices in the environment.
- Ran `composer static` (PHPStan) which did not complete in this environment due to the configured PHP memory limit (128M); static analysis should be re-run in CI or locally with increased memory if needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdcd754f4483298b8f502c967e640e)