### PR TITLE
fix: parameterize legacy superuser SQL editors

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -172,6 +172,10 @@ The 2.x branch is already aligned with Doctrine DBAL 4 result APIs and parameter
 
 If you maintain custom modules, update any legacy calls to `Database::fetchAssoc()` loops by switching to the DBAL `Result` APIs and named parameters as shown in the refactoring examples above.
 
+### Superuser endpoint hardening update
+
+Recent 2.x updates switched the superuser editors in `deathmessages.php`, `taunt.php`, and `untranslated.php` to explicit Doctrine parameter binding for write operations (and filtered untranslated lookups). These endpoints now rely on `executeStatement()` / `executeQuery()` with typed bound parameters instead of legacy wrapper escaping behavior. If you maintain custom overrides of these pages, update them to match bound-parameter execution semantics.
+
 ### Refactoring Legacy SQL to Prepared Statements
 
 Legacy database calls often used `Lotgd\MySQL\Database::query()` together with manual escaping via `addslashes`. When upgrading, migrate those calls to Doctrine DBAL prepared statements obtained through `Lotgd\MySQL\Database::getDoctrineConnection()`. The following example shows how to convert a legacy lookup:

--- a/deathmessages.php
+++ b/deathmessages.php
@@ -12,6 +12,7 @@ use Lotgd\Nav;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Settings;
+use Doctrine\DBAL\ParameterType;
 
 // addnews ready
 // mail ready
@@ -22,6 +23,7 @@ require_once __DIR__ . "/common.php";
 
 $settings = Settings::getInstance();
 $output = Output::getInstance();
+$connection = Database::getDoctrineConnection();
 
 Translator::getInstance()->setSchema("deathmessage");
 
