### PR TITLE
Passkey hardening

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -143,6 +143,10 @@ modules.
   - Table prefix subscribers need to prefix both primary tables and join tables using the new mapping object structures.
 - **PHP 8.3**: Old PHP 7.x-style code (e.g., deprecated array/string operations) will break.
 - **Async**: All Ajax endpoints rewritten to use Jaxon.
+- **Two-factor auth key derivation**:
+  - The `twofactorauth` module now derives its crypto key from installation-secret material stored in the main settings table (`twofactorauth_key_material`) instead of only `serverurl` and `gameadminemail`.
+  - Existing installs keep a compatibility window: encrypted TOTP secrets and signed disable links are still accepted with the legacy key and TOTP secrets are re-encrypted with the new key after a successful verification.
+  - Rotating or deleting `twofactorauth_key_material` invalidates any TOTP secrets already re-encrypted with the new key and any disable links signed with it. Plan rotations carefully and keep backups if you must replace the secret.
 
 ### DBAL 4 Migration Inventory (2.x)
 

--- a/async/common/jaxon.php
+++ b/async/common/jaxon.php
@@ -38,9 +38,31 @@ $jaxon->setOption('core.debug.verbose', false);
  * Register async handlers from the directory to keep the historical Jaxon
  * client export shape (Lotgd.Async.Handler.*) stable for runtime bridge code.
  *
- * Security note: passkey method allowlisting is enforced server-side in
- * async/process.php so hardening does not alter this client namespace contract.
+ * Security note: async/process.php still enforces its allowlist before Jaxon
+ * dispatch. The passkey class options below narrow Jaxon's callable surface as
+ * defense in depth so helper/test seams are never exported or invokable.
+ *
+ * @var array<int, string> $passkeyRuntimeMethods
  */
+$passkeyRuntimeMethods = [
+    'beginRegistration',
+    'finishRegistration',
+    'beginAuthentication',
+    'verifyAuthentication',
+];
+
 $jaxon->register(Jaxon::CALLABLE_DIR, __DIR__ . '/../../src/Lotgd/Async/Handler', [
     'namespace' => 'Lotgd\\Async\\Handler',
+    'classes' => [
+        'Lotgd\\Async\\Handler\\TwoFactorAuthPasskey' => [
+            'export' => [
+                'only' => $passkeyRuntimeMethods,
+            ],
+            'functions' => [
+                'setService,setRepository' => [
+                    'excluded' => true,
+                ],
+            ],
+        ],
+    ],
 ]);

--- a/install/data/tables.php
+++ b/install/data/tables.php
@@ -1575,7 +1575,7 @@ function get_all_tables()
         'charset' => 'utf8mb4',
         'collation' => 'utf8mb4_unicode_ci',
         'setting' => array(
-            'name' => 'setting', 'type' => 'varchar(25)'
+            'name' => 'setting', 'type' => 'varchar(50)'
             ),
         'value' => array(
             'name' => 'value', 'type' => 'varchar(255)'

--- a/migrations/Version20250724000023.php
+++ b/migrations/Version20250724000023.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Lotgd\MySQL\Database;
+
+/**
+ * Widen the main settings identifier column for longer core setting keys.
+ */
+final class Version20250724000023 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Increase settings.setting to VARCHAR(50) for new secret-backed 2FA key material storage in the main settings table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        Database::setDoctrineConnection($this->connection);
+
+        $table = Database::prefix('settings');
+
+        if (! Database::tableExists($table)) {
+            return;
+        }
+
+        $this->addSql("ALTER TABLE {$table} MODIFY setting VARCHAR(50) NOT NULL DEFAULT ''");
+    }
+
+    public function down(Schema $schema): void
+    {
+        Database::setDoctrineConnection($this->connection);
+
+        $table = Database::prefix('settings');
+
+        if (! Database::tableExists($table)) {
+            return;
+        }
+
+        $this->addSql("ALTER TABLE {$table} MODIFY setting VARCHAR(25) NOT NULL DEFAULT ''");
+    }
+}

--- a/modules/TwoFactorAuth/TwoFactorAuth.md
+++ b/modules/TwoFactorAuth/TwoFactorAuth.md
@@ -132,5 +132,7 @@ If passkey registration or verification fails, verify the relying party/domain s
 - **HTTPS is required** for passkeys in normal environments.
   - Local development can use `http://localhost`, but production/staging passkey flows should use valid TLS.
 - If you run behind a reverse proxy, ensure the external host players see is consistent with `serverurl`; host mismatches can cause browser-side `NotAllowedError` / RP mismatch failures.
+- When `serverurl` is malformed and the passkey service must fall back to `HTTP_HOST` for the RP ID, the server now emits an explicit diagnostic to the PHP/web server error log so admins can correct the configuration instead of debugging silent WebAuthn mismatches.
+- The module now stores dedicated installation secret material in the main settings table (`twofactorauth_key_material`) to derive 2FA encryption/signing keys. Changing that value impacts already re-encrypted TOTP secrets and newly signed disable links, so treat it like any other installation secret.
 - If the browser shows **"Unexpected end of JSON input"** during passkey begin/finish, the backend likely returned empty content, HTML, or another non-JSON response. Inspect the raw begin/finish endpoint response body first to identify redirects/login pages/PHP errors quickly.
 - If begin-response **Raw start is empty**, treat it as backend exception/empty output. Check the Two Factor Auth module debug log and your web server/PHP error log for the root cause.

--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 require_once __DIR__ . '/TwoFactorAuth/TwoFactorAuthService.php';
 
 use Lotgd\Http;
-use Lotgd\Security\PasskeyCredentialRepository;
-use Lotgd\Security\PasskeyService;
 use Lotgd\Nav;
 use Lotgd\Output;
 use Lotgd\Page\Footer;
@@ -15,7 +13,6 @@ use Lotgd\GameLog;
 use Lotgd\DebugLog;
 use Lotgd\Redirect;
 use Lotgd\Serialization;
-use Lotgd\Settings;
 use Lotgd\Translator;
 
 /**
@@ -23,17 +20,12 @@ use Lotgd\Translator;
  */
 function twofactorauth_getmoduleinfo(): array
 {
-    $overrideForcedNav = twofactorauth_should_override_forced_nav_for_setup_async();
-
     return [
         'name' => 'Two Factor Auth',
         'version' => '1.0.0',
         'author' => 'Oliver Brendei',
         'category' => 'Security',
         'download' => 'core_module',
-        // Only bypass forced-nav for authenticated setup async routes that must emit raw JSON.
-        // Leaving this broad would let normal module page flow skip nav enforcement.
-        'override_forced_nav' => $overrideForcedNav,
         'settings' => [
             'Two Factor Auth Settings,title',
             'issuer_name' => 'Issuer label shown in authenticator apps,text|Legend of the Green Dragon',
@@ -50,7 +42,6 @@ function twofactorauth_getmoduleinfo(): array
         'prefs' => [
             'Two Factor Auth Preferences,title',
             'enabled' => 'Is TOTP enabled for this account?,bool|0',
-            'passkeys_enabled' => 'Has at least one passkey enrolled,viewonly',
             'secret_encrypted' => 'Encrypted TOTP secret,viewonly',
             'temp_secret_encrypted' => 'Temporary setup secret awaiting confirmation,viewonly',
             'verified_at' => 'Unix time of first successful setup verification,int|0',
@@ -67,36 +58,6 @@ function twofactorauth_getmoduleinfo(): array
             'resume_allowednavs_json' => 'Stored pre-challenge allowed-nav map as JSON,viewonly',
         ],
     ];
-}
-
-/**
- * Restrict forced-nav bypass to passkey setup fetch endpoints.
- *
- * runmodule.php performs a second forced-nav check after common bootstrap. We only bypass
- * that check for setup async routes to prevent fetch requests from being treated as the user's
- * next interactive navigation target.
- */
-function twofactorauth_should_override_forced_nav_for_setup_async(): bool
-{
-    global $session;
-
-    if (!(($session['loggedin'] ?? false) === true) || (int) ($session['user']['acctid'] ?? 0) <= 0) {
-        return false;
-    }
-
-    $op = (string) Http::get('op');
-    $setupOp = (string) Http::get('setupop');
-    if ($op !== 'setup') {
-        return false;
-    }
-
-    if ($setupOp !== 'begin_passkey_registration' && $setupOp !== 'finish_passkey_registration') {
-        return false;
-    }
-
-    $requestMethod = strtoupper((string) ($_SERVER['REQUEST_METHOD'] ?? ''));
-
-    return $requestMethod === 'POST';
 }
 
 function twofactorauth_install(): bool
@@ -125,12 +86,7 @@ function twofactorauth_dohook(string $hookname, array $args): array
                 break;
             }
 
-            $totpEnabled = (int) get_module_pref('enabled') === 1;
-            $acctId = (int) ($session['user']['acctid'] ?? 0);
-            // Recompute passkey presence on login to avoid stale pref dead-ends.
-            $passkeysEnabled = $acctId > 0 && count(twofactorauth_passkey_repository()->listForAccount($acctId)) > 0;
-            set_module_pref('passkeys_enabled', $passkeysEnabled ? 1 : 0);
-            if (!$totpEnabled && !$passkeysEnabled) {
+            if ((int) get_module_pref('enabled') !== 1) {
                 twofactorauth_clear_pending_state();
                 break;
             }
@@ -178,12 +134,9 @@ function twofactorauth_dohook(string $hookname, array $args): array
             }
 
             // Normalize to script+query so matching tolerates host/path differences.
-            // Keep async transport requests allowlisted while the challenge is pending:
-            // Jaxon polling/passkey methods expect JSON, and an HTML redirect response
-            // causes the client parser to fail before challenge handlers can run.
             $uriPath = (string) parse_url($requestUri, PHP_URL_PATH);
             $uriQuery = (string) parse_url($requestUri, PHP_URL_QUERY);
-            $normalizedRequestUri = ltrim($uriPath, '/') . ($uriQuery !== '' ? ('?' . $uriQuery) : '');
+            $normalizedRequestUri = $uriPath . ($uriQuery !== '' ? ('?' . $uriQuery) : '');
 
             if (!TwoFactorAuthService::isUriAllowed($normalizedRequestUri, $allowed)) {
                 $challengeUrl = 'runmodule.php?module=twofactorauth&op=challenge';
@@ -209,63 +162,7 @@ function twofactorauth_run(): void
 
     Translator::tlschema('module_twofactorauth');
 
-    $acctId = (int) ($session['user']['acctid'] ?? 0);
-    if ($acctId > 0) {
-        DebugLog::add(
-            sprintf('2FA run entry account %d op=%s.', $acctId, $op),
-            $acctId,
-            $acctId,
-            '2fa_verify',
-            false,
-            false
-        );
-    }
-    twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'entry', $acctId);
-
-    // Keep setup async routes in the explicit nav allow-list for this request lifecycle.
-    // Forced navigation checks compare the incoming URI against allowednavs and can reroute
-    // requests before handlers run when async endpoints are not whitelisted.
-    twofactorauth_allow_setup_async_nav_routes();
-    twofactorauth_register_passkey_transition_nav_targets();
-
     if ($op === 'setup') {
-        $setupOp = (string) Http::get('setupop');
-        // Setup async handlers must short-circuit before page chrome/nav rendering so browser
-        // fetch callers always receive raw JSON responses.
-        if ($setupOp === 'begin_passkey_registration') {
-            // CSRF validation is performed in the handler; run() records delegation boundaries.
-            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'pre-csrf', $acctId);
-            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'pre-service_call', $acctId);
-            twofactorauth_handle_begin_passkey_registration();
-            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'post-service_call', $acctId);
-            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'post-csrf', $acctId);
-            // Output is emitted in the async handler; keep explicit run() checkpoints for traceability.
-            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'pre-output', $acctId);
-            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'post-output', $acctId);
-            Translator::tlschema();
-
-            return;
-        }
-
-        if ($setupOp === 'finish_passkey_registration') {
-            // CSRF validation is performed in the handler; run() records delegation boundaries.
-            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'pre-csrf', $acctId);
-            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'pre-service_call', $acctId);
-            twofactorauth_handle_finish_passkey_registration();
-            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'post-service_call', $acctId);
-            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'post-csrf', $acctId);
-            // Output is emitted in the async handler; keep explicit run() checkpoints for traceability.
-            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'pre-output', $acctId);
-            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'post-output', $acctId);
-            Translator::tlschema();
-
-            return;
-        }
-
-        // Passkey UI depends on Jaxon handlers; ensure async bootstrap is prepared
-        // regardless of the user's global AJAX preference for this critical 2FA flow.
-        twofactorauth_force_async_bootstrap();
-
         Header::pageHeader('Two-factor authentication setup');
         twofactorauth_render_setup($output);
         Footer::pageFooter();
@@ -277,24 +174,6 @@ function twofactorauth_run(): void
     if (!($session['loggedin'] ?? false)) {
         Redirect::redirect('index.php?op=timeout', '2FA endpoint without login');
     }
-
-    // JSON challenge operations must return raw JSON without page chrome wrappers.
-    if ($op === 'begin_passkey_auth') {
-        twofactorauth_handle_begin_passkey_auth();
-        Translator::tlschema();
-
-        return;
-    }
-
-    if ($op === 'verify_passkey') {
-        twofactorauth_handle_passkey_verification();
-        Translator::tlschema();
-
-        return;
-    }
-
-    // Challenge passkey actions also need Jaxon available even when normal polling is disabled.
-    twofactorauth_force_async_bootstrap();
 
     Header::pageHeader('Two-factor authentication challenge');
 
@@ -324,12 +203,10 @@ function twofactorauth_render_setup(Output $output): void
 {
     global $session;
 
-    $acctId = (int) ($session['user']['acctid'] ?? 0);
     $enabled = (int) get_module_pref('enabled') === 1;
     $requireVerified = (int) get_module_setting('require_verified_email') === 1;
     $secret = (string) get_module_pref('secret_encrypted');
     $email = (string) ($session['user']['emailaddress'] ?? '');
-    $csrf = twofactorauth_csrf_token();
 
     Nav::add('Navigation');
     Nav::add('Return to preferences', 'prefs.php');
@@ -343,60 +220,12 @@ function twofactorauth_render_setup(Output $output): void
     }
 
     if ($enabled) {
-        $output->output('`vTwo-factor authentication is currently enabled on your account.`0`n`n');
-        $output->output('`$If you lose access to your authenticator app, use the login challenge page to request email recovery.`0`n');
-    }
+        $output->output('Two-factor authentication is currently enabled on your account.`n');
+        $output->output('`$If you lose access to your authenticator app, use the login challenge page to request email recovery.`0`n`n');
 
-    $repo = twofactorauth_passkey_repository();
-    $passkeys = $repo->listForAccount($acctId);
-    set_module_pref('passkeys_enabled', count($passkeys) > 0 ? 1 : 0);
+    }
 
     $setupOp = (string) Http::get('setupop');
-    $deleteCredentialId = trim((string) Http::post('delete_credential_id'));
-    if ($setupOp === 'delete_passkey' && $deleteCredentialId !== '') {
-        $postedCsrf = (string) Http::post('csrf_token');
-        if (hash_equals($csrf, $postedCsrf)) {
-            if ($repo->deleteForAccount($acctId, $deleteCredentialId)) {
-                $output->output('Passkey removed.`n');
-            } else {
-                $output->output('Passkey deletion failed or credential is not yours.`n');
-            }
-            $passkeys = $repo->listForAccount($acctId);
-            set_module_pref('passkeys_enabled', count($passkeys) > 0 ? 1 : 0);
-        } else {
-            $output->output('Invalid request token.`n');
-        }
-    }
-
-    $output->output('`n`bPasskeys`b`n');
-    $output->output('Passkeys are available as an alternative second factor to TOTP during login.`n');
-
-    addnav('', 'runmodule.php?module=twofactorauth&op=setup&setupop=begin_passkey_registration');
-    addnav('', 'runmodule.php?module=twofactorauth&op=setup&setupop=finish_passkey_registration');
-    rawoutput("<div id='twofactorauth-passkey-registration'>");
-    rawoutput("<label>" . htmlspecialchars(translate_inline('Passkey label'), ENT_QUOTES, 'UTF-8') . "</label> ");
-    rawoutput("<input type='text' id='passkey-label' value='This device' maxlength='120'> ");
-    rawoutput("<button type='button' id='passkey-add-button'>" . htmlspecialchars(translate_inline('Add passkey'), ENT_QUOTES, 'UTF-8') . "</button>");
-    rawoutput('</div>');
-
-    if ($passkeys === []) {
-        $output->output('No passkeys enrolled yet.`n');
-    } else {
-        foreach ($passkeys as $item) {
-            $label = (string) ($item['label'] ?: 'Passkey');
-            $credentialId = htmlspecialchars((string) $item['credential_id'], ENT_QUOTES, 'UTF-8');
-            $created = (int) ($item['created_at'] ?? 0);
-            $lastUsed = (int) ($item['last_used_at'] ?? 0);
-            $output->output('• %s (created: %s, last used: %s)`n', $label, date('Y-m-d H:i', $created), $lastUsed > 0 ? date('Y-m-d H:i', $lastUsed) : 'never');
-            addnav('', 'runmodule.php?module=twofactorauth&op=setup&setupop=delete_passkey');
-            rawoutput("<form action='runmodule.php?module=twofactorauth&op=setup&setupop=delete_passkey' method='POST' style='display:inline-block;margin-bottom:6px'>");
-            rawoutput("<input type='hidden' name='csrf_token' value='" . htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8') . "'>");
-            rawoutput("<input type='hidden' name='delete_credential_id' value='" . $credentialId . "'>");
-            rawoutput("<button type='submit'>" . htmlspecialchars(translate_inline('Delete passkey'), ENT_QUOTES, 'UTF-8') . "</button>");
-            rawoutput('</form><br>');
-        }
-    }
-
     $cryptoKey = twofactorauth_signing_key();
 
     if ($setupOp === 'start') {
@@ -407,14 +236,12 @@ function twofactorauth_render_setup(Output $output): void
     $tempSecret = TwoFactorAuthService::decryptSecret((string) get_module_pref('temp_secret_encrypted'), $cryptoKey);
     if ($tempSecret === '') {
         Nav::add('Actions');
-        if ($secret !== '') {
-            $output->output("`nYou already have a TOTP device setup, you can remove it and setup a new device via email recovery`n`n");
-        } else {
-            $output->output('`nYou have not yet enrolled a TOTP device. Start setup to generate your TOTP secret.`n`n');
-            Nav::add('Begin TOTP setup', 'runmodule.php?module=twofactorauth&op=setup&setupop=start');
-        }
-
-        twofactorauth_render_passkey_registration_script($csrf);
+	if ($secret !== '') {
+		$output->output("You already have a device setup, you can remove it and setup a new device via email recovery`n`n");
+	} else {
+        	$output->output('You have not yet enrolled a device. Start setup to generate your TOTP secret.`n`n');
+        	Nav::add('Begin setup', 'runmodule.php?module=twofactorauth&op=setup&setupop=start');
+	}
 
         return;
     }
@@ -428,18 +255,19 @@ function twofactorauth_render_setup(Output $output): void
     $qrProviderEndpoint = trim((string) get_module_setting('qr_provider_endpoint'));
     $qrCodeSize = max(120, (int) get_module_setting('qr_code_size'));
 
-    $output->output('`n`bTOTP fallback`b`n');
     $output->output('Scan the QR code in your authenticator app, or enter the secret manually.`n');
     $output->output('Manual secret: `^%s`0`n', $tempSecret);
 
     if ($qrProviderEndpoint !== '') {
         $qrCodeUrl = TwoFactorAuthService::buildQrCodeUrl($qrProviderEndpoint, $otpauthUri, $qrCodeSize);
+        // Show a scannable QR image while also retaining manual setup options.
         rawoutput("<div class='twofactorauth-qr'><img src='" . htmlspecialchars($qrCodeUrl, ENT_QUOTES, 'UTF-8') . "' alt='" . htmlspecialchars(translate_inline('Authenticator enrollment QR code'), ENT_QUOTES, 'UTF-8') . "' width='" . (int) $qrCodeSize . "' height='" . (int) $qrCodeSize . "'></div>");
     }
 
     $output->output('Enrollment URI (copy/paste if needed):`n%s`n`n', $otpauthUri);
     $output->output('Then enter your first one-time token to finish activation.`n');
 
+    // Only verify after an actual token submission; avoid false errors on initial setup page load.
     $submittedToken = Http::post('token');
     if ($submittedToken !== null) {
         $token = trim((string) $submittedToken);
@@ -453,21 +281,20 @@ function twofactorauth_render_setup(Output $output): void
                 set_module_pref('temp_secret_encrypted', '');
                 set_module_pref('verified_at', time());
                 set_module_pref('last_used_timestep', $result['timestep']);
-                $output->output('Two-factor authentication is now enabled.`n');
+                $output->output('`n`$Two-factor authentication is now enabled.`n`n');
             } else {
                 $output->output('The token was invalid. Please try again.`n');
             }
         }
     }
 
+    // Raw form actions are not auto-whitelisted by addnav(), so register them explicitly.
     addnav('', 'runmodule.php?module=twofactorauth&op=setup');
     rawoutput("<form action='runmodule.php?module=twofactorauth&op=setup' method='POST'>");
     rawoutput("<label>" . translate_inline('Authenticator token') . "</label> ");
     rawoutput("<input type='text' name='token' maxlength='10'> ");
     rawoutput("<button type='submit'>" . translate_inline('Enable') . "</button>");
     rawoutput('</form>');
