### PR TITLE
fix: normalize raw request values in nav and petition abuse fields

### DIFF
--- a/deathmessages.php
+++ b/deathmessages.php
@@ -35,6 +35,7 @@ $op = Http::get('op');
 $deathmessageidRequest = Http::get('deathmessageid');
 $deathmessageid = deathmessages_normalize_optional_int($deathmessageidRequest);
 $deathmessageidParam = $deathmessageid === null ? '' : (string) $deathmessageid;
+$commentaryPage = deathmessages_normalize_optional_int(Http::get('c'));
 switch ($op) {
     case "edit":
         Nav::add("Deathmessages");
@@ -146,6 +147,9 @@ switch ($op) {
 
 /**
  * Normalise request values expected to be optional integer identifiers.
+ *
+ * Lotgd\Http now exposes raw request payloads, so we must explicitly narrow
+ * values such as c/deathmessageid before building navigation URLs.
  */
 function deathmessages_normalize_optional_int(mixed $value): ?int
 {
@@ -209,7 +213,7 @@ if ($op == "") {
         $edit = Translator::translateInline("Edit");
         $del = Translator::translateInline("Del");
         $conf = Translator::translateInline("Are you sure you wish to delete this deathmessage?");
-        $id = $row['deathmessageid'];
+        $id = (int) $row['deathmessageid'];
         $output->rawOutput("[ <a href='deathmessages.php?op=edit&deathmessageid=$id'>$edit</a> | <a href='deathmessages.php?op=del&deathmessageid=$id' onClick='return confirm(\"$conf\");'>$del</a> ]");
         Nav::add("", "deathmessages.php?op=edit&deathmessageid=$id");
         Nav::add("", "deathmessages.php?op=del&deathmessageid=$id");
@@ -225,7 +229,8 @@ if ($op == "") {
         $output->outputNotl("%s", $row['editor']);
         $output->rawOutput("</td></tr>");
     }
-    Nav::add("", "deathmessages.php?c=" . Http::get('c'));
+    $commentaryPageParam = $commentaryPage === null ? '' : (string) (int) $commentaryPage;
+    Nav::add("", "deathmessages.php?c=$commentaryPageParam");
     $output->rawOutput("</table>");
     Nav::add("Deathmessages");
     Nav::add("Add a new deathmessage", "deathmessages.php?op=edit");

--- a/pages/petition/petition_default.php
+++ b/pages/petition/petition_default.php
@@ -150,9 +150,12 @@ if (count($post) > 0 && (string) Http::post('abuse') !== 'yes') {
         $abuse = (string) Http::post('abuse');
     }
     if ($abuse === 'yes') {
+        $abusePlayer = petition_normalize_optional_int(Http::post('abuseplayer'));
+        $abusePlayerValue = $abusePlayer === null ? '' : (string) (int) $abusePlayer;
+        $abusePlayerAttr = htmlentities($abusePlayerValue, ENT_COMPAT, $settings->getSetting("charset", "UTF-8"));
         $output->rawOutput("<textarea name='description' cols='55' rows='7' class='input'></textarea>");
         $output->rawOutput("<input type='hidden' name='abuse' value=\"" . Stripslashes::deep($problem) . "\"><br><hr><pre>" . stripslashes(rawurldecode($problem)) . "</pre><hr><br>");
-        $output->rawOutput("<input type='hidden' name='abuseplayer' value=\"" . (string) Http::post('abuseplayer') . "\">");
+        $output->rawOutput("<input type='hidden' name='abuseplayer' value=\"$abusePlayerAttr\">");
     } else {
         $output->rawOutput("<textarea name='description' cols='55' rows='7' class='input'>" . Stripslashes::deep(($problem)) . "</textarea>");
     }
@@ -164,4 +167,27 @@ if (count($post) > 0 && (string) Http::post('abuse') !== 'yes') {
     $output->output("Petitions about game mechanics will more than likely not be answered unless they have something to do with a bug.");
     $output->output("Remember, if you are not signed in, and do not provide an email address, we have no way to contact you.");
     $output->rawOutput("</form>");
+}
+
+/**
+ * Normalise optional integer request values before rendering into HTML.
+ *
+ * Lotgd\Http now returns raw payloads, so abuseplayer must be narrowed to an
+ * integer identifier before writing into hidden input attributes.
+ */
+function petition_normalize_optional_int(mixed $value): ?int
+{
+    if ($value === '' || $value === null || is_array($value) || ! is_scalar($value)) {
+        return null;
+    }
+
+    $valueString = (string) $value;
+
+    if ($valueString === '' || ! ctype_digit($valueString)) {
+        return null;
+    }
+
+    $intValue = (int) $valueString;
+
+    return $intValue > 0 ? $intValue : null;
 }

--- a/taunt.php
+++ b/taunt.php
@@ -35,6 +35,7 @@ $op = Http::get('op');
 $tauntidRequest = Http::get('tauntid');
 $tauntid = taunt_normalize_optional_int($tauntidRequest);
 $tauntidParam = $tauntid === null ? '' : (string) $tauntid;
+$commentaryPage = taunt_normalize_optional_int(Http::get('c'));
 if ($op == "edit") {
     Nav::add("Taunts");
     Nav::add("Return to the taunt editor", "taunt.php");
@@ -133,7 +134,7 @@ if ($op == "") {
         $edit = Translator::translateInline("Edit");
         $del = Translator::translateInline("Del");
         $conf = Translator::translateInline("Are you sure you wish to delete this taunt?");
-        $id = $row['tauntid'];
+        $id = (int) $row['tauntid'];
         $output->rawOutput("[ <a href='taunt.php?op=edit&tauntid=$id'>$edit</a> | <a href='taunt.php?op=del&tauntid=$id' onClick='return confirm(\"$conf\");'>$del</a> ]");
         Nav::add("", "taunt.php?op=edit&tauntid=$id");
         Nav::add("", "taunt.php?op=del&tauntid=$id");
@@ -143,7 +144,8 @@ if ($op == "") {
         $output->outputNotl("%s", $row['editor']);
         $output->rawOutput("</td></tr>");
     }
-    Nav::add("", "taunt.php?c=" . Http::get('c'));
+    $commentaryPageParam = $commentaryPage === null ? '' : (string) (int) $commentaryPage;
+    Nav::add("", "taunt.php?c=$commentaryPageParam");
     $output->rawOutput("</table>");
     Nav::add("Taunts");
     Nav::add("Add a new taunt", "taunt.php?op=edit");
@@ -151,6 +153,9 @@ if ($op == "") {
 
 /**
  * Normalise request values expected to be optional integer identifiers.
+ *
+ * Lotgd\Http now exposes raw request payloads, so we must explicitly narrow
+ * values such as c/tauntid before building navigation URLs.
  */
 function taunt_normalize_optional_int(mixed $value): ?int
 {

--- a/tests/Petition/PetitionSubmitTest.php
+++ b/tests/Petition/PetitionSubmitTest.php
@@ -61,6 +61,8 @@ namespace Lotgd\Tests\Petition {
     use Lotgd\Tests\Stubs\DoctrineConnection;
     use PHPUnit\Framework\TestCase;
 
+    #[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+    #[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
     final class PetitionSubmitTest extends TestCase
     {
         private DoctrineConnection $connection;
@@ -198,6 +200,65 @@ namespace Lotgd\Tests\Petition {
             self::assertSame(ParameterType::STRING, $insertTypes['pageinfo'] ?? null);
             self::assertSame(ParameterType::STRING, $insertTypes['ip'] ?? null);
             self::assertSame(ParameterType::STRING, $insertTypes['cookie'] ?? null);
+        }
+
+        public function testAbusePlayerHiddenFieldIsNormalizedAndEscaped(): void
+        {
+            global $session, $settings, $output;
+
+            $session = [
+                'user' => [
+                    'acctid'       => 42,
+                    'password'     => 'hunter2',
+                    'superuser'    => 0,
+                    'name'         => 'TestUser',
+                    'emailaddress' => 'tester@example.com',
+                    'loggedin'     => true,
+                ],
+            ];
+            $settings = Settings::getInstance();
+            $GLOBALS['settings'] = $settings;
+
+            $output = new class {
+                public array $buffer = [];
+
+                public function output(string $format, mixed ...$args): void
+                {
+                    $this->buffer[] = vsprintf($format, $args);
+                }
+
+                public function outputNotl(string $format, mixed ...$args): void
+                {
+                    $this->buffer[] = vsprintf($format, $args);
+                }
+
+                public function rawOutput(string $text): void
+                {
+                    $this->buffer[] = $text;
+                }
+            };
+
+            $_GET = [];
+            $_POST = [
+                'problem' => 'Mail abuse report',
+                'abuse' => 'yes',
+                'abuseplayer' => "17\"><script>alert(1)</script>",
+            ];
+            $_COOKIE = [];
+            $_SERVER = [];
+
+            $include = static function (): void {
+                global $session, $settings, $output, $_POST, $_SERVER, $_COOKIE;
+
+                require __DIR__ . '/../../pages/petition/petition_default.php';
+            };
+            \Closure::bind($include, null, null)();
+
+            $rendered = implode("\n", $output->buffer);
+            self::assertStringContainsString('name=\'abuseplayer\' value="', $rendered);
+            self::assertStringContainsString('name=\'abuseplayer\' value=""', $rendered);
+            self::assertStringNotContainsString('<script>', $rendered);
+            self::assertStringNotContainsString('abuseplayer\' value="17', $rendered);
         }
     }
 }

--- a/tests/Security/DeathmessagesParameterBindingRegressionTest.php
+++ b/tests/Security/DeathmessagesParameterBindingRegressionTest.php
@@ -52,11 +52,16 @@ final class DeathmessagesParameterBindingRegressionTest extends TestCase
         self::assertStringContainsString('WHERE deathmessageid = :deathmessageid', $source);
         self::assertStringContainsString('deathmessages_normalize_text(Http::post(\'deathmessage\'))', $source);
         self::assertStringContainsString('rawurlencode($deathmessageidParam)', $source);
+        self::assertStringContainsString('deathmessages_normalize_optional_int(Http::get(\'c\'))', $source);
+        self::assertStringContainsString('Nav::add("", "deathmessages.php?c=$commentaryPageParam");', $source);
+        self::assertStringNotContainsString('Nav::add("", "deathmessages.php?c=" . Http::get(\'c\'));', $source);
         self::assertStringContainsString('deathmessageid = :deathmessageid', $source);
         self::assertStringContainsString('deathmessage = :deathmessage', $source);
         self::assertStringContainsString('ParameterType::INTEGER', $source);
         self::assertStringContainsString('ParameterType::STRING', $source);
         self::assertStringNotContainsString('addslashes($session[\'user\'][\'login\'])', $source);
+        self::assertStringContainsString('ctype_digit($valueString)', $source);
+        self::assertStringContainsString('$intValue <= 0', $source);
     }
 
     public function testPayloadRoundtripIsPreservedInBoundParameters(): void

--- a/tests/Security/TauntParameterBindingRegressionTest.php
+++ b/tests/Security/TauntParameterBindingRegressionTest.php
@@ -52,12 +52,17 @@ final class TauntParameterBindingRegressionTest extends TestCase
         self::assertStringContainsString('WHERE tauntid = :tauntid', $source);
         self::assertStringContainsString('taunt_normalize_text(Http::post(\'taunt\'))', $source);
         self::assertStringContainsString('rawurlencode($tauntidParam)', $source);
+        self::assertStringContainsString('taunt_normalize_optional_int(Http::get(\'c\'))', $source);
+        self::assertStringContainsString('Nav::add("", "taunt.php?c=$commentaryPageParam");', $source);
+        self::assertStringNotContainsString('Nav::add("", "taunt.php?c=" . Http::get(\'c\'));', $source);
         self::assertStringContainsString('tauntid = :tauntid', $source);
         self::assertStringContainsString('taunt = :taunt', $source);
         self::assertStringContainsString('editor = :editor', $source);
         self::assertStringContainsString('ParameterType::INTEGER', $source);
         self::assertStringContainsString('ParameterType::STRING', $source);
         self::assertStringNotContainsString('addslashes($session[\'user\'][\'login\'])', $source);
+        self::assertStringContainsString('! ctype_digit($value)', $source);
+        self::assertStringContainsString('$intValue > 0 ? $intValue : null;', $source);
     }
 
     public function testPayloadRoundtripIsPreservedInInsertBoundParameters(): void


### PR DESCRIPTION
### Motivation

- The raw `Lotgd\Http` request layer can return untrusted payloads for query/post fields such as `c` and `abuseplayer`, which risk leaking malformed values into navigation URLs or HTML attributes; these must be narrowed to the expected types before use.

### Description

- In `deathmessages.php` and `taunt.php` we read `c` once through the existing optional-int normalizer and build Nav links from the normalized value only, and we cast DB row ids to `(int)` before composing edit/delete URLs.
- Added short docblock comments to the optional-int normalizers explaining why values must be narrowed now that core uses raw `Lotgd\Http` payloads.
- In `pages/petition/petition_default.php` we normalize `abuseplayer` with a new `petition_normalize_optional_int` helper and HTML-escape the resulting value before rendering it into the hidden `<input value="...">` attribute.
- Added/updated focused regression tests: assertions in `tests/Security/DeathmessagesParameterBindingRegressionTest.php` and `tests/Security/TauntParameterBindingRegressionTest.php` to verify `c` normalization and nav composition patterns, and `tests/Petition/PetitionSubmitTest.php` to verify `abuseplayer` payloads with quotes/angle-brackets do not leak into the hidden input output.

### Testing

- Ran syntax checks with `php -l` on modified files: all passed.
- Ran the focused unit tests with `vendor/bin/phpunit tests/Security/DeathmessagesParameterBindingRegressionTest.php tests/Security/TauntParameterBindingRegressionTest.php tests/Petition/PetitionSubmitTest.php`: all tests passed (new assertions included).
- Ran the full test suite with `composer test`: suite completed (tests OK) though CI-style static analysis initially hit the environment PHPStan memory cap; a subsequent `vendor/bin/phpstan analyse --configuration phpstan.neon --memory-limit=512M` run completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c50f7af23883298a34fe7a83a87f8a)