### PR TITLE
refactor: normalize twofactorauth output rendering

### DIFF
--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -319,6 +319,9 @@ function twofactorauth_run(): void
 
 /**
  * Render and process the user-facing setup page in preferences.
+ *
+ * Use Output::output() for translated/game-formatted text and Output::rawOutput()
+ * for literal HTML or JavaScript fragments that should bypass game-text formatting.
  */
 function twofactorauth_render_setup(Output $output): void
 {
@@ -373,11 +376,12 @@ function twofactorauth_render_setup(Output $output): void
 
     addnav('', 'runmodule.php?module=twofactorauth&op=setup&setupop=begin_passkey_registration');
     addnav('', 'runmodule.php?module=twofactorauth&op=setup&setupop=finish_passkey_registration');
-    rawoutput("<div id='twofactorauth-passkey-registration'>");
-    rawoutput("<label>" . htmlspecialchars(translate_inline('Passkey label'), ENT_QUOTES, 'UTF-8') . "</label> ");
-    rawoutput("<input type='text' id='passkey-label' value='This device' maxlength='120'> ");
-    rawoutput("<button type='button' id='passkey-add-button'>" . htmlspecialchars(translate_inline('Add passkey'), ENT_QUOTES, 'UTF-8') . "</button>");
-    rawoutput('</div>');
+    // Literal markup stays on rawOutput(); player-facing text remains on output().
+    $output->rawOutput("<div id='twofactorauth-passkey-registration'>");
+    $output->rawOutput("<label>" . htmlspecialchars(translate_inline('Passkey label'), ENT_QUOTES, 'UTF-8') . "</label> ");
+    $output->rawOutput("<input type='text' id='passkey-label' value='This device' maxlength='120'> ");
+    $output->rawOutput("<button type='button' id='passkey-add-button'>" . htmlspecialchars(translate_inline('Add passkey'), ENT_QUOTES, 'UTF-8') . "</button>");
+    $output->rawOutput('</div>');
 
     if ($passkeys === []) {
         $output->output('No passkeys enrolled yet.`n');
@@ -389,11 +393,11 @@ function twofactorauth_render_setup(Output $output): void
             $lastUsed = (int) ($item['last_used_at'] ?? 0);
             $output->output('• %s (created: %s, last used: %s)`n', $label, date('Y-m-d H:i', $created), $lastUsed > 0 ? date('Y-m-d H:i', $lastUsed) : 'never');
             addnav('', 'runmodule.php?module=twofactorauth&op=setup&setupop=delete_passkey');
-            rawoutput("<form action='runmodule.php?module=twofactorauth&op=setup&setupop=delete_passkey' method='POST' style='display:inline-block;margin-bottom:6px'>");
-            rawoutput("<input type='hidden' name='csrf_token' value='" . htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8') . "'>");
-            rawoutput("<input type='hidden' name='delete_credential_id' value='" . $credentialId . "'>");
-            rawoutput("<button type='submit'>" . htmlspecialchars(translate_inline('Delete passkey'), ENT_QUOTES, 'UTF-8') . "</button>");
-            rawoutput('</form><br>');
+            $output->rawOutput("<form action='runmodule.php?module=twofactorauth&op=setup&setupop=delete_passkey' method='POST' style='display:inline-block;margin-bottom:6px'>");
+            $output->rawOutput("<input type='hidden' name='csrf_token' value='" . htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8') . "'>");
+            $output->rawOutput("<input type='hidden' name='delete_credential_id' value='" . $credentialId . "'>");
+            $output->rawOutput("<button type='submit'>" . htmlspecialchars(translate_inline('Delete passkey'), ENT_QUOTES, 'UTF-8') . "</button>");
+            $output->rawOutput('</form><br>');
         }
     }
 
@@ -414,7 +418,7 @@ function twofactorauth_render_setup(Output $output): void
             Nav::add('Begin TOTP setup', 'runmodule.php?module=twofactorauth&op=setup&setupop=start');
         }
 
-        twofactorauth_render_passkey_registration_script($csrf);
+        twofactorauth_render_passkey_registration_script($output, $csrf);
 
         return;
     }