@@ -75,8 +77,11 @@ switch ($op) {
         $output->rawOutput("</form>");
         break;
     case "del":
-        $sql = "DELETE FROM " . Database::prefix("deathmessages") . " WHERE deathmessageid=\"$deathmessageid\"";
-        Database::query($sql);
+        $connection->executeStatement(
+            "DELETE FROM " . Database::prefix("deathmessages") . " WHERE deathmessageid = :deathmessageid",
+            ['deathmessageid' => (int) $deathmessageid],
+            ['deathmessageid' => ParameterType::INTEGER]
+        );
         $op = "";
         Http::set("op", "");
         break;
@@ -86,11 +91,44 @@ switch ($op) {
         $graveyard = (int) Http::post('graveyard');
         $taunt = (int) Http::post('taunt');
         if ($deathmessageid != "") {
-            $sql = "UPDATE " . Database::prefix("deathmessages") . " SET deathmessage=\"$deathmessage\",taunt=$taunt,forest=$forest,graveyard=$graveyard,editor=\"" . addslashes($session['user']['login']) . "\" WHERE deathmessageid=\"$deathmessageid\"";
+            $connection->executeStatement(
+                "UPDATE " . Database::prefix("deathmessages") . " SET deathmessage = :deathmessage, taunt = :taunt, forest = :forest, graveyard = :graveyard, editor = :editor WHERE deathmessageid = :deathmessageid",
+                [
+                    'deathmessage' => $deathmessage,
+                    'taunt' => $taunt,
+                    'forest' => $forest,
+                    'graveyard' => $graveyard,
+                    'editor' => (string) $session['user']['login'],
+                    'deathmessageid' => (int) $deathmessageid,
+                ],
+                [
+                    'deathmessage' => ParameterType::STRING,
+                    'taunt' => ParameterType::INTEGER,
+                    'forest' => ParameterType::INTEGER,
+                    'graveyard' => ParameterType::INTEGER,
+                    'editor' => ParameterType::STRING,
+                    'deathmessageid' => ParameterType::INTEGER,
+                ]
+            );
         } else {
-            $sql = "INSERT INTO " . Database::prefix("deathmessages") . " (deathmessage,taunt,forest,graveyard,editor) VALUES (\"$deathmessage\",$taunt,$forest,$graveyard,\"" . addslashes($session['user']['login']) . "\")";
+            $connection->executeStatement(
+                "INSERT INTO " . Database::prefix("deathmessages") . " (deathmessage, taunt, forest, graveyard, editor) VALUES (:deathmessage, :taunt, :forest, :graveyard, :editor)",
+                [
+                    'deathmessage' => $deathmessage,
+                    'taunt' => $taunt,
+                    'forest' => $forest,
+                    'graveyard' => $graveyard,
+                    'editor' => (string) $session['user']['login'],
+                ],
+                [
+                    'deathmessage' => ParameterType::STRING,
+                    'taunt' => ParameterType::INTEGER,
+                    'forest' => ParameterType::INTEGER,
+                    'graveyard' => ParameterType::INTEGER,
+                    'editor' => ParameterType::STRING,
+                ]
+            );
         }
-        Database::query($sql);
         $op = "";
         Http::set("op", "");
         break;

--- a/taunt.php
+++ b/taunt.php
@@ -12,6 +12,7 @@ use Lotgd\Nav;
 use Lotgd\MySQL\Database;
 use Lotgd\Settings;
 use Lotgd\Translator;
+use Doctrine\DBAL\ParameterType;
 
 // addnews ready
 // mail ready
@@ -22,6 +23,7 @@ require_once __DIR__ . "/common.php";
 
 $settings = Settings::getInstance();
 $output = Output::getInstance();
+$connection = Database::getDoctrineConnection();
 
 Translator::getInstance()->setSchema("taunt");
 
@@ -66,18 +68,42 @@ if ($op == "edit") {
     $output->rawOutput("<input type='submit' class='button' value='$save'>");
     $output->rawOutput("</form>");
 } elseif ($op == "del") {
-    $sql = "DELETE FROM " . Database::prefix("taunts") . " WHERE tauntid=\"$tauntid\"";
-    Database::query($sql);
+    $connection->executeStatement(
+        "DELETE FROM " . Database::prefix("taunts") . " WHERE tauntid = :tauntid",
+        ['tauntid' => (int) $tauntid],
+        ['tauntid' => ParameterType::INTEGER]
+    );
     $op = "";
     Http::set("op", "");
 } elseif ($op == "save") {
     $taunt = Http::post('taunt');
     if ($tauntid != "") {
-        $sql = "UPDATE " . Database::prefix("taunts") . " SET taunt=\"$taunt\",editor=\"" . addslashes($session['user']['login']) . "\" WHERE tauntid=\"$tauntid\"";
+        $connection->executeStatement(
+            "UPDATE " . Database::prefix("taunts") . " SET taunt = :taunt, editor = :editor WHERE tauntid = :tauntid",
+            [
+                'taunt' => $taunt,
+                'editor' => (string) $session['user']['login'],
+                'tauntid' => (int) $tauntid,
+            ],
+            [
+                'taunt' => ParameterType::STRING,
+                'editor' => ParameterType::STRING,
+                'tauntid' => ParameterType::INTEGER,
+            ]
+        );
     } else {
-        $sql = "INSERT INTO " . Database::prefix("taunts") . " (taunt,editor) VALUES (\"$taunt\",\"" . addslashes($session['user']['login']) . "\")";
+        $connection->executeStatement(
+            "INSERT INTO " . Database::prefix("taunts") . " (taunt, editor) VALUES (:taunt, :editor)",
+            [
+                'taunt' => $taunt,
+                'editor' => (string) $session['user']['login'],
+            ],
+            [
+                'taunt' => ParameterType::STRING,
+                'editor' => ParameterType::STRING,
+            ]
+        );
     }
-    Database::query($sql);
     $op = "";
     Http::set("op", "");
 }

--- a/tests/Security/DeathmessagesParameterBindingRegressionTest.php
+++ b/tests/Security/DeathmessagesParameterBindingRegressionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Security;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\MySQL\Database;
+use Lotgd\Tests\Stubs\DoctrineBootstrap;
+use Lotgd\Tests\Stubs\DoctrineConnection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security regression coverage for deathmessage parameter binding.
+ */
+final class DeathmessagesParameterBindingRegressionTest extends TestCase
+{
+    private DoctrineConnection $connection;
+
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
+
+        DoctrineBootstrap::$conn = null;
+        Database::resetDoctrineConnection();
+        Database::setPrefix('lotgd_');
+
+        $this->connection = Database::getDoctrineConnection();
+        $this->connection->executeStatements = [];
+    }
+
+    public function testSourceUsesPreparedStatementsWithExplicitTypes(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/deathmessages.php');
+
+        self::assertStringContainsString('executeStatement(', $source);
+        self::assertStringContainsString('deathmessageid = :deathmessageid', $source);
+        self::assertStringContainsString('deathmessage = :deathmessage', $source);
+        self::assertStringContainsString('ParameterType::INTEGER', $source);
+        self::assertStringContainsString('ParameterType::STRING', $source);
+        self::assertStringNotContainsString('addslashes($session[\'user\'][\'login\'])', $source);
+    }
+
+    public function testPayloadRoundtripIsPreservedInBoundParameters(): void
+    {
+        $payload = "Death '\" \\\\ Ω漢字";
+
+        $this->connection->executeStatement(
+            'UPDATE ' . Database::prefix('deathmessages') . ' SET deathmessage = :deathmessage, taunt = :taunt, forest = :forest, graveyard = :graveyard, editor = :editor WHERE deathmessageid = :deathmessageid',
+            [
+                'deathmessage' => $payload,
+                'taunt' => 1,
+                'forest' => 0,
+                'graveyard' => 1,
+                'editor' => "Admin '\" \\\\ Ω",
+                'deathmessageid' => 17,
+            ],
+            [
+                'deathmessage' => ParameterType::STRING,
+                'taunt' => ParameterType::INTEGER,
+                'forest' => ParameterType::INTEGER,
+                'graveyard' => ParameterType::INTEGER,
+                'editor' => ParameterType::STRING,
+                'deathmessageid' => ParameterType::INTEGER,
+            ]
+        );
+
+        $statement = $this->connection->executeStatements[0] ?? null;
+        self::assertNotNull($statement);
+        self::assertStringNotContainsString($payload, $statement['sql']);
+        self::assertSame($payload, $statement['params']['deathmessage']);
+        self::assertSame(ParameterType::STRING, $statement['types']['deathmessage']);
+        self::assertSame(ParameterType::INTEGER, $statement['types']['deathmessageid']);
+    }
+}

--- a/tests/Security/DeathmessagesParameterBindingRegressionTest.php
+++ b/tests/Security/DeathmessagesParameterBindingRegressionTest.php
@@ -12,7 +12,12 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Security regression coverage for deathmessage parameter binding.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
 final class DeathmessagesParameterBindingRegressionTest extends TestCase
 {
     private DoctrineConnection $connection;
@@ -23,10 +28,19 @@ final class DeathmessagesParameterBindingRegressionTest extends TestCase
 
         DoctrineBootstrap::$conn = null;
         Database::resetDoctrineConnection();
-        Database::setPrefix('lotgd_');
+        // Avoid leaking prefix changes into unrelated suites.
+        Database::setPrefix('');
 
         $this->connection = Database::getDoctrineConnection();
         $this->connection->executeStatements = [];
+    }
+
+    protected function tearDown(): void
+    {
+        DoctrineBootstrap::$conn = null;
+        Database::resetDoctrineConnection();
+        Database::setPrefix('');
+        parent::tearDown();
     }
 
     public function testSourceUsesPreparedStatementsWithExplicitTypes(): void

--- a/tests/Security/TauntParameterBindingRegressionTest.php
+++ b/tests/Security/TauntParameterBindingRegressionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Security;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\MySQL\Database;
+use Lotgd\Tests\Stubs\DoctrineBootstrap;
+use Lotgd\Tests\Stubs\DoctrineConnection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security regression coverage for taunt parameter binding.
+ */
+final class TauntParameterBindingRegressionTest extends TestCase
+{
+    private DoctrineConnection $connection;
+
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
+
+        DoctrineBootstrap::$conn = null;
+        Database::resetDoctrineConnection();
+        Database::setPrefix('lotgd_');
+
+        $this->connection = Database::getDoctrineConnection();
+        $this->connection->executeStatements = [];
+    }
+
+    public function testSourceUsesPreparedStatementsWithTypedParams(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/taunt.php');
+
+        self::assertStringContainsString('executeStatement(', $source);
+        self::assertStringContainsString('tauntid = :tauntid', $source);
+        self::assertStringContainsString('taunt = :taunt', $source);
+        self::assertStringContainsString('editor = :editor', $source);
+        self::assertStringContainsString('ParameterType::INTEGER', $source);
+        self::assertStringContainsString('ParameterType::STRING', $source);
+        self::assertStringNotContainsString('addslashes($session[\'user\'][\'login\'])', $source);
+    }
+
+    public function testPayloadRoundtripIsPreservedInInsertBoundParameters(): void
+    {
+        $payload = "Taunt '\" \\\\ Ω漢字";
+        $editor = "Admin '\" \\\\ Ω";
+
+        $this->connection->executeStatement(
+            'INSERT INTO ' . Database::prefix('taunts') . ' (taunt, editor) VALUES (:taunt, :editor)',
+            [
+                'taunt' => $payload,
+                'editor' => $editor,
+            ],
+            [
+                'taunt' => ParameterType::STRING,
+                'editor' => ParameterType::STRING,
+            ]
+        );
+
+        $statement = $this->connection->executeStatements[0] ?? null;
+        self::assertNotNull($statement);
+        self::assertStringNotContainsString($payload, $statement['sql']);
+        self::assertSame($payload, $statement['params']['taunt']);
+        self::assertSame($editor, $statement['params']['editor']);
+        self::assertSame(ParameterType::STRING, $statement['types']['taunt']);
+    }
+}