-
-    twofactorauth_render_passkey_registration_script($csrf);
 }
 
 /**
@@ -475,46 +302,26 @@ function twofactorauth_render_setup(Output $output): void
  */
 function twofactorauth_render_challenge(Output $output): void
 {
-    global $session;
-
     if ((int) get_module_pref('pending_challenge') !== 1) {
         $output->output('No two-factor challenge is currently pending.`n');
 
         return;
     }
 
-    $acctId = (int) ($session['user']['acctid'] ?? 0);
-    $passkeys = twofactorauth_passkey_repository()->listForAccount($acctId);
-
     Nav::add('Actions');
     Nav::add('Submit token', 'runmodule.php?module=twofactorauth&op=verify');
-    if ($passkeys !== []) {
-        Nav::add('Use passkey', 'runmodule.php?module=twofactorauth&op=challenge');
-        addnav('', 'runmodule.php?module=twofactorauth&op=begin_passkey_auth');
-        addnav('', 'runmodule.php?module=twofactorauth&op=verify_passkey');
-    }
     Nav::add('Disable via email', 'runmodule.php?module=twofactorauth&op=disable_email');
 
-    $output->output('`vPassword accepted, two-factor authentication is required.`0`n`n');
+    $output->output('Password accepted, two-factor authentication is required.`n');
     $output->output('Enter the token from your authenticator app to continue.`n');
 
+    // Raw form actions are not auto-whitelisted by addnav(), so register them explicitly.
     addnav('', 'runmodule.php?module=twofactorauth&op=verify');
-    // Keep explicit POST action; challenge verification must remain a classic form submit.
-    rawoutput("<form id='twofactorauth-challenge-form' action='runmodule.php?module=twofactorauth&op=verify' method='POST'>");
+    rawoutput("<form action='runmodule.php?module=twofactorauth&op=verify' method='POST'>");
     rawoutput("<label>" . translate_inline('Authenticator token') . "</label> ");
     rawoutput("<input type='text' name='token' maxlength='10'> ");
     rawoutput("<button type='submit'>" . translate_inline('Verify') . "</button>");
     rawoutput('</form>');
-
-    if ($passkeys !== []) {
-        // Shared helper utilities are needed both on setup and challenge pages.
-        twofactorauth_render_passkey_js_helpers();
-        twofactorauth_render_passkey_jaxon_bridge();
-        $csrfJson = json_encode(twofactorauth_csrf_token()) ?: '""';
-        $showDebugJson = twofactorauth_is_megauser() ? 'true' : 'false';
-        rawoutput("<div style='margin-top:12px'><button type='button' id='twofactorauth-use-passkey'>" . htmlspecialchars(translate_inline('Use passkey'), ENT_QUOTES, 'UTF-8') . "</button></div>");
-        rawoutput("<script>(function(){if(window.__lotgdTwofactorauthChallengeSetupDone){return;}window.__lotgdTwofactorauthChallengeSetupDone=true;const btn=document.getElementById('twofactorauth-use-passkey');if(!btn){return;}const csrfToken=" . $csrfJson . ";const showDebug=" . $showDebugJson . ";const resolvedHandlers=typeof window.getJaxonHandlers==='function'?window.getJaxonHandlers():null;const namespace=resolvedHandlers&&resolvedHandlers.TwoFactorAuthPasskey?resolvedHandlers.TwoFactorAuthPasskey:(window.Lotgd&&window.Lotgd.Async&&window.Lotgd.Async.Handler&&window.Lotgd.Async.Handler.TwoFactorAuthPasskey?window.Lotgd.Async.Handler.TwoFactorAuthPasskey:(window.JaxonLotgd&&window.JaxonLotgd.Async&&window.JaxonLotgd.Async.Handler&&window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey?window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey:null));const beginExists=!!(namespace&&typeof namespace.beginAuthentication==='function');const buildDiag=function(data){if(!showDebug||!data){return'';}const code=data.error?String(data.error):'unknown';const diagId=data.diagnostic_id?String(data.diagnostic_id):'';const debug=data.debug_message?String(data.debug_message):'';const diagType=data.diagnostic&&data.diagnostic.type?String(data.diagnostic.type):'';let message='Passkey operation failed. Code: '+code+'.';if(diagId!==''){message+=' Diagnostic: '+diagId+'.';}if(diagType!==''){message+=' Type: '+diagType+'.';}if(debug!==''){message+=' Debug: '+debug;}return message;};btn.onclick=async function(){try{const beginData=await window.twofactorauthJaxonPasskeyCall('beginAuthentication',[csrfToken]);if(!beginData||!beginData.ok){alert(showDebug?buildDiag(beginData):'Passkey operation failed');return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const cred=await navigator.credentials.get({publicKey});if(!cred){alert('Passkey operation failed');return;}const body={id:cred.id,type:cred.type,response:{authenticatorData:window.twofactorauthArrayBufferToBase64Url(cred.response.authenticatorData),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(cred.response.clientDataJSON),signature:window.twofactorauthArrayBufferToBase64Url(cred.response.signature),userHandle:cred.response.userHandle?window.twofactorauthArrayBufferToBase64Url(cred.response.userHandle):''}};const verifyData=await window.twofactorauthJaxonPasskeyCall('verifyAuthentication',[csrfToken,body]);if(verifyData&&verifyData.ok){window.location='runmodule.php?module=twofactorauth&op=resume';return;}alert(showDebug?buildDiag(verifyData):'Passkey operation failed');}catch(e){const detail=e&&e.message?String(e.message):'';alert(showDebug&&detail!==''?'Passkey operation failed. Diagnostic: '+detail:'Passkey operation failed');}};})();</script>");
-    }
 }
 
 /**
@@ -524,77 +331,22 @@ function twofactorauth_handle_challenge_verification(Output $output): void
 {
     global $session;
 
-    $acctId = (int) ($session['user']['acctid'] ?? 0);
-    if ($acctId > 0) {
-        DebugLog::add(sprintf('2FA verify handler entry account %d.', $acctId), $acctId, $acctId, '2fa_verify', false, false);
-    }
     if ((int) get_module_pref('pending_challenge') !== 1) {
         Redirect::redirect('village.php', '2FA verify without pending state');
     }
 
-    $rawToken = Http::post('token');
-    if (!is_string($rawToken)) {
-        $token = '';
-    } else {
-        $token = trim($rawToken);
-    }
-    $hasToken = $token !== '';
-    $requestMethod = strtoupper((string) ($_SERVER['REQUEST_METHOD'] ?? 'GET'));
-    // Temporary diagnostics: only persist verify request-entry details for valid accounts to
-    // avoid noisy target=0 rows when unauthenticated/invalid requests hit the endpoint.
-    if ($acctId > 0) {
-        DebugLog::add(
-            sprintf(
-                '2FA verify entry account %d method=%s token_present=%s token_length=%d.',
-                $acctId,
-                $requestMethod,
-                $hasToken ? 'yes' : 'no',
-                strlen($token)
-            ),
-            $acctId,
-            $acctId,
-            '2fa_verify',
-            false,
-            false
-        );
-    }
-
-    if ($requestMethod !== 'POST') {
-        if ($acctId > 0) {
-            DebugLog::add(
-                sprintf(
-                    '2FA verify request account %d used unexpected method=%s.',
-                    $acctId,
-                    $requestMethod
-                ),
-                $acctId,
-                $acctId,
-                '2fa_verify',
-                false,
-                false
-            );
-        }
-        // Only classic form POST submissions are supported for verification; ignore other methods
-        // without mutating lockout or failed-attempts state.
-        $output->output('Invalid request method for verification.`n');
-
-        return;
-    }
-
     $now = time();
+    $acctId = (int) ($session['user']['acctid'] ?? 0);
     $lockedUntil = (int) get_module_pref('locked_until');
     if ($lockedUntil > $now) {
         twofactorauth_log_challenge_outcome($acctId, 'failure', 'locked');
-        if ($acctId > 0) {
-            DebugLog::add(sprintf('2FA verify exit account %d branch=locked.', $acctId), $acctId, $acctId, '2fa_verify', false, false);
-        }
         $output->output('Too many failures. Please wait before trying again.`n');
 
         return;
     }
 
-    $secretState = twofactorauth_decrypt_secret_with_compat((string) get_module_pref('secret_encrypted'));
-    $secret = $secretState['secret'];
+    $secret = TwoFactorAuthService::decryptSecret((string) get_module_pref('secret_encrypted'), twofactorauth_signing_key());
+    $token = (string) Http::post('token');
     $digits = (int) get_module_setting('token_digits');
     $period = (int) get_module_setting('period_seconds');
     $window = (int) get_module_setting('window');
@@ -602,13 +354,9 @@ function twofactorauth_handle_challenge_verification(Output $output): void
 
     $result = TwoFactorAuthService::verifyTotp($secret, $token, $digits, $period, $window, $lastStep, $now);
     if ($result['valid']) {
-        twofactorauth_migrate_secret_after_success($secretState);
         set_module_pref('last_used_timestep', $result['timestep']);
         twofactorauth_clear_pending_state();
         twofactorauth_log_challenge_outcome($acctId, 'success');
-        if ($acctId > 0) {
-            DebugLog::add(sprintf('2FA verify exit account %d branch=valid timestep=%d.', $acctId, (int) $result['timestep']), $acctId, $acctId, '2fa_verify', false, false);
-        }
         $output->output('Two-factor authentication complete. Welcome back.`n');
         Nav::add('Continue', 'runmodule.php?module=twofactorauth&op=resume');
 
@@ -623,17 +371,11 @@ function twofactorauth_handle_challenge_verification(Output $output): void
         $lockSeconds = (int) get_module_setting('lock_seconds');
         set_module_pref('locked_until', $now + $lockSeconds);
         twofactorauth_log_challenge_outcome($acctId, 'failure', 'locked');
-        if ($acctId > 0) {
-            DebugLog::add(sprintf('2FA verify exit account %d branch=locked fails=%d.', $acctId, $fails), $acctId, $acctId, '2fa_verify', false, false);
-        }
         $output->output('Too many failures. Challenge temporarily locked.`n');
     } else {
         // Slow down automated guessing while keeping the current challenge active for retries.
         sleep(2);
         twofactorauth_log_challenge_outcome($acctId, 'failure', (string) $result['reason']);
-        if ($acctId > 0) {
-            DebugLog::add(sprintf('2FA verify exit account %d branch=invalid reason=%s fails=%d.', $acctId, (string) ($result['reason'] ?? 'unknown'), $fails), $acctId, $acctId, '2fa_verify', false, false);
-        }
         $output->output('Invalid token. Please try again.`n');
         twofactorauth_render_challenge($output);
     }
@@ -711,7 +453,7 @@ function twofactorauth_handle_disable_via_email(Output $output): void
     }
 
     $expires = time() + ((int) get_module_setting('disable_link_ttl_minutes') * 60);
-    $token = TwoFactorAuthService::signDisableToken($acctId, $email, $expires, twofactorauth_current_signing_key());
+    $token = TwoFactorAuthService::signDisableToken($acctId, $email, $expires, twofactorauth_signing_key());
     $confirmUri = 'runmodule.php?module=twofactorauth&op=confirm_disable&token=' . rawurlencode($token);
 
     set_module_pref('disable_token_hash', hash('sha256', $token));
@@ -738,7 +480,7 @@ function twofactorauth_handle_disable_confirmation(Output $output): void
     global $session;
 
     $token = (string) Http::get('token');
-    $validation = twofactorauth_verify_disable_token_with_compat($token);
+    $validation = TwoFactorAuthService::verifyDisableToken($token, twofactorauth_signing_key());
     $expectedHash = (string) get_module_pref('disable_token_hash');
     $expires = (int) get_module_pref('disable_token_expires');
 
@@ -809,13 +551,13 @@ function twofactorauth_collect_resume_allowednavs_snapshot(): array
 
     $sessionAllowed = twofactorauth_snapshot_allowednavs($session['allowednavs'] ?? []);
     if ($sessionAllowed !== []) {
-        return twofactorauth_ensure_nav_snapshot_has_passkey_transitions($sessionAllowed);
+        return $sessionAllowed;
     }
 
     $serializedAccountAllowed = $session['user']['allowednavs'] ?? '';
     $decodedAccountAllowed = Serialization::safeUnserialize($serializedAccountAllowed);
 
-    return twofactorauth_ensure_nav_snapshot_has_passkey_transitions(twofactorauth_snapshot_allowednavs($decodedAccountAllowed));
+    return twofactorauth_snapshot_allowednavs($decodedAccountAllowed);
 }
 
 /**
@@ -826,9 +568,7 @@ function twofactorauth_persist_staged_resume_snapshot(): void
     global $session;
 
     $restorepage = (string) ($session['twofactorauth_resume_restorepage'] ?? '');
-    $allowedNavs = twofactorauth_ensure_nav_snapshot_has_passkey_transitions(
-        twofactorauth_snapshot_allowednavs($session['twofactorauth_resume_allowednavs'] ?? [])
-    );
+    $allowedNavs = twofactorauth_snapshot_allowednavs($session['twofactorauth_resume_allowednavs'] ?? []);
 
     set_module_pref('resume_restorepage', $restorepage);
     set_module_pref('resume_allowednavs_json', json_encode($allowedNavs, JSON_UNESCAPED_SLASHES) ?: '[]');
@@ -913,805 +653,10 @@ function twofactorauth_resolve_resume_target(string $target, array $allowedNavs)
     return '';
 }
 
-
 /**
- * Build or return a CSRF token for setup lifecycle actions.
- */
-function twofactorauth_csrf_token(): string
-{
-    global $session;
-
-    if (!isset($session['twofactorauth_csrf']) || !is_string($session['twofactorauth_csrf']) || $session['twofactorauth_csrf'] === '') {
-        $session['twofactorauth_csrf'] = bin2hex(random_bytes(16));
-    }
-
-    return (string) $session['twofactorauth_csrf'];
-}
-
-/**
- * Shared passkey credential repository instance.
- */
-function twofactorauth_passkey_repository(): PasskeyCredentialRepository
-{
-    static $repository = null;
-    if (!$repository instanceof PasskeyCredentialRepository) {
-        $repository = new PasskeyCredentialRepository();
-    }
-
-    return $repository;
-}
-
-/**
- * Shared passkey service instance.
- */
-function twofactorauth_passkey_service(): PasskeyService
-{
-    static $service = null;
-    if (!$service instanceof PasskeyService) {
-        $service = new PasskeyService(twofactorauth_passkey_repository());
-    }
-
-    return $service;
-}
-
-/**
- * Render browser helpers for base64url decoding and passkey registration.
- */
-function twofactorauth_render_passkey_js_helpers(): void
-{
-    rawoutput("<script>window.twofactorauthArrayBufferToBase64Url=window.twofactorauthArrayBufferToBase64Url||function(buffer){const bytes=new Uint8Array(buffer);let binary='';for(let i=0;i<bytes.length;i++){binary+=String.fromCharCode(bytes[i]);}return btoa(binary).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');};window.twofactorauthBase64UrlToArrayBuffer=window.twofactorauthBase64UrlToArrayBuffer||function(base64url){const padded=(base64url+'==='.slice((base64url.length+3)%4)).replace(/-/g,'+').replace(/_/g,'/');const binary=atob(padded);const bytes=new Uint8Array(binary.length);for(let i=0;i<binary.length;i++){bytes[i]=binary.charCodeAt(i);}return bytes.buffer;};window.twofactorauthDecodeCredentialOptions=window.twofactorauthDecodeCredentialOptions||function(publicKey){if(publicKey.challenge){publicKey.challenge=window.twofactorauthBase64UrlToArrayBuffer(publicKey.challenge);}if(publicKey.user&&publicKey.user.id){publicKey.user.id=window.twofactorauthBase64UrlToArrayBuffer(publicKey.user.id);}if(Array.isArray(publicKey.excludeCredentials)){publicKey.excludeCredentials=publicKey.excludeCredentials.map(function(c){if(c.id){c.id=window.twofactorauthBase64UrlToArrayBuffer(c.id);}return c;});}if(Array.isArray(publicKey.allowCredentials)){publicKey.allowCredentials=publicKey.allowCredentials.map(function(c){if(c.id){c.id=window.twofactorauthBase64UrlToArrayBuffer(c.id);}return c;});}return publicKey;};</script>");
-}
-
-/**
- * Render a small Jaxon bridge for promise-based passkey calls.
- *
- * Jaxon executes response commands asynchronously but does not return ceremony payloads
- * as fetch()-style JSON promises by default. This bridge maps request IDs to promise
- * resolvers and receives payloads from the async handler callback.
- *
- * Transport/parser failures can abort before callback execution; in that case we reject
- * pending promises immediately so users see the real failure instead of an artificial timeout.
- *
- * Preflight note: before invoking any passkey handler we verify the live Jaxon request URI still
- * points at /async/process.php. This catches endpoint drift immediately, instead of waiting for
- * bridge timeouts after requests are routed to non-JSON endpoints.
- */
-function twofactorauth_render_passkey_jaxon_bridge(): void
-{
-    $showDebugJson = twofactorauth_is_megauser() ? 'true' : 'false';
-
-    $script = <<<'JAVASCRIPT'
-<script>(function(){window.twofactorauthPendingRequests=window.twofactorauthPendingRequests||{};const showDebug=__SHOW_DEBUG__;const expectedRequestPath='/async/process.php';const resolveCurrentRequestUri=function(){if(!window.jaxon||!jaxon.config){return'';}const configured=typeof jaxon.config.requestURI==='string'?jaxon.config.requestURI:'';if(configured===''){return'';}try{return new URL(configured,window.location.origin).pathname;}catch(_error){return configured;}};const rejectPending=function(requestId,message,details){if(!requestId){return;}const entry=window.twofactorauthPendingRequests[requestId];if(!entry){return;}if(entry.timeoutId){window.clearTimeout(entry.timeoutId);}delete window.twofactorauthPendingRequests[requestId];const composed=showDebug&&details?message+' Details: '+details:message;entry.reject(new Error(composed));};window.twofactorauthRejectAllPending=window.twofactorauthRejectAllPending||function(message,details){const ids=Object.keys(window.twofactorauthPendingRequests||{});for(let i=0;i<ids.length;i++){rejectPending(ids[i],message,details);}return ids.length;};window.twofactorauthHandleJaxonResponse=window.twofactorauthHandleJaxonResponse||function(requestId,payload){if(!requestId){return;}const entry=window.twofactorauthPendingRequests[requestId];if(!entry){return;}if(entry.timeoutId){window.clearTimeout(entry.timeoutId);}delete window.twofactorauthPendingRequests[requestId];entry.resolve(payload||{ok:false,error:'empty_response'});};window.twofactorauthGetCurrentJaxonRequestUri=window.twofactorauthGetCurrentJaxonRequestUri||resolveCurrentRequestUri;window.twofactorauthPreflightPasskeyRequestUri=window.twofactorauthPreflightPasskeyRequestUri||function(method){const current=resolveCurrentRequestUri();if(current===expectedRequestPath){return{ok:true,current:current};}const detail='method='+String(method)+' requestURI='+String(current||'unset')+' expected='+expectedRequestPath;return{ok:false,error:'request_uri_mismatch',detail:detail,current:current,expected:expectedRequestPath};};/** Resolve the passkey handler across generated Jaxon namespace variants.
- *
- * Compatibility note: hardening must not assume a single export root because
- * Jaxon can emit namespaces under window.Lotgd, window.JaxonLotgd or helper accessors.
- */window.twofactorauthResolvePasskeyHandler=window.twofactorauthResolvePasskeyHandler||function(method){const resolvedHandlers=typeof window.getJaxonHandlers==='function'?window.getJaxonHandlers():null;const requestedMethod=String(method||'');const candidates=[resolvedHandlers&&resolvedHandlers.TwoFactorAuthPasskey?resolvedHandlers.TwoFactorAuthPasskey:null,window.Lotgd&&window.Lotgd.Async&&window.Lotgd.Async.Handler?window.Lotgd.Async.Handler.TwoFactorAuthPasskey:null,window.JaxonLotgd&&window.JaxonLotgd.Async&&window.JaxonLotgd.Async.Handler?window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey:null];for(let i=0;i<candidates.length;i++){const candidate=candidates[i];if(candidate&&typeof candidate[requestedMethod]==='function'){return candidate;}}return null;};window.twofactorauthJaxonPasskeyCall=window.twofactorauthJaxonPasskeyCall||function(method,args){return new Promise(function(resolve,reject){const preflight=window.twofactorauthPreflightPasskeyRequestUri(method);if(!preflight.ok){const message='Passkey async endpoint mismatch.';const detail=preflight.detail||'';reject(new Error(showDebug&&detail!==''?message+' '+detail:message));return;}const namespace=window.twofactorauthResolvePasskeyHandler(method);if(!namespace){reject(new Error('Passkey async handler unavailable.'));return;}const requestId='tfa_'+Date.now()+'_'+Math.random().toString(16).slice(2);const timeoutId=window.setTimeout(function(){rejectPending(requestId,'Passkey async request timed out.','method='+String(method));},20000);window.twofactorauthPendingRequests[requestId]={resolve:resolve,reject:reject,timeoutId:timeoutId,method:method};const params=Array.isArray(args)?args.slice():[];params.unshift(requestId);try{namespace[method].apply(namespace,params);}catch(error){rejectPending(requestId,'Passkey async request dispatch failed.',error&&error.message?String(error.message):'unknown');}});};if(!window.__lotgdTwofactorPasskeyBridgeRejectionHooks){window.__lotgdTwofactorPasskeyBridgeRejectionHooks=true;window.addEventListener('unhandledrejection',function(event){const reason=event&&event.reason&&event.reason.message?String(event.reason.message):'';if(reason.indexOf('Unexpected end of JSON input')!==-1||reason.indexOf('JSON')!==-1){if(showDebug){console.warn('[TwoFactorAuthPasskey] Transport failure:',reason);}window.twofactorauthRejectAllPending('Passkey async parser failure.',reason);}});window.addEventListener('error',function(event){const message=event&&event.message?String(event.message):'';if(message.indexOf('Unexpected end of JSON input')!==-1){if(showDebug){console.warn('[TwoFactorAuthPasskey] Transport failure:',message);}window.twofactorauthRejectAllPending('Passkey async parser failure.',message);}});}})();</script>
-JAVASCRIPT;
-
-    rawoutput(str_replace('__SHOW_DEBUG__', $showDebugJson, $script));
-}
-
-/**
- * Force-load async/Jaxon setup for passkey pages.
- *
- * Footer normally includes async/setup.php only when user AJAX preference is enabled.
- * Passkey 2FA must continue to work regardless of that preference, so this helper loads
- * the async bootstrap explicitly before headers are rendered on setup/challenge pages.
- *
- * Contract note: async/setup.php appends markup with string concatenation into a
- * $pre_headscript buffer that it expects to receive from the including scope. This must
- * be initialized as a string so Jaxon handler namespaces are bootstrapped reliably for
- * passkey setup/login flows.
- */
-function twofactorauth_force_async_bootstrap(): void
-{
-    static $bootstrapInjected = false;
-    if ($bootstrapInjected) {
-        return;
-    }
-
-    $asyncSetupFile = dirname(__DIR__) . '/async/setup.php';
-    if (!file_exists($asyncSetupFile)) {
-        return;
-    }
-
-    // Ensure async/setup.php sees the expected globals and capture any head scripts it registers.
-    global $session;
-
-    /** @var string|array<int, string> $pre_headscript */
-    // Keep string contract for async/setup.php and defensively normalize legacy array buffers.
-    $pre_headscript = '';
-
-    require_once $asyncSetupFile;
-
-    // async/setup.php expects string concatenation. Normalize array fallbacks into one buffer,
-    // then add the resulting head markup exactly once in this module request lifecycle.
-    if (is_array($pre_headscript)) {
-        $pre_headscript = implode('', array_filter($pre_headscript, static fn(mixed $item): bool => is_string($item) && $item !== ''));
-    } elseif (!is_string($pre_headscript)) {
-        $pre_headscript = '';
-    }
-
-    if ($pre_headscript !== '') {
-        Output::addHeadMarkup($pre_headscript);
-        $bootstrapInjected = true;
-    }
-}
-
-/**
- * Build an async challenge error payload and expose debug internals only to megausers.
- *
- * @return array<string, mixed>
- */
-function twofactorauth_challenge_async_error_payload(string $errorCode, ?\Throwable $exception = null): array
-{
-    $payload = ['ok' => false, 'error' => $errorCode, 'code' => $errorCode];
-    if ($exception instanceof \Throwable && twofactorauth_is_megauser()) {
-        $payload['debug_message'] = sprintf('%s: %s', $exception::class, $exception->getMessage());
-    }
-
-    return $payload;
-}
-
-/**
- * Determine whether deep client/server diagnostics may be shown.
- */
-function twofactorauth_is_megauser(): bool
-{
-    global $session;
-
-    $superuserFlags = (int) ($session['user']['superuser'] ?? 0);
-
-    return ($superuserFlags & SU_MEGAUSER) === SU_MEGAUSER;
-}
-
-/**
- * Render browser helpers for base64url decoding and passkey registration.
- */
-function twofactorauth_render_passkey_registration_script(string $csrf): void
-{
-    twofactorauth_render_passkey_js_helpers();
-    twofactorauth_render_passkey_jaxon_bridge();
-
-    $csrfJson = json_encode($csrf) ?: '""';
-    $showDebugJson = twofactorauth_is_megauser() ? 'true' : 'false';
-
-    // Assign via `onclick` so repeated script injection cannot stack multiple handlers.
-    // This setup page can be re-rendered in some module flows.
-    rawoutput("<script>(function(){const button=document.getElementById('passkey-add-button');if(!button){return;}const csrfToken=" . $csrfJson . ";const showDebug=" . $showDebugJson . ";const buildDiag=function(data){if(!showDebug||!data){return'';}const code=data.error?String(data.error):'unknown';const diagId=data.diagnostic_id?String(data.diagnostic_id):'';const debug=data.debug_message?String(data.debug_message):'';const diagType=data.diagnostic&&data.diagnostic.type?String(data.diagnostic.type):'';let message='Passkey operation failed. Code: '+code+'.';if(diagId!==''){message+=' Diagnostic: '+diagId+'.';}if(diagType!==''){message+=' Type: '+diagType+'.';}if(debug!==''){message+=' Debug: '+debug;}return message;};button.onclick=async function(){try{const labelEl=document.getElementById('passkey-label');const label=labelEl?labelEl.value:'';const beginData=await window.twofactorauthJaxonPasskeyCall('beginRegistration',[csrfToken,label]);if(!beginData||!beginData.ok){alert(showDebug?buildDiag(beginData):'Passkey operation failed');return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const credential=await navigator.credentials.create({publicKey});if(!credential){alert('Passkey operation failed');return;}const payload={id:credential.id,type:credential.type,response:{attestationObject:window.twofactorauthArrayBufferToBase64Url(credential.response.attestationObject),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(credential.response.clientDataJSON),transports:typeof credential.response.getTransports==='function'?credential.response.getTransports():[]}};const finishData=await window.twofactorauthJaxonPasskeyCall('finishRegistration',[csrfToken,label,payload]);if(finishData&&finishData.ok){window.location='runmodule.php?module=twofactorauth&op=setup';return;}alert(showDebug?buildDiag(finishData):'Passkey operation failed');}catch(error){const detail=error&&error.message?String(error.message):'';alert(showDebug&&detail!==''?'Passkey operation failed. Diagnostic: '+detail:'Passkey operation failed');}};})();</script>");
-}
-
-/**
- * Emit a JSON payload for passkey async endpoints.
- *
- * @param array<string, mixed> $payload
- */
-function twofactorauth_output_json(array $payload): void
-{
-    if (!headers_sent()) {
-        header('Content-Type: application/json; charset=UTF-8');
-    }
-
-    rawoutput(json_encode($payload) ?: '{"ok":false}');
-}
-
-/**
- * Read the raw request body for passkey endpoints.
- *
- * Tests can override the transport body with a fixture string because php://input is not
- * writable in the CLI runtime used by PHPUnit.
- */
-function twofactorauth_read_request_body(): string
-{
-    if (isset($GLOBALS['twofactorauth_test_request_body']) && is_string($GLOBALS['twofactorauth_test_request_body'])) {
-        return $GLOBALS['twofactorauth_test_request_body'];
-    }
-
-    return (string) (file_get_contents('php://input') ?: '');
-}
-
-/**
- * Decode a JSON request body into an associative array for passkey endpoints.
- *
- * @return array<string, mixed>
- */
-function twofactorauth_read_json_request_body(): array
-{
-    $requestBody = json_decode(twofactorauth_read_request_body() ?: '{}', true);
-
-    return is_array($requestBody) ? $requestBody : [];
-}
-
-/**
- * Extract the module CSRF token from either a JSON body or classic POST fields.
- *
- * The legacy synchronous passkey entry point may still receive either fetch()-style JSON
- * or a traditional POST payload. This helper normalizes both transports before the
- * handler compares the request token against the session token.
- */
-function twofactorauth_extract_request_csrf_token(): string
-{
-    $requestBody = twofactorauth_read_json_request_body();
-    $csrf = (string) ($requestBody['csrf_token'] ?? '');
-    if ($csrf !== '') {
-        return $csrf;
-    }
-
-    return (string) Http::post('csrf_token');
-}
-
-/**
- * Keep setup async routes explicitly in allowed navigation entries.
- *
- * Forced-nav can redirect requests before module code fully executes. These endpoints are called
- * by JavaScript fetch() during setup and must stay forced-nav safe so JSON responses are not
- * replaced by HTML redirects/chrome. Keep this allow-list narrow to avoid global bypasses.
- */
-function twofactorauth_allow_setup_async_nav_routes(): void
-{
-    $op = (string) Http::get('op');
-    $setupOp = (string) Http::get('setupop');
-
-    if ($op !== 'setup') {
-        return;
-    }
-
-    if ($setupOp !== 'begin_passkey_registration' && $setupOp !== 'finish_passkey_registration') {
-        return;
-    }
-
-    addnav('', 'runmodule.php?module=twofactorauth&op=setup&setupop=' . $setupOp);
-}
-
-/**
- * Return passkey lifecycle routes that must remain in allowed-nav snapshots.
- *
- * Async passkey success paths redirect the browser back to runmodule URLs. If these
- * routes are missing from the forced-nav allowlist snapshot, the player can be sent to
- * badnav.php after a successful ceremony.
- *
- * @return array<int, string>
- */
-function twofactorauth_passkey_transition_nav_targets(): array
-{
-    return [
-        'runmodule.php?module=twofactorauth&op=challenge',
-        'runmodule.php?module=twofactorauth&op=resume',
-        'runmodule.php?module=twofactorauth&op=setup',
-    ];
-}
-
-/**
- * Register passkey transition routes in the active request allowlist.
- *
- * These addnav() entries protect challenge/setup/resume redirects triggered by
- * passkey success/failure handlers and by browser-side async completion callbacks.
- */
-function twofactorauth_register_passkey_transition_nav_targets(): void
-{
-    foreach (twofactorauth_passkey_transition_nav_targets() as $target) {
-        addnav('', $target);
-    }
-}
-
-/**
- * Ensure stored allowed-nav snapshots retain passkey transition URLs.
- *
- * Persisting these entries prevents forced-nav mismatches when async completion lands on
- * op=resume or op=setup after the challenge lifecycle has already persisted its snapshot.
- *
- * @param array<string, bool> $allowedNavs
- *
- * @return array<string, bool>
- */
-function twofactorauth_ensure_nav_snapshot_has_passkey_transitions(array $allowedNavs): array
-{
-    foreach (twofactorauth_passkey_transition_nav_targets() as $target) {
-        $allowedNavs[$target] = true;
-    }
-
-    return $allowedNavs;
-}
-
-/**
- * Return a shared correlation id for this module request.
- *
- * Async passkey setup calls run via fetch() and never render full page chrome, so we attach
- * one request-scoped id to every checkpoint log line to make end-to-end tracing reliable.
- */
-function twofactorauth_setup_async_correlation_id(): string
-{
-    static $correlationId = null;
-    if (!is_string($correlationId)) {
-        $correlationId = bin2hex(random_bytes(8));
-    }
-
-    return $correlationId;
-}
-
-/**
- * Write structured debug checkpoint details for passkey setup async handlers.
- */
-function twofactorauth_log_setup_async_checkpoint(string $handler, string $checkpoint, int $acctId): void
-{
-    DebugLog::add(
-        sprintf(
-            '2FA passkey setup async [%s] checkpoint=%s corr=%s acct=%d.',
-            $handler,
-            $checkpoint,
-            twofactorauth_setup_async_correlation_id(),
-            $acctId
-        ),
-        $acctId,
-        $acctId,
-        '2fa_passkey',
-        false,
-        false
-    );
-}
-
-/**
- * Build a setup async error payload while limiting detailed diagnostic data to megausers.
- *
- * @return array<string, mixed>
- */
-function twofactorauth_setup_async_error_payload(string $errorCode, ?\Throwable $exception = null): array
-{
-    // Privilege-gate deep diagnostics: only megausers get internals to avoid leaking
-    // exception context to normal players while still enabling admin troubleshooting.
-    $payload = ['ok' => false, 'error' => $errorCode, 'code' => $errorCode];
-    if ($exception instanceof \Throwable && twofactorauth_is_megauser()) {
-        $payload['debug_message'] = sprintf('%s: %s', $exception::class, $exception->getMessage());
-    }
-
-    return $payload;
-}
-
-/**
- * Begin setup passkey registration and return publicKeyCredentialCreationOptions as JSON.
- *
- * Output contract note: this endpoint is called via fetch() and must always emit JSON on every
- * exit path. Returning HTML or an empty body breaks frontend parsing and hides actionable errors.
- */
-function twofactorauth_handle_begin_passkey_registration(): void
-{
-    global $session;
-
-    $acctId = (int) ($session['user']['acctid'] ?? 0);
-    twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'entry', $acctId);
-
-    try {
-        $requestBody = twofactorauth_read_json_request_body();
-
-        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'pre-csrf', $acctId);
-        $csrf = (string) ($requestBody['csrf_token'] ?? '');
-        if (!hash_equals(twofactorauth_csrf_token(), $csrf)) {
-            twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'post-csrf', $acctId);
-            twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'pre-output', $acctId);
-            twofactorauth_output_json(twofactorauth_setup_async_error_payload('csrf'));
-            twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'post-output', $acctId);
-
-            return;
-        }
-        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'post-csrf', $acctId);
-
-        $login = (string) ($session['user']['login'] ?? 'player');
-        $display = (string) ($session['user']['name'] ?? $login);
-        $existing = twofactorauth_passkey_repository()->listForAccount($acctId);
-        $excludeIds = array_map(static fn(array $item): string => (string) ($item['credential_id'] ?? ''), $existing);
-
-        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'pre-service_call', $acctId);
-        $options = twofactorauth_passkey_service()->beginRegistration($acctId, $login, $display, $excludeIds);
-        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'post-service_call', $acctId);
-
-        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'pre-output', $acctId);
-        twofactorauth_output_json(['ok' => true, 'options' => $options]);
-        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'post-output', $acctId);
-
-        return;
-    } catch (\Throwable $e) {
-        DebugLog::add(
-            sprintf(
-                '2FA passkey registration begin exception for account %d corr=%s (%s: %s).',
-                $acctId,
-                twofactorauth_setup_async_correlation_id(),
-                $e::class,
-                $e->getMessage()
-            ),
-            $acctId,
-            $acctId,
-            '2fa_passkey',
-            false,
-            false
-        );
-
-        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'pre-output', $acctId);
-        twofactorauth_output_json(twofactorauth_setup_async_error_payload('begin_exception', $e));
-        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'post-output', $acctId);
-
-        return;
-    }
-}
-
-/**
- * Complete setup passkey registration and persist credential metadata.
- *
- * Output contract note: this endpoint is called via fetch() and must always emit JSON on every
- * exit path. Returning HTML or an empty body breaks frontend parsing and hides actionable errors.
- */
-function twofactorauth_handle_finish_passkey_registration(): void
-{
-    global $session;
-
-    $acctId = (int) ($session['user']['acctid'] ?? 0);
-    twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'entry', $acctId);
-
-    try {
-        $requestBody = twofactorauth_read_json_request_body();
-
-        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'pre-csrf', $acctId);
-        $csrf = (string) ($requestBody['csrf_token'] ?? '');
-        if (!hash_equals(twofactorauth_csrf_token(), $csrf)) {
-            twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'post-csrf', $acctId);
-            twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'pre-output', $acctId);
-            twofactorauth_output_json(twofactorauth_setup_async_error_payload('csrf'));
-            twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'post-output', $acctId);
-
-            return;
-        }
-        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'post-csrf', $acctId);
-
-        $label = (string) ($requestBody['label'] ?? 'Passkey');
-
-        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'pre-service_call', $acctId);
-        $result = twofactorauth_passkey_service()->finishRegistration($acctId, $requestBody, $label);
-        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'post-service_call', $acctId);
-
-        if ($result['ok']) {
-            DebugLog::add(sprintf('2FA passkey registration success for account %d.', $acctId), $acctId, $acctId, '2fa_passkey', false, false);
-        } else {
-            DebugLog::add(sprintf('2FA passkey registration failure for account %d (reason: %s).', $acctId, $result['error']), $acctId, $acctId, '2fa_passkey', false, false);
-        }
-
-        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'pre-output', $acctId);
-        twofactorauth_output_json(['ok' => $result['ok'], 'error' => $result['error'], 'code' => $result['ok'] ? '' : (string) $result['error']]);
-        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'post-output', $acctId);
-
-        return;
-    } catch (\Throwable $e) {
-        DebugLog::add(
-            sprintf(
-                '2FA passkey registration finish exception for account %d corr=%s (%s: %s).',
-                $acctId,
-                twofactorauth_setup_async_correlation_id(),
-                $e::class,
-                $e->getMessage()
-            ),
-            $acctId,
-            $acctId,
-            '2fa_passkey',
-            false,
-            false
-        );
-
-        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'pre-output', $acctId);
-        twofactorauth_output_json(twofactorauth_setup_async_error_payload('finish_exception', $e));
-        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'post-output', $acctId);
-
-        return;
-    }
-}
-
-/**
- * Begin passkey authentication challenge for the pending 2FA login.
- *
- * Module prefs are the canonical persisted 2FA challenge state. Legacy ad-hoc
- * nested session data is not guaranteed to be synchronized for the synchronous
- * challenge flow, so this handler must read the pending challenge flags from
- * module prefs before applying the existing CSRF and ceremony begin logic.
- */
-function twofactorauth_handle_begin_passkey_auth(): void
-{
-    global $session;
-
-    // Module prefs are the persisted source of truth for pending 2FA state.
-    $pendingChallenge  = (int) get_module_pref('pending_challenge');
-    $lockedUntil       = (int) get_module_pref('locked_until');
-    $now               = time();
-
-    if ($pendingChallenge !== 1) {
-        twofactorauth_output_json([
-            'ok'    => false,
-            'error' => 'no_pending_2fa_challenge',
-        ]);
-        return;
-    }
-
-    if ($lockedUntil > 0 && $lockedUntil > $now) {
-        twofactorauth_output_json([
-            'ok'           => false,
-            'error'        => 'locked_out',
-            'locked_until' => $lockedUntil,
-        ]);
-        return;
-    }
-
-    $csrf = twofactorauth_extract_request_csrf_token();
-    if ($csrf === '' || !hash_equals(twofactorauth_csrf_token(), $csrf)) {
-        twofactorauth_output_json(twofactorauth_challenge_async_error_payload('csrf'));
-
-        return;
-    }
-
-    try {
-        $acctId = (int) ($session['user']['acctid'] ?? 0);
-        $existing = twofactorauth_passkey_repository()->listForAccount($acctId);
-        $credentialIds = array_map(static fn(array $item): string => (string) ($item['credential_id'] ?? ''), $existing);
-
-        $options = twofactorauth_passkey_service()->beginAuthentication($acctId, $credentialIds);
-
-        twofactorauth_output_json(['ok' => true, 'options' => $options]);
-    } catch (\Throwable $exception) {
-        $acctId = (int) ($session['user']['acctid'] ?? 0);
-        DebugLog::add(
-            sprintf('2FA passkey challenge begin exception for account %d (%s: %s).', $acctId, $exception::class, $exception->getMessage()),
-            $acctId,
-            $acctId,
-            '2fa_passkey',
-            false,
-            false
-        );
-
-        twofactorauth_output_json(twofactorauth_challenge_async_error_payload('begin_auth_exception', $exception));
-    }
-}
-
-/**
- * Complete passkey authentication and clear pending 2FA state on success.
- */
-function twofactorauth_handle_passkey_verification(): void
-{
-    global $session;
-
-    try {
-        if ((int) get_module_pref('pending_challenge') !== 1) {
-            twofactorauth_output_json(['ok' => false, 'error' => 'no_pending']);
-
-            return;
-        }
-
-        $acctId = (int) ($session['user']['acctid'] ?? 0);
-        $lockedUntil = (int) get_module_pref('locked_until');
-        $now = time();
-        if ($lockedUntil > $now) {
-            twofactorauth_output_json(['ok' => false, 'error' => 'locked']);
-
-            return;
-        }
-
-        $requestBody = twofactorauth_read_json_request_body();
-        $csrf = (string) ($requestBody['csrf_token'] ?? '');
-        if ($csrf === '' || !hash_equals(twofactorauth_csrf_token(), $csrf)) {
-            twofactorauth_output_json(twofactorauth_challenge_async_error_payload('csrf'));
-
-            return;
-        }
-
-        $result = twofactorauth_passkey_service()->finishAuthentication($acctId, $requestBody);
-        if ($result['ok']) {
-            twofactorauth_clear_pending_state();
-            twofactorauth_log_challenge_outcome($acctId, 'success', 'passkey');
-            DebugLog::add(sprintf('2FA passkey authentication success for account %d.', $acctId), $acctId, $acctId, '2fa_passkey', false, false);
-            twofactorauth_output_json(['ok' => true]);
-
-            return;
-        }
-
-        $fails = (int) get_module_pref('failed_attempts') + 1;
-        set_module_pref('failed_attempts', $fails);
-        $maxAttempts = (int) get_module_setting('max_attempts');
-        if ($fails >= $maxAttempts) {
-            set_module_pref('locked_until', $now + (int) get_module_setting('lock_seconds'));
-        }
-
-        twofactorauth_log_challenge_outcome($acctId, 'failure', 'passkey_' . $result['error']);
-        DebugLog::add(sprintf('2FA passkey authentication failure for account %d (reason: %s).', $acctId, $result['error']), $acctId, $acctId, '2fa_passkey', false, false);
-        twofactorauth_output_json(['ok' => false, 'error' => $result['error']]);
-    } catch (\Throwable $exception) {
-        $acctId = (int) ($session['user']['acctid'] ?? 0);
-        DebugLog::add(
-            sprintf('2FA passkey challenge verify exception for account %d (%s: %s).', $acctId, $exception::class, $exception->getMessage()),
-            $acctId,
-            $acctId,
-            '2fa_passkey',
-            false,
-            false
-        );
-
-        twofactorauth_output_json(twofactorauth_challenge_async_error_payload('verify_auth_exception', $exception));
-    }
-}
-
-/**
- * Return the preferred signing/encryption key material for this module.
- *
- * The current key is derived from installation-scoped secret material instead of only public
- * configuration. Existing installs may still hold data encrypted/signed with the legacy key, so
- * read/verify paths should call the compatibility helpers below during the transition window.
+ * Return the shared signing/encryption key material for this module.
  */
 function twofactorauth_signing_key(): string
 {
-    return twofactorauth_current_signing_key();
-}
-
-/**
- * Resolve the installation secret that anchors 2FA key derivation.
- *
- * The value is stored outside module settings so it is not exposed as routine public config. A
- * generated secret must stay stable across requests; rotating it invalidates encrypted TOTP
- * secrets and outstanding signed disable links unless the legacy fallback path can still read them.
- */
-function twofactorauth_secret_material(): string
-{
-    if (isset($GLOBALS['twofactorauth_test_install_secret']) && is_string($GLOBALS['twofactorauth_test_install_secret'])) {
-        $testSecret = trim($GLOBALS['twofactorauth_test_install_secret']);
-        if ($testSecret !== '') {
-            return $testSecret;
-        }
-    }
-
-    $settings = Settings::getInstance();
-    $settingName = 'twofactorauth_key_material';
-    $existing = trim((string) $settings->getSetting($settingName, ''));
-    if ($existing !== '') {
-        return $existing;
-    }
-
-    try {
-        $generated = bin2hex(random_bytes(32));
-    } catch (\Throwable) {
-        $generated = hash('sha256', uniqid('twofactorauth-key-', true) . '|' . microtime(true));
-    }
-
-    if ($settings->saveSetting($settingName, $generated)) {
-        return $generated;
-    }
-
-    // Re-read in case another request populated the setting first.
-    $reloaded = trim((string) $settings->getSetting($settingName, ''));
-    if ($reloaded !== '') {
-        return $reloaded;
-    }
-
-    // Last-resort fallback preserves availability in misconfigured environments, but this path
-    // should be treated as degraded because it cannot provide secret-backed key material.
-    return twofactorauth_legacy_signing_key();
-}
-
-/**
- * Derive the current 2FA key from installation-secret material.
- */
-function twofactorauth_current_signing_key(): string
-{
-    return hash_hmac('sha256', 'lotgd|twofactorauth|v2', twofactorauth_secret_material());
-}
-
-/**
- * Derive the legacy 2FA key used before secret-backed key material existed.
- *
- * This path exists only for backward compatibility while existing encrypted TOTP secrets and
- * disable-link tokens are migrated forward.
- */
-function twofactorauth_legacy_signing_key(): string
-{
     return hash('sha256', getsetting('serverurl', 'lotgd') . '|' . getsetting('gameadminemail', 'admin@example.com'));
-}
-
-/**
- * Return the ordered list of keys accepted for compatibility reads/verifications.
- *
- * @return array<int, string>
- */
-function twofactorauth_compatible_signing_keys(): array
-{
-    $keys = [twofactorauth_current_signing_key(), twofactorauth_legacy_signing_key()];
-
-    return array_values(array_unique(array_filter($keys, static fn(string $key): bool => $key !== '')));
-}
-
-/**
- * Decrypt a stored TOTP secret using the current key first, then the legacy key if needed.
- *
- * @return array{secret:string,key:string,used_legacy:bool,needs_reencrypt:bool,stored_secret:string}
- */
-function twofactorauth_decrypt_secret_with_compat(string $storedSecret): array
-{
-    $storedSecret = trim($storedSecret);
-    if ($storedSecret === '') {
-        return [
-            'secret' => '',
-            'key' => '',
-            'used_legacy' => false,
-            'needs_reencrypt' => false,
-            'stored_secret' => $storedSecret,
-        ];
-    }
-
-    $currentKey = twofactorauth_current_signing_key();
-    $canEncrypt = function_exists('openssl_encrypt');
-    foreach (twofactorauth_compatible_signing_keys() as $candidateKey) {
-        $secret = TwoFactorAuthService::decryptSecret($storedSecret, $candidateKey);
-        if ($secret === '') {
-            continue;
-        }
-
-        $usedLegacy = $candidateKey !== $currentKey;
-        $needsReencrypt = $usedLegacy || ($canEncrypt && !str_starts_with($storedSecret, 'enc:'));
-
-        return [
-            'secret' => $secret,
-            'key' => $candidateKey,
-            'used_legacy' => $usedLegacy,
-            'needs_reencrypt' => $needsReencrypt,
-            'stored_secret' => $storedSecret,
-        ];
-    }
-
-    return [
-        'secret' => '',
-        'key' => '',
-        'used_legacy' => false,
-        'needs_reencrypt' => false,
-        'stored_secret' => $storedSecret,
-    ];
-}
-
-/**
- * Re-encrypt a TOTP secret with the current key after a successful compatibility read.
- *
- * This keeps existing installs working while gradually moving accounts off the legacy key or
- * plaintext-at-rest fallback format during normal successful verification.
- *
- * @param array{secret:string,key:string,used_legacy:bool,needs_reencrypt:bool,stored_secret:string} $secretState
- */
-function twofactorauth_migrate_secret_after_success(array $secretState): void
-{
-    if (($secretState['secret'] ?? '') === '' || !($secretState['needs_reencrypt'] ?? false)) {
-        return;
-    }
-
-    $reencrypted = TwoFactorAuthService::encryptSecret((string) $secretState['secret'], twofactorauth_current_signing_key());
-    if ($reencrypted === '') {
-        return;
-    }
-
-    set_module_pref('secret_encrypted', $reencrypted);
-}
-
-/**
- * Verify disable-link tokens against both current and legacy signing keys.
- *
- * @return array{valid:bool,acctid:int,email:string,exp:int}
- */
-function twofactorauth_verify_disable_token_with_compat(string $token): array
-{
-    $currentKey = twofactorauth_current_signing_key();
-    $currentKeyValidation = null;
-
-    foreach (twofactorauth_compatible_signing_keys() as $candidateKey) {
-        $validation = TwoFactorAuthService::verifyDisableToken($token, $candidateKey);
-        if ($validation['valid']) {
-            return $validation;
-        }
-
-        if ($candidateKey === $currentKey) {
-            $currentKeyValidation = $validation;
-        }
-    }
-
-    if ($currentKeyValidation !== null) {
-        return $currentKeyValidation;
-    }
-
-    return TwoFactorAuthService::verifyDisableToken($token, $currentKey);
 }