@@ -434,7 +438,7 @@ function twofactorauth_render_setup(Output $output): void
 
     if ($qrProviderEndpoint !== '') {
         $qrCodeUrl = TwoFactorAuthService::buildQrCodeUrl($qrProviderEndpoint, $otpauthUri, $qrCodeSize);
-        rawoutput("<div class='twofactorauth-qr'><img src='" . htmlspecialchars($qrCodeUrl, ENT_QUOTES, 'UTF-8') . "' alt='" . htmlspecialchars(translate_inline('Authenticator enrollment QR code'), ENT_QUOTES, 'UTF-8') . "' width='" . (int) $qrCodeSize . "' height='" . (int) $qrCodeSize . "'></div>");
+        $output->rawOutput("<div class='twofactorauth-qr'><img src='" . htmlspecialchars($qrCodeUrl, ENT_QUOTES, 'UTF-8') . "' alt='" . htmlspecialchars(translate_inline('Authenticator enrollment QR code'), ENT_QUOTES, 'UTF-8') . "' width='" . (int) $qrCodeSize . "' height='" . (int) $qrCodeSize . "'></div>");
     }
 
     $output->output('Enrollment URI (copy/paste if needed):`n%s`n`n', $otpauthUri);
@@ -461,17 +465,20 @@ function twofactorauth_render_setup(Output $output): void
     }
 
     addnav('', 'runmodule.php?module=twofactorauth&op=setup');
-    rawoutput("<form action='runmodule.php?module=twofactorauth&op=setup' method='POST'>");
-    rawoutput("<label>" . translate_inline('Authenticator token') . "</label> ");
-    rawoutput("<input type='text' name='token' maxlength='10'> ");
-    rawoutput("<button type='submit'>" . translate_inline('Enable') . "</button>");
-    rawoutput('</form>');
+    $output->rawOutput("<form action='runmodule.php?module=twofactorauth&op=setup' method='POST'>");
+    $output->rawOutput("<label>" . translate_inline('Authenticator token') . "</label> ");
+    $output->rawOutput("<input type='text' name='token' maxlength='10'> ");
+    $output->rawOutput("<button type='submit'>" . translate_inline('Enable') . "</button>");
+    $output->rawOutput('</form>');
 