--- a/tests/Security/TauntParameterBindingRegressionTest.php
+++ b/tests/Security/TauntParameterBindingRegressionTest.php
@@ -12,7 +12,12 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Security regression coverage for taunt parameter binding.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
 final class TauntParameterBindingRegressionTest extends TestCase
 {
     private DoctrineConnection $connection;
@@ -23,10 +28,19 @@ final class TauntParameterBindingRegressionTest extends TestCase
 
         DoctrineBootstrap::$conn = null;
         Database::resetDoctrineConnection();
-        Database::setPrefix('lotgd_');
+        // Avoid leaking prefix changes into unrelated suites.
+        Database::setPrefix('');
 
         $this->connection = Database::getDoctrineConnection();
         $this->connection->executeStatements = [];
+    }
+
+    protected function tearDown(): void
+    {
+        DoctrineBootstrap::$conn = null;
+        Database::resetDoctrineConnection();
+        Database::setPrefix('');
+        parent::tearDown();
     }
 
     public function testSourceUsesPreparedStatementsWithTypedParams(): void

--- a/tests/Security/UntranslatedParameterBindingRegressionTest.php
+++ b/tests/Security/UntranslatedParameterBindingRegressionTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Security;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\MySQL\Database;
+use Lotgd\Tests\Stubs\DoctrineBootstrap;
+use Lotgd\Tests\Stubs\DoctrineConnection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security regression coverage for untranslated page parameter binding.
+ */
+final class UntranslatedParameterBindingRegressionTest extends TestCase
+{
+    private DoctrineConnection $connection;
+
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
+
+        DoctrineBootstrap::$conn = null;
+        Database::resetDoctrineConnection();
+        Database::setPrefix('lotgd_');
+
+        $this->connection = Database::getDoctrineConnection();
+        $this->connection->executeStatements = [];
+        $this->connection->queries = [];
+        $this->connection->executeQueryParams = [];
+        $this->connection->executeQueryTypes = [];
+    }
+
+    public function testSourceUsesBoundParamsForLanguageAndNamespaceFilters(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/untranslated.php');
+
+        self::assertStringContainsString('WHERE language = :language', $source);
+        self::assertStringContainsString('AND namespace = :namespace', $source);
+        self::assertStringContainsString('INSERT INTO " . Database::prefix("translations") . "', $source);
+        self::assertStringContainsString('DELETE FROM " . Database::prefix("untranslated") . "', $source);
+        self::assertStringContainsString('ParameterType::STRING', $source);
+    }
+
+    public function testQuotedMultibytePayloadRemainsBoundAndSqlShapeUnchanged(): void
+    {
+        $language = "en'\"\\Ω";
+        $namespace = "core/forest'\"\\漢字";
+        $intext = "Source '\" \\\\ Ω漢字";
+        $outtext = "Target '\" \\\\ Ω漢字";
+
+        $this->connection->executeQuery(
+            'SELECT * FROM ' . Database::prefix('untranslated') . ' WHERE language = :language AND namespace = :namespace',
+            [
+                'language' => $language,
+                'namespace' => $namespace,
+            ],
+            [
+                'language' => ParameterType::STRING,
+                'namespace' => ParameterType::STRING,
+            ]
+        );
+
+        $this->connection->executeStatement(
+            'INSERT INTO ' . Database::prefix('translations') . ' (language, uri, intext, outtext, author, version) VALUES (:language, :namespace, :intext, :outtext, :author, :version)',
+            [
+                'language' => $language,
+                'namespace' => $namespace,
+                'intext' => $intext,
+                'outtext' => $outtext,
+                'author' => "Editor '\" \\\\ Ω",
+                'version' => '2.0.0',
+            ],
+            [
+                'language' => ParameterType::STRING,
+                'namespace' => ParameterType::STRING,
+                'intext' => ParameterType::STRING,
+                'outtext' => ParameterType::STRING,
+                'author' => ParameterType::STRING,
+                'version' => ParameterType::STRING,
+            ]
+        );
+
+        $selectSql = $this->connection->queries[0] ?? '';
+        self::assertStringNotContainsString($language, $selectSql);
+        self::assertStringNotContainsString($namespace, $selectSql);
+
+        $insert = $this->connection->executeStatements[0] ?? null;
+        self::assertNotNull($insert);
+        self::assertStringNotContainsString($intext, $insert['sql']);
+        self::assertSame($intext, $insert['params']['intext']);
+        self::assertSame($outtext, $insert['params']['outtext']);
+    }
+}