--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -1404,15 +1404,19 @@ function twofactorauth_handle_finish_passkey_registration(): void
 
 /**
  * Begin passkey authentication challenge for the pending 2FA login.
+ *
+ * Module prefs are the canonical persisted 2FA challenge state. Legacy ad-hoc
+ * nested session data is not guaranteed to be synchronized for the synchronous
+ * challenge flow, so this handler must read the pending challenge flags from
+ * module prefs before applying the existing CSRF and ceremony begin logic.
  */
 function twofactorauth_handle_begin_passkey_auth(): void
 {
     global $session;
 
-    // Ensure there is a pending 2FA challenge and the account is not locked out
-    $twofaState        = $session['user']['twofactorauth'] ?? [];
-    $pendingChallenge  = (int) ($twofaState['pending_challenge'] ?? 0);
-    $lockedUntil       = isset($twofaState['locked_until']) ? (int) $twofaState['locked_until'] : 0;
+    // Module prefs are the persisted source of truth for pending 2FA state.
+    $pendingChallenge  = (int) get_module_pref('pending_challenge');
+    $lockedUntil       = (int) get_module_pref('locked_until');
     $now               = time();
 
     if ($pendingChallenge !== 1) {

--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -1093,6 +1093,51 @@ function twofactorauth_output_json(array $payload): void
 }
 
 /**
+ * Read the raw request body for passkey endpoints.
+ *
+ * Tests can override the transport body with a fixture string because php://input is not
+ * writable in the CLI runtime used by PHPUnit.
+ */
+function twofactorauth_read_request_body(): string
+{
+    if (isset($GLOBALS['twofactorauth_test_request_body']) && is_string($GLOBALS['twofactorauth_test_request_body'])) {
+        return $GLOBALS['twofactorauth_test_request_body'];
+    }
+
+    return (string) (file_get_contents('php://input') ?: '');
+}
+
+/**
+ * Decode a JSON request body into an associative array for passkey endpoints.
+ *
+ * @return array<string, mixed>
+ */
+function twofactorauth_read_json_request_body(): array
+{
+    $requestBody = json_decode(twofactorauth_read_request_body() ?: '{}', true);
+
+    return is_array($requestBody) ? $requestBody : [];
+}
+
+/**
+ * Extract the module CSRF token from either a JSON body or classic POST fields.
+ *
+ * The legacy synchronous passkey entry point may still receive either fetch()-style JSON
+ * or a traditional POST payload. This helper normalizes both transports before the
+ * handler compares the request token against the session token.
+ */
+function twofactorauth_extract_request_csrf_token(): string
+{
+    $requestBody = twofactorauth_read_json_request_body();
+    $csrf = (string) ($requestBody['csrf_token'] ?? '');
+    if ($csrf !== '') {
+        return $csrf;
+    }
+
+    return (string) Http::post('csrf_token');
+}
+
+/**
  * Keep setup async routes explicitly in allowed navigation entries.
  *
  * Forced-nav can redirect requests before module code fully executes. These endpoints are called
@@ -1233,10 +1278,7 @@ function twofactorauth_handle_begin_passkey_registration(): void
     twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'entry', $acctId);
 
     try {
-        $requestBody = json_decode(file_get_contents('php://input') ?: '{}', true);
-        if (!is_array($requestBody)) {
-            $requestBody = [];
-        }
+        $requestBody = twofactorauth_read_json_request_body();
 
         twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'pre-csrf', $acctId);
         $csrf = (string) ($requestBody['csrf_token'] ?? '');
@@ -1302,10 +1344,7 @@ function twofactorauth_handle_finish_passkey_registration(): void
     twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'entry', $acctId);
 
     try {
-        $requestBody = json_decode(file_get_contents('php://input') ?: '{}', true);
-        if (!is_array($requestBody)) {
-            $requestBody = [];
-        }
+        $requestBody = twofactorauth_read_json_request_body();
 
         twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'pre-csrf', $acctId);
         $csrf = (string) ($requestBody['csrf_token'] ?? '');
@@ -1390,6 +1429,13 @@ function twofactorauth_handle_begin_passkey_auth(): void
         return;
     }
 
+    $csrf = twofactorauth_extract_request_csrf_token();
+    if ($csrf === '' || !hash_equals(twofactorauth_csrf_token(), $csrf)) {
+        twofactorauth_output_json(twofactorauth_challenge_async_error_payload('csrf'));
+
+        return;
+    }
+
     try {
         $acctId = (int) ($session['user']['acctid'] ?? 0);
         $existing = twofactorauth_passkey_repository()->listForAccount($acctId);
@@ -1436,9 +1482,12 @@ function twofactorauth_handle_passkey_verification(): void
             return;
         }
 
-        $requestBody = json_decode(file_get_contents('php://input') ?: '{}', true);
-        if (!is_array($requestBody)) {
-            $requestBody = [];
+        $requestBody = twofactorauth_read_json_request_body();
+        $csrf = (string) ($requestBody['csrf_token'] ?? '');
+        if ($csrf === '' || !hash_equals(twofactorauth_csrf_token(), $csrf)) {
+            twofactorauth_output_json(twofactorauth_challenge_async_error_payload('csrf'));
+
+            return;
         }
 
         $result = twofactorauth_passkey_service()->finishAuthentication($acctId, $requestBody);

--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -15,6 +15,7 @@ use Lotgd\GameLog;
 use Lotgd\DebugLog;
 use Lotgd\Redirect;
 use Lotgd\Serialization;
+use Lotgd\Settings;
 use Lotgd\Translator;
 
 /**
@@ -592,7 +593,8 @@ function twofactorauth_handle_challenge_verification(Output $output): void
         return;
     }
 
-    $secret = TwoFactorAuthService::decryptSecret((string) get_module_pref('secret_encrypted'), twofactorauth_signing_key());
+    $secretState = twofactorauth_decrypt_secret_with_compat((string) get_module_pref('secret_encrypted'));
+    $secret = $secretState['secret'];
     $digits = (int) get_module_setting('token_digits');
     $period = (int) get_module_setting('period_seconds');
     $window = (int) get_module_setting('window');
@@ -600,6 +602,7 @@ function twofactorauth_handle_challenge_verification(Output $output): void
 
     $result = TwoFactorAuthService::verifyTotp($secret, $token, $digits, $period, $window, $lastStep, $now);
     if ($result['valid']) {
+        twofactorauth_migrate_secret_after_success($secretState);
         set_module_pref('last_used_timestep', $result['timestep']);
         twofactorauth_clear_pending_state();
         twofactorauth_log_challenge_outcome($acctId, 'success');
@@ -708,7 +711,7 @@ function twofactorauth_handle_disable_via_email(Output $output): void
     }
 
     $expires = time() + ((int) get_module_setting('disable_link_ttl_minutes') * 60);
-    $token = TwoFactorAuthService::signDisableToken($acctId, $email, $expires, twofactorauth_signing_key());
+    $token = TwoFactorAuthService::signDisableToken($acctId, $email, $expires, twofactorauth_current_signing_key());
     $confirmUri = 'runmodule.php?module=twofactorauth&op=confirm_disable&token=' . rawurlencode($token);
 
     set_module_pref('disable_token_hash', hash('sha256', $token));
@@ -735,7 +738,7 @@ function twofactorauth_handle_disable_confirmation(Output $output): void
     global $session;
 
     $token = (string) Http::get('token');
-    $validation = TwoFactorAuthService::verifyDisableToken($token, twofactorauth_signing_key());
+    $validation = twofactorauth_verify_disable_token_with_compat($token);
     $expectedHash = (string) get_module_pref('disable_token_hash');
     $expires = (int) get_module_pref('disable_token_expires');
 
@@ -1526,9 +1529,173 @@ function twofactorauth_handle_passkey_verification(): void
 }
 
 /**
- * Return the shared signing/encryption key material for this module.
+ * Return the preferred signing/encryption key material for this module.
+ *
+ * The current key is derived from installation-scoped secret material instead of only public
+ * configuration. Existing installs may still hold data encrypted/signed with the legacy key, so
+ * read/verify paths should call the compatibility helpers below during the transition window.
  */
 function twofactorauth_signing_key(): string
 {
+    return twofactorauth_current_signing_key();
+}
+
+/**
+ * Resolve the installation secret that anchors 2FA key derivation.
+ *
+ * The value is stored outside module settings so it is not exposed as routine public config. A
+ * generated secret must stay stable across requests; rotating it invalidates encrypted TOTP
+ * secrets and outstanding signed disable links unless the legacy fallback path can still read them.
+ */
+function twofactorauth_secret_material(): string
+{
+    if (isset($GLOBALS['twofactorauth_test_install_secret']) && is_string($GLOBALS['twofactorauth_test_install_secret'])) {
+        $testSecret = trim($GLOBALS['twofactorauth_test_install_secret']);
+        if ($testSecret !== '') {
+            return $testSecret;
+        }
+    }
+
+    $settings = Settings::getInstance();
+    $settingName = 'twofactorauth_key_material';
+    $existing = trim((string) $settings->getSetting($settingName, ''));
+    if ($existing !== '') {
+        return $existing;
+    }
+
+    try {
+        $generated = bin2hex(random_bytes(32));
+    } catch (\Throwable) {
+        $generated = hash('sha256', uniqid('twofactorauth-key-', true) . '|' . microtime(true));
+    }
+
+    if ($settings->saveSetting($settingName, $generated)) {
+        return $generated;
+    }
+
+    // Re-read in case another request populated the setting first.
+    $reloaded = trim((string) $settings->getSetting($settingName, ''));
+    if ($reloaded !== '') {
+        return $reloaded;
+    }
+
+    // Last-resort fallback preserves availability in misconfigured environments, but this path
+    // should be treated as degraded because it cannot provide secret-backed key material.
+    return twofactorauth_legacy_signing_key();
+}
+
+/**
+ * Derive the current 2FA key from installation-secret material.
+ */
+function twofactorauth_current_signing_key(): string
+{
+    return hash_hmac('sha256', 'lotgd|twofactorauth|v2', twofactorauth_secret_material());
+}
+
+/**
+ * Derive the legacy 2FA key used before secret-backed key material existed.
+ *
+ * This path exists only for backward compatibility while existing encrypted TOTP secrets and
+ * disable-link tokens are migrated forward.
+ */
+function twofactorauth_legacy_signing_key(): string
+{
     return hash('sha256', getsetting('serverurl', 'lotgd') . '|' . getsetting('gameadminemail', 'admin@example.com'));
+}
+
+/**
+ * Return the ordered list of keys accepted for compatibility reads/verifications.
+ *
+ * @return array<int, string>
+ */
+function twofactorauth_compatible_signing_keys(): array
+{
+    $keys = [twofactorauth_current_signing_key(), twofactorauth_legacy_signing_key()];
+
+    return array_values(array_unique(array_filter($keys, static fn(string $key): bool => $key !== '')));
+}
+
+/**
+ * Decrypt a stored TOTP secret using the current key first, then the legacy key if needed.
+ *
+ * @return array{secret:string,key:string,used_legacy:bool,needs_reencrypt:bool,stored_secret:string}
+ */
+function twofactorauth_decrypt_secret_with_compat(string $storedSecret): array
+{
+    $storedSecret = trim($storedSecret);
+    if ($storedSecret === '') {
+        return [
+            'secret' => '',
+            'key' => '',
+            'used_legacy' => false,
+            'needs_reencrypt' => false,
+            'stored_secret' => $storedSecret,
+        ];
+    }
+
+    $currentKey = twofactorauth_current_signing_key();
+    foreach (twofactorauth_compatible_signing_keys() as $candidateKey) {
+        $secret = TwoFactorAuthService::decryptSecret($storedSecret, $candidateKey);
+        if ($secret === '') {
+            continue;
+        }
+
+        $usedLegacy = $candidateKey !== $currentKey;
+        $needsReencrypt = $usedLegacy || !str_starts_with($storedSecret, 'enc:');
+
+        return [
+            'secret' => $secret,
+            'key' => $candidateKey,
+            'used_legacy' => $usedLegacy,
+            'needs_reencrypt' => $needsReencrypt,
+            'stored_secret' => $storedSecret,
+        ];
+    }
+
+    return [
+        'secret' => '',
+        'key' => '',
+        'used_legacy' => false,
+        'needs_reencrypt' => false,
+        'stored_secret' => $storedSecret,
+    ];
+}
+
+/**
+ * Re-encrypt a TOTP secret with the current key after a successful compatibility read.
+ *
+ * This keeps existing installs working while gradually moving accounts off the legacy key or
+ * plaintext-at-rest fallback format during normal successful verification.
+ *
+ * @param array{secret:string,key:string,used_legacy:bool,needs_reencrypt:bool,stored_secret:string} $secretState
+ */
+function twofactorauth_migrate_secret_after_success(array $secretState): void
+{
+    if (($secretState['secret'] ?? '') === '' || !($secretState['needs_reencrypt'] ?? false)) {
+        return;
+    }
+
+    $reencrypted = TwoFactorAuthService::encryptSecret((string) $secretState['secret'], twofactorauth_current_signing_key());
+    if ($reencrypted === '') {
+        return;
+    }
+
+    set_module_pref('secret_encrypted', $reencrypted);
+}
+
+/**
+ * Verify disable-link tokens against both current and legacy signing keys.
+ *
+ * @return array{valid:bool,acctid:int,email:string,exp:int}
+ */
+function twofactorauth_verify_disable_token_with_compat(string $token): array
+{
+    foreach (twofactorauth_compatible_signing_keys() as $candidateKey) {
+        $validation = TwoFactorAuthService::verifyDisableToken($token, $candidateKey);
+        if ($validation['valid']) {
+            return $validation;
+        }
+    }
+
+    return TwoFactorAuthService::verifyDisableToken($token, twofactorauth_current_signing_key());
 }

--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 require_once __DIR__ . '/TwoFactorAuth/TwoFactorAuthService.php';
 
 use Lotgd\Http;
+use Lotgd\Security\PasskeyCredentialRepository;
+use Lotgd\Security\PasskeyService;
 use Lotgd\Nav;
 use Lotgd\Output;
 use Lotgd\Page\Footer;
@@ -13,6 +15,7 @@ use Lotgd\GameLog;
 use Lotgd\DebugLog;
 use Lotgd\Redirect;
 use Lotgd\Serialization;
+use Lotgd\Settings;
 use Lotgd\Translator;
 
 /**
@@ -20,12 +23,17 @@ use Lotgd\Translator;
  */
 function twofactorauth_getmoduleinfo(): array
 {
+    $overrideForcedNav = twofactorauth_should_override_forced_nav_for_setup_async();
+
     return [
         'name' => 'Two Factor Auth',
         'version' => '1.0.0',
         'author' => 'Oliver Brendei',
         'category' => 'Security',
         'download' => 'core_module',
+        // Only bypass forced-nav for authenticated setup async routes that must emit raw JSON.
+        // Leaving this broad would let normal module page flow skip nav enforcement.
+        'override_forced_nav' => $overrideForcedNav,
         'settings' => [
             'Two Factor Auth Settings,title',
             'issuer_name' => 'Issuer label shown in authenticator apps,text|Legend of the Green Dragon',
@@ -42,6 +50,7 @@ function twofactorauth_getmoduleinfo(): array
         'prefs' => [
             'Two Factor Auth Preferences,title',
             'enabled' => 'Is TOTP enabled for this account?,bool|0',
+            'passkeys_enabled' => 'Has at least one passkey enrolled,viewonly',
             'secret_encrypted' => 'Encrypted TOTP secret,viewonly',
             'temp_secret_encrypted' => 'Temporary setup secret awaiting confirmation,viewonly',
             'verified_at' => 'Unix time of first successful setup verification,int|0',
@@ -58,6 +67,36 @@ function twofactorauth_getmoduleinfo(): array
             'resume_allowednavs_json' => 'Stored pre-challenge allowed-nav map as JSON,viewonly',
         ],
     ];
+}
+
+/**
+ * Restrict forced-nav bypass to passkey setup fetch endpoints.
+ *
+ * runmodule.php performs a second forced-nav check after common bootstrap. We only bypass
+ * that check for setup async routes to prevent fetch requests from being treated as the user's
+ * next interactive navigation target.
+ */
+function twofactorauth_should_override_forced_nav_for_setup_async(): bool
+{
+    global $session;
+
+    if (!(($session['loggedin'] ?? false) === true) || (int) ($session['user']['acctid'] ?? 0) <= 0) {
+        return false;
+    }
+
+    $op = (string) Http::get('op');
+    $setupOp = (string) Http::get('setupop');
+    if ($op !== 'setup') {
+        return false;
+    }
+
+    if ($setupOp !== 'begin_passkey_registration' && $setupOp !== 'finish_passkey_registration') {
+        return false;
+    }
+
+    $requestMethod = strtoupper((string) ($_SERVER['REQUEST_METHOD'] ?? ''));
+
+    return $requestMethod === 'POST';
 }
 
 function twofactorauth_install(): bool
@@ -86,7 +125,12 @@ function twofactorauth_dohook(string $hookname, array $args): array
                 break;
             }
 
-            if ((int) get_module_pref('enabled') !== 1) {
+            $totpEnabled = (int) get_module_pref('enabled') === 1;
+            $acctId = (int) ($session['user']['acctid'] ?? 0);
+            // Recompute passkey presence on login to avoid stale pref dead-ends.
+            $passkeysEnabled = $acctId > 0 && count(twofactorauth_passkey_repository()->listForAccount($acctId)) > 0;
+            set_module_pref('passkeys_enabled', $passkeysEnabled ? 1 : 0);
+            if (!$totpEnabled && !$passkeysEnabled) {
                 twofactorauth_clear_pending_state();
                 break;
             }
@@ -134,9 +178,12 @@ function twofactorauth_dohook(string $hookname, array $args): array
             }
 
             // Normalize to script+query so matching tolerates host/path differences.
+            // Keep async transport requests allowlisted while the challenge is pending:
+            // Jaxon polling/passkey methods expect JSON, and an HTML redirect response
+            // causes the client parser to fail before challenge handlers can run.
             $uriPath = (string) parse_url($requestUri, PHP_URL_PATH);
             $uriQuery = (string) parse_url($requestUri, PHP_URL_QUERY);
-            $normalizedRequestUri = $uriPath . ($uriQuery !== '' ? ('?' . $uriQuery) : '');
+            $normalizedRequestUri = ltrim($uriPath, '/') . ($uriQuery !== '' ? ('?' . $uriQuery) : '');
 
             if (!TwoFactorAuthService::isUriAllowed($normalizedRequestUri, $allowed)) {
                 $challengeUrl = 'runmodule.php?module=twofactorauth&op=challenge';
@@ -162,7 +209,63 @@ function twofactorauth_run(): void
 
     Translator::tlschema('module_twofactorauth');
 
+    $acctId = (int) ($session['user']['acctid'] ?? 0);
+    if ($acctId > 0) {
+        DebugLog::add(
+            sprintf('2FA run entry account %d op=%s.', $acctId, $op),
+            $acctId,
+            $acctId,
+            '2fa_verify',
+            false,
+            false
+        );
+    }
+    twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'entry', $acctId);
+
+    // Keep setup async routes in the explicit nav allow-list for this request lifecycle.
+    // Forced navigation checks compare the incoming URI against allowednavs and can reroute
+    // requests before handlers run when async endpoints are not whitelisted.
+    twofactorauth_allow_setup_async_nav_routes();
+    twofactorauth_register_passkey_transition_nav_targets();
+
     if ($op === 'setup') {
+        $setupOp = (string) Http::get('setupop');
+        // Setup async handlers must short-circuit before page chrome/nav rendering so browser
+        // fetch callers always receive raw JSON responses.
+        if ($setupOp === 'begin_passkey_registration') {
+            // CSRF validation is performed in the handler; run() records delegation boundaries.
+            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'pre-csrf', $acctId);
+            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'pre-service_call', $acctId);
+            twofactorauth_handle_begin_passkey_registration();
+            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'post-service_call', $acctId);
+            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'post-csrf', $acctId);
+            // Output is emitted in the async handler; keep explicit run() checkpoints for traceability.
+            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'pre-output', $acctId);
+            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'post-output', $acctId);
+            Translator::tlschema();
+
+            return;
+        }
+
+        if ($setupOp === 'finish_passkey_registration') {
+            // CSRF validation is performed in the handler; run() records delegation boundaries.
+            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'pre-csrf', $acctId);
+            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'pre-service_call', $acctId);
+            twofactorauth_handle_finish_passkey_registration();
+            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'post-service_call', $acctId);
+            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'post-csrf', $acctId);
+            // Output is emitted in the async handler; keep explicit run() checkpoints for traceability.
+            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'pre-output', $acctId);
+            twofactorauth_log_setup_async_checkpoint('twofactorauth_run', 'post-output', $acctId);
+            Translator::tlschema();
+
+            return;
+        }
+
+        // Passkey UI depends on Jaxon handlers; ensure async bootstrap is prepared
+        // regardless of the user's global AJAX preference for this critical 2FA flow.
+        twofactorauth_force_async_bootstrap();
+
         Header::pageHeader('Two-factor authentication setup');
         twofactorauth_render_setup($output);
         Footer::pageFooter();
