### PR TITLE
Parameterize legacy SQL queries with DBAL bindings and add regression tests

### DIFF
--- a/docs/Doctrine.md
+++ b/docs/Doctrine.md
@@ -64,6 +64,16 @@ values based on the parameter type if you supply a third argument to
 See the official [Doctrine DBAL prepared statements documentation](https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/data-retrieval-and-manipulation.html#prepared-statements)
 for more background.
 
+
+## Legacy Request SQL Refactor Checklist
+
+When converting legacy request-driven SQL to DBAL in place:
+
+1. Keep the SQL semantics unchanged (same table, predicates, grouping, ordering).
+2. Use named placeholders instead of concatenating request values.
+3. Pass an explicit `$types` array (`ParameterType::STRING` / `ParameterType::INTEGER`) for request values.
+4. Add/adjust regression tests with quote-containing payloads to ensure values stay in params, not SQL text.
+
 ## Running Migrations
 
 Schema migrations reside in the `migrations/` directory and are configured

--- a/superuser.php
+++ b/superuser.php
@@ -14,6 +14,7 @@ use Lotgd\Page\Footer;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Sanitize;
+use Doctrine\DBAL\ParameterType;
 
 // translator ready
 // addnews ready
@@ -38,8 +39,14 @@ if ($op == "keepalive") {
     echo '<html><meta http-equiv="Refresh" content="30;url=' . PhpGenericEnvironment::getRequestUri() . '"></html><body>' . date("Y-m-d H:i:s") . "</body></html>";
     exit();
 } elseif ($op == "newsdelete") {
-    $sql = "DELETE FROM " . Database::prefix("news") . " WHERE newsid='" . Http::get('newsid') . "'";
-    Database::query($sql);
+    $newsIdRequest = Http::get('newsid');
+    // Preserve legacy behavior by treating request payload as a string while binding it safely.
+    $newsId = is_string($newsIdRequest) ? $newsIdRequest : (string) $newsIdRequest;
+    Database::getDoctrineConnection()->executeStatement(
+        "DELETE FROM " . Database::prefix("news") . " WHERE newsid = :newsid",
+        ['newsid' => $newsId],
+        ['newsid' => ParameterType::STRING]
+    );
     $return = Http::get('return');
     $return = Sanitize::cmdSanitize($return);
     $return = basename($return);

--- a/tests/Legacy/HighRiskSqlMigrationTest.php
+++ b/tests/Legacy/HighRiskSqlMigrationTest.php
@@ -44,7 +44,7 @@ final class HighRiskSqlMigrationTest extends TestCase
         self::assertStringContainsString('WHERE language = :language GROUP BY uri ORDER BY uri ASC', $content);
         self::assertStringContainsString('WHERE language = :language AND uri = :uri', $content);
         self::assertStringContainsString("'language' => ParameterType::STRING", $content);
-        self::assertStringContainsString("'uri' => ParameterType::STRING", $content);
+        self::assertStringContainsString("'uri'      => ParameterType::STRING", $content);
         self::assertStringNotContainsString('. LANGUAGE .', $content);
     }
 

--- a/tests/Legacy/HighRiskSqlMigrationTest.php
+++ b/tests/Legacy/HighRiskSqlMigrationTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Legacy;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\MySQL\Database;
+use Lotgd\Tests\Stubs\DoctrineConnection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression checks for legacy request-driven SQL hardening.
+ */
+final class HighRiskSqlMigrationTest extends TestCase
+{
+    private DoctrineConnection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \Lotgd\Tests\Stubs\Database::setPrefix('');
+        Database::resetDoctrineConnection();
+        $this->connection = Database::getDoctrineConnection();
+        $this->connection->executeStatements = [];
+        $this->connection->lastFetchAllParams = [];
+        $this->connection->lastFetchAllTypes = [];
+    }
+
+    public function testSuperuserNewsDeleteSqlIsParameterizedInSource(): void
+    {
+        $content = (string) file_get_contents(dirname(__DIR__, 2) . '/superuser.php');
+
+        self::assertStringContainsString('WHERE newsid = :newsid', $content);
+        self::assertStringContainsString("['newsid' => ParameterType::STRING]", $content);
+        self::assertStringNotContainsString("WHERE newsid='" . "' . Http::get('newsid')", $content);
+    }
+
+    public function testTranslatortoolListQueriesUseTypedBoundLanguageAndUriInSource(): void
+    {
+        $content = (string) file_get_contents(dirname(__DIR__, 2) . '/translatortool.php');
+
+        self::assertStringContainsString('WHERE language = :language GROUP BY uri ORDER BY uri ASC', $content);
+        self::assertStringContainsString('WHERE language = :language AND uri = :uri', $content);
+        self::assertStringContainsString("'language' => ParameterType::STRING", $content);
+        self::assertStringContainsString("'uri'      => ParameterType::STRING", $content);
+        self::assertStringNotContainsString("WHERE language='" . LANGUAGE . "'", $content);
+    }
+
+    public function testQuoteContainingPayloadsRemainBoundParameters(): void
+    {
+        $newsPayload = "7' OR '1'='1";
+        $uriPayload = "quest's/intro\"line";
+
+        $this->connection->executeStatement(
+            'DELETE FROM news WHERE newsid = :newsid',
+            ['newsid' => $newsPayload],
+            ['newsid' => ParameterType::STRING]
+        );
+
+        $delete = $this->connection->executeStatements[0] ?? null;
+        self::assertNotNull($delete);
+        self::assertSame(['newsid' => $newsPayload], $delete['params']);
+        self::assertStringNotContainsString($newsPayload, $delete['sql']);
+
+        $this->connection->fetchAllAssociative(
+            'SELECT * FROM translations WHERE language = :language AND uri = :uri',
+            [
+                'language' => 'en',
+                'uri'      => $uriPayload,
+            ],
+            [
+                'language' => ParameterType::STRING,
+                'uri'      => ParameterType::STRING,
+            ]
+        );
+
+        self::assertSame(['language' => 'en', 'uri' => $uriPayload], $this->connection->lastFetchAllParams);
+        self::assertSame(
+            ['language' => ParameterType::STRING, 'uri' => ParameterType::STRING],
+            $this->connection->lastFetchAllTypes
+        );
+    }
+}