--- a/tests/Security/UntranslatedParameterBindingRegressionTest.php
+++ b/tests/Security/UntranslatedParameterBindingRegressionTest.php
@@ -12,7 +12,12 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Security regression coverage for untranslated page parameter binding.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
 final class UntranslatedParameterBindingRegressionTest extends TestCase
 {
     private DoctrineConnection $connection;
@@ -23,13 +28,22 @@ final class UntranslatedParameterBindingRegressionTest extends TestCase
 
         DoctrineBootstrap::$conn = null;
         Database::resetDoctrineConnection();
-        Database::setPrefix('lotgd_');
+        // Avoid leaking prefix changes into unrelated suites.
+        Database::setPrefix('');
 
         $this->connection = Database::getDoctrineConnection();
         $this->connection->executeStatements = [];
         $this->connection->queries = [];
         $this->connection->executeQueryParams = [];
         $this->connection->executeQueryTypes = [];
+    }
+
+    protected function tearDown(): void
+    {
+        DoctrineBootstrap::$conn = null;
+        Database::resetDoctrineConnection();
+        Database::setPrefix('');
+        parent::tearDown();
     }
 
     public function testSourceUsesBoundParamsForLanguageAndNamespaceFilters(): void

--- a/untranslated.php
+++ b/untranslated.php
@@ -12,6 +12,7 @@ use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Settings;
 use Lotgd\Random;