-    twofactorauth_render_passkey_registration_script($csrf);
+    twofactorauth_render_passkey_registration_script($output, $csrf);
 }
 
 /**
  * Render the 2FA challenge while login is pending.
+ *
+ * Keep Output::output() for translated/game text and Output::rawOutput() for
+ * literal form/button/script fragments rendered into the page.
  */
 function twofactorauth_render_challenge(Output $output): void
 {
@@ -500,20 +507,20 @@ function twofactorauth_render_challenge(Output $output): void
 
     addnav('', 'runmodule.php?module=twofactorauth&op=verify');
     // Keep explicit POST action; challenge verification must remain a classic form submit.
-    rawoutput("<form id='twofactorauth-challenge-form' action='runmodule.php?module=twofactorauth&op=verify' method='POST'>");
-    rawoutput("<label>" . translate_inline('Authenticator token') . "</label> ");
-    rawoutput("<input type='text' name='token' maxlength='10'> ");
-    rawoutput("<button type='submit'>" . translate_inline('Verify') . "</button>");
-    rawoutput('</form>');
+    $output->rawOutput("<form id='twofactorauth-challenge-form' action='runmodule.php?module=twofactorauth&op=verify' method='POST'>");
+    $output->rawOutput("<label>" . translate_inline('Authenticator token') . "</label> ");
+    $output->rawOutput("<input type='text' name='token' maxlength='10'> ");
+    $output->rawOutput("<button type='submit'>" . translate_inline('Verify') . "</button>");
+    $output->rawOutput('</form>');
 
     if ($passkeys !== []) {
         // Shared helper utilities are needed both on setup and challenge pages.
-        twofactorauth_render_passkey_js_helpers();
-        twofactorauth_render_passkey_jaxon_bridge();
+        twofactorauth_render_passkey_js_helpers($output);
+        twofactorauth_render_passkey_jaxon_bridge($output);
         $csrfJson = json_encode(twofactorauth_csrf_token()) ?: '""';
         $showDebugJson = twofactorauth_is_megauser() ? 'true' : 'false';
-        rawoutput("<div style='margin-top:12px'><button type='button' id='twofactorauth-use-passkey'>" . htmlspecialchars(translate_inline('Use passkey'), ENT_QUOTES, 'UTF-8') . "</button></div>");
-        rawoutput("<script>(function(){if(window.__lotgdTwofactorauthChallengeSetupDone){return;}window.__lotgdTwofactorauthChallengeSetupDone=true;const btn=document.getElementById('twofactorauth-use-passkey');if(!btn){return;}const csrfToken=" . $csrfJson . ";const showDebug=" . $showDebugJson . ";const resolvedHandlers=typeof window.getJaxonHandlers==='function'?window.getJaxonHandlers():null;const namespace=resolvedHandlers&&resolvedHandlers.TwoFactorAuthPasskey?resolvedHandlers.TwoFactorAuthPasskey:(window.Lotgd&&window.Lotgd.Async&&window.Lotgd.Async.Handler&&window.Lotgd.Async.Handler.TwoFactorAuthPasskey?window.Lotgd.Async.Handler.TwoFactorAuthPasskey:(window.JaxonLotgd&&window.JaxonLotgd.Async&&window.JaxonLotgd.Async.Handler&&window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey?window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey:null));const beginExists=!!(namespace&&typeof namespace.beginAuthentication==='function');const buildDiag=function(data){if(!showDebug||!data){return'';}const code=data.error?String(data.error):'unknown';const diagId=data.diagnostic_id?String(data.diagnostic_id):'';const debug=data.debug_message?String(data.debug_message):'';const diagType=data.diagnostic&&data.diagnostic.type?String(data.diagnostic.type):'';let message='Passkey operation failed. Code: '+code+'.';if(diagId!==''){message+=' Diagnostic: '+diagId+'.';}if(diagType!==''){message+=' Type: '+diagType+'.';}if(debug!==''){message+=' Debug: '+debug;}return message;};btn.onclick=async function(){try{const beginData=await window.twofactorauthJaxonPasskeyCall('beginAuthentication',[csrfToken]);if(!beginData||!beginData.ok){alert(showDebug?buildDiag(beginData):'Passkey operation failed');return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const cred=await navigator.credentials.get({publicKey});if(!cred){alert('Passkey operation failed');return;}const body={id:cred.id,type:cred.type,response:{authenticatorData:window.twofactorauthArrayBufferToBase64Url(cred.response.authenticatorData),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(cred.response.clientDataJSON),signature:window.twofactorauthArrayBufferToBase64Url(cred.response.signature),userHandle:cred.response.userHandle?window.twofactorauthArrayBufferToBase64Url(cred.response.userHandle):''}};const verifyData=await window.twofactorauthJaxonPasskeyCall('verifyAuthentication',[csrfToken,body]);if(verifyData&&verifyData.ok){window.location='runmodule.php?module=twofactorauth&op=resume';return;}alert(showDebug?buildDiag(verifyData):'Passkey operation failed');}catch(e){const detail=e&&e.message?String(e.message):'';alert(showDebug&&detail!==''?'Passkey operation failed. Diagnostic: '+detail:'Passkey operation failed');}};})();</script>");
+        $output->rawOutput("<div style='margin-top:12px'><button type='button' id='twofactorauth-use-passkey'>" . htmlspecialchars(translate_inline('Use passkey'), ENT_QUOTES, 'UTF-8') . "</button></div>");
+        $output->rawOutput("<script>(function(){if(window.__lotgdTwofactorauthChallengeSetupDone){return;}window.__lotgdTwofactorauthChallengeSetupDone=true;const btn=document.getElementById('twofactorauth-use-passkey');if(!btn){return;}const csrfToken=" . $csrfJson . ";const showDebug=" . $showDebugJson . ";const resolvedHandlers=typeof window.getJaxonHandlers==='function'?window.getJaxonHandlers():null;const namespace=resolvedHandlers&&resolvedHandlers.TwoFactorAuthPasskey?resolvedHandlers.TwoFactorAuthPasskey:(window.Lotgd&&window.Lotgd.Async&&window.Lotgd.Async.Handler&&window.Lotgd.Async.Handler.TwoFactorAuthPasskey?window.Lotgd.Async.Handler.TwoFactorAuthPasskey:(window.JaxonLotgd&&window.JaxonLotgd.Async&&window.JaxonLotgd.Async.Handler&&window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey?window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey:null));const beginExists=!!(namespace&&typeof namespace.beginAuthentication==='function');const buildDiag=function(data){if(!showDebug||!data){return'';}const code=data.error?String(data.error):'unknown';const diagId=data.diagnostic_id?String(data.diagnostic_id):'';const debug=data.debug_message?String(data.debug_message):'';const diagType=data.diagnostic&&data.diagnostic.type?String(data.diagnostic.type):'';let message='Passkey operation failed. Code: '+code+'.';if(diagId!==''){message+=' Diagnostic: '+diagId+'.';}if(diagType!==''){message+=' Type: '+diagType+'.';}if(debug!==''){message+=' Debug: '+debug;}return message;};btn.onclick=async function(){try{const beginData=await window.twofactorauthJaxonPasskeyCall('beginAuthentication',[csrfToken]);if(!beginData||!beginData.ok){alert(showDebug?buildDiag(beginData):'Passkey operation failed');return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const cred=await navigator.credentials.get({publicKey});if(!cred){alert('Passkey operation failed');return;}const body={id:cred.id,type:cred.type,response:{authenticatorData:window.twofactorauthArrayBufferToBase64Url(cred.response.authenticatorData),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(cred.response.clientDataJSON),signature:window.twofactorauthArrayBufferToBase64Url(cred.response.signature),userHandle:cred.response.userHandle?window.twofactorauthArrayBufferToBase64Url(cred.response.userHandle):''}};const verifyData=await window.twofactorauthJaxonPasskeyCall('verifyAuthentication',[csrfToken,body]);if(verifyData&&verifyData.ok){window.location='runmodule.php?module=twofactorauth&op=resume';return;}alert(showDebug?buildDiag(verifyData):'Passkey operation failed');}catch(e){const detail=e&&e.message?String(e.message):'';alert(showDebug&&detail!==''?'Passkey operation failed. Diagnostic: '+detail:'Passkey operation failed');}};})();</script>");
     }
 }
 