@@ -174,6 +277,24 @@ function twofactorauth_run(): void
     if (!($session['loggedin'] ?? false)) {
         Redirect::redirect('index.php?op=timeout', '2FA endpoint without login');
     }
+
+    // JSON challenge operations must return raw JSON without page chrome wrappers.
+    if ($op === 'begin_passkey_auth') {
+        twofactorauth_handle_begin_passkey_auth();
+        Translator::tlschema();
+
+        return;
+    }
+
+    if ($op === 'verify_passkey') {
+        twofactorauth_handle_passkey_verification();
+        Translator::tlschema();
+
+        return;
+    }
+
+    // Challenge passkey actions also need Jaxon available even when normal polling is disabled.
+    twofactorauth_force_async_bootstrap();
 
     Header::pageHeader('Two-factor authentication challenge');
 
@@ -203,10 +324,12 @@ function twofactorauth_render_setup(Output $output): void
 {
     global $session;
 
+    $acctId = (int) ($session['user']['acctid'] ?? 0);
     $enabled = (int) get_module_pref('enabled') === 1;
     $requireVerified = (int) get_module_setting('require_verified_email') === 1;
     $secret = (string) get_module_pref('secret_encrypted');
     $email = (string) ($session['user']['emailaddress'] ?? '');
+    $csrf = twofactorauth_csrf_token();
 
     Nav::add('Navigation');
     Nav::add('Return to preferences', 'prefs.php');
@@ -220,12 +343,60 @@ function twofactorauth_render_setup(Output $output): void
     }
 
     if ($enabled) {
-        $output->output('Two-factor authentication is currently enabled on your account.`n');
-        $output->output('`$If you lose access to your authenticator app, use the login challenge page to request email recovery.`0`n`n');
-
+        $output->output('`vTwo-factor authentication is currently enabled on your account.`0`n`n');
+        $output->output('`$If you lose access to your authenticator app, use the login challenge page to request email recovery.`0`n');
     }
 
+    $repo = twofactorauth_passkey_repository();
+    $passkeys = $repo->listForAccount($acctId);
+    set_module_pref('passkeys_enabled', count($passkeys) > 0 ? 1 : 0);
+
     $setupOp = (string) Http::get('setupop');
+    $deleteCredentialId = trim((string) Http::post('delete_credential_id'));
+    if ($setupOp === 'delete_passkey' && $deleteCredentialId !== '') {
+        $postedCsrf = (string) Http::post('csrf_token');
+        if (hash_equals($csrf, $postedCsrf)) {
+            if ($repo->deleteForAccount($acctId, $deleteCredentialId)) {
+                $output->output('Passkey removed.`n');
+            } else {
+                $output->output('Passkey deletion failed or credential is not yours.`n');
+            }
+            $passkeys = $repo->listForAccount($acctId);
+            set_module_pref('passkeys_enabled', count($passkeys) > 0 ? 1 : 0);
+        } else {
+            $output->output('Invalid request token.`n');
+        }
+    }
+
+    $output->output('`n`bPasskeys`b`n');
+    $output->output('Passkeys are available as an alternative second factor to TOTP during login.`n');
+
+    addnav('', 'runmodule.php?module=twofactorauth&op=setup&setupop=begin_passkey_registration');
+    addnav('', 'runmodule.php?module=twofactorauth&op=setup&setupop=finish_passkey_registration');
+    rawoutput("<div id='twofactorauth-passkey-registration'>");
+    rawoutput("<label>" . htmlspecialchars(translate_inline('Passkey label'), ENT_QUOTES, 'UTF-8') . "</label> ");
+    rawoutput("<input type='text' id='passkey-label' value='This device' maxlength='120'> ");
+    rawoutput("<button type='button' id='passkey-add-button'>" . htmlspecialchars(translate_inline('Add passkey'), ENT_QUOTES, 'UTF-8') . "</button>");
+    rawoutput('</div>');
+
+    if ($passkeys === []) {
+        $output->output('No passkeys enrolled yet.`n');
+    } else {
+        foreach ($passkeys as $item) {
+            $label = (string) ($item['label'] ?: 'Passkey');
+            $credentialId = htmlspecialchars((string) $item['credential_id'], ENT_QUOTES, 'UTF-8');
+            $created = (int) ($item['created_at'] ?? 0);
+            $lastUsed = (int) ($item['last_used_at'] ?? 0);
+            $output->output('• %s (created: %s, last used: %s)`n', $label, date('Y-m-d H:i', $created), $lastUsed > 0 ? date('Y-m-d H:i', $lastUsed) : 'never');
+            addnav('', 'runmodule.php?module=twofactorauth&op=setup&setupop=delete_passkey');
+            rawoutput("<form action='runmodule.php?module=twofactorauth&op=setup&setupop=delete_passkey' method='POST' style='display:inline-block;margin-bottom:6px'>");
+            rawoutput("<input type='hidden' name='csrf_token' value='" . htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8') . "'>");
+            rawoutput("<input type='hidden' name='delete_credential_id' value='" . $credentialId . "'>");
+            rawoutput("<button type='submit'>" . htmlspecialchars(translate_inline('Delete passkey'), ENT_QUOTES, 'UTF-8') . "</button>");
+            rawoutput('</form><br>');
+        }
+    }
+
     $cryptoKey = twofactorauth_signing_key();
 
     if ($setupOp === 'start') {
@@ -236,12 +407,14 @@ function twofactorauth_render_setup(Output $output): void
     $tempSecret = TwoFactorAuthService::decryptSecret((string) get_module_pref('temp_secret_encrypted'), $cryptoKey);
     if ($tempSecret === '') {
         Nav::add('Actions');
-	if ($secret !== '') {
-		$output->output("You already have a device setup, you can remove it and setup a new device via email recovery`n`n");
-	} else {
-        	$output->output('You have not yet enrolled a device. Start setup to generate your TOTP secret.`n`n');
-        	Nav::add('Begin setup', 'runmodule.php?module=twofactorauth&op=setup&setupop=start');
-	}
+        if ($secret !== '') {
+            $output->output("`nYou already have a TOTP device setup, you can remove it and setup a new device via email recovery`n`n");
+        } else {
+            $output->output('`nYou have not yet enrolled a TOTP device. Start setup to generate your TOTP secret.`n`n');
+            Nav::add('Begin TOTP setup', 'runmodule.php?module=twofactorauth&op=setup&setupop=start');
+        }
+
+        twofactorauth_render_passkey_registration_script($csrf);
 
         return;
     }
@@ -255,19 +428,18 @@ function twofactorauth_render_setup(Output $output): void
     $qrProviderEndpoint = trim((string) get_module_setting('qr_provider_endpoint'));
     $qrCodeSize = max(120, (int) get_module_setting('qr_code_size'));
 
+    $output->output('`n`bTOTP fallback`b`n');
     $output->output('Scan the QR code in your authenticator app, or enter the secret manually.`n');
     $output->output('Manual secret: `^%s`0`n', $tempSecret);
 
     if ($qrProviderEndpoint !== '') {
         $qrCodeUrl = TwoFactorAuthService::buildQrCodeUrl($qrProviderEndpoint, $otpauthUri, $qrCodeSize);
-        // Show a scannable QR image while also retaining manual setup options.
         rawoutput("<div class='twofactorauth-qr'><img src='" . htmlspecialchars($qrCodeUrl, ENT_QUOTES, 'UTF-8') . "' alt='" . htmlspecialchars(translate_inline('Authenticator enrollment QR code'), ENT_QUOTES, 'UTF-8') . "' width='" . (int) $qrCodeSize . "' height='" . (int) $qrCodeSize . "'></div>");
     }
 
     $output->output('Enrollment URI (copy/paste if needed):`n%s`n`n', $otpauthUri);
     $output->output('Then enter your first one-time token to finish activation.`n');
 
-    // Only verify after an actual token submission; avoid false errors on initial setup page load.
     $submittedToken = Http::post('token');
     if ($submittedToken !== null) {
         $token = trim((string) $submittedToken);
@@ -281,20 +453,21 @@ function twofactorauth_render_setup(Output $output): void
                 set_module_pref('temp_secret_encrypted', '');
                 set_module_pref('verified_at', time());
                 set_module_pref('last_used_timestep', $result['timestep']);
-                $output->output('`n`$Two-factor authentication is now enabled.`n`n');
+                $output->output('`$Two-factor authentication is now enabled.`n`n');
             } else {
                 $output->output('The token was invalid. Please try again.`n');
             }
         }
     }
 
-    // Raw form actions are not auto-whitelisted by addnav(), so register them explicitly.
     addnav('', 'runmodule.php?module=twofactorauth&op=setup');
     rawoutput("<form action='runmodule.php?module=twofactorauth&op=setup' method='POST'>");
     rawoutput("<label>" . translate_inline('Authenticator token') . "</label> ");
     rawoutput("<input type='text' name='token' maxlength='10'> ");
     rawoutput("<button type='submit'>" . translate_inline('Enable') . "</button>");
     rawoutput('</form>');