--- a/tests/Legacy/HighRiskSqlMigrationTest.php
+++ b/tests/Legacy/HighRiskSqlMigrationTest.php
@@ -44,8 +44,8 @@ final class HighRiskSqlMigrationTest extends TestCase
         self::assertStringContainsString('WHERE language = :language GROUP BY uri ORDER BY uri ASC', $content);
         self::assertStringContainsString('WHERE language = :language AND uri = :uri', $content);
         self::assertStringContainsString("'language' => ParameterType::STRING", $content);
-        self::assertStringContainsString("'uri'      => ParameterType::STRING", $content);
-        self::assertStringNotContainsString("WHERE language='" . LANGUAGE . "'", $content);
+        self::assertStringContainsString("'uri' => ParameterType::STRING", $content);
+        self::assertStringNotContainsString('. LANGUAGE .', $content);
     }
 
     public function testQuoteContainingPayloadsRemainBoundParameters(): void

--- a/translatortool.php
+++ b/translatortool.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\ParameterType;
 use Lotgd\MySQL\Database;
 use Lotgd\DataCache;
 use Lotgd\Sanitize;
@@ -255,15 +256,20 @@ if ($op == "") {
     }
 } elseif ($op == "list") {
     popup_header("Translation List");
-    $sql = "SELECT uri,count(*) AS c FROM " . Database::prefix("translations") . " WHERE language='" . LANGUAGE . "' GROUP BY uri ORDER BY uri ASC";
-    $result = Database::query($sql);
+    // Keep LANGUAGE explicit while ensuring the DBAL layer receives a typed bound parameter.
+    $language = (string) LANGUAGE;
+    $rows = Database::getDoctrineConnection()->fetchAllAssociative(
+        'SELECT uri,count(*) AS c FROM ' . Database::prefix('translations') . ' WHERE language = :language GROUP BY uri ORDER BY uri ASC',
+        ['language' => $language],
+        ['language' => ParameterType::STRING]
+    );
     $output->outputNotl("<form action='translatortool.php' method='GET'>", true);
     $output->outputNotl("<input type='hidden' name='op' value='list'>", true);
         $output->outputNotl("<label for='u'>", true);
         $output->output("Known Namespaces:");
         $output->outputNotl("</label>", true);
         $output->outputNotl("<select name='u' id='u'>", true);
-    while ($row = Database::fetchAssoc($result)) {
+    foreach ($rows as $row) {
         $output->outputNotl("<option value=\"" . htmlentities($row['uri']) . "\">" . htmlentities($row['uri'], ENT_COMPAT, $settings->getSetting('charset', 'UTF-8')) . " ({$row['c']})</option>", true);
     }
     $output->outputNotl("</select>", true);
@@ -278,11 +284,22 @@ if ($op == "") {
     $norows = Translator::translateInline("No rows found");
     $output->outputNotl("<table border='0' cellpadding='2' cellspacing='0'>", true);
     $output->outputNotl("<tr class='trhead'><td>$ops</td><td>$from</td><td>$to</td><td>$version</td><td>$author</td></tr>", true);
-    $sql = "SELECT * FROM " . Database::prefix("translations") . " WHERE language='" . LANGUAGE . "' AND uri='" . (string) Http::get('u') . "'";
-    $result = Database::query($sql);
-    if (Database::numRows($result) > 0) {
+    $uriRequest = Http::get('u');
+    $uri = is_string($uriRequest) ? $uriRequest : (string) $uriRequest;
+    $translations = Database::getDoctrineConnection()->fetchAllAssociative(
+        'SELECT * FROM ' . Database::prefix('translations') . ' WHERE language = :language AND uri = :uri',
+        [
+            'language' => $language,
+            'uri'      => $uri,
+        ],
+        [
+            'language' => ParameterType::STRING,
+            'uri'      => ParameterType::STRING,
+        ]
+    );
+    if (count($translations) > 0) {
         $i = 0;
-        while ($row = Database::fetchAssoc($result)) {
+        foreach ($translations as $row) {
             $i++;
             $output->outputNotl("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'><td>", true);
             $edit = Translator::translateInline("Edit");


### PR DESCRIPTION
### Motivation

- Harden legacy request-driven SQL by replacing inline request interpolation with DBAL prepared statements and explicit parameter types to prevent injection while keeping semantics unchanged.
- Provide guidance for future conversions of legacy request SQL to DBAL via documentation.
- Add regression checks to ensure values (including quote-containing payloads) remain bound parameters rather than being interpolated into SQL text.

### Description

- Replaced raw DELETE in `superuser.php` with `Database::getDoctrineConnection()->executeStatement(...)` using a named `:newsid` placeholder and `ParameterType::STRING`, and cast the request value to string to preserve legacy behavior.
- Rewrote two queries in `translatortool.php` to use `fetchAllAssociative(...)` with named placeholders for `language` and `uri`, provided `ParameterType::STRING` types, imported `Doctrine\DBAL\ParameterType`, and adapted result iteration from `while` to `foreach`.
- Added a new checklist section `Legacy Request SQL Refactor Checklist` to `docs/Doctrine.md` describing best practices for converting legacy request-driven SQL to DBAL.
- Added a PHPUnit regression test `tests/Legacy/HighRiskSqlMigrationTest.php` that asserts the source contains the parameterized SQL and types and that quote-containing payloads remain in bound parameters rather than embedded in SQL text.

### Testing

- Added `tests/Legacy/HighRiskSqlMigrationTest.php` to the test suite; no automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4ee17650c8329804680f71eeaa0fa)