@@ -956,10 +963,23 @@ function twofactorauth_passkey_service(): PasskeyService
 
 /**
  * Render browser helpers for base64url decoding and passkey registration.
+ *
+ * These are literal script fragments, so they should use Output::rawOutput() from
+ * the active page-rendering context instead of the legacy global rawoutput().
+ *
+ * The Output argument is optional to preserve direct helper/test invocations.
  */
-function twofactorauth_render_passkey_js_helpers(): void
+function twofactorauth_render_passkey_js_helpers(?Output $output = null): void
 {
-    rawoutput("<script>window.twofactorauthArrayBufferToBase64Url=window.twofactorauthArrayBufferToBase64Url||function(buffer){const bytes=new Uint8Array(buffer);let binary='';for(let i=0;i<bytes.length;i++){binary+=String.fromCharCode(bytes[i]);}return btoa(binary).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');};window.twofactorauthBase64UrlToArrayBuffer=window.twofactorauthBase64UrlToArrayBuffer||function(base64url){const padded=(base64url+'==='.slice((base64url.length+3)%4)).replace(/-/g,'+').replace(/_/g,'/');const binary=atob(padded);const bytes=new Uint8Array(binary.length);for(let i=0;i<binary.length;i++){bytes[i]=binary.charCodeAt(i);}return bytes.buffer;};window.twofactorauthDecodeCredentialOptions=window.twofactorauthDecodeCredentialOptions||function(publicKey){if(publicKey.challenge){publicKey.challenge=window.twofactorauthBase64UrlToArrayBuffer(publicKey.challenge);}if(publicKey.user&&publicKey.user.id){publicKey.user.id=window.twofactorauthBase64UrlToArrayBuffer(publicKey.user.id);}if(Array.isArray(publicKey.excludeCredentials)){publicKey.excludeCredentials=publicKey.excludeCredentials.map(function(c){if(c.id){c.id=window.twofactorauthBase64UrlToArrayBuffer(c.id);}return c;});}if(Array.isArray(publicKey.allowCredentials)){publicKey.allowCredentials=publicKey.allowCredentials.map(function(c){if(c.id){c.id=window.twofactorauthBase64UrlToArrayBuffer(c.id);}return c;});}return publicKey;};</script>");
+    $script = "<script>window.twofactorauthArrayBufferToBase64Url=window.twofactorauthArrayBufferToBase64Url||function(buffer){const bytes=new Uint8Array(buffer);let binary='';for(let i=0;i<bytes.length;i++){binary+=String.fromCharCode(bytes[i]);}return btoa(binary).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');};window.twofactorauthBase64UrlToArrayBuffer=window.twofactorauthBase64UrlToArrayBuffer||function(base64url){const padded=(base64url+'==='.slice((base64url.length+3)%4)).replace(/-/g,'+').replace(/_/g,'/');const binary=atob(padded);const bytes=new Uint8Array(binary.length);for(let i=0;i<binary.length;i++){bytes[i]=binary.charCodeAt(i);}return bytes.buffer;};window.twofactorauthDecodeCredentialOptions=window.twofactorauthDecodeCredentialOptions||function(publicKey){if(publicKey.challenge){publicKey.challenge=window.twofactorauthBase64UrlToArrayBuffer(publicKey.challenge);}if(publicKey.user&&publicKey.user.id){publicKey.user.id=window.twofactorauthBase64UrlToArrayBuffer(publicKey.user.id);}if(Array.isArray(publicKey.excludeCredentials)){publicKey.excludeCredentials=publicKey.excludeCredentials.map(function(c){if(c.id){c.id=window.twofactorauthBase64UrlToArrayBuffer(c.id);}return c;});}if(Array.isArray(publicKey.allowCredentials)){publicKey.allowCredentials=publicKey.allowCredentials.map(function(c){if(c.id){c.id=window.twofactorauthBase64UrlToArrayBuffer(c.id);}return c;});}return publicKey;};</script>";
+
+    if ($output instanceof Output) {
+        $output->rawOutput($script);
+
+        return;
+    }
+
+    rawoutput($script);
 }
 
 /**
@@ -975,8 +995,12 @@ function twofactorauth_render_passkey_js_helpers(): void
  * Preflight note: before invoking any passkey handler we verify the live Jaxon request URI still
  * points at /async/process.php. This catches endpoint drift immediately, instead of waiting for
  * bridge timeouts after requests are routed to non-JSON endpoints.
+ *
+ * This helper emits literal JavaScript, so it should stay on Output::rawOutput().
+ *
+ * The Output argument is optional to preserve direct helper/test invocations.
  */