+
+    twofactorauth_render_passkey_registration_script($csrf);
 }
 
 /**
@@ -302,26 +475,46 @@ function twofactorauth_render_setup(Output $output): void
  */
 function twofactorauth_render_challenge(Output $output): void
 {
+    global $session;
+
     if ((int) get_module_pref('pending_challenge') !== 1) {
         $output->output('No two-factor challenge is currently pending.`n');
 
         return;
     }
 
+    $acctId = (int) ($session['user']['acctid'] ?? 0);
+    $passkeys = twofactorauth_passkey_repository()->listForAccount($acctId);
+
     Nav::add('Actions');
     Nav::add('Submit token', 'runmodule.php?module=twofactorauth&op=verify');
+    if ($passkeys !== []) {
+        Nav::add('Use passkey', 'runmodule.php?module=twofactorauth&op=challenge');
+        addnav('', 'runmodule.php?module=twofactorauth&op=begin_passkey_auth');
+        addnav('', 'runmodule.php?module=twofactorauth&op=verify_passkey');
+    }
     Nav::add('Disable via email', 'runmodule.php?module=twofactorauth&op=disable_email');
 
-    $output->output('Password accepted, two-factor authentication is required.`n');
+    $output->output('`vPassword accepted, two-factor authentication is required.`0`n`n');
     $output->output('Enter the token from your authenticator app to continue.`n');
 
-    // Raw form actions are not auto-whitelisted by addnav(), so register them explicitly.
     addnav('', 'runmodule.php?module=twofactorauth&op=verify');
-    rawoutput("<form action='runmodule.php?module=twofactorauth&op=verify' method='POST'>");
+    // Keep explicit POST action; challenge verification must remain a classic form submit.
+    rawoutput("<form id='twofactorauth-challenge-form' action='runmodule.php?module=twofactorauth&op=verify' method='POST'>");
     rawoutput("<label>" . translate_inline('Authenticator token') . "</label> ");
     rawoutput("<input type='text' name='token' maxlength='10'> ");
     rawoutput("<button type='submit'>" . translate_inline('Verify') . "</button>");
     rawoutput('</form>');
+
+    if ($passkeys !== []) {
+        // Shared helper utilities are needed both on setup and challenge pages.
+        twofactorauth_render_passkey_js_helpers();
+        twofactorauth_render_passkey_jaxon_bridge();
+        $csrfJson = json_encode(twofactorauth_csrf_token()) ?: '""';
+        $showDebugJson = twofactorauth_is_megauser() ? 'true' : 'false';
+        rawoutput("<div style='margin-top:12px'><button type='button' id='twofactorauth-use-passkey'>" . htmlspecialchars(translate_inline('Use passkey'), ENT_QUOTES, 'UTF-8') . "</button></div>");
+        rawoutput("<script>(function(){if(window.__lotgdTwofactorauthChallengeSetupDone){return;}window.__lotgdTwofactorauthChallengeSetupDone=true;const btn=document.getElementById('twofactorauth-use-passkey');if(!btn){return;}const csrfToken=" . $csrfJson . ";const showDebug=" . $showDebugJson . ";const resolvedHandlers=typeof window.getJaxonHandlers==='function'?window.getJaxonHandlers():null;const namespace=resolvedHandlers&&resolvedHandlers.TwoFactorAuthPasskey?resolvedHandlers.TwoFactorAuthPasskey:(window.Lotgd&&window.Lotgd.Async&&window.Lotgd.Async.Handler&&window.Lotgd.Async.Handler.TwoFactorAuthPasskey?window.Lotgd.Async.Handler.TwoFactorAuthPasskey:(window.JaxonLotgd&&window.JaxonLotgd.Async&&window.JaxonLotgd.Async.Handler&&window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey?window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey:null));const beginExists=!!(namespace&&typeof namespace.beginAuthentication==='function');const buildDiag=function(data){if(!showDebug||!data){return'';}const code=data.error?String(data.error):'unknown';const diagId=data.diagnostic_id?String(data.diagnostic_id):'';const debug=data.debug_message?String(data.debug_message):'';const diagType=data.diagnostic&&data.diagnostic.type?String(data.diagnostic.type):'';let message='Passkey operation failed. Code: '+code+'.';if(diagId!==''){message+=' Diagnostic: '+diagId+'.';}if(diagType!==''){message+=' Type: '+diagType+'.';}if(debug!==''){message+=' Debug: '+debug;}return message;};btn.onclick=async function(){try{const beginData=await window.twofactorauthJaxonPasskeyCall('beginAuthentication',[csrfToken]);if(!beginData||!beginData.ok){alert(showDebug?buildDiag(beginData):'Passkey operation failed');return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const cred=await navigator.credentials.get({publicKey});if(!cred){alert('Passkey operation failed');return;}const body={id:cred.id,type:cred.type,response:{authenticatorData:window.twofactorauthArrayBufferToBase64Url(cred.response.authenticatorData),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(cred.response.clientDataJSON),signature:window.twofactorauthArrayBufferToBase64Url(cred.response.signature),userHandle:cred.response.userHandle?window.twofactorauthArrayBufferToBase64Url(cred.response.userHandle):''}};const verifyData=await window.twofactorauthJaxonPasskeyCall('verifyAuthentication',[csrfToken,body]);if(verifyData&&verifyData.ok){window.location='runmodule.php?module=twofactorauth&op=resume';return;}alert(showDebug?buildDiag(verifyData):'Passkey operation failed');}catch(e){const detail=e&&e.message?String(e.message):'';alert(showDebug&&detail!==''?'Passkey operation failed. Diagnostic: '+detail:'Passkey operation failed');}};})();</script>");
+    }
 }
 
 /**
@@ -331,22 +524,77 @@ function twofactorauth_handle_challenge_verification(Output $output): void
 {
     global $session;
 
+    $acctId = (int) ($session['user']['acctid'] ?? 0);
+    if ($acctId > 0) {
+        DebugLog::add(sprintf('2FA verify handler entry account %d.', $acctId), $acctId, $acctId, '2fa_verify', false, false);
+    }
     if ((int) get_module_pref('pending_challenge') !== 1) {
         Redirect::redirect('village.php', '2FA verify without pending state');
     }
 
+    $rawToken = Http::post('token');
+    if (!is_string($rawToken)) {
+        $token = '';
+    } else {
+        $token = trim($rawToken);
+    }
+    $hasToken = $token !== '';
+    $requestMethod = strtoupper((string) ($_SERVER['REQUEST_METHOD'] ?? 'GET'));
+    // Temporary diagnostics: only persist verify request-entry details for valid accounts to
+    // avoid noisy target=0 rows when unauthenticated/invalid requests hit the endpoint.
+    if ($acctId > 0) {
+        DebugLog::add(
+            sprintf(
+                '2FA verify entry account %d method=%s token_present=%s token_length=%d.',
+                $acctId,
+                $requestMethod,
+                $hasToken ? 'yes' : 'no',
+                strlen($token)
+            ),
+            $acctId,
+            $acctId,
+            '2fa_verify',
+            false,
+            false
+        );
+    }
+
+    if ($requestMethod !== 'POST') {
+        if ($acctId > 0) {
+            DebugLog::add(
+                sprintf(
+                    '2FA verify request account %d used unexpected method=%s.',
+                    $acctId,
+                    $requestMethod
+                ),
+                $acctId,
+                $acctId,
+                '2fa_verify',
+                false,
+                false
+            );
+        }
+        // Only classic form POST submissions are supported for verification; ignore other methods
+        // without mutating lockout or failed-attempts state.
+        $output->output('Invalid request method for verification.`n');
+
+        return;
+    }
+
     $now = time();
-    $acctId = (int) ($session['user']['acctid'] ?? 0);
     $lockedUntil = (int) get_module_pref('locked_until');
     if ($lockedUntil > $now) {
         twofactorauth_log_challenge_outcome($acctId, 'failure', 'locked');
+        if ($acctId > 0) {
+            DebugLog::add(sprintf('2FA verify exit account %d branch=locked.', $acctId), $acctId, $acctId, '2fa_verify', false, false);
+        }
         $output->output('Too many failures. Please wait before trying again.`n');
 
         return;
     }
 
-    $secret = TwoFactorAuthService::decryptSecret((string) get_module_pref('secret_encrypted'), twofactorauth_signing_key());
-    $token = (string) Http::post('token');
+    $secretState = twofactorauth_decrypt_secret_with_compat((string) get_module_pref('secret_encrypted'));
+    $secret = $secretState['secret'];
     $digits = (int) get_module_setting('token_digits');
     $period = (int) get_module_setting('period_seconds');
     $window = (int) get_module_setting('window');
@@ -354,9 +602,13 @@ function twofactorauth_handle_challenge_verification(Output $output): void
 
     $result = TwoFactorAuthService::verifyTotp($secret, $token, $digits, $period, $window, $lastStep, $now);
     if ($result['valid']) {
+        twofactorauth_migrate_secret_after_success($secretState);
         set_module_pref('last_used_timestep', $result['timestep']);
         twofactorauth_clear_pending_state();
         twofactorauth_log_challenge_outcome($acctId, 'success');
+        if ($acctId > 0) {
+            DebugLog::add(sprintf('2FA verify exit account %d branch=valid timestep=%d.', $acctId, (int) $result['timestep']), $acctId, $acctId, '2fa_verify', false, false);
+        }
         $output->output('Two-factor authentication complete. Welcome back.`n');
         Nav::add('Continue', 'runmodule.php?module=twofactorauth&op=resume');
 
@@ -371,11 +623,17 @@ function twofactorauth_handle_challenge_verification(Output $output): void
         $lockSeconds = (int) get_module_setting('lock_seconds');
         set_module_pref('locked_until', $now + $lockSeconds);
         twofactorauth_log_challenge_outcome($acctId, 'failure', 'locked');
+        if ($acctId > 0) {
+            DebugLog::add(sprintf('2FA verify exit account %d branch=locked fails=%d.', $acctId, $fails), $acctId, $acctId, '2fa_verify', false, false);
+        }
         $output->output('Too many failures. Challenge temporarily locked.`n');
     } else {
         // Slow down automated guessing while keeping the current challenge active for retries.
         sleep(2);
         twofactorauth_log_challenge_outcome($acctId, 'failure', (string) $result['reason']);
+        if ($acctId > 0) {
+            DebugLog::add(sprintf('2FA verify exit account %d branch=invalid reason=%s fails=%d.', $acctId, (string) ($result['reason'] ?? 'unknown'), $fails), $acctId, $acctId, '2fa_verify', false, false);
+        }
         $output->output('Invalid token. Please try again.`n');
         twofactorauth_render_challenge($output);
     }
@@ -453,7 +711,7 @@ function twofactorauth_handle_disable_via_email(Output $output): void
     }
 
     $expires = time() + ((int) get_module_setting('disable_link_ttl_minutes') * 60);
-    $token = TwoFactorAuthService::signDisableToken($acctId, $email, $expires, twofactorauth_signing_key());
+    $token = TwoFactorAuthService::signDisableToken($acctId, $email, $expires, twofactorauth_current_signing_key());
     $confirmUri = 'runmodule.php?module=twofactorauth&op=confirm_disable&token=' . rawurlencode($token);
 
     set_module_pref('disable_token_hash', hash('sha256', $token));
@@ -480,7 +738,7 @@ function twofactorauth_handle_disable_confirmation(Output $output): void
     global $session;
 
     $token = (string) Http::get('token');
-    $validation = TwoFactorAuthService::verifyDisableToken($token, twofactorauth_signing_key());
+    $validation = twofactorauth_verify_disable_token_with_compat($token);
     $expectedHash = (string) get_module_pref('disable_token_hash');
     $expires = (int) get_module_pref('disable_token_expires');
 
@@ -551,13 +809,13 @@ function twofactorauth_collect_resume_allowednavs_snapshot(): array
 
     $sessionAllowed = twofactorauth_snapshot_allowednavs($session['allowednavs'] ?? []);
     if ($sessionAllowed !== []) {
-        return $sessionAllowed;
+        return twofactorauth_ensure_nav_snapshot_has_passkey_transitions($sessionAllowed);
     }
 
     $serializedAccountAllowed = $session['user']['allowednavs'] ?? '';
     $decodedAccountAllowed = Serialization::safeUnserialize($serializedAccountAllowed);
 
-    return twofactorauth_snapshot_allowednavs($decodedAccountAllowed);
+    return twofactorauth_ensure_nav_snapshot_has_passkey_transitions(twofactorauth_snapshot_allowednavs($decodedAccountAllowed));
 }
 
 /**
@@ -568,7 +826,9 @@ function twofactorauth_persist_staged_resume_snapshot(): void
     global $session;
 
     $restorepage = (string) ($session['twofactorauth_resume_restorepage'] ?? '');
-    $allowedNavs = twofactorauth_snapshot_allowednavs($session['twofactorauth_resume_allowednavs'] ?? []);
+    $allowedNavs = twofactorauth_ensure_nav_snapshot_has_passkey_transitions(
+        twofactorauth_snapshot_allowednavs($session['twofactorauth_resume_allowednavs'] ?? [])
+    );
 
     set_module_pref('resume_restorepage', $restorepage);
     set_module_pref('resume_allowednavs_json', json_encode($allowedNavs, JSON_UNESCAPED_SLASHES) ?: '[]');
@@ -653,10 +913,805 @@ function twofactorauth_resolve_resume_target(string $target, array $allowedNavs)
     return '';
 }
 
+
 /**
- * Return the shared signing/encryption key material for this module.
+ * Build or return a CSRF token for setup lifecycle actions.
+ */
+function twofactorauth_csrf_token(): string
+{
+    global $session;
+
+    if (!isset($session['twofactorauth_csrf']) || !is_string($session['twofactorauth_csrf']) || $session['twofactorauth_csrf'] === '') {
+        $session['twofactorauth_csrf'] = bin2hex(random_bytes(16));
+    }
+
+    return (string) $session['twofactorauth_csrf'];
+}
+
+/**
+ * Shared passkey credential repository instance.
+ */
+function twofactorauth_passkey_repository(): PasskeyCredentialRepository
+{
+    static $repository = null;
+    if (!$repository instanceof PasskeyCredentialRepository) {
+        $repository = new PasskeyCredentialRepository();
+    }
+
+    return $repository;
+}
+
+/**
+ * Shared passkey service instance.
+ */
+function twofactorauth_passkey_service(): PasskeyService
+{
+    static $service = null;
+    if (!$service instanceof PasskeyService) {
+        $service = new PasskeyService(twofactorauth_passkey_repository());
+    }
+
+    return $service;
+}
+
+/**
+ * Render browser helpers for base64url decoding and passkey registration.
+ */
+function twofactorauth_render_passkey_js_helpers(): void
+{
+    rawoutput("<script>window.twofactorauthArrayBufferToBase64Url=window.twofactorauthArrayBufferToBase64Url||function(buffer){const bytes=new Uint8Array(buffer);let binary='';for(let i=0;i<bytes.length;i++){binary+=String.fromCharCode(bytes[i]);}return btoa(binary).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');};window.twofactorauthBase64UrlToArrayBuffer=window.twofactorauthBase64UrlToArrayBuffer||function(base64url){const padded=(base64url+'==='.slice((base64url.length+3)%4)).replace(/-/g,'+').replace(/_/g,'/');const binary=atob(padded);const bytes=new Uint8Array(binary.length);for(let i=0;i<binary.length;i++){bytes[i]=binary.charCodeAt(i);}return bytes.buffer;};window.twofactorauthDecodeCredentialOptions=window.twofactorauthDecodeCredentialOptions||function(publicKey){if(publicKey.challenge){publicKey.challenge=window.twofactorauthBase64UrlToArrayBuffer(publicKey.challenge);}if(publicKey.user&&publicKey.user.id){publicKey.user.id=window.twofactorauthBase64UrlToArrayBuffer(publicKey.user.id);}if(Array.isArray(publicKey.excludeCredentials)){publicKey.excludeCredentials=publicKey.excludeCredentials.map(function(c){if(c.id){c.id=window.twofactorauthBase64UrlToArrayBuffer(c.id);}return c;});}if(Array.isArray(publicKey.allowCredentials)){publicKey.allowCredentials=publicKey.allowCredentials.map(function(c){if(c.id){c.id=window.twofactorauthBase64UrlToArrayBuffer(c.id);}return c;});}return publicKey;};</script>");
+}
+
+/**
+ * Render a small Jaxon bridge for promise-based passkey calls.
+ *
+ * Jaxon executes response commands asynchronously but does not return ceremony payloads
+ * as fetch()-style JSON promises by default. This bridge maps request IDs to promise
+ * resolvers and receives payloads from the async handler callback.
+ *
+ * Transport/parser failures can abort before callback execution; in that case we reject
+ * pending promises immediately so users see the real failure instead of an artificial timeout.
+ *
+ * Preflight note: before invoking any passkey handler we verify the live Jaxon request URI still
+ * points at /async/process.php. This catches endpoint drift immediately, instead of waiting for
+ * bridge timeouts after requests are routed to non-JSON endpoints.
+ */
+function twofactorauth_render_passkey_jaxon_bridge(): void
+{
+    $showDebugJson = twofactorauth_is_megauser() ? 'true' : 'false';
+
+    $script = <<<'JAVASCRIPT'
+<script>(function(){window.twofactorauthPendingRequests=window.twofactorauthPendingRequests||{};const showDebug=__SHOW_DEBUG__;const expectedRequestPath='/async/process.php';const resolveCurrentRequestUri=function(){if(!window.jaxon||!jaxon.config){return'';}const configured=typeof jaxon.config.requestURI==='string'?jaxon.config.requestURI:'';if(configured===''){return'';}try{return new URL(configured,window.location.origin).pathname;}catch(_error){return configured;}};const rejectPending=function(requestId,message,details){if(!requestId){return;}const entry=window.twofactorauthPendingRequests[requestId];if(!entry){return;}if(entry.timeoutId){window.clearTimeout(entry.timeoutId);}delete window.twofactorauthPendingRequests[requestId];const composed=showDebug&&details?message+' Details: '+details:message;entry.reject(new Error(composed));};window.twofactorauthRejectAllPending=window.twofactorauthRejectAllPending||function(message,details){const ids=Object.keys(window.twofactorauthPendingRequests||{});for(let i=0;i<ids.length;i++){rejectPending(ids[i],message,details);}return ids.length;};window.twofactorauthHandleJaxonResponse=window.twofactorauthHandleJaxonResponse||function(requestId,payload){if(!requestId){return;}const entry=window.twofactorauthPendingRequests[requestId];if(!entry){return;}if(entry.timeoutId){window.clearTimeout(entry.timeoutId);}delete window.twofactorauthPendingRequests[requestId];entry.resolve(payload||{ok:false,error:'empty_response'});};window.twofactorauthGetCurrentJaxonRequestUri=window.twofactorauthGetCurrentJaxonRequestUri||resolveCurrentRequestUri;window.twofactorauthPreflightPasskeyRequestUri=window.twofactorauthPreflightPasskeyRequestUri||function(method){const current=resolveCurrentRequestUri();if(current===expectedRequestPath){return{ok:true,current:current};}const detail='method='+String(method)+' requestURI='+String(current||'unset')+' expected='+expectedRequestPath;return{ok:false,error:'request_uri_mismatch',detail:detail,current:current,expected:expectedRequestPath};};/** Resolve the passkey handler across generated Jaxon namespace variants.
+ *
+ * Compatibility note: hardening must not assume a single export root because
+ * Jaxon can emit namespaces under window.Lotgd, window.JaxonLotgd or helper accessors.
+ */window.twofactorauthResolvePasskeyHandler=window.twofactorauthResolvePasskeyHandler||function(method){const resolvedHandlers=typeof window.getJaxonHandlers==='function'?window.getJaxonHandlers():null;const requestedMethod=String(method||'');const candidates=[resolvedHandlers&&resolvedHandlers.TwoFactorAuthPasskey?resolvedHandlers.TwoFactorAuthPasskey:null,window.Lotgd&&window.Lotgd.Async&&window.Lotgd.Async.Handler?window.Lotgd.Async.Handler.TwoFactorAuthPasskey:null,window.JaxonLotgd&&window.JaxonLotgd.Async&&window.JaxonLotgd.Async.Handler?window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey:null];for(let i=0;i<candidates.length;i++){const candidate=candidates[i];if(candidate&&typeof candidate[requestedMethod]==='function'){return candidate;}}return null;};window.twofactorauthJaxonPasskeyCall=window.twofactorauthJaxonPasskeyCall||function(method,args){return new Promise(function(resolve,reject){const preflight=window.twofactorauthPreflightPasskeyRequestUri(method);if(!preflight.ok){const message='Passkey async endpoint mismatch.';const detail=preflight.detail||'';reject(new Error(showDebug&&detail!==''?message+' '+detail:message));return;}const namespace=window.twofactorauthResolvePasskeyHandler(method);if(!namespace){reject(new Error('Passkey async handler unavailable.'));return;}const requestId='tfa_'+Date.now()+'_'+Math.random().toString(16).slice(2);const timeoutId=window.setTimeout(function(){rejectPending(requestId,'Passkey async request timed out.','method='+String(method));},20000);window.twofactorauthPendingRequests[requestId]={resolve:resolve,reject:reject,timeoutId:timeoutId,method:method};const params=Array.isArray(args)?args.slice():[];params.unshift(requestId);try{namespace[method].apply(namespace,params);}catch(error){rejectPending(requestId,'Passkey async request dispatch failed.',error&&error.message?String(error.message):'unknown');}});};if(!window.__lotgdTwofactorPasskeyBridgeRejectionHooks){window.__lotgdTwofactorPasskeyBridgeRejectionHooks=true;window.addEventListener('unhandledrejection',function(event){const reason=event&&event.reason&&event.reason.message?String(event.reason.message):'';if(reason.indexOf('Unexpected end of JSON input')!==-1||reason.indexOf('JSON')!==-1){if(showDebug){console.warn('[TwoFactorAuthPasskey] Transport failure:',reason);}window.twofactorauthRejectAllPending('Passkey async parser failure.',reason);}});window.addEventListener('error',function(event){const message=event&&event.message?String(event.message):'';if(message.indexOf('Unexpected end of JSON input')!==-1){if(showDebug){console.warn('[TwoFactorAuthPasskey] Transport failure:',message);}window.twofactorauthRejectAllPending('Passkey async parser failure.',message);}});}})();</script>
+JAVASCRIPT;
+
+    rawoutput(str_replace('__SHOW_DEBUG__', $showDebugJson, $script));
+}
+
+/**
+ * Force-load async/Jaxon setup for passkey pages.
+ *
+ * Footer normally includes async/setup.php only when user AJAX preference is enabled.
+ * Passkey 2FA must continue to work regardless of that preference, so this helper loads
+ * the async bootstrap explicitly before headers are rendered on setup/challenge pages.
+ *
+ * Contract note: async/setup.php appends markup with string concatenation into a
+ * $pre_headscript buffer that it expects to receive from the including scope. This must
+ * be initialized as a string so Jaxon handler namespaces are bootstrapped reliably for
+ * passkey setup/login flows.
+ */
+function twofactorauth_force_async_bootstrap(): void
+{
+    static $bootstrapInjected = false;
+    if ($bootstrapInjected) {
+        return;
+    }
+
+    $asyncSetupFile = dirname(__DIR__) . '/async/setup.php';
+    if (!file_exists($asyncSetupFile)) {
+        return;
+    }
+
+    // Ensure async/setup.php sees the expected globals and capture any head scripts it registers.
+    global $session;
+
+    /** @var string|array<int, string> $pre_headscript */
+    // Keep string contract for async/setup.php and defensively normalize legacy array buffers.
+    $pre_headscript = '';
+
+    require_once $asyncSetupFile;
+
+    // async/setup.php expects string concatenation. Normalize array fallbacks into one buffer,
+    // then add the resulting head markup exactly once in this module request lifecycle.
+    if (is_array($pre_headscript)) {
+        $pre_headscript = implode('', array_filter($pre_headscript, static fn(mixed $item): bool => is_string($item) && $item !== ''));
+    } elseif (!is_string($pre_headscript)) {
+        $pre_headscript = '';
+    }
+
+    if ($pre_headscript !== '') {
+        Output::addHeadMarkup($pre_headscript);
+        $bootstrapInjected = true;
+    }
+}
+
+/**
+ * Build an async challenge error payload and expose debug internals only to megausers.
+ *
+ * @return array<string, mixed>
+ */
+function twofactorauth_challenge_async_error_payload(string $errorCode, ?\Throwable $exception = null): array
+{
+    $payload = ['ok' => false, 'error' => $errorCode, 'code' => $errorCode];
+    if ($exception instanceof \Throwable && twofactorauth_is_megauser()) {
+        $payload['debug_message'] = sprintf('%s: %s', $exception::class, $exception->getMessage());
+    }
+
+    return $payload;
+}
+
+/**
+ * Determine whether deep client/server diagnostics may be shown.
+ */
+function twofactorauth_is_megauser(): bool
+{
+    global $session;
+
+    $superuserFlags = (int) ($session['user']['superuser'] ?? 0);
+
+    return ($superuserFlags & SU_MEGAUSER) === SU_MEGAUSER;
+}
+
+/**
+ * Render browser helpers for base64url decoding and passkey registration.
+ */
+function twofactorauth_render_passkey_registration_script(string $csrf): void
+{
+    twofactorauth_render_passkey_js_helpers();
+    twofactorauth_render_passkey_jaxon_bridge();
+
+    $csrfJson = json_encode($csrf) ?: '""';
+    $showDebugJson = twofactorauth_is_megauser() ? 'true' : 'false';
+
+    // Assign via `onclick` so repeated script injection cannot stack multiple handlers.
+    // This setup page can be re-rendered in some module flows.
+    rawoutput("<script>(function(){const button=document.getElementById('passkey-add-button');if(!button){return;}const csrfToken=" . $csrfJson . ";const showDebug=" . $showDebugJson . ";const buildDiag=function(data){if(!showDebug||!data){return'';}const code=data.error?String(data.error):'unknown';const diagId=data.diagnostic_id?String(data.diagnostic_id):'';const debug=data.debug_message?String(data.debug_message):'';const diagType=data.diagnostic&&data.diagnostic.type?String(data.diagnostic.type):'';let message='Passkey operation failed. Code: '+code+'.';if(diagId!==''){message+=' Diagnostic: '+diagId+'.';}if(diagType!==''){message+=' Type: '+diagType+'.';}if(debug!==''){message+=' Debug: '+debug;}return message;};button.onclick=async function(){try{const labelEl=document.getElementById('passkey-label');const label=labelEl?labelEl.value:'';const beginData=await window.twofactorauthJaxonPasskeyCall('beginRegistration',[csrfToken,label]);if(!beginData||!beginData.ok){alert(showDebug?buildDiag(beginData):'Passkey operation failed');return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const credential=await navigator.credentials.create({publicKey});if(!credential){alert('Passkey operation failed');return;}const payload={id:credential.id,type:credential.type,response:{attestationObject:window.twofactorauthArrayBufferToBase64Url(credential.response.attestationObject),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(credential.response.clientDataJSON),transports:typeof credential.response.getTransports==='function'?credential.response.getTransports():[]}};const finishData=await window.twofactorauthJaxonPasskeyCall('finishRegistration',[csrfToken,label,payload]);if(finishData&&finishData.ok){window.location='runmodule.php?module=twofactorauth&op=setup';return;}alert(showDebug?buildDiag(finishData):'Passkey operation failed');}catch(error){const detail=error&&error.message?String(error.message):'';alert(showDebug&&detail!==''?'Passkey operation failed. Diagnostic: '+detail:'Passkey operation failed');}};})();</script>");
+}
+
+/**
+ * Emit a JSON payload for passkey async endpoints.
+ *
+ * @param array<string, mixed> $payload
+ */
+function twofactorauth_output_json(array $payload): void
+{
+    if (!headers_sent()) {
+        header('Content-Type: application/json; charset=UTF-8');
+    }
+
+    rawoutput(json_encode($payload) ?: '{"ok":false}');
+}
+
+/**
+ * Read the raw request body for passkey endpoints.
+ *
+ * Tests can override the transport body with a fixture string because php://input is not
+ * writable in the CLI runtime used by PHPUnit.
+ */
+function twofactorauth_read_request_body(): string
+{
+    if (isset($GLOBALS['twofactorauth_test_request_body']) && is_string($GLOBALS['twofactorauth_test_request_body'])) {
+        return $GLOBALS['twofactorauth_test_request_body'];
+    }
+
+    return (string) (file_get_contents('php://input') ?: '');
+}
+
+/**
+ * Decode a JSON request body into an associative array for passkey endpoints.
+ *
+ * @return array<string, mixed>
+ */
+function twofactorauth_read_json_request_body(): array
+{
+    $requestBody = json_decode(twofactorauth_read_request_body() ?: '{}', true);
+
+    return is_array($requestBody) ? $requestBody : [];
+}
+
+/**
+ * Extract the module CSRF token from either a JSON body or classic POST fields.
+ *
+ * The legacy synchronous passkey entry point may still receive either fetch()-style JSON
+ * or a traditional POST payload. This helper normalizes both transports before the
+ * handler compares the request token against the session token.
+ */
+function twofactorauth_extract_request_csrf_token(): string
+{
+    $requestBody = twofactorauth_read_json_request_body();
+    $csrf = (string) ($requestBody['csrf_token'] ?? '');
+    if ($csrf !== '') {
+        return $csrf;
+    }
+
+    return (string) Http::post('csrf_token');
+}
+
+/**
+ * Keep setup async routes explicitly in allowed navigation entries.
+ *
+ * Forced-nav can redirect requests before module code fully executes. These endpoints are called
+ * by JavaScript fetch() during setup and must stay forced-nav safe so JSON responses are not
+ * replaced by HTML redirects/chrome. Keep this allow-list narrow to avoid global bypasses.
+ */
+function twofactorauth_allow_setup_async_nav_routes(): void
+{
+    $op = (string) Http::get('op');
+    $setupOp = (string) Http::get('setupop');
+
+    if ($op !== 'setup') {
+        return;
+    }
+
+    if ($setupOp !== 'begin_passkey_registration' && $setupOp !== 'finish_passkey_registration') {
+        return;
+    }
+
+    addnav('', 'runmodule.php?module=twofactorauth&op=setup&setupop=' . $setupOp);
+}
+
+/**
+ * Return passkey lifecycle routes that must remain in allowed-nav snapshots.
+ *
+ * Async passkey success paths redirect the browser back to runmodule URLs. If these
+ * routes are missing from the forced-nav allowlist snapshot, the player can be sent to
+ * badnav.php after a successful ceremony.
+ *
+ * @return array<int, string>
+ */
+function twofactorauth_passkey_transition_nav_targets(): array
+{
+    return [
+        'runmodule.php?module=twofactorauth&op=challenge',
+        'runmodule.php?module=twofactorauth&op=resume',
+        'runmodule.php?module=twofactorauth&op=setup',
+    ];
+}
+
+/**
+ * Register passkey transition routes in the active request allowlist.
+ *
+ * These addnav() entries protect challenge/setup/resume redirects triggered by
+ * passkey success/failure handlers and by browser-side async completion callbacks.
+ */
+function twofactorauth_register_passkey_transition_nav_targets(): void
+{
+    foreach (twofactorauth_passkey_transition_nav_targets() as $target) {
+        addnav('', $target);
+    }
+}
+
+/**
+ * Ensure stored allowed-nav snapshots retain passkey transition URLs.
+ *
+ * Persisting these entries prevents forced-nav mismatches when async completion lands on
+ * op=resume or op=setup after the challenge lifecycle has already persisted its snapshot.
+ *
+ * @param array<string, bool> $allowedNavs
+ *
+ * @return array<string, bool>
+ */
+function twofactorauth_ensure_nav_snapshot_has_passkey_transitions(array $allowedNavs): array
+{
+    foreach (twofactorauth_passkey_transition_nav_targets() as $target) {
+        $allowedNavs[$target] = true;
+    }
+
+    return $allowedNavs;
+}
+
+/**
+ * Return a shared correlation id for this module request.
+ *
+ * Async passkey setup calls run via fetch() and never render full page chrome, so we attach
+ * one request-scoped id to every checkpoint log line to make end-to-end tracing reliable.
+ */
+function twofactorauth_setup_async_correlation_id(): string
+{
+    static $correlationId = null;
+    if (!is_string($correlationId)) {
+        $correlationId = bin2hex(random_bytes(8));
+    }
+
+    return $correlationId;
+}
+
+/**
+ * Write structured debug checkpoint details for passkey setup async handlers.
+ */
+function twofactorauth_log_setup_async_checkpoint(string $handler, string $checkpoint, int $acctId): void
+{
+    DebugLog::add(
+        sprintf(
+            '2FA passkey setup async [%s] checkpoint=%s corr=%s acct=%d.',
+            $handler,
+            $checkpoint,
+            twofactorauth_setup_async_correlation_id(),
+            $acctId
+        ),
+        $acctId,
+        $acctId,
+        '2fa_passkey',
+        false,
+        false
+    );
+}
+
+/**
+ * Build a setup async error payload while limiting detailed diagnostic data to megausers.
+ *
+ * @return array<string, mixed>
+ */
+function twofactorauth_setup_async_error_payload(string $errorCode, ?\Throwable $exception = null): array
+{
+    // Privilege-gate deep diagnostics: only megausers get internals to avoid leaking
+    // exception context to normal players while still enabling admin troubleshooting.
+    $payload = ['ok' => false, 'error' => $errorCode, 'code' => $errorCode];
+    if ($exception instanceof \Throwable && twofactorauth_is_megauser()) {
+        $payload['debug_message'] = sprintf('%s: %s', $exception::class, $exception->getMessage());
+    }
+
+    return $payload;
+}
+
+/**
+ * Begin setup passkey registration and return publicKeyCredentialCreationOptions as JSON.
+ *
+ * Output contract note: this endpoint is called via fetch() and must always emit JSON on every
+ * exit path. Returning HTML or an empty body breaks frontend parsing and hides actionable errors.
+ */
+function twofactorauth_handle_begin_passkey_registration(): void
+{
+    global $session;
+
+    $acctId = (int) ($session['user']['acctid'] ?? 0);
+    twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'entry', $acctId);
+
+    try {
+        $requestBody = twofactorauth_read_json_request_body();
+
+        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'pre-csrf', $acctId);
+        $csrf = (string) ($requestBody['csrf_token'] ?? '');
+        if (!hash_equals(twofactorauth_csrf_token(), $csrf)) {
+            twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'post-csrf', $acctId);
+            twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'pre-output', $acctId);
+            twofactorauth_output_json(twofactorauth_setup_async_error_payload('csrf'));
+            twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'post-output', $acctId);
+
+            return;
+        }
+        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'post-csrf', $acctId);
+
+        $login = (string) ($session['user']['login'] ?? 'player');
+        $display = (string) ($session['user']['name'] ?? $login);
+        $existing = twofactorauth_passkey_repository()->listForAccount($acctId);
+        $excludeIds = array_map(static fn(array $item): string => (string) ($item['credential_id'] ?? ''), $existing);
+
+        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'pre-service_call', $acctId);
+        $options = twofactorauth_passkey_service()->beginRegistration($acctId, $login, $display, $excludeIds);
+        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'post-service_call', $acctId);
+
+        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'pre-output', $acctId);
+        twofactorauth_output_json(['ok' => true, 'options' => $options]);
+        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'post-output', $acctId);
+
+        return;
+    } catch (\Throwable $e) {
+        DebugLog::add(
+            sprintf(
+                '2FA passkey registration begin exception for account %d corr=%s (%s: %s).',
+                $acctId,
+                twofactorauth_setup_async_correlation_id(),
+                $e::class,
+                $e->getMessage()
+            ),
+            $acctId,
+            $acctId,
+            '2fa_passkey',
+            false,
+            false
+        );
+
+        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'pre-output', $acctId);
+        twofactorauth_output_json(twofactorauth_setup_async_error_payload('begin_exception', $e));
+        twofactorauth_log_setup_async_checkpoint('begin_passkey_registration', 'post-output', $acctId);
+
+        return;
+    }
+}
+
+/**
+ * Complete setup passkey registration and persist credential metadata.
+ *
+ * Output contract note: this endpoint is called via fetch() and must always emit JSON on every
+ * exit path. Returning HTML or an empty body breaks frontend parsing and hides actionable errors.
+ */
+function twofactorauth_handle_finish_passkey_registration(): void
+{
+    global $session;
+
+    $acctId = (int) ($session['user']['acctid'] ?? 0);
+    twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'entry', $acctId);
+
+    try {
+        $requestBody = twofactorauth_read_json_request_body();
+
+        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'pre-csrf', $acctId);
+        $csrf = (string) ($requestBody['csrf_token'] ?? '');
+        if (!hash_equals(twofactorauth_csrf_token(), $csrf)) {
+            twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'post-csrf', $acctId);
+            twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'pre-output', $acctId);
+            twofactorauth_output_json(twofactorauth_setup_async_error_payload('csrf'));
+            twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'post-output', $acctId);
+
+            return;
+        }
+        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'post-csrf', $acctId);
+
+        $label = (string) ($requestBody['label'] ?? 'Passkey');
+
+        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'pre-service_call', $acctId);
+        $result = twofactorauth_passkey_service()->finishRegistration($acctId, $requestBody, $label);
+        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'post-service_call', $acctId);
+
+        if ($result['ok']) {
+            DebugLog::add(sprintf('2FA passkey registration success for account %d.', $acctId), $acctId, $acctId, '2fa_passkey', false, false);
+        } else {
+            DebugLog::add(sprintf('2FA passkey registration failure for account %d (reason: %s).', $acctId, $result['error']), $acctId, $acctId, '2fa_passkey', false, false);
+        }
+
+        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'pre-output', $acctId);
+        twofactorauth_output_json(['ok' => $result['ok'], 'error' => $result['error'], 'code' => $result['ok'] ? '' : (string) $result['error']]);
+        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'post-output', $acctId);
+
+        return;
+    } catch (\Throwable $e) {
+        DebugLog::add(
+            sprintf(
+                '2FA passkey registration finish exception for account %d corr=%s (%s: %s).',
+                $acctId,
+                twofactorauth_setup_async_correlation_id(),
+                $e::class,
+                $e->getMessage()
+            ),
+            $acctId,
+            $acctId,
+            '2fa_passkey',
+            false,
+            false
+        );
+
+        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'pre-output', $acctId);
+        twofactorauth_output_json(twofactorauth_setup_async_error_payload('finish_exception', $e));
+        twofactorauth_log_setup_async_checkpoint('finish_passkey_registration', 'post-output', $acctId);
+
+        return;
+    }
+}
+
+/**
+ * Begin passkey authentication challenge for the pending 2FA login.
+ *
+ * Module prefs are the canonical persisted 2FA challenge state. Legacy ad-hoc
+ * nested session data is not guaranteed to be synchronized for the synchronous
+ * challenge flow, so this handler must read the pending challenge flags from
+ * module prefs before applying the existing CSRF and ceremony begin logic.
+ */
+function twofactorauth_handle_begin_passkey_auth(): void
+{
+    global $session;
+
+    // Module prefs are the persisted source of truth for pending 2FA state.
+    $pendingChallenge  = (int) get_module_pref('pending_challenge');
+    $lockedUntil       = (int) get_module_pref('locked_until');
+    $now               = time();
+
+    if ($pendingChallenge !== 1) {
+        twofactorauth_output_json([
+            'ok'    => false,
+            'error' => 'no_pending_2fa_challenge',
+        ]);
+        return;
+    }
+
+    if ($lockedUntil > 0 && $lockedUntil > $now) {
+        twofactorauth_output_json([
+            'ok'           => false,
+            'error'        => 'locked_out',
+            'locked_until' => $lockedUntil,
+        ]);
+        return;
+    }
+
+    $csrf = twofactorauth_extract_request_csrf_token();
+    if ($csrf === '' || !hash_equals(twofactorauth_csrf_token(), $csrf)) {
+        twofactorauth_output_json(twofactorauth_challenge_async_error_payload('csrf'));
+
+        return;
+    }
+
+    try {
+        $acctId = (int) ($session['user']['acctid'] ?? 0);
+        $existing = twofactorauth_passkey_repository()->listForAccount($acctId);
+        $credentialIds = array_map(static fn(array $item): string => (string) ($item['credential_id'] ?? ''), $existing);
+
+        $options = twofactorauth_passkey_service()->beginAuthentication($acctId, $credentialIds);
+
+        twofactorauth_output_json(['ok' => true, 'options' => $options]);
+    } catch (\Throwable $exception) {
+        $acctId = (int) ($session['user']['acctid'] ?? 0);
+        DebugLog::add(
+            sprintf('2FA passkey challenge begin exception for account %d (%s: %s).', $acctId, $exception::class, $exception->getMessage()),
+            $acctId,
+            $acctId,
+            '2fa_passkey',
+            false,
+            false
+        );
+
+        twofactorauth_output_json(twofactorauth_challenge_async_error_payload('begin_auth_exception', $exception));
+    }
+}
+
+/**
+ * Complete passkey authentication and clear pending 2FA state on success.
+ */
+function twofactorauth_handle_passkey_verification(): void
+{
+    global $session;
+
+    try {
+        if ((int) get_module_pref('pending_challenge') !== 1) {
+            twofactorauth_output_json(['ok' => false, 'error' => 'no_pending']);
+
+            return;
+        }
+
+        $acctId = (int) ($session['user']['acctid'] ?? 0);
+        $lockedUntil = (int) get_module_pref('locked_until');
+        $now = time();
+        if ($lockedUntil > $now) {
+            twofactorauth_output_json(['ok' => false, 'error' => 'locked']);
+
+            return;
+        }
+
+        $requestBody = twofactorauth_read_json_request_body();
+        $csrf = (string) ($requestBody['csrf_token'] ?? '');
+        if ($csrf === '' || !hash_equals(twofactorauth_csrf_token(), $csrf)) {
+            twofactorauth_output_json(twofactorauth_challenge_async_error_payload('csrf'));
+
+            return;
+        }
+
+        $result = twofactorauth_passkey_service()->finishAuthentication($acctId, $requestBody);
+        if ($result['ok']) {
+            twofactorauth_clear_pending_state();
+            twofactorauth_log_challenge_outcome($acctId, 'success', 'passkey');
+            DebugLog::add(sprintf('2FA passkey authentication success for account %d.', $acctId), $acctId, $acctId, '2fa_passkey', false, false);
+            twofactorauth_output_json(['ok' => true]);
+
+            return;
+        }
+
+        $fails = (int) get_module_pref('failed_attempts') + 1;
+        set_module_pref('failed_attempts', $fails);
+        $maxAttempts = (int) get_module_setting('max_attempts');
+        if ($fails >= $maxAttempts) {
+            set_module_pref('locked_until', $now + (int) get_module_setting('lock_seconds'));
+        }
+
+        twofactorauth_log_challenge_outcome($acctId, 'failure', 'passkey_' . $result['error']);
+        DebugLog::add(sprintf('2FA passkey authentication failure for account %d (reason: %s).', $acctId, $result['error']), $acctId, $acctId, '2fa_passkey', false, false);
+        twofactorauth_output_json(['ok' => false, 'error' => $result['error']]);
+    } catch (\Throwable $exception) {
+        $acctId = (int) ($session['user']['acctid'] ?? 0);
+        DebugLog::add(
+            sprintf('2FA passkey challenge verify exception for account %d (%s: %s).', $acctId, $exception::class, $exception->getMessage()),
+            $acctId,
+            $acctId,
+            '2fa_passkey',
+            false,
+            false
+        );
+
+        twofactorauth_output_json(twofactorauth_challenge_async_error_payload('verify_auth_exception', $exception));
+    }
+}
+
+/**
+ * Return the preferred signing/encryption key material for this module.
+ *
+ * The current key is derived from installation-scoped secret material instead of only public
+ * configuration. Existing installs may still hold data encrypted/signed with the legacy key, so
+ * read/verify paths should call the compatibility helpers below during the transition window.
  */
 function twofactorauth_signing_key(): string
 {
+    return twofactorauth_current_signing_key();
+}
+
+/**
+ * Resolve the installation secret that anchors 2FA key derivation.
+ *
+ * The value is stored outside module settings so it is not exposed as routine public config. A
+ * generated secret must stay stable across requests; rotating it invalidates encrypted TOTP
+ * secrets and outstanding signed disable links unless the legacy fallback path can still read them.
+ */
+function twofactorauth_secret_material(): string
+{
+    if (isset($GLOBALS['twofactorauth_test_install_secret']) && is_string($GLOBALS['twofactorauth_test_install_secret'])) {
+        $testSecret = trim($GLOBALS['twofactorauth_test_install_secret']);
+        if ($testSecret !== '') {
+            return $testSecret;
+        }
+    }
+
+    $settings = Settings::getInstance();
+    $settingName = 'twofactorauth_key_material';
+    $existing = trim((string) $settings->getSetting($settingName, ''));
+    if ($existing !== '') {
+        return $existing;
+    }
+
+    try {
+        $generated = bin2hex(random_bytes(32));
+    } catch (\Throwable) {
+        $generated = hash('sha256', uniqid('twofactorauth-key-', true) . '|' . microtime(true));
+    }
+
+    if ($settings->saveSetting($settingName, $generated)) {
+        return $generated;
+    }
+
+    // Re-read in case another request populated the setting first.
+    $reloaded = trim((string) $settings->getSetting($settingName, ''));
+    if ($reloaded !== '') {
+        return $reloaded;
+    }
+
+    // Last-resort fallback preserves availability in misconfigured environments, but this path
+    // should be treated as degraded because it cannot provide secret-backed key material.
+    return twofactorauth_legacy_signing_key();
+}
+
+/**
+ * Derive the current 2FA key from installation-secret material.
+ */
+function twofactorauth_current_signing_key(): string
+{
+    return hash_hmac('sha256', 'lotgd|twofactorauth|v2', twofactorauth_secret_material());
+}
+
+/**
+ * Derive the legacy 2FA key used before secret-backed key material existed.
+ *
+ * This path exists only for backward compatibility while existing encrypted TOTP secrets and
+ * disable-link tokens are migrated forward.
+ */
+function twofactorauth_legacy_signing_key(): string
+{
     return hash('sha256', getsetting('serverurl', 'lotgd') . '|' . getsetting('gameadminemail', 'admin@example.com'));
+}
+
+/**
+ * Return the ordered list of keys accepted for compatibility reads/verifications.
+ *
+ * @return array<int, string>
+ */
+function twofactorauth_compatible_signing_keys(): array
+{
+    $keys = [twofactorauth_current_signing_key(), twofactorauth_legacy_signing_key()];
+
+    return array_values(array_unique(array_filter($keys, static fn(string $key): bool => $key !== '')));
+}
+
+/**
+ * Decrypt a stored TOTP secret using the current key first, then the legacy key if needed.
+ *
+ * @return array{secret:string,key:string,used_legacy:bool,needs_reencrypt:bool,stored_secret:string}
+ */
+function twofactorauth_decrypt_secret_with_compat(string $storedSecret): array
+{
+    $storedSecret = trim($storedSecret);
+    if ($storedSecret === '') {
+        return [
+            'secret' => '',
+            'key' => '',
+            'used_legacy' => false,
+            'needs_reencrypt' => false,
+            'stored_secret' => $storedSecret,
+        ];
+    }
+
+    $currentKey = twofactorauth_current_signing_key();
+    $canEncrypt = function_exists('openssl_encrypt');
+    foreach (twofactorauth_compatible_signing_keys() as $candidateKey) {
+        $secret = TwoFactorAuthService::decryptSecret($storedSecret, $candidateKey);
+        if ($secret === '') {
+            continue;
+        }
+
+        $usedLegacy = $candidateKey !== $currentKey;
+        $needsReencrypt = $usedLegacy || ($canEncrypt && !str_starts_with($storedSecret, 'enc:'));
+
+        return [
+            'secret' => $secret,
+            'key' => $candidateKey,
+            'used_legacy' => $usedLegacy,
+            'needs_reencrypt' => $needsReencrypt,
+            'stored_secret' => $storedSecret,
+        ];
+    }
+
+    return [
+        'secret' => '',
+        'key' => '',
+        'used_legacy' => false,
+        'needs_reencrypt' => false,
+        'stored_secret' => $storedSecret,
+    ];
+}
+
+/**
+ * Re-encrypt a TOTP secret with the current key after a successful compatibility read.
+ *
+ * This keeps existing installs working while gradually moving accounts off the legacy key or
+ * plaintext-at-rest fallback format during normal successful verification.
+ *
+ * @param array{secret:string,key:string,used_legacy:bool,needs_reencrypt:bool,stored_secret:string} $secretState
+ */
+function twofactorauth_migrate_secret_after_success(array $secretState): void
+{
+    if (($secretState['secret'] ?? '') === '' || !($secretState['needs_reencrypt'] ?? false)) {
+        return;
+    }
+
+    $reencrypted = TwoFactorAuthService::encryptSecret((string) $secretState['secret'], twofactorauth_current_signing_key());
+    if ($reencrypted === '') {
+        return;
+    }
+
+    set_module_pref('secret_encrypted', $reencrypted);
+}
+
+/**
+ * Verify disable-link tokens against both current and legacy signing keys.
+ *
+ * @return array{valid:bool,acctid:int,email:string,exp:int}
+ */
+function twofactorauth_verify_disable_token_with_compat(string $token): array
+{
+    $currentKey = twofactorauth_current_signing_key();
+    $currentKeyValidation = null;
+
+    foreach (twofactorauth_compatible_signing_keys() as $candidateKey) {
+        $validation = TwoFactorAuthService::verifyDisableToken($token, $candidateKey);
+        if ($validation['valid']) {
+            return $validation;
+        }
+
+        if ($candidateKey === $currentKey) {
+            $currentKeyValidation = $validation;
+        }
+    }
+
+    if ($currentKeyValidation !== null) {
+        return $currentKeyValidation;
+    }
+
+    return TwoFactorAuthService::verifyDisableToken($token, $currentKey);
 }

