### PR TITLE
Align translatortool save handling with Translator lookup and use parameterized DB writes

### DIFF
--- a/translatortool.php
+++ b/translatortool.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Doctrine\DBAL\ArrayParameterType;
 use Lotgd\MySQL\Database;
 use Lotgd\DataCache;
 use Lotgd\Sanitize;
@@ -44,8 +45,8 @@ function translatortoolGetActiveLanguage(): string
 /**
  * Build the exact translation cache key format used by Translator::translateLoadNamespace().
  *
- * The namespace segment must follow the loader's normalization and length
- * handling so reopening the same translation after save cannot hit stale cache.
+ * The namespace segment uses the original namespace argument, with the same
+ * overlong-value sha1 fallback that the loader applies before caching.
  */
 function translatortoolBuildTranslationCacheKey(string $namespace, string $language): string
 {
@@ -92,8 +93,9 @@ if ($op == "") {
      * Persist a translator edit using the same namespace normalization as the loader.
      *
      * Matching Translator::translateLoadNamespace() matters because the loader
-     * queries by both page and normalized URI and caches under the normalized
-     * namespace string. Writes therefore use bound parameters instead of raw
+     * queries by both page and normalized URI, while its cache key keeps the
+     * original namespace argument unless it must fall back to sha1 for length.
+     * Writes therefore use bound parameters instead of raw
      * interpolation so translator-entered text such as apostrophes is stored
      * safely and so save-time SQL matches lookup semantics exactly.
      */
@@ -196,12 +198,16 @@ if ($op == "") {
                 $connection->executeStatement(
                     'UPDATE ' . $translationsTable . '
                         SET author = :author, version = :version, uri = :uri, outtext = :translation
-                      WHERE tid IN (' . implode(',', $matchingIds) . ')',
+                      WHERE tid IN (:tids)',
                     [
                         'author'      => $session['user']['login'],
                         'version'     => $logd_version,
                         'uri'         => $namespace,
                         'translation' => $trans,
+                        'tids'        => $matchingIds,
+                    ],
+                    [
+                        'tids' => ArrayParameterType::INTEGER,
                     ]
                 );
             }

--- a/translatortool.php
+++ b/translatortool.php
@@ -217,22 +217,14 @@ if ($op == "") {
             'DELETE FROM ' . $untranslatedTable . '
                 WHERE intext = :text
                   AND language = :language
-                  AND namespace = :namespace',
+                  AND namespace IN (:namespaces)',
             [
-                'text'      => $text,
-                'language'  => $language,
-                'namespace' => $rawUri,
-            ]
-        );
-        $connection->executeStatement(
-            'DELETE FROM ' . $untranslatedTable . '
-                WHERE intext = :text
-                  AND language = :language
-                  AND namespace = :namespace',
+                'text'       => $text,
+                'language'   => $language,
+                'namespaces' => [$rawUri, $namespace],
+            ],
             [
-                'text'      => $text,
-                'language'  => $language,
-                'namespace' => $namespace,
+                'namespaces' => ArrayParameterType::STRING,
             ]
         );
 

--- a/translatortool.php
+++ b/translatortool.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Lotgd\MySQL\Database;
+use Lotgd\DataCache;
+use Lotgd\Sanitize;
 use Lotgd\Translator;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
@@ -21,6 +23,39 @@ require_once __DIR__ . "/common.php";
 $settings = Settings::getInstance();
 $output = Output::getInstance();
 Translator::getInstance()->setSchema("translatortool");
+
+/**
+ * Return the active translator language used by translation loading.
+ *
+ * The loader prefers the LANGUAGE constant once translator setup has run, so
+ * the save handler must invalidate caches with that same language value.
+ */
+function translatortoolGetActiveLanguage(): string
+{
+    if (defined('LANGUAGE')) {
+        return (string) constant('LANGUAGE');
+    }
+
+    Translator::translatorSetup();
+
+    return Translator::getInstance()->getLanguage();
+}
+
+/**
+ * Build the exact translation cache key format used by Translator::translateLoadNamespace().
+ *
+ * The namespace segment must follow the loader's normalization and length
+ * handling so reopening the same translation after save cannot hit stale cache.
+ */
+function translatortoolBuildTranslationCacheKey(string $namespace, string $language): string
+{
+    $cacheNamespace = $namespace;
+    if (strlen($cacheNamespace) > Sanitize::URI_MAX_LENGTH) {
+        $cacheNamespace = sha1($cacheNamespace);
+    }
+
+    return 'translations-' . $cacheNamespace . '-' . $language;
+}
 
 SuAccess::check(SU_IS_TRANSLATOR);
 $opRequest = Http::get('op');
@@ -53,65 +88,169 @@ if ($op == "") {
     $output->rawOutput("</form>");
     popup_footer();
 } elseif ($op == 'save') {
+    /**
+     * Persist a translator edit using the same namespace normalization as the loader.
+     *
+     * Matching Translator::translateLoadNamespace() matters because the loader
+     * queries by both page and normalized URI and caches under the normalized
+     * namespace string. Writes therefore use bound parameters instead of raw
+     * interpolation so translator-entered text such as apostrophes is stored
+     * safely and so save-time SQL matches lookup semantics exactly.
+     */
+    global $session, $logd_version;
+
     $uriPost = Http::post('uri');
-    $uri = is_string($uriPost) ? $uriPost : '';
+    $rawUri = is_string($uriPost) ? $uriPost : '';
     $textPost = Http::post('text');
     $text = is_string($textPost) ? $textPost : '';
     $transPost = Http::post('trans');
     $trans = is_string($transPost) ? $transPost : '';
+    $language = translatortoolGetActiveLanguage();
+    $namespace = Sanitize::translatorUri($rawUri);
+    $page = Sanitize::translatorPage($rawUri);
+    $connection = Database::getDoctrineConnection();
+    $translationsTable = Database::prefix('translations');
+    $untranslatedTable = Database::prefix('untranslated');
 
-    $page = $uri;
-    if (strpos($page, "?") !== false) {
-        $page = substr($page, 0, strpos($page, "?"));
-    }
+    $rows = $connection->fetchAllAssociative(
+        'SELECT tid, intext FROM ' . $translationsTable . '
+            WHERE language = :language
+              AND intext = :text
+              AND (uri = :page OR uri = :uri)',
+        [
+            'language' => $language,
+            'text'     => $text,
+            'page'     => $page,
+            'uri'      => $namespace,
+        ]
+    );
 
-    if ($trans == "") {
-        $sql = "DELETE ";
+    $saveSucceeded = false;
+
+    if ($trans === '') {
+        $connection->executeStatement(
+            'DELETE FROM ' . $translationsTable . '
+                WHERE language = :language
+                  AND intext = :text
+                  AND (uri = :page OR uri = :uri)',
+            [
+                'language' => $language,
+                'text'     => $text,
+                'page'     => $page,
+                'uri'      => $namespace,
+            ]
+        );
+        $saveSucceeded = true;
     } else {
-        $sql = "SELECT * ";
-    }
-    $sql .= "
-		FROM " . Database::prefix("translations") . "
-		WHERE language='" . LANGUAGE . "'
-			AND intext='$text'
-			AND (uri='$page' OR uri='$uri')";
-    if ($trans > "") {
-        $result = Database::query($sql);
-        invalidatedatacache("translations-" . $uri . "-" . $language);
-        if (Database::numRows($result) == 0) {
-            $sql = "INSERT INTO " . Database::prefix("translations") . " (language,uri,intext,outtext,author,version) VALUES ('" . LANGUAGE . "','$uri','$text','$trans','{$session['user']['login']}','$logd_version ')";
-            $sql1 = "DELETE FROM " . Database::prefix("untranslated") .
-                " WHERE intext='$text' AND language='" . LANGUAGE .
-                "' AND namespace='$url'";
-            Database::query($sql1);
-        } elseif (Database::numRows($result) == 1) {
-            $row = Database::fetchAssoc($result);
-            // MySQL is case insensitive so we need to do it here.
-            if ($row['intext'] == $text) {
-                $sql = "UPDATE " . Database::prefix("translations") . " SET author='{$session['user']['login']}', version='$logd_version', uri='$uri', outtext='$trans' WHERE tid={$row['tid']}";
-            } else {
-                $sql = "INSERT INTO " . Database::prefix("translations") . " (language,uri,intext,outtext,author,version) VALUES ('" . LANGUAGE . "','$uri','$text','$trans','{$session['user']['login']}','$logd_version ')";
-                $sql1 = "DELETE FROM " . Database::prefix("untranslated") . " WHERE intext='$text' AND language='" . LANGUAGE . "' AND namespace='$url'";
-                Database::query($sql1);
-            }
-        } elseif (Database::numRows($result) > 1) {
-        /* To say the least, this case is bad. Simply because if there are duplicates, you make them even more equal. But most likely you won't get this far, as the code itself should not produce duplicates unless you insert manually or via module the same row more than once*/
-            $rows = array();
-            while ($row = Database::fetchAssoc($result)) {
-                // MySQL is case insensitive so we need to do it here.
-                if ($row['intext'] == $text) {
-                    $rows[] = $row['tid'];
+        if (count($rows) === 0) {
+            $connection->executeStatement(
+                'INSERT INTO ' . $translationsTable . '
+                    (language, uri, intext, outtext, author, version)
+                 VALUES (:language, :uri, :text, :translation, :author, :version)',
+                [
+                    'language'    => $language,
+                    'uri'         => $namespace,
+                    'text'        => $text,
+                    'translation' => $trans,
+                    'author'      => $session['user']['login'],
+                    'version'     => $logd_version,
+                ]
+            );
+        } elseif (count($rows) === 1 && $rows[0]['intext'] === $text) {
+            $connection->executeStatement(
+                'UPDATE ' . $translationsTable . '
+                    SET author = :author, version = :version, uri = :uri, outtext = :translation
+                  WHERE tid = :tid',
+                [
+                    'author'      => $session['user']['login'],
+                    'version'     => $logd_version,
+                    'uri'         => $namespace,
+                    'translation' => $trans,
+                    'tid'         => (int) $rows[0]['tid'],
+                ]
+            );
+        } else {
+            $matchingIds = [];
+            foreach ($rows as $row) {
+                // MySQL comparisons can be case-insensitive, so keep the legacy exact-text guard.
+                if ($row['intext'] === $text) {
+                    $matchingIds[] = (int) $row['tid'];
                 }
             }
-            $sql = "UPDATE " . Database::prefix("translations") . " SET author='{$session['user']['login']}', version='$logd_version', uri='$page', outtext='$trans' WHERE tid IN (" . join(",", $rows) . ")";
+
+            if ($matchingIds === []) {
+                $connection->executeStatement(
+                    'INSERT INTO ' . $translationsTable . '
+                        (language, uri, intext, outtext, author, version)
+                     VALUES (:language, :uri, :text, :translation, :author, :version)',
+                    [
+                        'language'    => $language,
+                        'uri'         => $namespace,
+                        'text'        => $text,
+                        'translation' => $trans,
+                        'author'      => $session['user']['login'],
+                        'version'     => $logd_version,
+                    ]
+                );
+            } else {
+                $connection->executeStatement(
+                    'UPDATE ' . $translationsTable . '
+                        SET author = :author, version = :version, uri = :uri, outtext = :translation
+                      WHERE tid IN (' . implode(',', $matchingIds) . ')',
+                    [
+                        'author'      => $session['user']['login'],
+                        'version'     => $logd_version,
+                        'uri'         => $namespace,
+                        'translation' => $trans,
+                    ]
+                );
+            }
+        }
+
+        $connection->executeStatement(
+            'DELETE FROM ' . $untranslatedTable . '
+                WHERE intext = :text
+                  AND language = :language
+                  AND namespace = :namespace',
+            [
+                'text'      => $text,
+                'language'  => $language,
+                'namespace' => $rawUri,
+            ]
+        );
+        $connection->executeStatement(
+            'DELETE FROM ' . $untranslatedTable . '
+                WHERE intext = :text
+                  AND language = :language
+                  AND namespace = :namespace',
+            [
+                'text'      => $text,
+                'language'  => $language,
+                'namespace' => $namespace,
+            ]
+        );
+
+        $saveSucceeded = true;
+    }
+
+    if ($saveSucceeded) {
+        // The cache key must exactly mirror Translator::translateLoadNamespace() so immediate re-open shows fresh data.
+        foreach (array_unique([$rawUri, $namespace, $page]) as $cacheNamespace) {
+            if ($cacheNamespace === '') {
+                continue;
+            }
+
+            DataCache::getInstance()->invalidatedatacache(
+                translatortoolBuildTranslationCacheKey($cacheNamespace, $language)
+            );
         }
     }
-    Database::query($sql);
+
     $saveNotClosePost = Http::post('savenotclose');
-    if (is_string($saveNotClosePost) && $saveNotClosePost > "") {
-        header("Location: translatortool.php?op=list&u=$page");
+    if ($saveSucceeded && is_string($saveNotClosePost) && $saveNotClosePost > "") {
+        header("Location: translatortool.php?op=list&u=" . rawurlencode($page));
         exit();
-    } else {
+    } elseif ($saveSucceeded) {
         popup_header("Updated");
         $output->rawOutput("<script language='javascript'>window.close();</script>");
         popup_footer();


### PR DESCRIPTION
### Motivation
- The translator save path built SQL with raw interpolation and used undefined variables which caused unsafe writes, incorrect untranslated cleanup, and cache invalidation that did not match the loader, creating stale results when re-opening translations.
- The save handler must normalize namespace/URI and invalidate the exact cache key used by `Translator::translateLoadNamespace()` so a saved translation is immediately visible.
- Writes must be parameterized/escaped so translator-entered text (including apostrophes and printf-like strings such as `%s dragon kills`) is stored safely and reliably.

### Description
- Refactored the `op=save` branch in `translatortool.php` to stop using raw string interpolation and use Doctrine DBAL parameterized queries via `Database::getDoctrineConnection()` for all lookup, insert, update, and delete operations to prevent SQL issues and handle apostrophes safely.
- Added two helpers: `translatortoolGetActiveLanguage()` to resolve the active translation language the same way the loader does (prefers the `LANGUAGE` constant), and `translatortoolBuildTranslationCacheKey()` to build the `translations-<namespace>-<language>` cache key using the same normalization/length handling as the loader.
- Normalized posted URI values with `Sanitize::translatorUri()` and `Sanitize::translatorPage()` so save-time namespace/page use the same normalization as `Translator::translateLoadNamespace()` and replaced the undefined `$url` with the correct namespace variables when cleaning `untranslated` rows.
- Invalidate the matching translation cache key(s) only after a successful write; to be conservative the code invalidates keys for the raw URI, normalized namespace, and page (unique), using the exact key format the loader caches (including the sha1 fallback for overlong namespaces).
- Kept the existing popup UX (`Save & Close`, `Save No Close`) but only redirect or close after the DB write and cache invalidation succeeded, and added PHPDoc and inline comments explaining namespace normalization, exact cache-key invalidation, and why parameterized writes are used.

### Testing
- Ran `php -l translatortool.php` with no syntax errors detected.
- Ran the full test suite with `composer test`, which executed the project's PHPUnit suite (613 tests) and completed successfully with standard warnings/notices recorded by the suite.
- Ran static checks: `composer static` failed in this environment because PHPStan hit the environment's configured 128M memory limit; running `vendor/bin/phpstan analyse --configuration phpstan.neon --memory-limit=1G translatortool.php` completed but still reported unresolved legacy-script global symbols (`popup_header`, `popup_footer`, `translate_loadnamespace`, and `LANGUAGE`) that exist in the legacy script context outside the revised save logic.
- The save flow changes address the requested verification cases (editing `%s dragon kills`, saving text with apostrophes, and reopening immediately to see the updated value) by using bound parameters for writes and invalidating the exact `translations-<namespace>-<language>` cache key so reopening should show fresh data.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be5fc4a2348329883de2c17ac06dc3)