-function twofactorauth_render_passkey_jaxon_bridge(): void
+function twofactorauth_render_passkey_jaxon_bridge(?Output $output = null): void
 {
     $showDebugJson = twofactorauth_is_megauser() ? 'true' : 'false';
 
@@ -987,6 +1011,12 @@ function twofactorauth_render_passkey_jaxon_bridge(): void
  * Jaxon can emit namespaces under window.Lotgd, window.JaxonLotgd or helper accessors.
  */window.twofactorauthResolvePasskeyHandler=window.twofactorauthResolvePasskeyHandler||function(method){const resolvedHandlers=typeof window.getJaxonHandlers==='function'?window.getJaxonHandlers():null;const requestedMethod=String(method||'');const candidates=[resolvedHandlers&&resolvedHandlers.TwoFactorAuthPasskey?resolvedHandlers.TwoFactorAuthPasskey:null,window.Lotgd&&window.Lotgd.Async&&window.Lotgd.Async.Handler?window.Lotgd.Async.Handler.TwoFactorAuthPasskey:null,window.JaxonLotgd&&window.JaxonLotgd.Async&&window.JaxonLotgd.Async.Handler?window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey:null];for(let i=0;i<candidates.length;i++){const candidate=candidates[i];if(candidate&&typeof candidate[requestedMethod]==='function'){return candidate;}}return null;};window.twofactorauthJaxonPasskeyCall=window.twofactorauthJaxonPasskeyCall||function(method,args){return new Promise(function(resolve,reject){const preflight=window.twofactorauthPreflightPasskeyRequestUri(method);if(!preflight.ok){const message='Passkey async endpoint mismatch.';const detail=preflight.detail||'';reject(new Error(showDebug&&detail!==''?message+' '+detail:message));return;}const namespace=window.twofactorauthResolvePasskeyHandler(method);if(!namespace){reject(new Error('Passkey async handler unavailable.'));return;}const requestId='tfa_'+Date.now()+'_'+Math.random().toString(16).slice(2);const timeoutId=window.setTimeout(function(){rejectPending(requestId,'Passkey async request timed out.','method='+String(method));},20000);window.twofactorauthPendingRequests[requestId]={resolve:resolve,reject:reject,timeoutId:timeoutId,method:method};const params=Array.isArray(args)?args.slice():[];params.unshift(requestId);try{namespace[method].apply(namespace,params);}catch(error){rejectPending(requestId,'Passkey async request dispatch failed.',error&&error.message?String(error.message):'unknown');}});};if(!window.__lotgdTwofactorPasskeyBridgeRejectionHooks){window.__lotgdTwofactorPasskeyBridgeRejectionHooks=true;window.addEventListener('unhandledrejection',function(event){const reason=event&&event.reason&&event.reason.message?String(event.reason.message):'';if(reason.indexOf('Unexpected end of JSON input')!==-1||reason.indexOf('JSON')!==-1){if(showDebug){console.warn('[TwoFactorAuthPasskey] Transport failure:',reason);}window.twofactorauthRejectAllPending('Passkey async parser failure.',reason);}});window.addEventListener('error',function(event){const message=event&&event.message?String(event.message):'';if(message.indexOf('Unexpected end of JSON input')!==-1){if(showDebug){console.warn('[TwoFactorAuthPasskey] Transport failure:',message);}window.twofactorauthRejectAllPending('Passkey async parser failure.',message);}});}})();</script>
 JAVASCRIPT;
