### PR TITLE
refactor: enforce Lotgd\Http policy, preserve legacy wrapper escaping, add QA gate and migrate core HTTP usage

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -204,6 +204,22 @@ $result = $conn->executeQuery($sql, ['login' => $login]);
 
 `executeQuery()` returns a `Result` object for `SELECT` statements, while `executeStatement()` returns the affected row count for `INSERT`, `UPDATE`, or `DELETE` queries. See [docs/Doctrine.md#prepared-statements](docs/Doctrine.md#prepared-statements) and the official [Doctrine DBAL prepared statement guide](https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/data-retrieval-and-manipulation.html#prepared-statements) for more details.
 
+### HTTP API Policy and Deprecation Timeline
+
+To keep request handling explicit and secure during the 2.x modernization:
+
+- **Core/refactored code policy (effective now in 2.x):**
+  - Use `Lotgd\Http` (`Http::get()`, `Http::post()`, `Http::allGet()`, `Http::allPost()`) as the only HTTP API.
+  - Do not introduce `httpget()` / `httppost()` in core/refactored paths.
+- **Legacy compatibility policy (2.x only):**
+  - `lib/http.php` wrappers remain for legacy/module compatibility.
+  - Those wrappers intentionally preserve legacy escaped behaviour.
+- **Planned major-version change (3.0 target):**
+  - Escaped wrapper semantics are scheduled for retirement in the next major version.
+  - Legacy wrappers will either be removed or aligned to raw `Lotgd\Http` semantics; module maintainers should migrate to `Lotgd\Http` and bound DBAL parameters before upgrading to 3.0.
+
+As of this policy, static QA enforcement runs during `composer static` and fails when `httpget()` / `httppost()` usage appears in core/refactored paths.
+
 ---
 
 ## 8. After Upgrade

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,11 @@
         }
     },
     "scripts": {
-        "static": "phpstan analyse --configuration phpstan.neon",
+        "qa:http-wrappers": "php scripts/check-legacy-http-wrappers.php",
+        "static": [
+            "@qa:http-wrappers",
+            "phpstan analyse --configuration phpstan.neon"
+        ],
         "test": "phpunit --configuration phpunit.xml",
         "lint": "phpcs .",
         "lint:fix": "phpcbf ."

--- a/docs/Deprecations.md
+++ b/docs/Deprecations.md
@@ -38,6 +38,13 @@ This project aims to preserve legacy compatibility while moving to a modern stac
   - Replacement: `Lotgd\PlayerSearch::legacyLookup()` and other `PlayerSearch` helpers
   - Migration: Inject or instantiate `PlayerSearch` directly and call `legacyLookup()` (or a more specific finder), removing usage of the legacy array/SQL wrapper.
 
+- Legacy HTTP wrappers `httpget()` / `httppost()` in core/refactored paths
+  - Status: Deprecated in 2.x for core and refactored modules (legacy compatibility only)
+  - Policy: `Lotgd\Http` is the only allowed HTTP API in core/refactored code; legacy wrappers are reserved for legacy/module compatibility paths.
+  - Behaviour note: `lib/http.php` wrappers intentionally preserve escaped legacy semantics for compatibility, while `Lotgd\Http` returns raw request values for typed and parameterized handling.
+  - Migration: Replace legacy helper calls with `Lotgd\Http::get()` / `Lotgd\Http::post()` and use bound DBAL parameters instead of SQL string concatenation.
+  - QA enforcement: `composer static` now runs a policy gate that fails when new wrapper usage appears in core/refactored paths.
+
 ### Upgrade Guidance (1.3.x → 2.0)
 
 See `UPGRADING.md` for the full process. Key points:
@@ -47,4 +54,3 @@ See `UPGRADING.md` for the full process. Key points:
 
 ### Contact
 Open an issue if you need a longer grace period or migration examples for a specific API.
-

--- a/lib/http.php
+++ b/lib/http.php
@@ -5,13 +5,39 @@
 // mail ready
 use Lotgd\Http;
 
+/**
+ * Legacy compatibility escape helper for lib/http.php wrappers.
+ *
+ * The legacy wrappers intentionally preserve historical behaviour by returning
+ * addslashes()-escaped scalar values. Core/refactored code must use
+ * Lotgd\Http directly, which intentionally returns raw values.
+ *
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function legacy_http_escape(mixed $value): mixed
+{
+    if (is_string($value)) {
+        return addslashes($value);
+    }
+
+    if (is_array($value)) {
+        foreach ($value as $key => $item) {
+            $value[$key] = legacy_http_escape($item);
+        }
+    }
+
+    return $value;
+}
+
 function httpget($var)
 {
-    return Http::get($var);
+    return legacy_http_escape(Http::get($var));
 }
 function httpallget()
 {
-    return Http::allGet();
+    return legacy_http_escape(Http::allGet());
 }
 function httpset($var, $val, $force = false)
 {
@@ -19,7 +45,7 @@ function httpset($var, $val, $force = false)
 }
 function httppost($var)
 {
-    return Http::post($var);
+    return legacy_http_escape(Http::post($var));
 }
 function httppostisset($var)
 {
@@ -31,9 +57,11 @@ function httppostset($var, $val, $sub = false)
 }
 function httpallpost()
 {
-    return Http::allPost();
+    return legacy_http_escape(Http::allPost());
 }
 function postparse($verify = false, $subval = false)
 {
-    return Http::postParse($verify, $subval);
+    [$columns, $placeholders, $parameters] = Http::postParse($verify, $subval);
+
+    return [$columns, $placeholders, legacy_http_escape($parameters)];
 }

--- a/pages/bans/case_setupban.php
+++ b/pages/bans/case_setupban.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\ParameterType;
 
 $output = Output::getInstance();
 $settings = Settings::getInstance();
+$charset = $settings->getSetting('charset', 'UTF-8');
 
 $sql = 'SELECT name,lastip,uniqueid FROM ' . Database::prefix('accounts') . ' WHERE acctid=' . (int) $userid;
 $result = Database::query($sql);
@@ -69,7 +70,11 @@ if (isset($row['name']) && !empty($row['name'])) {
             $row['lastip'],
             $row['name'],
             $row['gentimecount'],
-            DateTime::relTime(strtotime($row['laston']))
+            (
+                isset($row['laston']) && is_string($row['laston']) && $row['laston'] !== ''
+                    ? DateTime::relTime(strtotime($row['laston']))
+                    : Translator::translateInline('unknown')
+            )
         );
     }
     $sameIdResult->free();
@@ -99,7 +104,9 @@ if (isset($row['name']) && !empty($row['name'])) {
             if (!$hasRows) {
                 $hasRows = true;
                 $output->output("IP Filter: %s ", $thisip);
-                $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
+                $thisIpJson = json_encode($thisip, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+                $onClick = "document.getElementById('ip').value={$thisIpJson}; document.getElementById('ipradio').checked = true; return false";
+                $output->rawOutput("<a href='#' onClick=\"" . HTMLEntities($onClick, ENT_QUOTES, $charset) . "\">");
                 $output->output("Use this filter");
                 $output->rawOutput("</a>");
                 $output->outputNotl("`n");
@@ -112,7 +119,11 @@ if (isset($row['name']) && !empty($row['name'])) {
                     $row['uniqueid'],
                     $row['name'],
                     $row['gentimecount'],
-                    DateTime::relTime(strtotime($row['laston']))
+                    (
+                        isset($row['laston']) && is_string($row['laston']) && $row['laston'] !== ''
+                            ? DateTime::relTime(strtotime($row['laston']))
+                            : Translator::translateInline('unknown')
+                    )
                 );
         }
         $similarIpResult->free();

--- a/pages/bans/case_setupban.php
+++ b/pages/bans/case_setupban.php
@@ -9,6 +9,7 @@ use Lotgd\Http;
 use Lotgd\Output;
 use Lotgd\Settings;
 use Lotgd\DateTime;
+use Doctrine\DBAL\ParameterType;
 
 $output = Output::getInstance();
 $settings = Settings::getInstance();
@@ -47,14 +48,18 @@ $output->rawOutput("</form>");
 $output->output("For an IP ban, enter the beginning part of the IP you wish to ban if you wish to ban a range, or simply a full IP to ban a single IP`n`n");
 Nav::add("", "bans.php?op=saveban");
 if (isset($row['name']) && !empty($row['name'])) {
+    $conn = Database::getDoctrineConnection();
     $id = $row['uniqueid'];
     $ip = $row['lastip'];
     $name = $row['name'];
     $output->output("`0To help locate similar users to `@%s`0, here are some other users who are close:`n", $name);
     $output->output("`bSame ID (%s):`b`n", $id);
-    $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . Database::prefix("accounts") . " WHERE uniqueid='" . addslashes($id) . "' ORDER BY lastip";
-    $result = Database::query($sql);
-    while ($row = Database::fetchAssoc($result)) {
+    $sameIdRows = $conn->fetchAllAssociative(
+        'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE uniqueid = :uniqueid ORDER BY lastip',
+        ['uniqueid' => $id],
+        ['uniqueid' => ParameterType::STRING]
+    );
+    foreach ($sameIdRows as $row) {
         $output->output(
             "`0* (%s) `%%s`0 - %s hits, last: %s`n",
             $row['lastip'],
@@ -72,16 +77,25 @@ if (isset($row['name']) && !empty($row['name'])) {
             break;
         }
         $thisip = substr($ip, 0, $x);
-        $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . Database::prefix("accounts") . " WHERE lastip LIKE '$thisip%' AND NOT (lastip LIKE '$oip') ORDER BY uniqueid";
-        //$output->output("$sql`n");
-        $result = Database::query($sql);
-        if (Database::numRows($result) > 0) {
+        $similarIpRows = $conn->fetchAllAssociative(
+            'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE lastip LIKE :thisIp AND NOT (lastip LIKE :oldIp) ORDER BY uniqueid',
+            [
+                'thisIp' => $thisip . '%',
+                'oldIp' => $oip,
+            ],
+            [
+                'thisIp' => ParameterType::STRING,
+                'oldIp' => ParameterType::STRING,
+            ]
+        );
+
+        if (count($similarIpRows) > 0) {
             $output->output("IP Filter: %s ", $thisip);
             $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
             $output->output("Use this filter");
             $output->rawOutput("</a>");
             $output->outputNotl("`n");
-            while ($row = Database::fetchAssoc($result)) {
+            foreach ($similarIpRows as $row) {
                 $output->output("&nbsp;&nbsp;", true);
                 $output->output(
                     "(%s) [%s] `%%s`0 - %s hits, last: %s`n",

--- a/pages/bans/case_setupban.php
+++ b/pages/bans/case_setupban.php
@@ -54,12 +54,16 @@ if (isset($row['name']) && !empty($row['name'])) {
     $name = $row['name'];
     $output->output("`0To help locate similar users to `@%s`0, here are some other users who are close:`n", $name);
     $output->output("`bSame ID (%s):`b`n", $id);
-    $sameIdRows = $conn->fetchAllAssociative(
+    /**
+     * Stream rows instead of materialising all matches in memory.
+     * This keeps legacy broad filters safer on large account tables.
+     */
+    $sameIdResult = $conn->executeQuery(
         'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE uniqueid = :uniqueid ORDER BY lastip',
         ['uniqueid' => $id],
         ['uniqueid' => ParameterType::STRING]
     );
-    foreach ($sameIdRows as $row) {
+    while (($row = $sameIdResult->fetchAssociative()) !== false) {
         $output->output(
             "`0* (%s) `%%s`0 - %s hits, last: %s`n",
             $row['lastip'],
@@ -68,6 +72,7 @@ if (isset($row['name']) && !empty($row['name'])) {
             DateTime::relTime(strtotime($row['laston']))
         );
     }
+    $sameIdResult->free();
     $output->outputNotl("`n");
         $oip = "";
     $dots = 0;
@@ -77,7 +82,7 @@ if (isset($row['name']) && !empty($row['name'])) {
             break;
         }
         $thisip = substr($ip, 0, $x);
-        $similarIpRows = $conn->fetchAllAssociative(
+        $similarIpResult = $conn->executeQuery(
             'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE lastip LIKE :thisIp AND NOT (lastip LIKE :oldIp) ORDER BY uniqueid',
             [
                 'thisIp' => $thisip . '%',
@@ -89,13 +94,17 @@ if (isset($row['name']) && !empty($row['name'])) {
             ]
         );
 
-        if (count($similarIpRows) > 0) {
-            $output->output("IP Filter: %s ", $thisip);
-            $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
-            $output->output("Use this filter");
-            $output->rawOutput("</a>");
-            $output->outputNotl("`n");
-            foreach ($similarIpRows as $row) {
+        $hasRows = false;
+        while (($row = $similarIpResult->fetchAssociative()) !== false) {
+            if (!$hasRows) {
+                $hasRows = true;
+                $output->output("IP Filter: %s ", $thisip);
+                $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
+                $output->output("Use this filter");
+                $output->rawOutput("</a>");
+                $output->outputNotl("`n");
+            }
+
                 $output->output("&nbsp;&nbsp;", true);
                 $output->output(
                     "(%s) [%s] `%%s`0 - %s hits, last: %s`n",
@@ -105,7 +114,10 @@ if (isset($row['name']) && !empty($row['name'])) {
                     $row['gentimecount'],
                     DateTime::relTime(strtotime($row['laston']))
                 );
-            }
+        }
+        $similarIpResult->free();
+
+        if ($hasRows) {
             $output->outputNotl("`n");
         }
         if (substr($ip, $x - 1, 1) == ".") {

--- a/pages/user/user_debuglog.php
+++ b/pages/user/user_debuglog.php
@@ -6,6 +6,7 @@ use Lotgd\Nav;
 use Lotgd\Translator;
 use Lotgd\MySQL\Database;
 use Lotgd\Sanitize;
+use Lotgd\Http;
 
 if ($petition != "") {
     Nav::add("Navigation");
@@ -43,7 +44,7 @@ $row = Database::fetchAssoc($result);
 $max += $row['c'];
 
 
-$start = (int)httpget('start');
+$start = (int) Http::get('start');
 
 $sql = "(
                         SELECT {$debuglog}.*,

--- a/pages/user/user_delban.php
+++ b/pages/user/user_delban.php
@@ -8,11 +8,14 @@ use Lotgd\Http;
 use Doctrine\DBAL\ParameterType;
 
 $conn = Database::getDoctrineConnection();
+$ipFilter = (string) (Http::get('ipfilter') ?: '');
+$uniqueId = (string) (Http::get('uniqueid') ?: '');
+
 $conn->executeStatement(
     'DELETE FROM ' . Database::prefix('bans') . ' WHERE ipfilter = :ip AND uniqueid = :id',
     [
-        'ip' => Http::get('ipfilter'),
-        'id' => Http::get('uniqueid'),
+        'ip' => $ipFilter,
+        'id' => $uniqueId,
     ],
     [
         'ip' => ParameterType::STRING,

--- a/pages/user/user_delban.php
+++ b/pages/user/user_delban.php
@@ -4,7 +4,19 @@ declare(strict_types=1);
 
 use Lotgd\Redirect;
 use Lotgd\MySQL\Database;
+use Lotgd\Http;
+use Doctrine\DBAL\ParameterType;
 
-$sql = "DELETE FROM " . Database::prefix("bans") . " WHERE ipfilter = '" . httpget("ipfilter") . "' AND uniqueid = '" . httpget("uniqueid") . "'";
-Database::query($sql);
+$conn = Database::getDoctrineConnection();
+$conn->executeStatement(
+    'DELETE FROM ' . Database::prefix('bans') . ' WHERE ipfilter = :ip AND uniqueid = :id',
+    [
+        'ip' => Http::get('ipfilter'),
+        'id' => Http::get('uniqueid'),
+    ],
+    [
+        'ip' => ParameterType::STRING,
+        'id' => ParameterType::STRING,
+    ]
+);
 Redirect::redirect('bans.php?op=removeban');

--- a/pages/user/user_delban.php
+++ b/pages/user/user_delban.php
@@ -8,8 +8,15 @@ use Lotgd\Http;
 use Doctrine\DBAL\ParameterType;
 
 $conn = Database::getDoctrineConnection();
-$ipFilter = (string) (Http::get('ipfilter') ?: '');
-$uniqueId = (string) (Http::get('uniqueid') ?: '');
+$ipFilterRaw = Http::get('ipfilter');
+$uniqueIdRaw = Http::get('uniqueid');
+
+/**
+ * Normalize only missing values (false) to empty strings.
+ * Keep valid falsy string values (e.g. "0") unchanged.
+ */
+$ipFilter = $ipFilterRaw === false ? '' : (string) $ipFilterRaw;
+$uniqueId = $uniqueIdRaw === false ? '' : (string) $uniqueIdRaw;
 
 $conn->executeStatement(
     'DELETE FROM ' . Database::prefix('bans') . ' WHERE ipfilter = :ip AND uniqueid = :id',

--- a/pages/user/user_save.php
+++ b/pages/user/user_save.php
@@ -207,7 +207,7 @@ foreach ($post as $key => $val) {
         }
     }
 }
-$petition = httpget("returnpetition");
+$petition = (string) Http::get('returnpetition');
 if ($petition != "") {
     Nav::add("", "viewpetition.php?op=view&id=$petition");
 }

--- a/pages/user/user_savemodule.php
+++ b/pages/user/user_savemodule.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
+use Lotgd\Http;
+use Doctrine\DBAL\ParameterType;
 
 //save module settings.
-$userid = (int)httpget('userid');
-$module = httpget('module');
-$post = httpallpost();
+$userid = (int) Http::get('userid');
+$module = (string) Http::get('module');
+$post = Http::allPost();
 $post = modulehook("validateprefs", $post, true, $module);
 if (isset($post['validation_error']) && $post['validation_error']) {
     Translator::getInstance()->setSchema("module-$module");
@@ -17,15 +19,25 @@ if (isset($post['validation_error']) && $post['validation_error']) {
     Translator::getInstance()->setSchema();
     $output->output("Unable to change settings: `\$%s`0", $post['validation_error']);
 } else {
+    $conn = Database::getDoctrineConnection();
     $output->outputNotl("`n");
     foreach ($post as $key => $val) {
         $output->output("`\$Setting '`2%s`\$' to '`2%s`\$'`n", $key, htmlspecialchars($val, ENT_QUOTES, 'UTF-8'));
-        $sql = "REPLACE INTO " . Database::prefix("module_userprefs") .
-            " (modulename,userid,setting,value) VALUES ('" .
-            Database::escape($module) . "',$userid,'" .
-            Database::escape($key) . "','" .
-            Database::escape($val) . "')";
-        Database::query($sql);
+        $conn->executeStatement(
+            'REPLACE INTO ' . Database::prefix('module_userprefs') . ' (modulename,userid,setting,value) VALUES (:module,:userid,:setting,:value)',
+            [
+                'module' => $module,
+                'userid' => $userid,
+                'setting' => $key,
+                'value' => (string) $val,
+            ],
+            [
+                'module' => ParameterType::STRING,
+                'userid' => ParameterType::INTEGER,
+                'setting' => ParameterType::STRING,
+                'value' => ParameterType::STRING,
+            ]
+        );
     }
     $output->output("`^Preferences for module %s saved.`n", $module);
 }

--- a/pages/user/user_setupban.php
+++ b/pages/user/user_setupban.php
@@ -101,7 +101,11 @@ if ($row['name'] != "") {
             $row['lastip'],
             $row['name'],
             $row['gentimecount'],
-            reltime(strtotime($row['laston']))
+            (
+                isset($row['laston']) && is_string($row['laston']) && $row['laston'] !== ''
+                    ? reltime(strtotime($row['laston']))
+                    : Translator::translateInline('unknown')
+            )
         );
     }
     $sameIdResult->free();
@@ -131,7 +135,9 @@ if ($row['name'] != "") {
             if (!$hasRows) {
                 $hasRows = true;
                 $output->output("• IP Filter: %s ", $thisip);
-                $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
+                $thisIpJson = json_encode($thisip, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+                $onClick = "document.getElementById('ip').value={$thisIpJson}; document.getElementById('ipradio').checked = true; return false";
+                $output->rawOutput("<a href='#' onClick=\"" . HTMLEntities($onClick, ENT_QUOTES, $charset) . "\">");
                 $output->output("Use this filter");
                 $output->rawOutput("</a>");
                 $output->outputNotl("`n");
@@ -144,7 +150,11 @@ if ($row['name'] != "") {
                     $row['uniqueid'],
                     $row['name'],
                     $row['gentimecount'],
-                    reltime(strtotime($row['laston']))
+                    (
+                        isset($row['laston']) && is_string($row['laston']) && $row['laston'] !== ''
+                            ? reltime(strtotime($row['laston']))
+                            : Translator::translateInline('unknown')
+                    )
                 );
         }
         $similarIpResult->free();

--- a/pages/user/user_setupban.php
+++ b/pages/user/user_setupban.php
@@ -9,6 +9,7 @@ use Lotgd\Output;
 use Lotgd\Settings;
 use Lotgd\Http;
 use Lotgd\Sanitize;
+use Doctrine\DBAL\ParameterType;
 
 global $session;
 
@@ -79,14 +80,18 @@ $output->rawOutput("</form>");
 $output->output("For an IP ban, enter the beginning part of the IP you wish to ban if you wish to ban a range, or simply a full IP to ban a single IP`n`n");
 Nav::add("", "user.php?op=saveban");
 if ($row['name'] != "") {
+    $conn = Database::getDoctrineConnection();
     $id = $row['uniqueid'];
     $ip = $row['lastip'];
     $name = $row['name'];
     $output->output("`0To help locate similar users to `@%s`0, here are some other users who are close:`n", $name);
     $output->output("`bSame ID (%s):`b`n", $id);
-    $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . Database::prefix("accounts") . " WHERE uniqueid='" . addslashes($id) . "' ORDER BY lastip";
-    $result = Database::query($sql);
-    while ($row = Database::fetchAssoc($result)) {
+    $sameIdRows = $conn->fetchAllAssociative(
+        'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE uniqueid = :uniqueid ORDER BY lastip',
+        ['uniqueid' => $id],
+        ['uniqueid' => ParameterType::STRING]
+    );
+    foreach ($sameIdRows as $row) {
         $output->output(
             "`0• (%s) `%%s`0 - %s hits, last: %s`n",
             $row['lastip'],
@@ -104,16 +109,25 @@ if ($row['name'] != "") {
             break;
         }
         $thisip = substr($ip, 0, $x);
-        $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . Database::prefix("accounts") . " WHERE lastip LIKE '$thisip%' AND NOT (lastip LIKE '$oip') ORDER BY uniqueid";
-        //$output->output("$sql`n");
-        $result = Database::query($sql);
-        if (Database::numRows($result) > 0) {
+        $similarIpRows = $conn->fetchAllAssociative(
+            'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE lastip LIKE :thisIp AND NOT (lastip LIKE :oldIp) ORDER BY uniqueid',
+            [
+                'thisIp' => $thisip . '%',
+                'oldIp' => $oip,
+            ],
+            [
+                'thisIp' => ParameterType::STRING,
+                'oldIp' => ParameterType::STRING,
+            ]
+        );
+
+        if (count($similarIpRows) > 0) {
             $output->output("• IP Filter: %s ", $thisip);
             $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
             $output->output("Use this filter");
             $output->rawOutput("</a>");
             $output->outputNotl("`n");
-            while ($row = Database::fetchAssoc($result)) {
+            foreach ($similarIpRows as $row) {
                 $output->output("&nbsp;&nbsp;", true);
                 $output->output(
                     "• (%s) [%s] `%%s`0 - %s hits, last: %s`n",

--- a/pages/user/user_setupban.php
+++ b/pages/user/user_setupban.php
@@ -86,12 +86,16 @@ if ($row['name'] != "") {
     $name = $row['name'];
     $output->output("`0To help locate similar users to `@%s`0, here are some other users who are close:`n", $name);
     $output->output("`bSame ID (%s):`b`n", $id);
-    $sameIdRows = $conn->fetchAllAssociative(
+    /**
+     * Stream rows instead of fetching everything at once so broad matches
+     * remain predictable on larger installs.
+     */
+    $sameIdResult = $conn->executeQuery(
         'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE uniqueid = :uniqueid ORDER BY lastip',
         ['uniqueid' => $id],
         ['uniqueid' => ParameterType::STRING]
     );
-    foreach ($sameIdRows as $row) {
+    while (($row = $sameIdResult->fetchAssociative()) !== false) {
         $output->output(
             "`0• (%s) `%%s`0 - %s hits, last: %s`n",
             $row['lastip'],
@@ -100,6 +104,7 @@ if ($row['name'] != "") {
             reltime(strtotime($row['laston']))
         );
     }
+    $sameIdResult->free();
     $output->outputNotl("`n");
         $oip = "";
     $dots = 0;
@@ -109,7 +114,7 @@ if ($row['name'] != "") {
             break;
         }
         $thisip = substr($ip, 0, $x);
-        $similarIpRows = $conn->fetchAllAssociative(
+        $similarIpResult = $conn->executeQuery(
             'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE lastip LIKE :thisIp AND NOT (lastip LIKE :oldIp) ORDER BY uniqueid',
             [
                 'thisIp' => $thisip . '%',
@@ -121,13 +126,17 @@ if ($row['name'] != "") {
             ]
         );
 
-        if (count($similarIpRows) > 0) {
-            $output->output("• IP Filter: %s ", $thisip);
-            $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
-            $output->output("Use this filter");
-            $output->rawOutput("</a>");
-            $output->outputNotl("`n");
-            foreach ($similarIpRows as $row) {
+        $hasRows = false;
+        while (($row = $similarIpResult->fetchAssociative()) !== false) {
+            if (!$hasRows) {
+                $hasRows = true;
+                $output->output("• IP Filter: %s ", $thisip);
+                $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
+                $output->output("Use this filter");
+                $output->rawOutput("</a>");
+                $output->outputNotl("`n");
+            }
+
                 $output->output("&nbsp;&nbsp;", true);
                 $output->output(
                     "• (%s) [%s] `%%s`0 - %s hits, last: %s`n",
@@ -137,7 +146,10 @@ if ($row['name'] != "") {
                     $row['gentimecount'],
                     reltime(strtotime($row['laston']))
                 );
-            }
+        }
+        $similarIpResult->free();
+
+        if ($hasRows) {
             $output->outputNotl("`n");
         }
         if (substr($ip, $x - 1, 1) == ".") {

--- a/scripts/check-legacy-http-wrappers.php
+++ b/scripts/check-legacy-http-wrappers.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Lotgd\QA\LegacyHttpWrapperUsageCheck;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$checker = new LegacyHttpWrapperUsageCheck();
+exit($checker->run(dirname(__DIR__)));
+

--- a/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
+++ b/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
@@ -92,7 +92,7 @@ final class LegacyHttpWrapperUsageCheck
     private function isWhitelistedPath(string $relativePath): bool
     {
         foreach (self::ALLOWED_PATHS as $allowedPath) {
-            if (str_starts_with($relativePath, $allowedPath)) {
+            if ($relativePath === $allowedPath) {
                 return true;
             }
         }
@@ -111,7 +111,7 @@ final class LegacyHttpWrapperUsageCheck
         }
 
         $tokens = token_get_all($contents);
-        $lines = file($absolutePath, FILE_IGNORE_NEW_LINES) ?: [];
+        $lines = preg_split("/\r\n|\n|\r/", $contents) ?: [];
         $violations = [];
 
         foreach ($tokens as $index => $token) {

--- a/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
+++ b/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\QA;
+
+/**
+ * Detects legacy httpget()/httppost() helper usage in core/refactored code.
+ *
+ * Policy:
+ *  - Core/refactored code must use Lotgd\Http directly.
+ *  - Legacy wrappers are permitted only in explicitly whitelisted paths.
+ */
+final class LegacyHttpWrapperUsageCheck
+{
+    /**
+     * @var list<string>
+     */
+    private const DISALLOWED_PATTERNS = [
+        '/\bhttpget\s*\(/i',
+        '/\bhttppost\s*\(/i',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const SCAN_ROOTS = [
+        'pages',
+        'src',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const ALLOWED_ROOTS = [
+        'lib/',
+        'modules/',
+        'install/',
+        'tests/',
+        'vendor/',
+        'src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php',
+    ];
+
+    /**
+     * @return list<string> Human-readable violations in "file:line:text" format.
+     */
+    public function collectViolations(string $repositoryRoot): array
+    {
+        $violations = [];
+
+        foreach (self::SCAN_ROOTS as $relativeRoot) {
+            $absoluteRoot = rtrim($repositoryRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relativeRoot;
+            if (!is_dir($absoluteRoot)) {
+                continue;
+            }
+
+            $directoryIterator = new \RecursiveDirectoryIterator($absoluteRoot, \FilesystemIterator::SKIP_DOTS);
+            $iterator = new \RecursiveIteratorIterator($directoryIterator);
+
+            foreach ($iterator as $file) {
+                if (!($file instanceof \SplFileInfo) || $file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $relativePath = str_replace('\\', '/', substr($file->getPathname(), strlen(rtrim($repositoryRoot, DIRECTORY_SEPARATOR)) + 1));
+                if ($this->isWhitelistedPath($relativePath)) {
+                    continue;
+                }
+
+                $lines = file($file->getPathname(), FILE_IGNORE_NEW_LINES);
+                if ($lines === false) {
+                    continue;
+                }
+
+                foreach ($lines as $lineNumber => $line) {
+                    $trimmed = ltrim($line);
+                    if (str_starts_with($trimmed, '//') || str_starts_with($trimmed, '#')) {
+                        continue;
+                    }
+
+                    foreach (self::DISALLOWED_PATTERNS as $pattern) {
+                        if (preg_match($pattern, $line) === 1) {
+                            $violations[] = sprintf(
+                                '%s:%d:%s',
+                                $relativePath,
+                                $lineNumber + 1,
+                                trim($line)
+                            );
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        sort($violations);
+
+        return $violations;
+    }
+
+    public function run(string $repositoryRoot): int
+    {
+        $violations = $this->collectViolations($repositoryRoot);
+        if ($violations === []) {
+            echo "Legacy HTTP wrapper usage check passed.\n";
+            return 0;
+        }
+
+        fwrite(STDERR, "Legacy HTTP wrapper usage detected in core/refactored paths.\n");
+        fwrite(STDERR, "Use Lotgd\\\\Http::* in core paths and keep httpget()/httppost() for legacy compatibility paths only.\n");
+        foreach ($violations as $violation) {
+            fwrite(STDERR, " - {$violation}\n");
+        }
+
+        return 1;
+    }
+
+    private function isWhitelistedPath(string $relativePath): bool
+    {
+        foreach (self::ALLOWED_ROOTS as $allowedRoot) {
+            if (str_starts_with($relativePath, $allowedRoot)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
+++ b/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
@@ -32,12 +32,8 @@ final class LegacyHttpWrapperUsageCheck
     /**
      * @var list<string>
      */
-    private const ALLOWED_ROOTS = [
-        'lib/',
-        'modules/',
-        'install/',
-        'tests/',
-        'vendor/',
+    private const ALLOWED_PATHS = [
+        // Self-exclusion so policy text/examples in this checker are not flagged.
         'src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php',
     ];
 
@@ -95,8 +91,8 @@ final class LegacyHttpWrapperUsageCheck
 
     private function isWhitelistedPath(string $relativePath): bool
     {
-        foreach (self::ALLOWED_ROOTS as $allowedRoot) {
-            if (str_starts_with($relativePath, $allowedRoot)) {
+        foreach (self::ALLOWED_PATHS as $allowedPath) {
+            if (str_starts_with($relativePath, $allowedPath)) {
                 return true;
             }
         }

--- a/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
+++ b/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
@@ -16,9 +16,9 @@ final class LegacyHttpWrapperUsageCheck
     /**
      * @var list<string>
      */
-    private const DISALLOWED_PATTERNS = [
-        '/\bhttpget\s*\(/i',
-        '/\bhttppost\s*\(/i',
+    private const DISALLOWED_FUNCTIONS = [
+        'httpget',
+        'httppost',
     ];
 
     /**
@@ -67,29 +67,7 @@ final class LegacyHttpWrapperUsageCheck
                     continue;
                 }
 
-                $lines = file($file->getPathname(), FILE_IGNORE_NEW_LINES);
-                if ($lines === false) {
-                    continue;
-                }
-
-                foreach ($lines as $lineNumber => $line) {
-                    $trimmed = ltrim($line);
-                    if (str_starts_with($trimmed, '//') || str_starts_with($trimmed, '#')) {
-                        continue;
-                    }
-
-                    foreach (self::DISALLOWED_PATTERNS as $pattern) {
-                        if (preg_match($pattern, $line) === 1) {
-                            $violations[] = sprintf(
-                                '%s:%d:%s',
-                                $relativePath,
-                                $lineNumber + 1,
-                                trim($line)
-                            );
-                            break;
-                        }
-                    }
-                }
+                $violations = array_merge($violations, $this->collectFileViolations($file->getPathname(), $relativePath));
             }
         }
 
@@ -124,5 +102,93 @@ final class LegacyHttpWrapperUsageCheck
         }
 
         return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectFileViolations(string $absolutePath, string $relativePath): array
+    {
+        $contents = file_get_contents($absolutePath);
+        if ($contents === false) {
+            return [];
+        }
+
+        $tokens = token_get_all($contents);
+        $lines = file($absolutePath, FILE_IGNORE_NEW_LINES) ?: [];
+        $violations = [];
+
+        foreach ($tokens as $index => $token) {
+            if (!is_array($token) || $token[0] !== T_STRING) {
+                continue;
+            }
+
+            $functionName = strtolower($token[1]);
+            if (!in_array($functionName, self::DISALLOWED_FUNCTIONS, true)) {
+                continue;
+            }
+
+            if (!$this->isFunctionCallToken($tokens, $index)) {
+                continue;
+            }
+
+            $lineNumber = (int) $token[2];
+            $lineText = trim($lines[$lineNumber - 1] ?? '');
+            $violations[] = sprintf('%s:%d:%s', $relativePath, $lineNumber, $lineText);
+        }
+
+        return $violations;
+    }
+
+    /**
+     * @param list<array<int, int|string>|string> $tokens
+     */
+    private function isFunctionCallToken(array $tokens, int $index): bool
+    {
+        $previousToken = $this->findPreviousSignificantToken($tokens, $index);
+        if (is_array($previousToken) && in_array($previousToken[0], [T_FUNCTION, T_FN, T_OBJECT_OPERATOR, T_DOUBLE_COLON], true)) {
+            return false;
+        }
+        if ($previousToken === '->' || $previousToken === '::') {
+            return false;
+        }
+
+        $nextToken = $this->findNextSignificantToken($tokens, $index);
+        return $nextToken === '(';
+    }
+
+    /**
+     * @param list<array<int, int|string>|string> $tokens
+     */
+    private function findPreviousSignificantToken(array $tokens, int $index): array|string|null
+    {
+        for ($i = $index - 1; $i >= 0; $i--) {
+            $token = $tokens[$i];
+            if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            return $token;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<array<int, int|string>|string> $tokens
+     */
+    private function findNextSignificantToken(array $tokens, int $index): array|string|null
+    {
+        $count = count($tokens);
+        for ($i = $index + 1; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            return $token;
+        }
+
+        return null;
     }
 }

--- a/tests/LegacyHttpWrapperCompatibilityTest.php
+++ b/tests/LegacyHttpWrapperCompatibilityTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+final class LegacyHttpWrapperCompatibilityTest extends TestCase
+{
+    public function testLegacyWrappersEscapeButLotgdHttpReturnsRawValues(): void
+    {
+        $payload = $this->runIsolatedPhp(<<<'PHP'
+$_GET['id'] = "ab'c";
+$_POST['title'] = 'x"y';
+echo json_encode([
+    'legacy_get' => httpget('id'),
+    'legacy_post' => httppost('title'),
+    'raw_get' => \Lotgd\Http::get('id'),
+    'raw_post' => \Lotgd\Http::post('title'),
+], JSON_THROW_ON_ERROR);
+PHP);
+
+        $this->assertSame("ab\\'c", $payload['legacy_get'] ?? null);
+        $this->assertSame('x\\"y', $payload['legacy_post'] ?? null);
+        $this->assertSame("ab'c", $payload['raw_get'] ?? null);
+        $this->assertSame('x"y', $payload['raw_post'] ?? null);
+    }
+
+    public function testLegacyPostParseEscapesOnlyLegacyWrapperOutput(): void
+    {
+        $payload = $this->runIsolatedPhp(<<<'PHP'
+$_POST = ['title' => "O'Reilly"];
+[, , $rawParameters] = \Lotgd\Http::postParse();
+[, , $legacyParameters] = postparse();
+echo json_encode([
+    'raw' => $rawParameters,
+    'legacy' => $legacyParameters,
+], JSON_THROW_ON_ERROR);
+PHP);
+
+        $this->assertSame(["O'Reilly"], $payload['raw'] ?? null);
+        $this->assertSame(["O\\'Reilly"], $payload['legacy'] ?? null);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function runIsolatedPhp(string $snippet): array
+    {
+        $root = dirname(__DIR__);
+        $bootstrap = sprintf(
+            "require %s;\nrequire %s;\n",
+            var_export($root . '/autoload.php', true),
+            var_export($root . '/lib/http.php', true)
+        );
+
+        $code = $bootstrap . "\n" . $snippet;
+        $command = sprintf('%s -r %s', escapeshellarg(PHP_BINARY), escapeshellarg($code));
+        $output = shell_exec($command);
+
+        $this->assertNotFalse($output, 'Isolated php process did not produce output.');
+
+        /** @var array<string,mixed> $decoded */
+        $decoded = json_decode((string) $output, true, 512, JSON_THROW_ON_ERROR);
+        return $decoded;
+    }
+}

--- a/tests/LegacyHttpWrapperCompatibilityTest.php
+++ b/tests/LegacyHttpWrapperCompatibilityTest.php
@@ -59,7 +59,8 @@ PHP);
         $command = sprintf('%s -r %s', escapeshellarg(PHP_BINARY), escapeshellarg($code));
         $output = shell_exec($command);
 
-        $this->assertNotFalse($output, 'Isolated php process did not produce output.');
+        $this->assertNotNull($output, 'Isolated php process did not produce output.');
+        $this->assertIsString($output);
 
         /** @var array<string,mixed> $decoded */
         $decoded = json_decode((string) $output, true, 512, JSON_THROW_ON_ERROR);

--- a/tests/QA/LegacyHttpWrapperUsageCheckTest.php
+++ b/tests/QA/LegacyHttpWrapperUsageCheckTest.php
@@ -24,8 +24,8 @@ final class LegacyHttpWrapperUsageCheckTest extends TestCase
     public function testCheckerAllowsLegacyHttpWrappersInWhitelistedLegacyPaths(): void
     {
         $root = $this->createFixtureRoot();
-        file_put_contents($root . '/modules/example.php', "<?php\n\$a = httpget('foo');\n");
-        file_put_contents($root . '/lib/example.php', "<?php\n\$a = httppost('bar');\n");
+        mkdir($root . '/src/Lotgd/QA', 0777, true);
+        file_put_contents($root . '/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php', "<?php\n\$a = httpget('foo');\n");
 
         $checker = new LegacyHttpWrapperUsageCheck();
         $violations = $checker->collectViolations($root);
@@ -58,8 +58,6 @@ PHP
         $root = sys_get_temp_dir() . '/lotgd-http-check-' . uniqid('', true);
         mkdir($root . '/pages', 0777, true);
         mkdir($root . '/src', 0777, true);
-        mkdir($root . '/lib', 0777, true);
-        mkdir($root . '/modules', 0777, true);
 
         return $root;
     }

--- a/tests/QA/LegacyHttpWrapperUsageCheckTest.php
+++ b/tests/QA/LegacyHttpWrapperUsageCheckTest.php
@@ -33,6 +33,26 @@ final class LegacyHttpWrapperUsageCheckTest extends TestCase
         $this->assertSame([], $violations);
     }
 
+    public function testCheckerIgnoresMentionsInsideCommentsAndStrings(): void
+    {
+        $root = $this->createFixtureRoot();
+        file_put_contents(
+            $root . '/pages/docs-example.php',
+            <<<'PHP'
+<?php
+/**
+ * Example docs mentioning httpget('foo') for migration notes.
+ */
+$message = "Use httppost('bar') in legacy wrappers only.";
+PHP
+        );
+
+        $checker = new LegacyHttpWrapperUsageCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertSame([], $violations);
+    }
+
     private function createFixtureRoot(): string
     {
         $root = sys_get_temp_dir() . '/lotgd-http-check-' . uniqid('', true);
@@ -44,4 +64,3 @@ final class LegacyHttpWrapperUsageCheckTest extends TestCase
         return $root;
     }
 }
-

--- a/tests/QA/LegacyHttpWrapperUsageCheckTest.php
+++ b/tests/QA/LegacyHttpWrapperUsageCheckTest.php
@@ -9,6 +9,19 @@ use PHPUnit\Framework\TestCase;
 
 final class LegacyHttpWrapperUsageCheckTest extends TestCase
 {
+    /**
+     * @var list<string>
+     */
+    private array $fixtureRoots = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->fixtureRoots as $root) {
+            $this->removeDirectoryRecursively($root);
+        }
+        $this->fixtureRoots = [];
+    }
+
     public function testCheckerFlagsLegacyHttpWrappersInCorePaths(): void
     {
         $root = $this->createFixtureRoot();
@@ -58,7 +71,36 @@ PHP
         $root = sys_get_temp_dir() . '/lotgd-http-check-' . uniqid('', true);
         mkdir($root . '/pages', 0777, true);
         mkdir($root . '/src', 0777, true);
+        $this->fixtureRoots[] = $root;
 
         return $root;
+    }
+
+    private function removeDirectoryRecursively(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $items = scandir($path);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $current = $path . DIRECTORY_SEPARATOR . $item;
+            if (is_dir($current)) {
+                $this->removeDirectoryRecursively($current);
+                continue;
+            }
+
+            @unlink($current);
+        }
+
+        @rmdir($path);
     }
 }

--- a/tests/QA/LegacyHttpWrapperUsageCheckTest.php
+++ b/tests/QA/LegacyHttpWrapperUsageCheckTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\QA;
+
+use Lotgd\QA\LegacyHttpWrapperUsageCheck;
+use PHPUnit\Framework\TestCase;
+
+final class LegacyHttpWrapperUsageCheckTest extends TestCase
+{
+    public function testCheckerFlagsLegacyHttpWrappersInCorePaths(): void
+    {
+        $root = $this->createFixtureRoot();
+        file_put_contents($root . '/pages/example.php', "<?php\n\$a = httpget('foo');\n\$b = \\Lotgd\\Http::get('bar');\n");
+
+        $checker = new LegacyHttpWrapperUsageCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertNotEmpty($violations);
+        $this->assertStringContainsString('pages/example.php:2:', $violations[0]);
+    }
+
+    public function testCheckerAllowsLegacyHttpWrappersInWhitelistedLegacyPaths(): void
+    {
+        $root = $this->createFixtureRoot();
+        file_put_contents($root . '/modules/example.php', "<?php\n\$a = httpget('foo');\n");
+        file_put_contents($root . '/lib/example.php', "<?php\n\$a = httppost('bar');\n");
+
+        $checker = new LegacyHttpWrapperUsageCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertSame([], $violations);
+    }
+
+    private function createFixtureRoot(): string
+    {
+        $root = sys_get_temp_dir() . '/lotgd-http-check-' . uniqid('', true);
+        mkdir($root . '/pages', 0777, true);
+        mkdir($root . '/src', 0777, true);
+        mkdir($root . '/lib', 0777, true);
+        mkdir($root . '/modules', 0777, true);
+
+        return $root;
+    }
+}
+

--- a/tests/QA/LegacyHttpWrapperUsageCheckTest.php
+++ b/tests/QA/LegacyHttpWrapperUsageCheckTest.php
@@ -46,6 +46,19 @@ final class LegacyHttpWrapperUsageCheckTest extends TestCase
         $this->assertSame([], $violations);
     }
 
+    public function testCheckerDoesNotWhitelistPrefixMatchedFilenames(): void
+    {
+        $root = $this->createFixtureRoot();
+        mkdir($root . '/src/Lotgd/QA', 0777, true);
+        file_put_contents($root . '/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php.bypass.php', "<?php\n\$a = httpget('foo');\n");
+
+        $checker = new LegacyHttpWrapperUsageCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('LegacyHttpWrapperUsageCheck.php.bypass.php', $violations[0]);
+    }
+
     public function testCheckerIgnoresMentionsInsideCommentsAndStrings(): void
     {
         $root = $this->createFixtureRoot();

--- a/tests/User/UserLegacyHttpMigrationTest.php
+++ b/tests/User/UserLegacyHttpMigrationTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (!function_exists('modulehook')) {
+        /**
+         * Minimal modulehook shim for isolated page include tests.
+         *
+         * @param array<mixed> $args
+         * @return array<mixed>
+         */
+        function modulehook(string $hookname, array $args = [], bool $allowinactive = false, string $modulename = ''): array
+        {
+            return $args;
+        }
+    }
+
+    if (!function_exists('httpset')) {
+        function httpset(string $var, mixed $value, bool $force = false): void
+        {
+        }
+    }
+}
+
+namespace Lotgd {
+    if (!class_exists(__NAMESPACE__ . '\\Redirect', false)) {
+        class Redirect
+        {
+            public static function redirect(string $location, string|bool $reason = false): void
+            {
+            }
+        }
+    }
+}
+
+namespace Lotgd\Tests\User {
+
+    use Doctrine\DBAL\ParameterType;
+    use Lotgd\MySQL\Database;
+    use Lotgd\Tests\Stubs\DoctrineBootstrap;
+    use PHPUnit\Framework\TestCase;
+
+    final class UserLegacyHttpMigrationTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
+            Database::$doctrineConnection = null;
+            Database::$instance = null;
+            DoctrineBootstrap::$conn = null;
+            Database::$mockResults = [];
+            $_GET = [];
+            $_POST = [];
+            $GLOBALS['output'] = new class {
+                public function outputNotl(string $format, mixed ...$args): void
+                {
+                }
+
+                public function output(string $format, mixed ...$args): void
+                {
+                }
+            };
+        }
+
+        public function testUserDelbanUsesRawHttpAndTypedBoundParameters(): void
+        {
+            $_GET['ipfilter'] = "10.0.0.1' OR 1=1 --";
+            $_GET['uniqueid'] = 'abc"xyz';
+
+            $include = static function (): void {
+                require __DIR__ . '/../../pages/user/user_delban.php';
+            };
+            $include();
+
+            $conn = Database::getDoctrineConnection();
+            $statement = $conn->executeStatements[0] ?? null;
+            $this->assertIsArray($statement);
+            $this->assertSame($_GET['ipfilter'], $statement['params']['ip'] ?? null);
+            $this->assertSame($_GET['uniqueid'], $statement['params']['id'] ?? null);
+            $this->assertSame(ParameterType::STRING, $statement['types']['ip'] ?? null);
+            $this->assertSame(ParameterType::STRING, $statement['types']['id'] ?? null);
+        }
+
+        public function testUserSavemoduleUsesHttpClassAndParameterizedReplace(): void
+        {
+            $_GET['userid'] = '42';
+            $_GET['module'] = 'samplemodule';
+            $_POST = ['display_name' => "O'Reilly"];
+
+            $include = static function (): void {
+                $output = $GLOBALS['output'];
+                require __DIR__ . '/../../pages/user/user_savemodule.php';
+            };
+            $include();
+
+            $conn = Database::getDoctrineConnection();
+            $statement = $conn->executeStatements[0] ?? null;
+            $this->assertIsArray($statement);
+            $this->assertStringContainsString('VALUES (:module,:userid,:setting,:value)', $statement['sql']);
+            $this->assertSame("O'Reilly", $statement['params']['value'] ?? null);
+            $this->assertSame(ParameterType::INTEGER, $statement['types']['userid'] ?? null);
+        }
+    }
+}

--- a/tests/User/UserLegacyHttpMigrationTest.php
+++ b/tests/User/UserLegacyHttpMigrationTest.php
@@ -101,5 +101,22 @@ namespace Lotgd\Tests\User {
             $this->assertSame("O'Reilly", $statement['params']['value'] ?? null);
             $this->assertSame(ParameterType::INTEGER, $statement['types']['userid'] ?? null);
         }
+
+        public function testUserDelbanPreservesZeroStringParameters(): void
+        {
+            $_GET['ipfilter'] = '0';
+            $_GET['uniqueid'] = '0';
+
+            $include = static function (): void {
+                require __DIR__ . '/../../pages/user/user_delban.php';
+            };
+            $include();
+
+            $conn = Database::getDoctrineConnection();
+            $statement = $conn->executeStatements[0] ?? null;
+            $this->assertIsArray($statement);
+            $this->assertSame('0', $statement['params']['ip'] ?? null);
+            $this->assertSame('0', $statement['params']['id'] ?? null);
+        }
     }
 }

--- a/tests/User/UserLegacyHttpMigrationTest.php
+++ b/tests/User/UserLegacyHttpMigrationTest.php
@@ -14,7 +14,7 @@ final class UserLegacyHttpMigrationTest extends TestCase
 $_GET['ipfilter'] = "10.0.0.1' OR 1=1 --";
 $_GET['uniqueid'] = 'abc"xyz';
 
-require __DIR__ . '/tests/User/isolated_user_delban.php';
+require LOTGD_TEST_ROOT . '/tests/User/isolated_user_delban.php';
 PHP);
 
         $statement = $payload['statement'] ?? null;
@@ -31,7 +31,7 @@ PHP);
 $_GET['ipfilter'] = '0';
 $_GET['uniqueid'] = '0';
 
-require __DIR__ . '/tests/User/isolated_user_delban.php';
+require LOTGD_TEST_ROOT . '/tests/User/isolated_user_delban.php';
 PHP);
 
         $statement = $payload['statement'] ?? null;
@@ -47,7 +47,7 @@ $_GET['userid'] = '42';
 $_GET['module'] = 'samplemodule';
 $_POST = ['display_name' => "O'Reilly"];
 
-require __DIR__ . '/tests/User/isolated_user_savemodule.php';
+require LOTGD_TEST_ROOT . '/tests/User/isolated_user_savemodule.php';
 PHP);
 
         $statement = $payload['statement'] ?? null;

--- a/tests/User/UserLegacyHttpMigrationTest.php
+++ b/tests/User/UserLegacyHttpMigrationTest.php
@@ -2,121 +2,85 @@
 
 declare(strict_types=1);
 
-namespace {
-    if (!function_exists('modulehook')) {
-        /**
-         * Minimal modulehook shim for isolated page include tests.
-         *
-         * @param array<mixed> $args
-         * @return array<mixed>
-         */
-        function modulehook(string $hookname, array $args = [], bool $allowinactive = false, string $modulename = ''): array
-        {
-            return $args;
-        }
-    }
+namespace Lotgd\Tests\User;
 
-    if (!function_exists('httpset')) {
-        function httpset(string $var, mixed $value, bool $force = false): void
-        {
-        }
-    }
-}
+use PHPUnit\Framework\TestCase;
 
-namespace Lotgd {
-    if (!class_exists(__NAMESPACE__ . '\\Redirect', false)) {
-        class Redirect
-        {
-            public static function redirect(string $location, string|bool $reason = false): void
-            {
-            }
-        }
-    }
-}
-
-namespace Lotgd\Tests\User {
-
-    use Doctrine\DBAL\ParameterType;
-    use Lotgd\MySQL\Database;
-    use Lotgd\Tests\Stubs\DoctrineBootstrap;
-    use PHPUnit\Framework\TestCase;
-
-    final class UserLegacyHttpMigrationTest extends TestCase
+final class UserLegacyHttpMigrationTest extends TestCase
+{
+    public function testUserDelbanUsesRawHttpAndTypedBoundParameters(): void
     {
-        protected function setUp(): void
-        {
-            require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
-            Database::$doctrineConnection = null;
-            Database::$instance = null;
-            DoctrineBootstrap::$conn = null;
-            Database::$mockResults = [];
-            $_GET = [];
-            $_POST = [];
-            $GLOBALS['output'] = new class {
-                public function outputNotl(string $format, mixed ...$args): void
-                {
-                }
+        $payload = $this->runIsolatedPageScript(<<<'PHP'
+$_GET['ipfilter'] = "10.0.0.1' OR 1=1 --";
+$_GET['uniqueid'] = 'abc"xyz';
 
-                public function output(string $format, mixed ...$args): void
-                {
-                }
-            };
-        }
+require __DIR__ . '/tests/User/isolated_user_delban.php';
+PHP);
 
-        public function testUserDelbanUsesRawHttpAndTypedBoundParameters(): void
-        {
-            $_GET['ipfilter'] = "10.0.0.1' OR 1=1 --";
-            $_GET['uniqueid'] = 'abc"xyz';
+        $statement = $payload['statement'] ?? null;
+        $this->assertIsArray($statement);
+        $this->assertSame("10.0.0.1' OR 1=1 --", $statement['params']['ip'] ?? null);
+        $this->assertSame('abc"xyz', $statement['params']['id'] ?? null);
+        $this->assertSame('STRING', $statement['types']['ip'] ?? null);
+        $this->assertSame('STRING', $statement['types']['id'] ?? null);
+    }
 
-            $include = static function (): void {
-                require __DIR__ . '/../../pages/user/user_delban.php';
-            };
-            $include();
+    public function testUserDelbanPreservesZeroStringParameters(): void
+    {
+        $payload = $this->runIsolatedPageScript(<<<'PHP'
+$_GET['ipfilter'] = '0';
+$_GET['uniqueid'] = '0';
 
-            $conn = Database::getDoctrineConnection();
-            $statement = $conn->executeStatements[0] ?? null;
-            $this->assertIsArray($statement);
-            $this->assertSame($_GET['ipfilter'], $statement['params']['ip'] ?? null);
-            $this->assertSame($_GET['uniqueid'], $statement['params']['id'] ?? null);
-            $this->assertSame(ParameterType::STRING, $statement['types']['ip'] ?? null);
-            $this->assertSame(ParameterType::STRING, $statement['types']['id'] ?? null);
-        }
+require __DIR__ . '/tests/User/isolated_user_delban.php';
+PHP);
 
-        public function testUserSavemoduleUsesHttpClassAndParameterizedReplace(): void
-        {
-            $_GET['userid'] = '42';
-            $_GET['module'] = 'samplemodule';
-            $_POST = ['display_name' => "O'Reilly"];
+        $statement = $payload['statement'] ?? null;
+        $this->assertIsArray($statement);
+        $this->assertSame('0', $statement['params']['ip'] ?? null);
+        $this->assertSame('0', $statement['params']['id'] ?? null);
+    }
 
-            $include = static function (): void {
-                $output = $GLOBALS['output'];
-                require __DIR__ . '/../../pages/user/user_savemodule.php';
-            };
-            $include();
+    public function testUserSavemoduleUsesHttpClassAndParameterizedReplace(): void
+    {
+        $payload = $this->runIsolatedPageScript(<<<'PHP'
+$_GET['userid'] = '42';
+$_GET['module'] = 'samplemodule';
+$_POST = ['display_name' => "O'Reilly"];
 
-            $conn = Database::getDoctrineConnection();
-            $statement = $conn->executeStatements[0] ?? null;
-            $this->assertIsArray($statement);
-            $this->assertStringContainsString('VALUES (:module,:userid,:setting,:value)', $statement['sql']);
-            $this->assertSame("O'Reilly", $statement['params']['value'] ?? null);
-            $this->assertSame(ParameterType::INTEGER, $statement['types']['userid'] ?? null);
-        }
+require __DIR__ . '/tests/User/isolated_user_savemodule.php';
+PHP);
 
-        public function testUserDelbanPreservesZeroStringParameters(): void
-        {
-            $_GET['ipfilter'] = '0';
-            $_GET['uniqueid'] = '0';
+        $statement = $payload['statement'] ?? null;
+        $this->assertIsArray($statement);
+        $this->assertStringContainsString('VALUES (:module,:userid,:setting,:value)', $statement['sql'] ?? '');
+        $this->assertSame("O'Reilly", $statement['params']['value'] ?? null);
+        $this->assertSame('INTEGER', $statement['types']['userid'] ?? null);
+    }
 
-            $include = static function (): void {
-                require __DIR__ . '/../../pages/user/user_delban.php';
-            };
-            $include();
+    /**
+     * Execute page-inclusion tests in an isolated PHP process so test-only
+     * function/class shims cannot leak into the main PHPUnit process.
+     *
+     * @return array<string,mixed>
+     */
+    private function runIsolatedPageScript(string $snippet): array
+    {
+        $root = dirname(__DIR__, 2);
+        $bootstrap = sprintf(
+            "define('LOTGD_TEST_ROOT', %s);\nrequire %s;\n",
+            var_export($root, true),
+            var_export($root . '/tests/bootstrap.php', true)
+        );
 
-            $conn = Database::getDoctrineConnection();
-            $statement = $conn->executeStatements[0] ?? null;
-            $this->assertIsArray($statement);
-            $this->assertSame('0', $statement['params']['ip'] ?? null);
-            $this->assertSame('0', $statement['params']['id'] ?? null);
-        }
+        $code = $bootstrap . $snippet;
+        $command = sprintf('%s -r %s', escapeshellarg(PHP_BINARY), escapeshellarg($code));
+        $output = shell_exec($command);
+
+        $this->assertNotNull($output, 'Isolated page script produced no output.');
+        $this->assertIsString($output);
+
+        /** @var array<string,mixed> $decoded */
+        $decoded = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+        return $decoded;
     }
 }

--- a/tests/User/isolated_user_delban.php
+++ b/tests/User/isolated_user_delban.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd {
+    if (!class_exists(__NAMESPACE__ . '\\Redirect', false)) {
+        class Redirect
+        {
+            public static function redirect(string $location, string|bool $reason = false): void
+            {
+            }
+        }
+    }
+}
+
+namespace {
+    use Lotgd\MySQL\Database;
+    Database::$doctrineConnection = null;
+    Database::$instance = null;
+    Database::$mockResults = [];
+
+    require LOTGD_TEST_ROOT . '/pages/user/user_delban.php';
+
+    $conn = Database::getDoctrineConnection();
+    $statement = $conn->executeStatements[0] ?? null;
+    $normalize = static function (mixed $value) use (&$normalize): mixed {
+        if ($value instanceof \UnitEnum) {
+            return $value->name;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $key => $item) {
+                $value[$key] = $normalize($item);
+            }
+        }
+
+        return $value;
+    };
+
+    echo json_encode(['statement' => $normalize($statement)], JSON_THROW_ON_ERROR);
+}

--- a/tests/User/isolated_user_savemodule.php
+++ b/tests/User/isolated_user_savemodule.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    use Lotgd\MySQL\Database;
+    use Lotgd\Translator;
+
+    if (!function_exists('modulehook')) {
+        /**
+         * Test shim for module validation hooks.
+         *
+         * @param array<mixed> $args
+         * @return array<mixed>
+         */
+        function modulehook(string $hookname, array $args = [], bool $allowinactive = false, string $modulename = ''): array
+        {
+            return $args;
+        }
+    }
+
+    if (!function_exists('httpset')) {
+        function httpset(string $var, mixed $value, bool $force = false): void
+        {
+        }
+    }
+
+    $output = new class {
+        public function outputNotl(string $format, mixed ...$args): void
+        {
+        }
+
+        public function output(string $format, mixed ...$args): void
+        {
+        }
+    };
+
+    Database::$doctrineConnection = null;
+    Database::$instance = null;
+    Database::$mockResults = [];
+    Translator::enableTranslation(false);
+
+    require LOTGD_TEST_ROOT . '/pages/user/user_savemodule.php';
+
+    $conn = Database::getDoctrineConnection();
+    $statement = $conn->executeStatements[0] ?? null;
+    $normalize = static function (mixed $value) use (&$normalize): mixed {
+        if ($value instanceof \UnitEnum) {
+            return $value->name;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $key => $item) {
+                $value[$key] = $normalize($item);
+            }
+        }
+
+        return $value;
+    };
+
+    echo json_encode(['statement' => $normalize($statement)], JSON_THROW_ON_ERROR);
+}


### PR DESCRIPTION
### Motivation

- Establish a clear HTTP API policy so core/refactored code uses the typed/raw `Lotgd\Http` API while legacy `httpget()`/`httppost()` wrappers remain only for legacy/module compatibility.
- Preserve historical escaping behaviour for legacy modules that rely on `addslashes()` semantics while enabling safe, parameterized DB access for core code.
- Prevent future regressions by adding a static QA check that fails when legacy wrappers are introduced in core/refactored paths.

### Description

- Documented the policy and deprecation timeline in `UPGRADING.md` and `docs/Deprecations.md` clarifying that `Lotgd\Http` is the canonical API for core and the legacy wrappers are compatibility shims in 2.x. 
- Updated `lib/http.php` to implement `legacy_http_escape()` so `httpget()/httppost()/httpall*()/postparse()` return intentionally escaped legacy values while leaving `src/Lotgd/Http.php` unmodified and returning raw values. 
- Added a QA scanner `Lotgd\QA\LegacyHttpWrapperUsageCheck` and CLI script `scripts/check-legacy-http-wrappers.php`, and wired it into `composer static` as `qa:http-wrappers` to block new wrapper usage in `pages/` and `src/` (whitelisted legacy locations: `lib/`, `modules/`, `install/`, `tests/`, `vendor/`).
- Performed targeted migrations in core pages to use `Lotgd\Http` + Doctrine DBAL prepared/typed statements instead of `httpget()/httppost()` and SQL string concatenation; affected files include `pages/user/user_delban.php`, `pages/user/user_debuglog.php`, `pages/user/user_save.php`, `pages/user/user_savemodule.php`, `pages/bans/case_setupban.php`, and `pages/user/user_setupban.php`.
- Added tests to cover raw vs legacy wrapper semantics, QA checker behaviour, and the migrated core usage: `tests/LegacyHttpWrapperCompatibilityTest.php`, `tests/QA/LegacyHttpWrapperUsageCheckTest.php`, and `tests/User/UserLegacyHttpMigrationTest.php`.

### Testing

- Ran `php -l` on all changed PHP files and reported no syntax errors. (success)
- Executed targeted PHPUnit runs for the new/related tests and then the full suite via `composer test`; targeted tests passed and the full test suite completed (existing warnings/deprecations noted but not blocking). (success)
- Executed the new QA script `php scripts/check-legacy-http-wrappers.php` which reports no violations in the current tree. (success)
- Ran static analysis: `phpstan` initially hit the default 128M worker limit in this environment when invoked through `composer static`, so `vendor/bin/phpstan analyse --configuration phpstan.neon --memory-limit=512M` was used and completed with no errors; the QA gate itself runs successfully as part of `composer static` when adequate memory is available. (QA gate passed; note about increased PHPStan memory requirement)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4307e37248329bac5d3a16a16058a)