+use Doctrine\DBAL\ParameterType;
 
 // translator ready
 // addnews ready
@@ -30,6 +31,7 @@ require_once __DIR__ . "/common.php";
 
 $settings = Settings::getInstance();
 $output = Output::getInstance();
+$connection = Database::getDoctrineConnection();
 
 SuAccess::check(SU_IS_TRANSLATOR);
 
@@ -58,10 +60,38 @@ if ($op == "list") {
         if ($outtext <> "") {
             $login = $session['user']['login'];
             $language = $session['user']['prefs']['language'];
-            $sql = "INSERT INTO " . Database::prefix("translations") . " (language,uri,intext,outtext,author,version) VALUES" . " ('$language','$namespace','$intext','$outtext','$login','$logd_version')";
-            Database::query($sql);
-            $sql = "DELETE FROM " . Database::prefix("untranslated") . " WHERE intext = '$intext' AND language = '$language' AND namespace = '$namespace'";
-            Database::query($sql);
+            $connection->executeStatement(
+                "INSERT INTO " . Database::prefix("translations") . " (language, uri, intext, outtext, author, version) VALUES (:language, :namespace, :intext, :outtext, :author, :version)",
+                [
+                    'language' => (string) $language,
+                    'namespace' => (string) $namespace,
+                    'intext' => (string) $intext,
+                    'outtext' => (string) $outtext,
+                    'author' => (string) $login,
+                    'version' => (string) $logd_version,
+                ],
+                [
+                    'language' => ParameterType::STRING,
+                    'namespace' => ParameterType::STRING,
+                    'intext' => ParameterType::STRING,
+                    'outtext' => ParameterType::STRING,
+                    'author' => ParameterType::STRING,
+                    'version' => ParameterType::STRING,
+                ]
+            );
+            $connection->executeStatement(
+                "DELETE FROM " . Database::prefix("untranslated") . " WHERE intext = :intext AND language = :language AND namespace = :namespace",
+                [
+                    'intext' => (string) $intext,
+                    'language' => (string) $language,
+                    'namespace' => (string) $namespace,
+                ],
+                [
+                    'intext' => ParameterType::STRING,
+                    'language' => ParameterType::STRING,
+                    'namespace' => ParameterType::STRING,
+                ]
+            );
         }
     }
 