+
+    if ($output instanceof Output) {
+        $output->rawOutput(str_replace('__SHOW_DEBUG__', $showDebugJson, $script));
+
+        return;
+    }
 
     rawoutput(str_replace('__SHOW_DEBUG__', $showDebugJson, $script));
 }
@@ -1066,18 +1096,29 @@ function twofactorauth_is_megauser(): bool
 }
 
 /**
- * Render browser helpers for base64url decoding and passkey registration.
+ * Render the setup-page passkey registration script.
+ *
+ * The setup script is raw JavaScript markup, while nearby explanatory strings remain
+ * in Output::output() so they continue through the game's formatting/translation path.
+ *
+ * The Output argument is optional to preserve direct helper/test invocations.
  */
-function twofactorauth_render_passkey_registration_script(string $csrf): void
+function twofactorauth_render_passkey_registration_script(?Output $output = null, string $csrf = ''): void
 {
-    twofactorauth_render_passkey_js_helpers();
-    twofactorauth_render_passkey_jaxon_bridge();
+    twofactorauth_render_passkey_js_helpers($output);
+    twofactorauth_render_passkey_jaxon_bridge($output);
 
     $csrfJson = json_encode($csrf) ?: '""';
     $showDebugJson = twofactorauth_is_megauser() ? 'true' : 'false';
 
     // Assign via `onclick` so repeated script injection cannot stack multiple handlers.
     // This setup page can be re-rendered in some module flows.
+    if ($output instanceof Output) {
+        $output->rawOutput("<script>(function(){const button=document.getElementById('passkey-add-button');if(!button){return;}const csrfToken=" . $csrfJson . ";const showDebug=" . $showDebugJson . ";const buildDiag=function(data){if(!showDebug||!data){return'';}const code=data.error?String(data.error):'unknown';const diagId=data.diagnostic_id?String(data.diagnostic_id):'';const debug=data.debug_message?String(data.debug_message):'';const diagType=data.diagnostic&&data.diagnostic.type?String(data.diagnostic.type):'';let message='Passkey operation failed. Code: '+code+'.';if(diagId!==''){message+=' Diagnostic: '+diagId+'.';}if(diagType!==''){message+=' Type: '+diagType+'.';}if(debug!==''){message+=' Debug: '+debug;}return message;};button.onclick=async function(){try{const labelEl=document.getElementById('passkey-label');const label=labelEl?labelEl.value:'';const beginData=await window.twofactorauthJaxonPasskeyCall('beginRegistration',[csrfToken,label]);if(!beginData||!beginData.ok){alert(showDebug?buildDiag(beginData):'Passkey operation failed');return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const credential=await navigator.credentials.create({publicKey});if(!credential){alert('Passkey operation failed');return;}const payload={id:credential.id,type:credential.type,response:{attestationObject:window.twofactorauthArrayBufferToBase64Url(credential.response.attestationObject),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(credential.response.clientDataJSON),transports:typeof credential.response.getTransports==='function'?credential.response.getTransports():[]}};const finishData=await window.twofactorauthJaxonPasskeyCall('finishRegistration',[csrfToken,label,payload]);if(finishData&&finishData.ok){window.location='runmodule.php?module=twofactorauth&op=setup';return;}alert(showDebug?buildDiag(finishData):'Passkey operation failed');}catch(error){const detail=error&&error.message?String(error.message):'';alert(showDebug&&detail!==''?'Passkey operation failed. Diagnostic: '+detail:'Passkey operation failed');}};})();</script>");
+
+        return;
+    }
+
     rawoutput("<script>(function(){const button=document.getElementById('passkey-add-button');if(!button){return;}const csrfToken=" . $csrfJson . ";const showDebug=" . $showDebugJson . ";const buildDiag=function(data){if(!showDebug||!data){return'';}const code=data.error?String(data.error):'unknown';const diagId=data.diagnostic_id?String(data.diagnostic_id):'';const debug=data.debug_message?String(data.debug_message):'';const diagType=data.diagnostic&&data.diagnostic.type?String(data.diagnostic.type):'';let message='Passkey operation failed. Code: '+code+'.';if(diagId!==''){message+=' Diagnostic: '+diagId+'.';}if(diagType!==''){message+=' Type: '+diagType+'.';}if(debug!==''){message+=' Debug: '+debug;}return message;};button.onclick=async function(){try{const labelEl=document.getElementById('passkey-label');const label=labelEl?labelEl.value:'';const beginData=await window.twofactorauthJaxonPasskeyCall('beginRegistration',[csrfToken,label]);if(!beginData||!beginData.ok){alert(showDebug?buildDiag(beginData):'Passkey operation failed');return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const credential=await navigator.credentials.create({publicKey});if(!credential){alert('Passkey operation failed');return;}const payload={id:credential.id,type:credential.type,response:{attestationObject:window.twofactorauthArrayBufferToBase64Url(credential.response.attestationObject),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(credential.response.clientDataJSON),transports:typeof credential.response.getTransports==='function'?credential.response.getTransports():[]}};const finishData=await window.twofactorauthJaxonPasskeyCall('finishRegistration',[csrfToken,label,payload]);if(finishData&&finishData.ok){window.location='runmodule.php?module=twofactorauth&op=setup';return;}alert(showDebug?buildDiag(finishData):'Passkey operation failed');}catch(error){const detail=error&&error.message?String(error.message):'';alert(showDebug&&detail!==''?'Passkey operation failed. Diagnostic: '+detail:'Passkey operation failed');}};})();</script>");
 }
 