--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -1691,12 +1691,23 @@ function twofactorauth_migrate_secret_after_success(array $secretState): void
  */
 function twofactorauth_verify_disable_token_with_compat(string $token): array
 {
+    $currentKey = twofactorauth_current_signing_key();
+    $currentKeyValidation = null;
+
     foreach (twofactorauth_compatible_signing_keys() as $candidateKey) {
         $validation = TwoFactorAuthService::verifyDisableToken($token, $candidateKey);
         if ($validation['valid']) {
             return $validation;
         }
+
+        if ($candidateKey === $currentKey) {
+            $currentKeyValidation = $validation;
+        }
     }
 
-    return TwoFactorAuthService::verifyDisableToken($token, twofactorauth_current_signing_key());
+    if ($currentKeyValidation !== null) {
+        return $currentKeyValidation;
+    }
+
+    return TwoFactorAuthService::verifyDisableToken($token, $currentKey);
 }

--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -1634,6 +1634,7 @@ function twofactorauth_decrypt_secret_with_compat(string $storedSecret): array
     }
 
     $currentKey = twofactorauth_current_signing_key();
+    $canEncrypt = function_exists('openssl_encrypt');
     foreach (twofactorauth_compatible_signing_keys() as $candidateKey) {
         $secret = TwoFactorAuthService::decryptSecret($storedSecret, $candidateKey);
         if ($secret === '') {
@@ -1641,7 +1642,7 @@ function twofactorauth_decrypt_secret_with_compat(string $storedSecret): array
         }
 
         $usedLegacy = $candidateKey !== $currentKey;
-        $needsReencrypt = $usedLegacy || !str_starts_with($storedSecret, 'enc:');
+        $needsReencrypt = $usedLegacy || ($canEncrypt && !str_starts_with($storedSecret, 'enc:'));
 
         return [
             'secret' => $secret,

--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -319,6 +319,9 @@ function twofactorauth_run(): void
 
 /**
  * Render and process the user-facing setup page in preferences.
+ *
+ * Use Output::output() for translated/game-formatted text and Output::rawOutput()
+ * for literal HTML or JavaScript fragments that should bypass game-text formatting.
  */
 function twofactorauth_render_setup(Output $output): void
 {
@@ -373,11 +376,12 @@ function twofactorauth_render_setup(Output $output): void
 
     addnav('', 'runmodule.php?module=twofactorauth&op=setup&setupop=begin_passkey_registration');
     addnav('', 'runmodule.php?module=twofactorauth&op=setup&setupop=finish_passkey_registration');
-    rawoutput("<div id='twofactorauth-passkey-registration'>");
-    rawoutput("<label>" . htmlspecialchars(translate_inline('Passkey label'), ENT_QUOTES, 'UTF-8') . "</label> ");
-    rawoutput("<input type='text' id='passkey-label' value='This device' maxlength='120'> ");
-    rawoutput("<button type='button' id='passkey-add-button'>" . htmlspecialchars(translate_inline('Add passkey'), ENT_QUOTES, 'UTF-8') . "</button>");
-    rawoutput('</div>');
+    // Literal markup stays on rawOutput(); player-facing text remains on output().
+    $output->rawOutput("<div id='twofactorauth-passkey-registration'>");
+    $output->rawOutput("<label>" . htmlspecialchars(translate_inline('Passkey label'), ENT_QUOTES, 'UTF-8') . "</label> ");
+    $output->rawOutput("<input type='text' id='passkey-label' value='This device' maxlength='120'> ");
+    $output->rawOutput("<button type='button' id='passkey-add-button'>" . htmlspecialchars(translate_inline('Add passkey'), ENT_QUOTES, 'UTF-8') . "</button>");
+    $output->rawOutput('</div>');
 
     if ($passkeys === []) {
         $output->output('No passkeys enrolled yet.`n');
@@ -389,11 +393,11 @@ function twofactorauth_render_setup(Output $output): void
             $lastUsed = (int) ($item['last_used_at'] ?? 0);
             $output->output('• %s (created: %s, last used: %s)`n', $label, date('Y-m-d H:i', $created), $lastUsed > 0 ? date('Y-m-d H:i', $lastUsed) : 'never');
             addnav('', 'runmodule.php?module=twofactorauth&op=setup&setupop=delete_passkey');
-            rawoutput("<form action='runmodule.php?module=twofactorauth&op=setup&setupop=delete_passkey' method='POST' style='display:inline-block;margin-bottom:6px'>");
-            rawoutput("<input type='hidden' name='csrf_token' value='" . htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8') . "'>");
-            rawoutput("<input type='hidden' name='delete_credential_id' value='" . $credentialId . "'>");
-            rawoutput("<button type='submit'>" . htmlspecialchars(translate_inline('Delete passkey'), ENT_QUOTES, 'UTF-8') . "</button>");
-            rawoutput('</form><br>');
+            $output->rawOutput("<form action='runmodule.php?module=twofactorauth&op=setup&setupop=delete_passkey' method='POST' style='display:inline-block;margin-bottom:6px'>");
+            $output->rawOutput("<input type='hidden' name='csrf_token' value='" . htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8') . "'>");
+            $output->rawOutput("<input type='hidden' name='delete_credential_id' value='" . $credentialId . "'>");
+            $output->rawOutput("<button type='submit'>" . htmlspecialchars(translate_inline('Delete passkey'), ENT_QUOTES, 'UTF-8') . "</button>");
+            $output->rawOutput('</form><br>');
         }
     }
 
@@ -414,7 +418,7 @@ function twofactorauth_render_setup(Output $output): void
             Nav::add('Begin TOTP setup', 'runmodule.php?module=twofactorauth&op=setup&setupop=start');
         }
 
-        twofactorauth_render_passkey_registration_script($csrf);
+        twofactorauth_render_passkey_registration_script($output, $csrf);
 
         return;
     }
@@ -434,7 +438,7 @@ function twofactorauth_render_setup(Output $output): void
 
     if ($qrProviderEndpoint !== '') {
         $qrCodeUrl = TwoFactorAuthService::buildQrCodeUrl($qrProviderEndpoint, $otpauthUri, $qrCodeSize);
-        rawoutput("<div class='twofactorauth-qr'><img src='" . htmlspecialchars($qrCodeUrl, ENT_QUOTES, 'UTF-8') . "' alt='" . htmlspecialchars(translate_inline('Authenticator enrollment QR code'), ENT_QUOTES, 'UTF-8') . "' width='" . (int) $qrCodeSize . "' height='" . (int) $qrCodeSize . "'></div>");
+        $output->rawOutput("<div class='twofactorauth-qr'><img src='" . htmlspecialchars($qrCodeUrl, ENT_QUOTES, 'UTF-8') . "' alt='" . htmlspecialchars(translate_inline('Authenticator enrollment QR code'), ENT_QUOTES, 'UTF-8') . "' width='" . (int) $qrCodeSize . "' height='" . (int) $qrCodeSize . "'></div>");
     }
 
     $output->output('Enrollment URI (copy/paste if needed):`n%s`n`n', $otpauthUri);
@@ -461,17 +465,20 @@ function twofactorauth_render_setup(Output $output): void
     }
 
     addnav('', 'runmodule.php?module=twofactorauth&op=setup');
-    rawoutput("<form action='runmodule.php?module=twofactorauth&op=setup' method='POST'>");
-    rawoutput("<label>" . translate_inline('Authenticator token') . "</label> ");
-    rawoutput("<input type='text' name='token' maxlength='10'> ");
-    rawoutput("<button type='submit'>" . translate_inline('Enable') . "</button>");
-    rawoutput('</form>');
+    $output->rawOutput("<form action='runmodule.php?module=twofactorauth&op=setup' method='POST'>");
+    $output->rawOutput("<label>" . translate_inline('Authenticator token') . "</label> ");
+    $output->rawOutput("<input type='text' name='token' maxlength='10'> ");
+    $output->rawOutput("<button type='submit'>" . translate_inline('Enable') . "</button>");
+    $output->rawOutput('</form>');
 
-    twofactorauth_render_passkey_registration_script($csrf);
+    twofactorauth_render_passkey_registration_script($output, $csrf);
 }
 
 /**
  * Render the 2FA challenge while login is pending.
+ *
+ * Keep Output::output() for translated/game text and Output::rawOutput() for
+ * literal form/button/script fragments rendered into the page.
  */
 function twofactorauth_render_challenge(Output $output): void
 {
@@ -500,20 +507,20 @@ function twofactorauth_render_challenge(Output $output): void
 
     addnav('', 'runmodule.php?module=twofactorauth&op=verify');
     // Keep explicit POST action; challenge verification must remain a classic form submit.
-    rawoutput("<form id='twofactorauth-challenge-form' action='runmodule.php?module=twofactorauth&op=verify' method='POST'>");
-    rawoutput("<label>" . translate_inline('Authenticator token') . "</label> ");
-    rawoutput("<input type='text' name='token' maxlength='10'> ");
-    rawoutput("<button type='submit'>" . translate_inline('Verify') . "</button>");
-    rawoutput('</form>');
+    $output->rawOutput("<form id='twofactorauth-challenge-form' action='runmodule.php?module=twofactorauth&op=verify' method='POST'>");
+    $output->rawOutput("<label>" . translate_inline('Authenticator token') . "</label> ");
+    $output->rawOutput("<input type='text' name='token' maxlength='10'> ");
+    $output->rawOutput("<button type='submit'>" . translate_inline('Verify') . "</button>");
+    $output->rawOutput('</form>');
 
     if ($passkeys !== []) {
         // Shared helper utilities are needed both on setup and challenge pages.
-        twofactorauth_render_passkey_js_helpers();
-        twofactorauth_render_passkey_jaxon_bridge();
+        twofactorauth_render_passkey_js_helpers($output);
+        twofactorauth_render_passkey_jaxon_bridge($output);
         $csrfJson = json_encode(twofactorauth_csrf_token()) ?: '""';
         $showDebugJson = twofactorauth_is_megauser() ? 'true' : 'false';
-        rawoutput("<div style='margin-top:12px'><button type='button' id='twofactorauth-use-passkey'>" . htmlspecialchars(translate_inline('Use passkey'), ENT_QUOTES, 'UTF-8') . "</button></div>");
-        rawoutput("<script>(function(){if(window.__lotgdTwofactorauthChallengeSetupDone){return;}window.__lotgdTwofactorauthChallengeSetupDone=true;const btn=document.getElementById('twofactorauth-use-passkey');if(!btn){return;}const csrfToken=" . $csrfJson . ";const showDebug=" . $showDebugJson . ";const resolvedHandlers=typeof window.getJaxonHandlers==='function'?window.getJaxonHandlers():null;const namespace=resolvedHandlers&&resolvedHandlers.TwoFactorAuthPasskey?resolvedHandlers.TwoFactorAuthPasskey:(window.Lotgd&&window.Lotgd.Async&&window.Lotgd.Async.Handler&&window.Lotgd.Async.Handler.TwoFactorAuthPasskey?window.Lotgd.Async.Handler.TwoFactorAuthPasskey:(window.JaxonLotgd&&window.JaxonLotgd.Async&&window.JaxonLotgd.Async.Handler&&window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey?window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey:null));const beginExists=!!(namespace&&typeof namespace.beginAuthentication==='function');const buildDiag=function(data){if(!showDebug||!data){return'';}const code=data.error?String(data.error):'unknown';const diagId=data.diagnostic_id?String(data.diagnostic_id):'';const debug=data.debug_message?String(data.debug_message):'';const diagType=data.diagnostic&&data.diagnostic.type?String(data.diagnostic.type):'';let message='Passkey operation failed. Code: '+code+'.';if(diagId!==''){message+=' Diagnostic: '+diagId+'.';}if(diagType!==''){message+=' Type: '+diagType+'.';}if(debug!==''){message+=' Debug: '+debug;}return message;};btn.onclick=async function(){try{const beginData=await window.twofactorauthJaxonPasskeyCall('beginAuthentication',[csrfToken]);if(!beginData||!beginData.ok){alert(showDebug?buildDiag(beginData):'Passkey operation failed');return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const cred=await navigator.credentials.get({publicKey});if(!cred){alert('Passkey operation failed');return;}const body={id:cred.id,type:cred.type,response:{authenticatorData:window.twofactorauthArrayBufferToBase64Url(cred.response.authenticatorData),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(cred.response.clientDataJSON),signature:window.twofactorauthArrayBufferToBase64Url(cred.response.signature),userHandle:cred.response.userHandle?window.twofactorauthArrayBufferToBase64Url(cred.response.userHandle):''}};const verifyData=await window.twofactorauthJaxonPasskeyCall('verifyAuthentication',[csrfToken,body]);if(verifyData&&verifyData.ok){window.location='runmodule.php?module=twofactorauth&op=resume';return;}alert(showDebug?buildDiag(verifyData):'Passkey operation failed');}catch(e){const detail=e&&e.message?String(e.message):'';alert(showDebug&&detail!==''?'Passkey operation failed. Diagnostic: '+detail:'Passkey operation failed');}};})();</script>");
+        $output->rawOutput("<div style='margin-top:12px'><button type='button' id='twofactorauth-use-passkey'>" . htmlspecialchars(translate_inline('Use passkey'), ENT_QUOTES, 'UTF-8') . "</button></div>");
+        $output->rawOutput("<script>(function(){if(window.__lotgdTwofactorauthChallengeSetupDone){return;}window.__lotgdTwofactorauthChallengeSetupDone=true;const btn=document.getElementById('twofactorauth-use-passkey');if(!btn){return;}const csrfToken=" . $csrfJson . ";const showDebug=" . $showDebugJson . ";const resolvedHandlers=typeof window.getJaxonHandlers==='function'?window.getJaxonHandlers():null;const namespace=resolvedHandlers&&resolvedHandlers.TwoFactorAuthPasskey?resolvedHandlers.TwoFactorAuthPasskey:(window.Lotgd&&window.Lotgd.Async&&window.Lotgd.Async.Handler&&window.Lotgd.Async.Handler.TwoFactorAuthPasskey?window.Lotgd.Async.Handler.TwoFactorAuthPasskey:(window.JaxonLotgd&&window.JaxonLotgd.Async&&window.JaxonLotgd.Async.Handler&&window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey?window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey:null));const beginExists=!!(namespace&&typeof namespace.beginAuthentication==='function');const buildDiag=function(data){if(!showDebug||!data){return'';}const code=data.error?String(data.error):'unknown';const diagId=data.diagnostic_id?String(data.diagnostic_id):'';const debug=data.debug_message?String(data.debug_message):'';const diagType=data.diagnostic&&data.diagnostic.type?String(data.diagnostic.type):'';let message='Passkey operation failed. Code: '+code+'.';if(diagId!==''){message+=' Diagnostic: '+diagId+'.';}if(diagType!==''){message+=' Type: '+diagType+'.';}if(debug!==''){message+=' Debug: '+debug;}return message;};btn.onclick=async function(){try{const beginData=await window.twofactorauthJaxonPasskeyCall('beginAuthentication',[csrfToken]);if(!beginData||!beginData.ok){alert(showDebug?buildDiag(beginData):'Passkey operation failed');return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const cred=await navigator.credentials.get({publicKey});if(!cred){alert('Passkey operation failed');return;}const body={id:cred.id,type:cred.type,response:{authenticatorData:window.twofactorauthArrayBufferToBase64Url(cred.response.authenticatorData),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(cred.response.clientDataJSON),signature:window.twofactorauthArrayBufferToBase64Url(cred.response.signature),userHandle:cred.response.userHandle?window.twofactorauthArrayBufferToBase64Url(cred.response.userHandle):''}};const verifyData=await window.twofactorauthJaxonPasskeyCall('verifyAuthentication',[csrfToken,body]);if(verifyData&&verifyData.ok){window.location='runmodule.php?module=twofactorauth&op=resume';return;}alert(showDebug?buildDiag(verifyData):'Passkey operation failed');}catch(e){const detail=e&&e.message?String(e.message):'';alert(showDebug&&detail!==''?'Passkey operation failed. Diagnostic: '+detail:'Passkey operation failed');}};})();</script>");
     }
 }
 
@@ -956,10 +963,23 @@ function twofactorauth_passkey_service(): PasskeyService
 
 /**
  * Render browser helpers for base64url decoding and passkey registration.
+ *
+ * These are literal script fragments, so they should use Output::rawOutput() from
+ * the active page-rendering context instead of the legacy global rawoutput().
+ *
+ * The Output argument is optional to preserve direct helper/test invocations.
  */
-function twofactorauth_render_passkey_js_helpers(): void
+function twofactorauth_render_passkey_js_helpers(?Output $output = null): void
 {
-    rawoutput("<script>window.twofactorauthArrayBufferToBase64Url=window.twofactorauthArrayBufferToBase64Url||function(buffer){const bytes=new Uint8Array(buffer);let binary='';for(let i=0;i<bytes.length;i++){binary+=String.fromCharCode(bytes[i]);}return btoa(binary).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');};window.twofactorauthBase64UrlToArrayBuffer=window.twofactorauthBase64UrlToArrayBuffer||function(base64url){const padded=(base64url+'==='.slice((base64url.length+3)%4)).replace(/-/g,'+').replace(/_/g,'/');const binary=atob(padded);const bytes=new Uint8Array(binary.length);for(let i=0;i<binary.length;i++){bytes[i]=binary.charCodeAt(i);}return bytes.buffer;};window.twofactorauthDecodeCredentialOptions=window.twofactorauthDecodeCredentialOptions||function(publicKey){if(publicKey.challenge){publicKey.challenge=window.twofactorauthBase64UrlToArrayBuffer(publicKey.challenge);}if(publicKey.user&&publicKey.user.id){publicKey.user.id=window.twofactorauthBase64UrlToArrayBuffer(publicKey.user.id);}if(Array.isArray(publicKey.excludeCredentials)){publicKey.excludeCredentials=publicKey.excludeCredentials.map(function(c){if(c.id){c.id=window.twofactorauthBase64UrlToArrayBuffer(c.id);}return c;});}if(Array.isArray(publicKey.allowCredentials)){publicKey.allowCredentials=publicKey.allowCredentials.map(function(c){if(c.id){c.id=window.twofactorauthBase64UrlToArrayBuffer(c.id);}return c;});}return publicKey;};</script>");
+    $script = "<script>window.twofactorauthArrayBufferToBase64Url=window.twofactorauthArrayBufferToBase64Url||function(buffer){const bytes=new Uint8Array(buffer);let binary='';for(let i=0;i<bytes.length;i++){binary+=String.fromCharCode(bytes[i]);}return btoa(binary).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');};window.twofactorauthBase64UrlToArrayBuffer=window.twofactorauthBase64UrlToArrayBuffer||function(base64url){const padded=(base64url+'==='.slice((base64url.length+3)%4)).replace(/-/g,'+').replace(/_/g,'/');const binary=atob(padded);const bytes=new Uint8Array(binary.length);for(let i=0;i<binary.length;i++){bytes[i]=binary.charCodeAt(i);}return bytes.buffer;};window.twofactorauthDecodeCredentialOptions=window.twofactorauthDecodeCredentialOptions||function(publicKey){if(publicKey.challenge){publicKey.challenge=window.twofactorauthBase64UrlToArrayBuffer(publicKey.challenge);}if(publicKey.user&&publicKey.user.id){publicKey.user.id=window.twofactorauthBase64UrlToArrayBuffer(publicKey.user.id);}if(Array.isArray(publicKey.excludeCredentials)){publicKey.excludeCredentials=publicKey.excludeCredentials.map(function(c){if(c.id){c.id=window.twofactorauthBase64UrlToArrayBuffer(c.id);}return c;});}if(Array.isArray(publicKey.allowCredentials)){publicKey.allowCredentials=publicKey.allowCredentials.map(function(c){if(c.id){c.id=window.twofactorauthBase64UrlToArrayBuffer(c.id);}return c;});}return publicKey;};</script>";
+
+    if ($output instanceof Output) {
+        $output->rawOutput($script);
+
+        return;
+    }
+
+    rawoutput($script);
 }
 
 /**
@@ -975,8 +995,12 @@ function twofactorauth_render_passkey_js_helpers(): void
  * Preflight note: before invoking any passkey handler we verify the live Jaxon request URI still
  * points at /async/process.php. This catches endpoint drift immediately, instead of waiting for
  * bridge timeouts after requests are routed to non-JSON endpoints.
+ *
+ * This helper emits literal JavaScript, so it should stay on Output::rawOutput().
+ *
+ * The Output argument is optional to preserve direct helper/test invocations.
  */