@@ -73,8 +103,11 @@ if ($op == "list") {
         Nav::add("", "untranslated.php?op=list");
     }
 
-    $sql = "SELECT namespace,count(*) AS c FROM " . Database::prefix("untranslated") . " WHERE language='" . $session['user']['prefs']['language'] . "' GROUP BY namespace ORDER BY namespace ASC";
-    $result = Database::query($sql);
+    $result = $connection->executeQuery(
+        "SELECT namespace, count(*) AS c FROM " . Database::prefix("untranslated") . " WHERE language = :language GROUP BY namespace ORDER BY namespace ASC",
+        ['language' => (string) $session['user']['prefs']['language']],
+        ['language' => ParameterType::STRING]
+    );
     $output->rawOutput("<input type='hidden' name='op' value='list'>");
         $output->rawOutput("<label for='ns'>");
         $output->output("Known Namespaces:");
@@ -98,8 +131,17 @@ if ($op == "list") {
     } else {
         $output->rawOutput("<table border='0' cellpadding='2' cellspacing='0'>");
         $output->rawOutput("<tr class='trhead'><td>" . Translator::translateInline("Ops") . "</td><td>" . Translator::translateInline("Text") . "</td></tr>");
-        $sql = "SELECT * FROM " . Database::prefix("untranslated") . " WHERE language='" . $session['user']['prefs']['language'] . "' AND namespace='" . $namespace . "'";
-        $result = Database::query($sql);
+        $result = $connection->executeQuery(
+            "SELECT * FROM " . Database::prefix("untranslated") . " WHERE language = :language AND namespace = :namespace",
+            [
+                'language' => (string) $session['user']['prefs']['language'],
+                'namespace' => (string) $namespace,
+            ],
+            [
+                'language' => ParameterType::STRING,
+                'namespace' => ParameterType::STRING,
+            ]
+        );
         if (Database::numRows($result) > 0) {
             $i = 0;
             while ($row = Database::fetchAssoc($result)) {
@@ -126,10 +168,38 @@ if ($op == "list") {
         $language = Http::post('language');
         if ($outtext <> "") {
             $login = $session['user']['login'];
-            $sql = "INSERT INTO " . Database::prefix("translations") . " (language,uri,intext,outtext,author,version) VALUES" . " ('$language','$namespace','$intext','$outtext','$login','$logd_version')";
-            Database::query($sql);
-            $sql = "DELETE FROM " . Database::prefix("untranslated") . " WHERE intext = '$intext' AND language = '$language' AND namespace = '$namespace'";
-            Database::query($sql);
+            $connection->executeStatement(
+                "INSERT INTO " . Database::prefix("translations") . " (language, uri, intext, outtext, author, version) VALUES (:language, :namespace, :intext, :outtext, :author, :version)",
+                [
+                    'language' => (string) $language,
+                    'namespace' => (string) $namespace,
+                    'intext' => (string) $intext,
+                    'outtext' => (string) $outtext,
+                    'author' => (string) $login,
+                    'version' => (string) $logd_version,
+                ],
+                [
+                    'language' => ParameterType::STRING,
+                    'namespace' => ParameterType::STRING,
+                    'intext' => ParameterType::STRING,
+                    'outtext' => ParameterType::STRING,
+                    'author' => ParameterType::STRING,
+                    'version' => ParameterType::STRING,
+                ]
+            );
+            $connection->executeStatement(
+                "DELETE FROM " . Database::prefix("untranslated") . " WHERE intext = :intext AND language = :language AND namespace = :namespace",
+                [
+                    'intext' => (string) $intext,
+                    'language' => (string) $language,
+                    'namespace' => (string) $namespace,
+                ],
+                [
+                    'intext' => ParameterType::STRING,
+                    'language' => ParameterType::STRING,
+                    'namespace' => ParameterType::STRING,
+                ]
+            );
             invalidatedatacache("translations-" . $namespace . "-" . $language);
         }
     }
@@ -137,8 +207,11 @@ if ($op == "list") {
     $sql = "SELECT count(intext) AS count FROM " . Database::prefix("untranslated");
     $count = Database::fetchAssoc(Database::query($sql));
     if ($count['count'] > 0) {
-        $sql = "SELECT * FROM " . Database::prefix("untranslated") . " WHERE language = '" . $session['user']['prefs']['language'] . "' ORDER BY rand(" . Random::eRand() . ") LIMIT 1";
-        $result = Database::query($sql);
+        $result = $connection->executeQuery(
+            "SELECT * FROM " . Database::prefix("untranslated") . " WHERE language = :language ORDER BY rand(" . Random::eRand() . ") LIMIT 1",
+            ['language' => (string) $session['user']['prefs']['language']],
+            ['language' => ParameterType::STRING]
+        );
         if (Database::numRows($result) == 1) {
             $row = Database::fetchAssoc($result);
             $row['intext'] = stripslashes($row['intext']);


### PR DESCRIPTION
### Motivation

- Harden legacy superuser editor pages to avoid SQL injection and brittle string-escaping by using DBAL prepared execution with explicit parameter types.  
- Replace ad-hoc `addslashes`/string-concatenation SQL with typed bindings to preserve payload roundtrips (quotes, backslashes, multibyte) safely.  
- Keep existing behavior (language/namespace selection and cache invalidation) while moving to DBAL `executeQuery()`/`executeStatement()` semantics.

### Description

- Reworked `deathmessages.php` to use `Database::getDoctrineConnection()->executeStatement(...)` for `DELETE`, `UPDATE`, and `INSERT` paths, binding `deathmessageid`, `deathmessage`, `taunt`, `forest`, `graveyard`, and `editor` with `Doctrine\DBAL\ParameterType` types.  
- Reworked `taunt.php` to use `executeStatement(...)` for `DELETE`, `UPDATE`, and `INSERT` with typed parameters for `tauntid`, `taunt`, and `editor`.  
- Reworked `untranslated.php` to use `executeQuery(...)` for filtered `SELECT` operations and `executeStatement(...)` for `INSERT`/`DELETE` translation flows, binding `language`, `namespace`, `intext`, `outtext`, `author`, and `version` with explicit types and preserving the existing cache invalidation call.  
- Added focused security-regression tests under `tests/Security/` for each page (`DeathmessagesParameterBindingRegressionTest`, `TauntParameterBindingRegressionTest`, `UntranslatedParameterBindingRegressionTest`) that assert prepared usage, ensure payloads containing quotes/backslashes/multibyte characters remain intact in bound params, and verify that SQL strings do not contain raw payloads.  
- Added a short note to `UPGRADING.md` documenting that these superuser endpoints now require parameterized execution semantics and no longer rely on legacy wrapper escaping behavior.

### Testing

- Ran syntax checks with `php -l` on the modified pages and new tests, which reported no syntax errors.  
- Ran the new focused PHPUnit tests with `vendor/bin/phpunit` for the three added tests, which passed (6 tests, 34 assertions).  
- Ran `composer test` which reports unrelated pre-existing failures in the current branch (`SettingsTest` type errors and `ServerFunctionsTest` failure) and therefore is not green in this environment.  
- Ran `composer static` where PHPStan aborted due to the CI environment PHP memory limit (128M), producing an incomplete static analysis run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4f9d77aac8329ac2cc46e910c02f0)