### PR DESCRIPTION
### Motivation

- Ensure page-rendering paths in the Two Factor Auth module consistently use the injected `Lotgd\Output` instance for literal HTML/JS instead of the legacy global `rawoutput()` helper. 
- Make the distinction explicit: use `Output::output()` for translated/game-formatted text and `Output::rawOutput()` for literal markup, and document that rule in helper docblocks. 

### Description

- Replaced direct `rawoutput(...)` usages with `$output->rawOutput(...)` in the setup page renderer (`twofactorauth_render_setup`) for the passkey form, delete form, QR markup, and the TOTP enrollment form. 
- Replaced `rawoutput(...)` usages with `$output->rawOutput(...)` in the challenge renderer (`twofactorauth_render_challenge`) for the verification form, passkey button, and inline challenge script. 
- Updated passkey helper functions to accept an optional `Output` parameter and to emit markup through `$output->rawOutput()` when an `Output` instance is provided while preserving a fallback for direct/test invocations (helpers remain callable without an `Output` instance). 
- Added/updated docblocks and inline comments explaining the output convention (`Output::output()` vs `Output::rawOutput()`), and adjusted internal calls so helper usages pass the `Output` instance where available. 

### Testing

- Ran `php -l modules/twofactorauth.php` with no syntax errors detected. 
- Ran the focused PHPUnit file `vendor/bin/phpunit --configuration phpunit.xml tests/Async/TwoFactorAuthPasskeyBridgeScriptTest.php` and it passed (all assertions OK). 
- Ran the full test suite via `composer test`; the suite completed successfully in this environment (tests passed), with unrelated environment warnings/notices reported by PHPUnit that are not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bee7bbd5a08329bdea19920f46e1f7)