-function twofactorauth_render_passkey_jaxon_bridge(): void
+function twofactorauth_render_passkey_jaxon_bridge(?Output $output = null): void
 {
     $showDebugJson = twofactorauth_is_megauser() ? 'true' : 'false';
 
@@ -987,6 +1011,12 @@ function twofactorauth_render_passkey_jaxon_bridge(): void
  * Jaxon can emit namespaces under window.Lotgd, window.JaxonLotgd or helper accessors.
  */window.twofactorauthResolvePasskeyHandler=window.twofactorauthResolvePasskeyHandler||function(method){const resolvedHandlers=typeof window.getJaxonHandlers==='function'?window.getJaxonHandlers():null;const requestedMethod=String(method||'');const candidates=[resolvedHandlers&&resolvedHandlers.TwoFactorAuthPasskey?resolvedHandlers.TwoFactorAuthPasskey:null,window.Lotgd&&window.Lotgd.Async&&window.Lotgd.Async.Handler?window.Lotgd.Async.Handler.TwoFactorAuthPasskey:null,window.JaxonLotgd&&window.JaxonLotgd.Async&&window.JaxonLotgd.Async.Handler?window.JaxonLotgd.Async.Handler.TwoFactorAuthPasskey:null];for(let i=0;i<candidates.length;i++){const candidate=candidates[i];if(candidate&&typeof candidate[requestedMethod]==='function'){return candidate;}}return null;};window.twofactorauthJaxonPasskeyCall=window.twofactorauthJaxonPasskeyCall||function(method,args){return new Promise(function(resolve,reject){const preflight=window.twofactorauthPreflightPasskeyRequestUri(method);if(!preflight.ok){const message='Passkey async endpoint mismatch.';const detail=preflight.detail||'';reject(new Error(showDebug&&detail!==''?message+' '+detail:message));return;}const namespace=window.twofactorauthResolvePasskeyHandler(method);if(!namespace){reject(new Error('Passkey async handler unavailable.'));return;}const requestId='tfa_'+Date.now()+'_'+Math.random().toString(16).slice(2);const timeoutId=window.setTimeout(function(){rejectPending(requestId,'Passkey async request timed out.','method='+String(method));},20000);window.twofactorauthPendingRequests[requestId]={resolve:resolve,reject:reject,timeoutId:timeoutId,method:method};const params=Array.isArray(args)?args.slice():[];params.unshift(requestId);try{namespace[method].apply(namespace,params);}catch(error){rejectPending(requestId,'Passkey async request dispatch failed.',error&&error.message?String(error.message):'unknown');}});};if(!window.__lotgdTwofactorPasskeyBridgeRejectionHooks){window.__lotgdTwofactorPasskeyBridgeRejectionHooks=true;window.addEventListener('unhandledrejection',function(event){const reason=event&&event.reason&&event.reason.message?String(event.reason.message):'';if(reason.indexOf('Unexpected end of JSON input')!==-1||reason.indexOf('JSON')!==-1){if(showDebug){console.warn('[TwoFactorAuthPasskey] Transport failure:',reason);}window.twofactorauthRejectAllPending('Passkey async parser failure.',reason);}});window.addEventListener('error',function(event){const message=event&&event.message?String(event.message):'';if(message.indexOf('Unexpected end of JSON input')!==-1){if(showDebug){console.warn('[TwoFactorAuthPasskey] Transport failure:',message);}window.twofactorauthRejectAllPending('Passkey async parser failure.',message);}});}})();</script>
 JAVASCRIPT;
+
+    if ($output instanceof Output) {
+        $output->rawOutput(str_replace('__SHOW_DEBUG__', $showDebugJson, $script));
+
+        return;
+    }
 
     rawoutput(str_replace('__SHOW_DEBUG__', $showDebugJson, $script));
 }
@@ -1066,18 +1096,29 @@ function twofactorauth_is_megauser(): bool
 }
 
 /**
- * Render browser helpers for base64url decoding and passkey registration.
+ * Render the setup-page passkey registration script.
+ *
+ * The setup script is raw JavaScript markup, while nearby explanatory strings remain
+ * in Output::output() so they continue through the game's formatting/translation path.
+ *
+ * The Output argument is optional to preserve direct helper/test invocations.
  */
-function twofactorauth_render_passkey_registration_script(string $csrf): void
+function twofactorauth_render_passkey_registration_script(?Output $output = null, string $csrf = ''): void
 {
-    twofactorauth_render_passkey_js_helpers();
-    twofactorauth_render_passkey_jaxon_bridge();
+    twofactorauth_render_passkey_js_helpers($output);
+    twofactorauth_render_passkey_jaxon_bridge($output);
 
     $csrfJson = json_encode($csrf) ?: '""';
     $showDebugJson = twofactorauth_is_megauser() ? 'true' : 'false';
 
     // Assign via `onclick` so repeated script injection cannot stack multiple handlers.
     // This setup page can be re-rendered in some module flows.
+    if ($output instanceof Output) {
+        $output->rawOutput("<script>(function(){const button=document.getElementById('passkey-add-button');if(!button){return;}const csrfToken=" . $csrfJson . ";const showDebug=" . $showDebugJson . ";const buildDiag=function(data){if(!showDebug||!data){return'';}const code=data.error?String(data.error):'unknown';const diagId=data.diagnostic_id?String(data.diagnostic_id):'';const debug=data.debug_message?String(data.debug_message):'';const diagType=data.diagnostic&&data.diagnostic.type?String(data.diagnostic.type):'';let message='Passkey operation failed. Code: '+code+'.';if(diagId!==''){message+=' Diagnostic: '+diagId+'.';}if(diagType!==''){message+=' Type: '+diagType+'.';}if(debug!==''){message+=' Debug: '+debug;}return message;};button.onclick=async function(){try{const labelEl=document.getElementById('passkey-label');const label=labelEl?labelEl.value:'';const beginData=await window.twofactorauthJaxonPasskeyCall('beginRegistration',[csrfToken,label]);if(!beginData||!beginData.ok){alert(showDebug?buildDiag(beginData):'Passkey operation failed');return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const credential=await navigator.credentials.create({publicKey});if(!credential){alert('Passkey operation failed');return;}const payload={id:credential.id,type:credential.type,response:{attestationObject:window.twofactorauthArrayBufferToBase64Url(credential.response.attestationObject),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(credential.response.clientDataJSON),transports:typeof credential.response.getTransports==='function'?credential.response.getTransports():[]}};const finishData=await window.twofactorauthJaxonPasskeyCall('finishRegistration',[csrfToken,label,payload]);if(finishData&&finishData.ok){window.location='runmodule.php?module=twofactorauth&op=setup';return;}alert(showDebug?buildDiag(finishData):'Passkey operation failed');}catch(error){const detail=error&&error.message?String(error.message):'';alert(showDebug&&detail!==''?'Passkey operation failed. Diagnostic: '+detail:'Passkey operation failed');}};})();</script>");
+
+        return;
+    }
+
     rawoutput("<script>(function(){const button=document.getElementById('passkey-add-button');if(!button){return;}const csrfToken=" . $csrfJson . ";const showDebug=" . $showDebugJson . ";const buildDiag=function(data){if(!showDebug||!data){return'';}const code=data.error?String(data.error):'unknown';const diagId=data.diagnostic_id?String(data.diagnostic_id):'';const debug=data.debug_message?String(data.debug_message):'';const diagType=data.diagnostic&&data.diagnostic.type?String(data.diagnostic.type):'';let message='Passkey operation failed. Code: '+code+'.';if(diagId!==''){message+=' Diagnostic: '+diagId+'.';}if(diagType!==''){message+=' Type: '+diagType+'.';}if(debug!==''){message+=' Debug: '+debug;}return message;};button.onclick=async function(){try{const labelEl=document.getElementById('passkey-label');const label=labelEl?labelEl.value:'';const beginData=await window.twofactorauthJaxonPasskeyCall('beginRegistration',[csrfToken,label]);if(!beginData||!beginData.ok){alert(showDebug?buildDiag(beginData):'Passkey operation failed');return;}const publicKey=window.twofactorauthDecodeCredentialOptions(beginData.options.publicKey);const credential=await navigator.credentials.create({publicKey});if(!credential){alert('Passkey operation failed');return;}const payload={id:credential.id,type:credential.type,response:{attestationObject:window.twofactorauthArrayBufferToBase64Url(credential.response.attestationObject),clientDataJSON:window.twofactorauthArrayBufferToBase64Url(credential.response.clientDataJSON),transports:typeof credential.response.getTransports==='function'?credential.response.getTransports():[]}};const finishData=await window.twofactorauthJaxonPasskeyCall('finishRegistration',[csrfToken,label,payload]);if(finishData&&finishData.ok){window.location='runmodule.php?module=twofactorauth&op=setup';return;}alert(showDebug?buildDiag(finishData):'Passkey operation failed');}catch(error){const detail=error&&error.message?String(error.message):'';alert(showDebug&&detail!==''?'Passkey operation failed. Diagnostic: '+detail:'Passkey operation failed');}};})();</script>");
 }
 

--- a/modules/twofactorauth.php
+++ b/modules/twofactorauth.php
@@ -343,8 +343,8 @@ function twofactorauth_render_setup(Output $output): void
     }
 
     if ($enabled) {
-        $output->output('Two-factor authentication is currently enabled on your account.`n');
-        $output->output('`$If you lose access to your authenticator app, use the login challenge page to request email recovery.`0`n`n');
+        $output->output('`vTwo-factor authentication is currently enabled on your account.`0`n`n');
+        $output->output('`$If you lose access to your authenticator app, use the login challenge page to request email recovery.`0`n');
     }
 
     $repo = twofactorauth_passkey_repository();
@@ -495,7 +495,7 @@ function twofactorauth_render_challenge(Output $output): void
     }
     Nav::add('Disable via email', 'runmodule.php?module=twofactorauth&op=disable_email');
 
-    $output->output('Password accepted, two-factor authentication is required.`n');
+    $output->output('`vPassword accepted, two-factor authentication is required.`0`n`n');
     $output->output('Enter the token from your authenticator app to continue.`n');
 
     addnav('', 'runmodule.php?module=twofactorauth&op=verify');

--- a/src/Lotgd/Async/Handler/TwoFactorAuthPasskey.php
+++ b/src/Lotgd/Async/Handler/TwoFactorAuthPasskey.php
@@ -55,32 +55,28 @@ class TwoFactorAuthPasskey
     /**
      * Test-only seam to override the passkey service without constructor injection.
      *
-     * This is intentionally public so async handler tests can inject stubs.
-     * It is not part of the runtime API surface and should not be used by
-     * production call sites.
+     * This remains public only so async handler tests can inject stubs.
+     * Jaxon registration explicitly excludes it from the remote callable
+     * surface, so production async requests cannot invoke this helper seam.
      */
     public function setService(PasskeyService $service): void
     {
-        // Jaxon only invokes explicitly registered handler methods
-        // (beginRegistration, finishRegistration, beginAuthentication,
-        // verifyAuthentication), so widening this setter does not create an
-        // additional remote-call surface.
+        // Keep test wiring local to the object instance. Runtime requests are
+        // blocked earlier because async/common/jaxon.php excludes this helper.
         $this->service = $service;
     }
 
     /**
      * Test-only seam to override the passkey repository without constructor injection.
      *
-     * This is intentionally public so async handler tests can inject stubs.
-     * It is not part of the runtime API surface and should not be used by
-     * production call sites.
+     * This remains public only so async handler tests can inject stubs.
+     * Jaxon registration explicitly excludes it from the remote callable
+     * surface, so production async requests cannot invoke this helper seam.
      */
     public function setRepository(PasskeyCredentialRepository $repository): void
     {
-        // Jaxon only invokes explicitly registered handler methods
-        // (beginRegistration, finishRegistration, beginAuthentication,
-        // verifyAuthentication), so widening this setter does not create an
-        // additional remote-call surface.
+        // Keep test wiring local to the object instance. Runtime requests are
+        // blocked earlier because async/common/jaxon.php excludes this helper.
         $this->repository = $repository;
     }
 

--- a/src/Lotgd/Entity/Setting.php
+++ b/src/Lotgd/Entity/Setting.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 class Setting
 {
     #[ORM\Id]
-    #[ORM\Column(type: 'string', length: 25, name: 'setting')]
+    #[ORM\Column(type: 'string', length: 50, name: 'setting')]
     private string $setting = '';
 
     #[ORM\Column(type: 'string', length: 255, name: 'value')]

--- a/src/Lotgd/Security/PasskeyService.php
+++ b/src/Lotgd/Security/PasskeyService.php
@@ -19,6 +19,9 @@ class PasskeyService
     private const SESSION_KEY_PREFIX = 'twofactorauth_passkey_challenge_';
     private const CHALLENGE_TTL_SECONDS = 300;
 
+    /** @var array<int, string> */
+    private static array $diagnostics = [];
+
     public function __construct(private readonly PasskeyCredentialRepository $credentials)
     {
     }
@@ -188,6 +191,24 @@ class PasskeyService
         return ['ok' => true, 'error' => '', 'clone' => false];
     }
 
+    /**
+     * Clear captured diagnostics between requests/tests.
+     */
+    public static function clearDiagnostics(): void
+    {
+        self::$diagnostics = [];
+    }
+
+    /**
+     * Return captured diagnostics emitted while resolving passkey configuration.
+     *
+     * @return array<int, string>
+     */
+    public static function getDiagnostics(): array
+    {
+        return self::$diagnostics;
+    }
+
     private function createWebAuthn(): WebAuthn
     {
         $rpId = $this->resolveRpId();
@@ -207,11 +228,32 @@ class PasskeyService
         if ($host === '') {
             $requestHost = trim((string) ($_SERVER['HTTP_HOST'] ?? ''));
             if ($requestHost !== '') {
-                $host = explode(':', $requestHost, 2)[0];
+                $fallbackHost = explode(':', $requestHost, 2)[0];
+                $this->emitRpIdDiagnostic(sprintf(
+                    'Passkey rpId fallback: configured serverurl "%s" did not yield a valid host; using HTTP_HOST "%s" (rpId "%s").',
+                    $serverUrl !== '' ? $serverUrl : '[empty]',
+                    $requestHost,
+                    $fallbackHost
+                ));
+                $host = $fallbackHost;
+            } else {
+                $this->emitRpIdDiagnostic(sprintf(
+                    'Passkey rpId fallback: configured serverurl "%s" did not yield a valid host and HTTP_HOST is unavailable; using localhost.',
+                    $serverUrl !== '' ? $serverUrl : '[empty]'
+                ));
             }
         }
 
         return $host !== '' ? $host : 'localhost';
+    }
+
+    /**
+     * Emit an observable diagnostic when passkey rpId resolution has to fall back.
+     */
+    private function emitRpIdDiagnostic(string $message): void
+    {
+        self::$diagnostics[] = $message;
+        error_log($message);
     }
 
     private function resolveRpName(): string

--- a/src/Lotgd/Security/PasskeyService.php
+++ b/src/Lotgd/Security/PasskeyService.php
@@ -218,6 +218,9 @@ class PasskeyService
 
     private function resolveRpId(): string
     {
+        // Ensure diagnostics are scoped to a single rpId resolution and do not leak across requests.
+        self::$diagnostics = [];
+
         $settings = Settings::getInstance();
         $serverUrl = trim((string) $settings->getSetting('serverurl', 'http://localhost'));
         $host = (string) parse_url($serverUrl, PHP_URL_HOST);
@@ -253,6 +256,13 @@ class PasskeyService
     private function emitRpIdDiagnostic(string $message): void
     {
         self::$diagnostics[] = $message;
+
+        // Enforce a small bounded size on diagnostics to avoid unbounded growth in long-lived workers.
+        $maxDiagnostics = 50;
+        if (count(self::$diagnostics) > $maxDiagnostics) {
+            self::$diagnostics = array_slice(self::$diagnostics, -$maxDiagnostics);
+        }
+
         error_log($message);
     }
 

--- a/src/Lotgd/Security/PasskeyService.php
+++ b/src/Lotgd/Security/PasskeyService.php
@@ -216,6 +216,26 @@ class PasskeyService
         return new WebAuthn($this->resolveRpName(), $rpId, ['none', 'packed', 'fido-u2f', 'apple'], true);
     }
 
+    /**
+     * Normalizes potentially untrusted values before including them in log messages.
+     *
+     * Strips control characters (including newlines) and truncates to a safe length.
+     */
+    private function sanitizeForLog(string $value, int $maxLength = 200): string
+    {
+        // Remove non-printable characters, including newlines and other control characters.
+        $sanitized = preg_replace('/[[:^print:]]/', '', $value);
+        if ($sanitized === null) {
+            $sanitized = '';
+        }
+
+        if (strlen($sanitized) > $maxLength) {
+            $sanitized = substr($sanitized, 0, $maxLength) . '...';
+        }
+
+        return $sanitized;
+    }
+
     private function resolveRpId(): string
     {
         // Ensure diagnostics are scoped to a single rpId resolution and do not leak across requests.
@@ -232,17 +252,22 @@ class PasskeyService
             $requestHost = trim((string) ($_SERVER['HTTP_HOST'] ?? ''));
             if ($requestHost !== '') {
                 $fallbackHost = explode(':', $requestHost, 2)[0];
+
+                $logServerUrl   = $this->sanitizeForLog($serverUrl !== '' ? $serverUrl : '[empty]');
+                $logFallbackHost = $this->sanitizeForLog($fallbackHost);
+
                 $this->emitRpIdDiagnostic(sprintf(
-                    'Passkey rpId fallback: configured serverurl "%s" did not yield a valid host; using HTTP_HOST "%s" (rpId "%s").',
-                    $serverUrl !== '' ? $serverUrl : '[empty]',
-                    $requestHost,
-                    $fallbackHost
+                    'Passkey rpId fallback: configured serverurl "%s" did not yield a valid host; using derived rpId "%s" from HTTP_HOST.',
+                    $logServerUrl,
+                    $logFallbackHost
                 ));
                 $host = $fallbackHost;
             } else {
+                $logServerUrl = $this->sanitizeForLog($serverUrl !== '' ? $serverUrl : '[empty]');
+
                 $this->emitRpIdDiagnostic(sprintf(
                     'Passkey rpId fallback: configured serverurl "%s" did not yield a valid host and HTTP_HOST is unavailable; using localhost.',
-                    $serverUrl !== '' ? $serverUrl : '[empty]'
+                    $logServerUrl
                 ));
             }
         }

--- a/tests/Async/ProcessAuthorizationTest.php
+++ b/tests/Async/ProcessAuthorizationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lotgd\Tests\Async {
 
+    use PHPUnit\Framework\Attributes\DataProvider;
     use PHPUnit\Framework\TestCase;
 
     /**
@@ -135,6 +136,42 @@ namespace Lotgd\Tests\Async {
             $this->assertSame(1, $jaxon->processCount);
         }
 
+
+        #[DataProvider('deniedPasskeyHelperMethodProvider')]
+        public function testPasskeyHelperCallableIsDeniedBeforeJaxonDispatch(string $methodName): void
+        {
+            global $jaxon, $ajax_rate_limit_seconds;
+
+            $ajax_rate_limit_seconds = 1.0;
+            $_POST['jxncls'] = 'Lotgd.Async.Handler.TwoFactorAuthPasskey';
+            $_POST['jxnmthd'] = $methodName;
+
+            $jaxon = new class {
+                public int $processCount = 0;
+
+                public function canProcessRequest(): bool
+                {
+                    return true;
+                }
+
+                public function processRequest(): void
+                {
+                    $this->processCount++;
+                }
+            };
+
+            ob_start();
+            lotgd_async_process_entrypoint();
+            $body = (string) ob_get_clean();
+
+            $payload = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+            $this->assertSame(403, http_response_code());
+            $this->assertSame(0, $jaxon->processCount);
+            $this->assertSame('callable_not_allowed', $payload['error'] ?? null);
+            $this->assertSame('Forbidden', $payload['message'] ?? null);
+        }
+
         public function testDeniedResponsesHaveConsistentJsonShape(): void
         {
             global $jaxon, $ajax_rate_limit_seconds;
@@ -186,6 +223,18 @@ namespace Lotgd\Tests\Async {
             $_SESSION = [];
 
             $this->assertTrue(lotgd_async_denied_request_is_throttled($start + 0.2, 2.0));
+        }
+
+
+        /**
+         * @return array<string, array{0:string}>
+         */
+        public static function deniedPasskeyHelperMethodProvider(): array
+        {
+            return [
+                'setService helper' => ['setService'],
+                'setRepository helper' => ['setRepository'],
+            ];
         }
 
         public function testAbuseKeyIgnoresSessionIdWhenNoCookieIsPresent(): void

--- a/tests/Async/TwoFactorAuthPasskeyHandlerTest.php
+++ b/tests/Async/TwoFactorAuthPasskeyHandlerTest.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Lotgd\Tests\Async {
 
+    use Jaxon\Exception\RequestException;
     use Lotgd\Async\Handler\TwoFactorAuthPasskey;
     use Lotgd\Security\PasskeyCredentialRepository;
     use Lotgd\Security\PasskeyService;
+    use Nyholm\Psr7Server\ServerRequestCreator;
+    use Psr\Http\Message\ServerRequestInterface;
+    use PHPUnit\Framework\Attributes\DataProvider;
     use PHPUnit\Framework\Attributes\PreserveGlobalState;
     use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
     use PHPUnit\Framework\TestCase;
@@ -258,6 +262,35 @@ namespace Lotgd\Tests\Async {
             self::assertContains('finishRegistration', $exportedMethods);
             self::assertContains('beginAuthentication', $exportedMethods);
             self::assertContains('verifyAuthentication', $exportedMethods);
+            self::assertNotContains('setService', $exportedMethods);
+            self::assertNotContains('setRepository', $exportedMethods);
+        }
+
+        #[DataProvider('excludedPasskeyHelperMethodProvider')]
+        public function testJaxonBootstrapRejectsExcludedPasskeyHelperRequestsBeforeInvocation(string $methodName): void
+        {
+            require __DIR__ . '/../../async/common/jaxon.php';
+
+            global $jaxon;
+            self::assertNotNull($jaxon);
+
+            $jaxon->setOption('core.response.send', false);
+            $jaxon->di()->set(ServerRequestInterface::class, static fn($container) =>
+                $container->g(ServerRequestCreator::class)
+                    ->fromGlobals()
+                    ->withParsedBody([
+                        'jxncall' => json_encode([
+                            'type' => 'class',
+                            'name' => 'Lotgd.Async.Handler.TwoFactorAuthPasskey',
+                            'method' => $methodName,
+                            'args' => [],
+                        ], JSON_THROW_ON_ERROR),
+                    ]));
+
+            $this->expectException(RequestException::class);
+            $this->expectExceptionMessage('excluded method');
+
+            $jaxon->processRequest();
         }
 
         public function testJaxonBootstrapPreservesLegacyNamespaceExportShapeForPasskeyBridge(): void
@@ -338,6 +371,17 @@ namespace Lotgd\Tests\Async {
             return [
                 'requestId' => (string) ($first['args']['args'][0] ?? ''),
                 'data' => (array) ($first['args']['args'][1] ?? []),
+            ];
+        }
+
+        /**
+         * @return array<string, array{0:string}>
+         */
+        public static function excludedPasskeyHelperMethodProvider(): array
+        {
+            return [
+                'setService helper' => ['setService'],
+                'setRepository helper' => ['setRepository'],
             ];
         }
 

--- a/tests/Migrations/SettingsSettingWidthMigrationTest.php
+++ b/tests/Migrations/SettingsSettingWidthMigrationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Migrations;
+
+use PHPUnit\Framework\TestCase;
+
+final class SettingsSettingWidthMigrationTest extends TestCase
+{
+    /**
+     * Ensure the migration explicitly widens the primary settings identifier
+     * column so longer keys such as the 2FA key-material setting fit without
+     * truncation on upgrade.
+     */
+    public function testMigrationWidensSettingsIdentifierColumn(): void
+    {
+        $migrationFile = dirname(__DIR__, 2) . '/migrations/Version20250724000023.php';
+        $contents = file_get_contents($migrationFile);
+
+        self::assertNotFalse($contents);
+        self::assertStringContainsString("Database::prefix('settings')", $contents);
+        self::assertStringContainsString('VARCHAR(50)', $contents);
+        self::assertStringContainsString('VARCHAR(25)', $contents);
+        self::assertStringContainsString('secret-backed 2FA key material storage', $contents);
+        self::assertStringContainsString('if (! Database::tableExists($table)) {', $contents);
+    }
+
+    /**
+     * Keep the installer schema and Doctrine metadata aligned with the new
+     * column width to prevent schema drift after fresh installs.
+     */
+    public function testSchemaDefinitionsUseFiftyCharacterSettingIdentifiers(): void
+    {
+        $installerSchema = file_get_contents(dirname(__DIR__, 2) . '/install/data/tables.php');
+        $settingEntity = file_get_contents(dirname(__DIR__, 2) . '/src/Lotgd/Entity/Setting.php');
+
+        self::assertNotFalse($installerSchema);
+        self::assertNotFalse($settingEntity);
+        self::assertStringContainsString("'name' => 'setting', 'type' => 'varchar(50)'", $installerSchema);
+        self::assertStringContainsString("length: 50, name: 'setting'", $settingEntity);
+    }
+}

--- a/tests/Security/PasskeyServiceTest.php
+++ b/tests/Security/PasskeyServiceTest.php
@@ -85,6 +85,7 @@ class PasskeyServiceTest extends TestCase
     {
         $this->repo = new InMemoryPasskeyCredentialRepository();
         $GLOBALS['session'] = [];
+        PasskeyService::clearDiagnostics();
 
         $settings = $this->createMock(Settings::class);
         $settings->method('getSetting')->willReturnCallback(static function (string $name, mixed $default = false): mixed {
@@ -101,6 +102,7 @@ class PasskeyServiceTest extends TestCase
 
     protected function tearDown(): void
     {
+        PasskeyService::clearDiagnostics();
         Settings::setInstance(null);
         unset($GLOBALS['settings']);
         unset($_SERVER['HTTP_HOST']);
@@ -310,6 +312,9 @@ class PasskeyServiceTest extends TestCase
         $service = new PasskeyService($this->repo);
 
         self::assertSame('fallback.example.test', $this->invokeResolveRpId($service));
+        self::assertSame([
+            'Passkey rpId fallback: configured serverurl "example.test/no-scheme" did not yield a valid host; using HTTP_HOST "fallback.example.test:8080" (rpId "fallback.example.test").',
+        ], PasskeyService::getDiagnostics());
     }
 
     public function testResolveRpIdFallsBackToLocalhostWhenNoConfiguredOrRequestHostExists(): void
@@ -330,6 +335,9 @@ class PasskeyServiceTest extends TestCase
         $service = new PasskeyService($this->repo);
 
         self::assertSame('localhost', $this->invokeResolveRpId($service));
+        self::assertSame([
+            'Passkey rpId fallback: configured serverurl "[empty]" did not yield a valid host and HTTP_HOST is unavailable; using localhost.',
+        ], PasskeyService::getDiagnostics());
     }
 
     private function invokeResolveRpId(PasskeyService $service): string

--- a/tests/Security/PasskeyServiceTest.php
+++ b/tests/Security/PasskeyServiceTest.php
@@ -312,9 +312,13 @@ class PasskeyServiceTest extends TestCase
         $service = new PasskeyService($this->repo);
 
         self::assertSame('fallback.example.test', $this->invokeResolveRpId($service));
-        self::assertSame([
-            'Passkey rpId fallback: configured serverurl "example.test/no-scheme" did not yield a valid host; using HTTP_HOST "fallback.example.test:8080" (rpId "fallback.example.test").',
-        ], PasskeyService::getDiagnostics());
+
+        $diagnostics = PasskeyService::getDiagnostics();
+
+        self::assertCount(1, $diagnostics);
+        self::assertStringContainsString('configured serverurl "example.test/no-scheme"', $diagnostics[0]);
+        self::assertStringContainsString('derived rpId "fallback.example.test"', $diagnostics[0]);
+        self::assertStringContainsString('from HTTP_HOST', $diagnostics[0]);
     }
 
     public function testResolveRpIdFallsBackToLocalhostWhenNoConfiguredOrRequestHostExists(): void

--- a/tests/Security/TwoFactorAuthModuleFlowTest.php
+++ b/tests/Security/TwoFactorAuthModuleFlowTest.php
@@ -75,6 +75,8 @@ namespace Lotgd\Tests\Security {
             ];
             $_GET = [];
             $_POST = [];
+            $GLOBALS['forms_output'] = '';
+            unset($GLOBALS['twofactorauth_test_request_body']);
             $_SERVER['REQUEST_URI'] = 'runmodule.php?module=twofactorauth&op=challenge';
             $_SERVER['REQUEST_METHOD'] = 'POST';
         }
@@ -268,6 +270,52 @@ namespace Lotgd\Tests\Security {
             self::assertGreaterThan(time(), (int) $GLOBALS['twofactorauth_test_prefs']['locked_until']);
 
             $this->assertDebugLogContains('2FA token verification failure for account 7 (reason: locked).', '2fa_verify');
+        }
+
+        public function testBeginPasskeyAuthRejectsInvalidCsrfOnSynchronousRoute(): void
+        {
+            global $session;
+
+            $session['user']['twofactorauth'] = [
+                'pending_challenge' => 1,
+                'locked_until' => 0,
+            ];
+            $session['twofactorauth_csrf'] = 'csrf-test-token';
+            $_POST['csrf_token'] = 'wrong-token';
+            $GLOBALS['forms_output'] = '';
+
+            twofactorauth_handle_begin_passkey_auth();
+
+            $payload = json_decode((string) $GLOBALS['forms_output'], true);
+            self::assertSame([
+                'ok' => false,
+                'error' => 'csrf',
+                'code' => 'csrf',
+            ], $payload);
+        }
+
+        public function testVerifyPasskeyRejectsEmptyCsrfOnSynchronousRoute(): void
+        {
+            global $session;
+
+            $GLOBALS['twofactorauth_test_prefs']['pending_challenge'] = 1;
+            $GLOBALS['twofactorauth_test_prefs']['failed_attempts'] = 0;
+            $session['twofactorauth_csrf'] = 'csrf-test-token';
+            $GLOBALS['twofactorauth_test_request_body'] = json_encode([
+                'id' => 'credential-id',
+                'response' => [],
+            ]);
+            $GLOBALS['forms_output'] = '';
+
+            twofactorauth_handle_passkey_verification();
+
+            $payload = json_decode((string) $GLOBALS['forms_output'], true);
+            self::assertSame([
+                'ok' => false,
+                'error' => 'csrf',
+                'code' => 'csrf',
+            ], $payload);
+            self::assertSame(0, $GLOBALS['twofactorauth_test_prefs']['failed_attempts']);
         }
 
         #[RunInSeparateProcess]

--- a/tests/Security/TwoFactorAuthModuleFlowTest.php
+++ b/tests/Security/TwoFactorAuthModuleFlowTest.php
@@ -73,12 +73,20 @@ namespace Lotgd\Tests\Security {
                 'max_attempts' => 5,
                 'lock_seconds' => 120,
             ];
+            $GLOBALS['twofactorauth_test_install_secret'] = 'test-install-secret-material';
             $_GET = [];
             $_POST = [];
             $GLOBALS['forms_output'] = '';
             unset($GLOBALS['twofactorauth_test_request_body']);
             $_SERVER['REQUEST_URI'] = 'runmodule.php?module=twofactorauth&op=challenge';
             $_SERVER['REQUEST_METHOD'] = 'POST';
+        }
+
+        protected function tearDown(): void
+        {
+            unset($GLOBALS['twofactorauth_test_install_secret']);
+
+            parent::tearDown();
         }
 
         public function testLoginStagesSessionSnapshotAndEveryhitPersistsIt(): void
@@ -252,6 +260,54 @@ namespace Lotgd\Tests\Security {
             self::assertSame(0, (int) ($GLOBALS['twofactorauth_test_prefs']['locked_until'] ?? 0));
 
             $this->assertDebugLogContains('2FA token verification failure for account 7 (reason: mismatch).', '2fa_verify');
+        }
+
+        public function testVerifyAcceptsLegacyEncryptedSecretAndReencryptsWithCurrentKey(): void
+        {
+            $secret = \TwoFactorAuthService::generateSecret();
+            $legacyStoredSecret = \TwoFactorAuthService::encryptSecret($secret, twofactorauth_legacy_signing_key());
+
+            $GLOBALS['twofactorauth_test_prefs']['pending_challenge'] = 1;
+            $GLOBALS['twofactorauth_test_prefs']['secret_encrypted'] = $legacyStoredSecret;
+            $GLOBALS['twofactorauth_test_prefs']['last_used_timestep'] = 0;
+            $_POST['token'] = \TwoFactorAuthService::generateTokenAtTime($secret, 6, 30, time());
+
+            twofactorauth_handle_challenge_verification(Output::getInstance());
+
+            self::assertSame(0, $GLOBALS['twofactorauth_test_prefs']['pending_challenge']);
+            self::assertNotSame($legacyStoredSecret, $GLOBALS['twofactorauth_test_prefs']['secret_encrypted']);
+            self::assertSame(
+                $secret,
+                \TwoFactorAuthService::decryptSecret(
+                    (string) $GLOBALS['twofactorauth_test_prefs']['secret_encrypted'],
+                    twofactorauth_current_signing_key()
+                )
+            );
+        }
+
+        public function testDisableConfirmationAcceptsLegacySignedToken(): void
+        {
+            global $session;
+
+            $legacyToken = \TwoFactorAuthService::signDisableToken(
+                7,
+                'player@example.test',
+                time() + 300,
+                twofactorauth_legacy_signing_key()
+            );
+
+            $session['user']['emailaddress'] = 'player@example.test';
+            $_GET['token'] = $legacyToken;
+            $GLOBALS['twofactorauth_test_prefs']['enabled'] = 1;
+            $GLOBALS['twofactorauth_test_prefs']['secret_encrypted'] = $this->encodePlainStoredSecret(\TwoFactorAuthService::generateSecret());
+            $GLOBALS['twofactorauth_test_prefs']['disable_token_hash'] = hash('sha256', $legacyToken);
+            $GLOBALS['twofactorauth_test_prefs']['disable_token_expires'] = time() + 300;
+
+            twofactorauth_handle_disable_confirmation(Output::getInstance());
+
+            self::assertSame(0, $GLOBALS['twofactorauth_test_prefs']['enabled']);
+            self::assertSame('', $GLOBALS['twofactorauth_test_prefs']['secret_encrypted']);
+            self::assertSame('', $GLOBALS['twofactorauth_test_prefs']['disable_token_hash']);
         }
 
         public function testVerifyLockoutStillAppliesAfterThreshold(): void

--- a/tests/Security/TwoFactorAuthModuleFlowTest.php
+++ b/tests/Security/TwoFactorAuthModuleFlowTest.php
@@ -378,14 +378,15 @@ namespace Lotgd\Tests\Security {
             $this->assertDebugLogContains('2FA token verification failure for account 7 (reason: locked).', '2fa_verify');
         }
 
-        public function testBeginPasskeyAuthRejectsInvalidCsrfOnSynchronousRoute(): void
+        public function testBeginPasskeyAuthReadsPendingStateFromModulePrefsOnSynchronousRoute(): void
         {
             global $session;
 
-            $session['user']['twofactorauth'] = [
-                'pending_challenge' => 1,
-                'locked_until' => 0,
-            ];
+            // Module prefs are the canonical persisted 2FA challenge state for
+            // synchronous passkey routes; nested session data is intentionally
+            // not seeded here so this regression covers the persisted-path read.
+            $GLOBALS['twofactorauth_test_prefs']['pending_challenge'] = 1;
+            $GLOBALS['twofactorauth_test_prefs']['locked_until'] = 0;
             $session['twofactorauth_csrf'] = 'csrf-test-token';
             $_POST['csrf_token'] = 'wrong-token';
             $GLOBALS['forms_output'] = '';

--- a/tests/Security/TwoFactorAuthModuleFlowTest.php
+++ b/tests/Security/TwoFactorAuthModuleFlowTest.php
@@ -262,6 +262,56 @@ namespace Lotgd\Tests\Security {
             $this->assertDebugLogContains('2FA token verification failure for account 7 (reason: mismatch).', '2fa_verify');
         }
 
+
+        /**
+         * The 2FA bootstrap path must persist secret-backed key material in the
+         * main settings table using the longer identifier without truncation.
+         */
+        public function testSecretMaterialBootstrapPersistsLongMainSettingKey(): void
+        {
+            unset($GLOBALS['twofactorauth_test_install_secret']);
+
+            $capturedSettingName = null;
+            $capturedSettingValue = null;
+
+            $settings = new class () extends \Lotgd\Settings {
+                /** @var array<string, string> */
+                private array $values = [];
+
+                public function __construct()
+                {
+                }
+
+                public function getSetting(string|int $settingname, mixed $default = false): mixed
+                {
+                    return $this->values[(string) $settingname] ?? $default;
+                }
+
+                public function saveSetting(string|int $settingname, mixed $value): bool
+                {
+                    $this->values[(string) $settingname] = (string) $value;
+                    $GLOBALS['twofactorauth_saved_setting_name'] = (string) $settingname;
+                    $GLOBALS['twofactorauth_saved_setting_value'] = (string) $value;
+
+                    return true;
+                }
+            };
+
+            $GLOBALS['settings'] = $settings;
+            \Lotgd\Settings::setInstance($settings);
+
+            $secretMaterial = twofactorauth_secret_material();
+            $currentSigningKey = twofactorauth_current_signing_key();
+            $capturedSettingName = $GLOBALS['twofactorauth_saved_setting_name'] ?? null;
+            $capturedSettingValue = $GLOBALS['twofactorauth_saved_setting_value'] ?? null;
+
+            self::assertSame('twofactorauth_key_material', $capturedSettingName);
+            self::assertIsString($capturedSettingValue);
+            self::assertSame($capturedSettingValue, $secretMaterial);
+            self::assertSame(64, strlen($secretMaterial));
+            self::assertSame(hash_hmac('sha256', 'lotgd|twofactorauth|v2', $secretMaterial), $currentSigningKey);
+        }
+
         public function testVerifyAcceptsLegacyEncryptedSecretAndReencryptsWithCurrentKey(): void
         {
             $secret = \TwoFactorAuthService::generateSecret();

--- a/translatortool.php
+++ b/translatortool.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Doctrine\DBAL\ArrayParameterType;
 use Lotgd\MySQL\Database;
 use Lotgd\DataCache;
 use Lotgd\Sanitize;
@@ -44,8 +45,8 @@ function translatortoolGetActiveLanguage(): string
 /**
  * Build the exact translation cache key format used by Translator::translateLoadNamespace().
  *
- * The namespace segment must follow the loader's normalization and length
- * handling so reopening the same translation after save cannot hit stale cache.
+ * The namespace segment uses the original namespace argument, with the same
+ * overlong-value sha1 fallback that the loader applies before caching.
  */
 function translatortoolBuildTranslationCacheKey(string $namespace, string $language): string
 {
@@ -92,8 +93,9 @@ if ($op == "") {
      * Persist a translator edit using the same namespace normalization as the loader.
      *
      * Matching Translator::translateLoadNamespace() matters because the loader
-     * queries by both page and normalized URI and caches under the normalized
-     * namespace string. Writes therefore use bound parameters instead of raw
+     * queries by both page and normalized URI, while its cache key keeps the
+     * original namespace argument unless it must fall back to sha1 for length.
+     * Writes therefore use bound parameters instead of raw
      * interpolation so translator-entered text such as apostrophes is stored
      * safely and so save-time SQL matches lookup semantics exactly.
      */
@@ -196,12 +198,16 @@ if ($op == "") {
                 $connection->executeStatement(
                     'UPDATE ' . $translationsTable . '
                         SET author = :author, version = :version, uri = :uri, outtext = :translation
-                      WHERE tid IN (' . implode(',', $matchingIds) . ')',
+                      WHERE tid IN (:tids)',
                     [
                         'author'      => $session['user']['login'],
                         'version'     => $logd_version,
                         'uri'         => $namespace,
                         'translation' => $trans,
+                        'tids'        => $matchingIds,
+                    ],
+                    [
+                        'tids' => ArrayParameterType::INTEGER,
                     ]
                 );
             }

--- a/translatortool.php
+++ b/translatortool.php
@@ -217,22 +217,14 @@ if ($op == "") {
             'DELETE FROM ' . $untranslatedTable . '
                 WHERE intext = :text
                   AND language = :language
-                  AND namespace = :namespace',
+                  AND namespace IN (:namespaces)',
             [
-                'text'      => $text,
-                'language'  => $language,
-                'namespace' => $rawUri,
-            ]
-        );
-        $connection->executeStatement(
-            'DELETE FROM ' . $untranslatedTable . '
-                WHERE intext = :text
-                  AND language = :language
-                  AND namespace = :namespace',
+                'text'       => $text,
+                'language'   => $language,
+                'namespaces' => [$rawUri, $namespace],
+            ],
             [
-                'text'      => $text,
-                'language'  => $language,
-                'namespace' => $namespace,
+                'namespaces' => ArrayParameterType::STRING,
             ]
         );
 

--- a/translatortool.php
+++ b/translatortool.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Lotgd\MySQL\Database;
+use Lotgd\DataCache;
+use Lotgd\Sanitize;
 use Lotgd\Translator;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
@@ -21,6 +23,39 @@ require_once __DIR__ . "/common.php";
 $settings = Settings::getInstance();
 $output = Output::getInstance();
 Translator::getInstance()->setSchema("translatortool");
+
+/**
+ * Return the active translator language used by translation loading.
+ *
+ * The loader prefers the LANGUAGE constant once translator setup has run, so
+ * the save handler must invalidate caches with that same language value.
+ */
+function translatortoolGetActiveLanguage(): string
+{
+    if (defined('LANGUAGE')) {
+        return (string) constant('LANGUAGE');
+    }
+
+    Translator::translatorSetup();
+
+    return Translator::getInstance()->getLanguage();
+}
+
+/**
+ * Build the exact translation cache key format used by Translator::translateLoadNamespace().
+ *
+ * The namespace segment must follow the loader's normalization and length
+ * handling so reopening the same translation after save cannot hit stale cache.
+ */
+function translatortoolBuildTranslationCacheKey(string $namespace, string $language): string
+{
+    $cacheNamespace = $namespace;
+    if (strlen($cacheNamespace) > Sanitize::URI_MAX_LENGTH) {
+        $cacheNamespace = sha1($cacheNamespace);
+    }
+
+    return 'translations-' . $cacheNamespace . '-' . $language;
+}
 
 SuAccess::check(SU_IS_TRANSLATOR);
 $opRequest = Http::get('op');
@@ -53,65 +88,169 @@ if ($op == "") {
     $output->rawOutput("</form>");
     popup_footer();
 } elseif ($op == 'save') {
+    /**
+     * Persist a translator edit using the same namespace normalization as the loader.
+     *
+     * Matching Translator::translateLoadNamespace() matters because the loader
+     * queries by both page and normalized URI and caches under the normalized
+     * namespace string. Writes therefore use bound parameters instead of raw
+     * interpolation so translator-entered text such as apostrophes is stored
+     * safely and so save-time SQL matches lookup semantics exactly.
+     */
+    global $session, $logd_version;
+
     $uriPost = Http::post('uri');
-    $uri = is_string($uriPost) ? $uriPost : '';
+    $rawUri = is_string($uriPost) ? $uriPost : '';
     $textPost = Http::post('text');
     $text = is_string($textPost) ? $textPost : '';
     $transPost = Http::post('trans');
     $trans = is_string($transPost) ? $transPost : '';
+    $language = translatortoolGetActiveLanguage();
+    $namespace = Sanitize::translatorUri($rawUri);
+    $page = Sanitize::translatorPage($rawUri);
+    $connection = Database::getDoctrineConnection();
+    $translationsTable = Database::prefix('translations');
+    $untranslatedTable = Database::prefix('untranslated');
 
-    $page = $uri;
-    if (strpos($page, "?") !== false) {
-        $page = substr($page, 0, strpos($page, "?"));
-    }
+    $rows = $connection->fetchAllAssociative(
+        'SELECT tid, intext FROM ' . $translationsTable . '
+            WHERE language = :language
+              AND intext = :text
+              AND (uri = :page OR uri = :uri)',
+        [
+            'language' => $language,
+            'text'     => $text,
+            'page'     => $page,
+            'uri'      => $namespace,
+        ]
+    );
 
-    if ($trans == "") {
-        $sql = "DELETE ";
+    $saveSucceeded = false;
+
+    if ($trans === '') {
+        $connection->executeStatement(
+            'DELETE FROM ' . $translationsTable . '
+                WHERE language = :language
+                  AND intext = :text
+                  AND (uri = :page OR uri = :uri)',
+            [
+                'language' => $language,
+                'text'     => $text,
+                'page'     => $page,
+                'uri'      => $namespace,
+            ]
+        );
+        $saveSucceeded = true;
     } else {
-        $sql = "SELECT * ";
-    }
-    $sql .= "
-		FROM " . Database::prefix("translations") . "
-		WHERE language='" . LANGUAGE . "'
-			AND intext='$text'
-			AND (uri='$page' OR uri='$uri')";
-    if ($trans > "") {
-        $result = Database::query($sql);
-        invalidatedatacache("translations-" . $uri . "-" . $language);
-        if (Database::numRows($result) == 0) {
-            $sql = "INSERT INTO " . Database::prefix("translations") . " (language,uri,intext,outtext,author,version) VALUES ('" . LANGUAGE . "','$uri','$text','$trans','{$session['user']['login']}','$logd_version ')";
-            $sql1 = "DELETE FROM " . Database::prefix("untranslated") .
-                " WHERE intext='$text' AND language='" . LANGUAGE .
-                "' AND namespace='$url'";
-            Database::query($sql1);
-        } elseif (Database::numRows($result) == 1) {
-            $row = Database::fetchAssoc($result);
-            // MySQL is case insensitive so we need to do it here.
-            if ($row['intext'] == $text) {
-                $sql = "UPDATE " . Database::prefix("translations") . " SET author='{$session['user']['login']}', version='$logd_version', uri='$uri', outtext='$trans' WHERE tid={$row['tid']}";
-            } else {
-                $sql = "INSERT INTO " . Database::prefix("translations") . " (language,uri,intext,outtext,author,version) VALUES ('" . LANGUAGE . "','$uri','$text','$trans','{$session['user']['login']}','$logd_version ')";
-                $sql1 = "DELETE FROM " . Database::prefix("untranslated") . " WHERE intext='$text' AND language='" . LANGUAGE . "' AND namespace='$url'";
-                Database::query($sql1);
-            }
-        } elseif (Database::numRows($result) > 1) {
-        /* To say the least, this case is bad. Simply because if there are duplicates, you make them even more equal. But most likely you won't get this far, as the code itself should not produce duplicates unless you insert manually or via module the same row more than once*/
-            $rows = array();
-            while ($row = Database::fetchAssoc($result)) {
-                // MySQL is case insensitive so we need to do it here.
-                if ($row['intext'] == $text) {
-                    $rows[] = $row['tid'];
+        if (count($rows) === 0) {
+            $connection->executeStatement(
+                'INSERT INTO ' . $translationsTable . '
+                    (language, uri, intext, outtext, author, version)
+                 VALUES (:language, :uri, :text, :translation, :author, :version)',
+                [
+                    'language'    => $language,
+                    'uri'         => $namespace,
+                    'text'        => $text,
+                    'translation' => $trans,
+                    'author'      => $session['user']['login'],
+                    'version'     => $logd_version,
+                ]
+            );
+        } elseif (count($rows) === 1 && $rows[0]['intext'] === $text) {
+            $connection->executeStatement(
+                'UPDATE ' . $translationsTable . '
+                    SET author = :author, version = :version, uri = :uri, outtext = :translation
+                  WHERE tid = :tid',
+                [
+                    'author'      => $session['user']['login'],
+                    'version'     => $logd_version,
+                    'uri'         => $namespace,
+                    'translation' => $trans,
+                    'tid'         => (int) $rows[0]['tid'],
+                ]
+            );
+        } else {
+            $matchingIds = [];
+            foreach ($rows as $row) {
+                // MySQL comparisons can be case-insensitive, so keep the legacy exact-text guard.
+                if ($row['intext'] === $text) {
+                    $matchingIds[] = (int) $row['tid'];
                 }
             }
-            $sql = "UPDATE " . Database::prefix("translations") . " SET author='{$session['user']['login']}', version='$logd_version', uri='$page', outtext='$trans' WHERE tid IN (" . join(",", $rows) . ")";
+
+            if ($matchingIds === []) {
+                $connection->executeStatement(
+                    'INSERT INTO ' . $translationsTable . '
+                        (language, uri, intext, outtext, author, version)
+                     VALUES (:language, :uri, :text, :translation, :author, :version)',
+                    [
+                        'language'    => $language,
+                        'uri'         => $namespace,
+                        'text'        => $text,
+                        'translation' => $trans,
+                        'author'      => $session['user']['login'],
+                        'version'     => $logd_version,
+                    ]
+                );
+            } else {
+                $connection->executeStatement(
+                    'UPDATE ' . $translationsTable . '
+                        SET author = :author, version = :version, uri = :uri, outtext = :translation
+                      WHERE tid IN (' . implode(',', $matchingIds) . ')',
+                    [
+                        'author'      => $session['user']['login'],
+                        'version'     => $logd_version,
+                        'uri'         => $namespace,
+                        'translation' => $trans,
+                    ]
+                );
+            }
+        }
+
+        $connection->executeStatement(
+            'DELETE FROM ' . $untranslatedTable . '
+                WHERE intext = :text
+                  AND language = :language
+                  AND namespace = :namespace',
+            [
+                'text'      => $text,
+                'language'  => $language,
+                'namespace' => $rawUri,
+            ]
+        );
+        $connection->executeStatement(
+            'DELETE FROM ' . $untranslatedTable . '
+                WHERE intext = :text
+                  AND language = :language
+                  AND namespace = :namespace',
+            [
+                'text'      => $text,
+                'language'  => $language,
+                'namespace' => $namespace,
+            ]
+        );
+
+        $saveSucceeded = true;
+    }
+
+    if ($saveSucceeded) {
+        // The cache key must exactly mirror Translator::translateLoadNamespace() so immediate re-open shows fresh data.
+        foreach (array_unique([$rawUri, $namespace, $page]) as $cacheNamespace) {
+            if ($cacheNamespace === '') {
+                continue;
+            }
+
+            DataCache::getInstance()->invalidatedatacache(
+                translatortoolBuildTranslationCacheKey($cacheNamespace, $language)
+            );
         }
     }
-    Database::query($sql);
+
     $saveNotClosePost = Http::post('savenotclose');
-    if (is_string($saveNotClosePost) && $saveNotClosePost > "") {
-        header("Location: translatortool.php?op=list&u=$page");
+    if ($saveSucceeded && is_string($saveNotClosePost) && $saveNotClosePost > "") {
+        header("Location: translatortool.php?op=list&u=" . rawurlencode($page));
         exit();
-    } else {
+    } elseif ($saveSucceeded) {
         popup_header("Updated");
         $output->rawOutput("<script language='javascript'>window.close();</script>");
         popup_footer();


### PR DESCRIPTION
This pull request introduces major improvements to the Two-Factor Authentication (2FA) system, focusing on enhanced cryptographic key management, improved passkey diagnostics, and code modernization for output handling. The most significant change is the introduction of installation-secret–backed key derivation for 2FA, which strengthens security and enables future key rotation. Additionally, the database schema is updated to support longer setting keys, and output handling in the 2FA module is modernized for clarity and maintainability.

**Two-Factor Authentication Security and Key Management:**

- The 2FA module now derives its cryptographic key from installation-secret material stored in the main settings table (`twofactorauth_key_material`), rather than from less secure sources like `serverurl` and `gameadminemail`. Existing installations retain a compatibility window: old encrypted TOTP secrets and signed links are still accepted, and TOTP secrets are re-encrypted with the new key after successful verification. Rotating or deleting this key will invalidate re-encrypted secrets and new disable links, so rotations must be planned carefully. [[1]](diffhunk://#diff-f411a5009131db5a6c7242b49ca78488f2d274ef9e5e5f4de9262a42108a5386R146-R149) [[2]](diffhunk://#diff-320fe792337be92668988e1b2c877bbc64423f4a1d8b5444623e70d9827a7874R135-R136)

- The documentation is updated to warn administrators about the impact of changing the installation secret and to clarify the new key derivation mechanism.

**Database Schema Changes:**

- The `settings.setting` column is widened from `VARCHAR(25)` to `VARCHAR(50)` to accommodate longer core setting keys, especially for storing the new 2FA key material. A migration is added to handle this schema change. [[1]](diffhunk://#diff-d704fdb4872bc6cbb7911b95a4d160ec1348da5bf33257bced2dc6bd0ccca899L1578-R1578) [[2]](diffhunk://#diff-1e86cb1bc957120032f4ff70e2e2ecdd40702f012e7c3b23ba42898e9a679f1cR1-R46)

**Passkey and Output Handling Improvements:**

- The passkey registration and authentication process now emits explicit diagnostics to the server error log if `serverurl` is malformed, making it easier for administrators to debug relying party/domain mismatches.

- Output handling in the 2FA module is modernized: all literal HTML or JavaScript fragments now use `Output::rawOutput()`, while player-facing text uses `Output::output()`. This clarifies intent and improves maintainability. [[1]](diffhunk://#diff-4ed07a2aba42836a16076e241a996709ad7f6cf104588881fba0bbb69c5c8d33R322-R324) [[2]](diffhunk://#diff-4ed07a2aba42836a16076e241a996709ad7f6cf104588881fba0bbb69c5c8d33L345-R350) [[3]](diffhunk://#diff-4ed07a2aba42836a16076e241a996709ad7f6cf104588881fba0bbb69c5c8d33L375-R384) [[4]](diffhunk://#diff-4ed07a2aba42836a16076e241a996709ad7f6cf104588881fba0bbb69c5c8d33L391-R400) [[5]](diffhunk://#diff-4ed07a2aba42836a16076e241a996709ad7f6cf104588881fba0bbb69c5c8d33L416-R421) [[6]](diffhunk://#diff-4ed07a2aba42836a16076e241a996709ad7f6cf104588881fba0bbb69c5c8d33L436-R441) [[7]](diffhunk://#diff-4ed07a2aba42836a16076e241a996709ad7f6cf104588881fba0bbb69c5c8d33L455-R481) [[8]](diffhunk://#diff-4ed07a2aba42836a16076e241a996709ad7f6cf104588881fba0bbb69c5c8d33L497-R523)

**Async Handler Security:**

- The Jaxon async handler registration is hardened by allowlisting only specific runtime methods for the `TwoFactorAuthPasskey` handler, reducing the callable surface for defense in depth.

**2FA Secret Migration Logic:**

- The challenge verification flow now uses a compatibility-aware secret decryption routine and migrates secrets to the new key after successful verification, ensuring a smooth transition for existing users.