### PR TITLE
Normalize and validate request inputs; use prepared queries and encode nav params

### DIFF
--- a/healer.php
+++ b/healer.php
@@ -26,8 +26,15 @@ Translator::getInstance()->setSchema("healer");
 
 $config = unserialize($session['user']['donationconfig']);
 
-$return = Http::get("return");
-$returnline = $return > "" ? "&return=$return" : "";
+/**
+ * Lotgd\Http returns raw input; keep return target as an internal route token
+ * from a strict allow-list before reusing it in nav/query links.
+ */
+$returnRequest = Http::get("return");
+$returnToken = is_string($returnRequest) ? basename(parse_url($returnRequest, PHP_URL_PATH) ?? '') : '';
+$allowedReturnTokens = ['forest.php', 'village.php'];
+$return = in_array($returnToken, $allowedReturnTokens, true) ? $returnToken : '';
+$returnline = $return !== '' ? '&return=' . rawurlencode($return) : "";
 
 Header::pageHeader("Healer's Hut");
 $output->output("`#`b`cHealer's Hut`c`b`n");

--- a/hof.php
+++ b/hof.php
@@ -37,14 +37,14 @@ VillageNav::render();
 
 $playersperpage = 50;
 
-$op = Http::get('op');
-if ($op == "") {
-    $op = "kills";
-}
-$subop = Http::get('subop');
-if ($subop == "") {
-    $subop = "most";
-}
+/**
+ * Lotgd\Http yields raw values; whitelist operation enums before nav reuse.
+ */
+$opRequest = Http::get('op');
+$allowedOps = ['kills', 'money', 'gems', 'charm', 'tough', 'resurrects', 'days'];
+$op = is_string($opRequest) && in_array($opRequest, $allowedOps, true) ? $opRequest : 'kills';
+$subopRequest = Http::get('subop');
+$subop = is_string($subopRequest) && in_array($subopRequest, ['most', 'least'], true) ? $subopRequest : 'most';
 
 $sql = "SELECT count(acctid) AS c FROM " . Database::prefix("accounts") . " WHERE $standardwhere";
 $extra = "";

--- a/modules.php
+++ b/modules.php
@@ -138,10 +138,19 @@ foreach ($seencats as $cat => $count) {
     if ($subnav !== '') {
             Nav::addSubHeader($subnav);
     }
-        Nav::add(array(" ?%s - (%s modules)", $category, $count), "modules.php?cat=$cat");
+        Nav::add(
+            array(" ?%s - (%s modules)", $category, $count),
+            "modules.php?cat=" . rawurlencode($cat)
+        );
 }
 
-$cat = Http::get('cat');
+/**
+ * Lotgd\Http values are raw; constrain category to known categories and
+ * URL-encode when composing links/forms/nav entries.
+ */
+$catRequest = Http::get('cat');
+$cat = is_string($catRequest) && array_key_exists($catRequest, $seencats) ? $catRequest : '';
+$catQuery = rawurlencode($cat);
 if ($op == "") {
     if ($cat) {
         $sortby = Http::get('sortby');
@@ -168,21 +177,21 @@ if ($op == "") {
         $installstr = Translator::translateInline("by %s");
         $active = Translator::translateInline("`@Active`0");
         $inactive = Translator::translateInline("`\$Inactive`0");
-        $output->rawOutput("<form action='modules.php?op=mass&cat=$cat' method='POST'>");
-        Nav::add("", "modules.php?op=mass&cat=$cat");
+        $output->rawOutput("<form action='modules.php?op=mass&cat=$catQuery' method='POST'>");
+        Nav::add("", "modules.php?op=mass&cat=$catQuery");
         $installedCaption = Translator::translateInline("Installed modules table");
         $output->rawOutput("<div class='table-responsive'>");
         $output->rawOutput("<table class='table table-striped table-hover js-modules-table'>");
         $output->rawOutput("<caption class='visually-hidden'>{$installedCaption}</caption>");
         $output->rawOutput("<thead>");
         $selectAllLabel = Translator::translateInline("Select all");
-        $output->rawOutput("<tr class='table-secondary'><th scope='col'><input type='checkbox' class='js-select-all' aria-label='{$selectAllLabel}'></th><th scope='col'>$ops</th><th scope='col'><a href='modules.php?cat=$cat&sortby=active&order=" . ($sortby == "active" ? !$order : 1) . "'>$status</a></th><th scope='col'><a href='modules.php?cat=$cat&sortby=formalname&order=" . ($sortby == "formalname" ? !$order : 1) . "'>$mname</a></th><th scope='col'><a href='modules.php?cat=$cat&sortby=moduleauthor&order=" . ($sortby == "moduleauthor" ? !$order : 1) . "'>$mauth</a></th><th scope='col'><a href='modules.php?cat=$cat&sortby=installdate&order=" . ($sortby == "installdate" ? !$order : 0) . "'>$inon</a></th></tr>");
+        $output->rawOutput("<tr class='table-secondary'><th scope='col'><input type='checkbox' class='js-select-all' aria-label='{$selectAllLabel}'></th><th scope='col'>$ops</th><th scope='col'><a href='modules.php?cat=$catQuery&sortby=active&order=" . ($sortby == "active" ? !$order : 1) . "'>$status</a></th><th scope='col'><a href='modules.php?cat=$catQuery&sortby=formalname&order=" . ($sortby == "formalname" ? !$order : 1) . "'>$mname</a></th><th scope='col'><a href='modules.php?cat=$catQuery&sortby=moduleauthor&order=" . ($sortby == "moduleauthor" ? !$order : 1) . "'>$mauth</a></th><th scope='col'><a href='modules.php?cat=$catQuery&sortby=installdate&order=" . ($sortby == "installdate" ? !$order : 0) . "'>$inon</a></th></tr>");
         $output->rawOutput("</thead>");
         $output->rawOutput("<tbody>");
-        Nav::add("", "modules.php?cat=$cat&sortby=active&order=" . ($sortby == "active" ? !$order : 1));
-        Nav::add("", "modules.php?cat=$cat&sortby=formalname&order=" . ($sortby == "formalname" ? !$order : 1));
-        Nav::add("", "modules.php?cat=$cat&sortby=moduleauthor&order=" . ($sortby == "moduleauthor" ? !$order : 1));
-        Nav::add("", "modules.php?cat=$cat&sortby=installdate&order=" . ($sortby == "installdate" ? $order : 0));
+        Nav::add("", "modules.php?cat=$catQuery&sortby=active&order=" . ($sortby == "active" ? !$order : 1));
+        Nav::add("", "modules.php?cat=$catQuery&sortby=formalname&order=" . ($sortby == "formalname" ? !$order : 1));
+        Nav::add("", "modules.php?cat=$catQuery&sortby=moduleauthor&order=" . ($sortby == "moduleauthor" ? !$order : 1));
+        Nav::add("", "modules.php?cat=$catQuery&sortby=installdate&order=" . ($sortby == "installdate" ? $order : 0));
                 $rows = ModuleManager::listInstalled($cat, $sortby, (bool)$order);
         if (count($rows) == 0) {
                 $output->rawOutput("<tr class='table-light'><td colspan='6' class='text-center'>");
@@ -197,28 +206,28 @@ if ($op == "") {
             $output->rawOutput("<input type='checkbox' name='module[]' value=\"{$row['modulename']}\">");
             $output->rawOutput("</td><td class='text-nowrap align-top'>[ ");
             if ($row['active']) {
-                $output->rawOutput("<a href='modules.php?op=deactivate&module={$row['modulename']}&cat=$cat'>");
+                $output->rawOutput("<a href='modules.php?op=deactivate&module={$row['modulename']}&cat=$catQuery'>");
                 $output->outputNotl($deactivate);
                 $output->rawOutput("</a>");
-                Nav::add("", "modules.php?op=deactivate&module={$row['modulename']}&cat=$cat");
+                Nav::add("", "modules.php?op=deactivate&module={$row['modulename']}&cat=$catQuery");
             } else {
-                $output->rawOutput("<a href='modules.php?op=activate&module={$row['modulename']}&cat=$cat'>");
+                $output->rawOutput("<a href='modules.php?op=activate&module={$row['modulename']}&cat=$catQuery'>");
                 $output->outputNotl($activate);
                 $output->rawOutput("</a>");
-                Nav::add("", "modules.php?op=activate&module={$row['modulename']}&cat=$cat");
+                Nav::add("", "modules.php?op=activate&module={$row['modulename']}&cat=$catQuery");
             }
-            $output->rawOutput(" |<a href='modules.php?op=uninstall&module={$row['modulename']}&cat=$cat' onClick='return confirm(\"$uninstallconfirm\");'>");
+            $output->rawOutput(" |<a href='modules.php?op=uninstall&module={$row['modulename']}&cat=$catQuery' onClick='return confirm(\"$uninstallconfirm\");'>");
             $output->outputNotl($uninstall);
             $output->rawOutput("</a>");
-            Nav::add("", "modules.php?op=uninstall&module={$row['modulename']}&cat=$cat");
-            $output->rawOutput(" | <a href='modules.php?op=reinstall&module={$row['modulename']}&cat=$cat'>");
+            Nav::add("", "modules.php?op=uninstall&module={$row['modulename']}&cat=$catQuery");
+            $output->rawOutput(" | <a href='modules.php?op=reinstall&module={$row['modulename']}&cat=$catQuery'>");
             $output->outputNotl($reinstall);
             $output->rawOutput("</a>");
-            Nav::add("", "modules.php?op=reinstall&module={$row['modulename']}&cat=$cat");
-            $output->rawOutput(" | <a href='modules.php?op=remove&module={$row['modulename']}&cat=$cat' onClick='return confirm(\"$removeconfirm\");'>");
+            Nav::add("", "modules.php?op=reinstall&module={$row['modulename']}&cat=$catQuery");
+            $output->rawOutput(" | <a href='modules.php?op=remove&module={$row['modulename']}&cat=$catQuery' onClick='return confirm(\"$removeconfirm\");'>");
             $output->outputNotl($remove);
             $output->rawOutput("</a>");
-            Nav::add("", "modules.php?op=remove&module={$row['modulename']}&cat=$cat");
+            Nav::add("", "modules.php?op=remove&module={$row['modulename']}&cat=$catQuery");
 
             if ($session['user']['superuser'] & SU_EDIT_CONFIG) {
                 if (strstr($row['infokeys'], "|settings|")) {
@@ -277,8 +286,8 @@ if ($op == "") {
         $mauth = Translator::translateInline("Module Author");
         $categ = Translator::translateInline("Category");
         $fname = Translator::translateInline("Filename");
-        $output->rawOutput("<form action='modules.php?op=mass&cat=$cat' method='POST'>");
-        Nav::add("", "modules.php?op=mass&cat=$cat");
+        $output->rawOutput("<form action='modules.php?op=mass&cat=$catQuery' method='POST'>");
+        Nav::add("", "modules.php?op=mass&cat=$catQuery");
         $uninstalledCaption = Translator::translateInline("Uninstalled modules table");
         $output->rawOutput("<div class='table-responsive'>");
         $output->rawOutput("<table class='table table-striped table-hover js-uninstalled-modules-table'>");

--- a/pages/user/user_edit.php
+++ b/pages/user/user_edit.php
@@ -17,10 +17,15 @@ $row = Database::fetchAssoc($result);
 $output = Output::getInstance();
 $settings = Settings::getInstance();
 $charset = $settings->getSetting('charset', 'UTF-8');
-$petition = Http::get('returnpetition');
-if ($petition != "") {
-    $returnpetition = "&returnpetition=$petition";
-}
+/**
+ * Lotgd\Http returns raw payloads, so normalize returnpetition as optional int
+ * before embedding it back into operation/nav URLs.
+ */
+$petitionRequest = Http::get('returnpetition');
+$petition = is_string($petitionRequest) && ctype_digit($petitionRequest) && (int) $petitionRequest > 0
+    ? (int) $petitionRequest
+    : null;
+$returnpetition = $petition === null ? '' : "&returnpetition=$petition";
 if ($petition != "") {
     Nav::add("Navigation");
     Nav::add("Return to the petition", "viewpetition.php?op=view&id=$petition");

--- a/pages/user/user_edit.php
+++ b/pages/user/user_edit.php
@@ -26,7 +26,7 @@ $petition = is_string($petitionRequest) && ctype_digit($petitionRequest) && (int
     ? (int) $petitionRequest
     : null;
 $returnpetition = $petition === null ? '' : "&returnpetition=$petition";
-if ($petition != "") {
+if ($petition !== null) {
     Nav::add("Navigation");
     Nav::add("Return to the petition", "viewpetition.php?op=view&id=$petition");
 }

--- a/stables.php
+++ b/stables.php
@@ -19,6 +19,7 @@ use Lotgd\Sanitize;
 use Lotgd\DebugLog;
 use Lotgd\DateTime;
 use Lotgd\Random;
+use Lotgd\DataCache;
 use Doctrine\DBAL\ParameterType;
 
 // translator ready
@@ -121,6 +122,37 @@ if (in_array((string) $op, ['examine', 'buymount', 'confirmbuy'], true) && $id =
     $op = "";
 }
 
+/**
+ * Fetch mount data by normalized mount id with datacache fallback.
+ *
+ * Lotgd\Http request values are normalized before reaching this helper, so the
+ * cache key and bound parameter stay stable and safe.
+ *
+ * @return array<string, mixed>|false
+ */
+function stables_load_mount_by_id(int $mountId): array|false
+{
+    $cache = DataCache::getInstance();
+    $cacheKey = "mountdata-$mountId";
+    $cached = $cache->datacache($cacheKey, 3600);
+    if (is_array($cached) && array_key_exists('mountid', $cached)) {
+        return $cached;
+    }
+
+    $row = Database::getDoctrineConnection()->executeQuery(
+        "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid = :mountid",
+        ['mountid' => $mountId],
+        ['mountid' => ParameterType::INTEGER]
+    )->fetchAssociative();
+
+    if (!is_array($row)) {
+        return false;
+    }
+
+    $cache->updatedatacache($cacheKey, $row);
+    return $row;
+}
+
 
 if ($op == "") {
     DateTime::checkDay();
@@ -135,12 +167,8 @@ if ($op == "") {
     $translator->setSchema();
     HookHandler::hook("stables-desc");
 } elseif ($op == "examine") {
-    $result = Database::getDoctrineConnection()->executeQuery(
-        "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid = :mountid",
-        ['mountid' => $id],
-        ['mountid' => ParameterType::INTEGER]
-    );
-    if (Database::numRows($result) <= 0) {
+    $mount = stables_load_mount_by_id((int) $id);
+    if ($mount === false) {
         $translator->setSchema($schemas['nosuchbeast']);
         $output->output('%s', $texts['nosuchbeast']);
         $translator->setSchema();
@@ -150,7 +178,6 @@ if ($op == "") {
         $translator->setSchema($schemas['finebeast']);
         $output->output('%s', $texts['finebeast'][$t]);
         $translator->setSchema();
-        $mount = Database::fetchAssoc($result);
         $mount = HookHandler::hook("mount-modifycosts", $mount);
         $output->output("`7Creature: `&%s`0`n", $mount['mountname']);
         $output->output("`7Description: `&%s`0`n", $mount['mountdesc']);
@@ -176,17 +203,12 @@ if ($op == "") {
     }
 }
 if ($op == 'confirmbuy') {
-    $result = Database::getDoctrineConnection()->executeQuery(
-        "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid = :mountid",
-        ['mountid' => $id],
-        ['mountid' => ParameterType::INTEGER]
-    );
-    if (Database::numRows($result) <= 0) {
+    $mount = stables_load_mount_by_id((int) $id);
+    if ($mount === false) {
         $translator->setSchema($schemas['nosuchbeast']);
         $output->output('%s', $texts['nosuchbeast']);
         $translator->setSchema();
     } else {
-        $mount = Database::fetchAssoc($result);
         $mount = HookHandler::hook("mount-modifycosts", $mount);
         if (
             ($session['user']['gold'] + $repaygold) < $mount['mountcostgold'] ||

--- a/stables.php
+++ b/stables.php
@@ -19,6 +19,7 @@ use Lotgd\Sanitize;
 use Lotgd\DebugLog;
 use Lotgd\DateTime;
 use Lotgd\Random;
+use Doctrine\DBAL\ParameterType;
 
 // translator ready
 // addnews ready
@@ -110,7 +111,15 @@ if ($playerMount) {
 $confirm = 0;
 
 $op = Http::get('op');
-$id = Http::get('id');
+/**
+ * Lotgd\Http returns raw request payloads; mount ids must be normalized
+ * before SQL and cache-key usage.
+ */
+$idRequest = Http::get('id');
+$id = is_string($idRequest) && ctype_digit($idRequest) && (int) $idRequest > 0 ? (int) $idRequest : null;
+if (in_array((string) $op, ['examine', 'buymount', 'confirmbuy'], true) && $id === null) {
+    $op = "";
+}
 
 
 if ($op == "") {
@@ -126,8 +135,11 @@ if ($op == "") {
     $translator->setSchema();
     HookHandler::hook("stables-desc");
 } elseif ($op == "examine") {
-    $sql = "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid='$id'";
-    $result = Database::queryCached($sql, "mountdata-$id", 3600);
+    $result = Database::getDoctrineConnection()->executeQuery(
+        "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid = :mountid",
+        ['mountid' => $id],
+        ['mountid' => ParameterType::INTEGER]
+    );
     if (Database::numRows($result) <= 0) {
         $translator->setSchema($schemas['nosuchbeast']);
         $output->output('%s', $texts['nosuchbeast']);
@@ -164,8 +176,11 @@ if ($op == "") {
     }
 }
 if ($op == 'confirmbuy') {
-    $sql = "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid='$id'";
-    $result = Database::queryCached($sql, "mountdata-$id", 3600);
+    $result = Database::getDoctrineConnection()->executeQuery(
+        "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid = :mountid",
+        ['mountid' => $id],
+        ['mountid' => ParameterType::INTEGER]
+    );
     if (Database::numRows($result) <= 0) {
         $translator->setSchema($schemas['nosuchbeast']);
         $output->output('%s', $texts['nosuchbeast']);

--- a/tests/Security/RequestNormalizationRegressionTest.php
+++ b/tests/Security/RequestNormalizationRegressionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+
+final class RequestNormalizationRegressionTest extends TestCase
+{
+    public function testViewpetitionUsesTypedBindingsForRequestDrivenPetitionIdQueries(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../viewpetition.php');
+        self::assertIsString($source);
+        self::assertStringContainsString('WHERE petitionid = :petitionid', $source);
+        self::assertStringContainsString("'petitionid' => ParameterType::INTEGER", $source);
+        self::assertStringNotContainsString("petitionid='$id'", $source);
+    }
+
+    public function testStablesUsesPreparedStatementForMountLookup(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../stables.php');
+        self::assertIsString($source);
+        self::assertStringContainsString('WHERE mountid = :mountid', $source);
+        self::assertStringContainsString("'mountid' => ParameterType::INTEGER", $source);
+        self::assertStringNotContainsString("mountid='$id'", $source);
+    }
+
+    public function testNavCompositionUsesNormalizedOrEncodedQueryComponents(): void
+    {
+        $healer = file_get_contents(__DIR__ . '/../../healer.php');
+        $user = file_get_contents(__DIR__ . '/../../user.php');
+        $userEdit = file_get_contents(__DIR__ . '/../../pages/user/user_edit.php');
+        $hof = file_get_contents(__DIR__ . '/../../hof.php');
+        $modules = file_get_contents(__DIR__ . '/../../modules.php');
+
+        self::assertIsString($healer);
+        self::assertIsString($user);
+        self::assertIsString($userEdit);
+        self::assertIsString($hof);
+        self::assertIsString($modules);
+
+        self::assertStringContainsString("rawurlencode(\$return)", $healer);
+        self::assertStringContainsString('modulename_sanitize($moduleRequest)', $user);
+        self::assertStringContainsString("rawurlencode(\$moduleSlug)", $user);
+        self::assertStringContainsString("ctype_digit(\$petitionRequest)", $userEdit);
+        self::assertStringContainsString("\$allowedOps = ['kills', 'money', 'gems', 'charm', 'tough', 'resurrects', 'days'];", $hof);
+        self::assertStringContainsString("array_key_exists(\$catRequest, \$seencats)", $modules);
+        self::assertStringContainsString("rawurlencode(\$cat)", $modules);
+    }
+}

--- a/tests/Security/RequestNormalizationRegressionTest.php
+++ b/tests/Security/RequestNormalizationRegressionTest.php
@@ -12,18 +12,19 @@ final class RequestNormalizationRegressionTest extends TestCase
     {
         $source = file_get_contents(__DIR__ . '/../../viewpetition.php');
         self::assertIsString($source);
-        self::assertStringContainsString('WHERE petitionid = :petitionid', $source);
-        self::assertStringContainsString("'petitionid' => ParameterType::INTEGER", $source);
-        self::assertStringNotContainsString("petitionid='$id'", $source);
+        $nonCommentSource = (string) preg_replace('/^\\s*\\/\\/.*$/m', '', $source);
+        self::assertMatchesRegularExpression('/WHERE\\s+petitionid\\s*=\\s*:petitionid/i', $source);
+        self::assertMatchesRegularExpression('/[\'"]petitionid[\'"]\\s*=>\\s*ParameterType::INTEGER/', $source);
+        self::assertDoesNotMatchRegularExpression('/petitionid\\s*=\\s*[\'"]\\$id[\'"]/', $nonCommentSource);
     }
 
     public function testStablesUsesPreparedStatementForMountLookup(): void
     {
         $source = file_get_contents(__DIR__ . '/../../stables.php');
         self::assertIsString($source);
-        self::assertStringContainsString('WHERE mountid = :mountid', $source);
-        self::assertStringContainsString("'mountid' => ParameterType::INTEGER", $source);
-        self::assertStringNotContainsString("mountid='$id'", $source);
+        self::assertMatchesRegularExpression('/WHERE\\s+mountid\\s*=\\s*:mountid/i', $source);
+        self::assertMatchesRegularExpression('/[\'"]mountid[\'"]\\s*=>\\s*ParameterType::INTEGER/', $source);
+        self::assertDoesNotMatchRegularExpression('/mountid\\s*=\\s*[\'"]\\$id[\'"]/', $source);
     }
 
     public function testNavCompositionUsesNormalizedOrEncodedQueryComponents(): void
@@ -40,12 +41,12 @@ final class RequestNormalizationRegressionTest extends TestCase
         self::assertIsString($hof);
         self::assertIsString($modules);
 
-        self::assertStringContainsString("rawurlencode(\$return)", $healer);
-        self::assertStringContainsString('modulename_sanitize($moduleRequest)', $user);
-        self::assertStringContainsString("rawurlencode(\$moduleSlug)", $user);
-        self::assertStringContainsString("ctype_digit(\$petitionRequest)", $userEdit);
-        self::assertStringContainsString("\$allowedOps = ['kills', 'money', 'gems', 'charm', 'tough', 'resurrects', 'days'];", $hof);
-        self::assertStringContainsString("array_key_exists(\$catRequest, \$seencats)", $modules);
-        self::assertStringContainsString("rawurlencode(\$cat)", $modules);
+        self::assertMatchesRegularExpression('/rawurlencode\\(\\$return\\)/', $healer);
+        self::assertMatchesRegularExpression('/modulename_sanitize\\(\\$moduleRequest\\)/', $user);
+        self::assertMatchesRegularExpression('/rawurlencode\\(\\$moduleSlug\\)/', $user);
+        self::assertMatchesRegularExpression('/ctype_digit\\(\\$petitionRequest\\)/', $userEdit);
+        self::assertMatchesRegularExpression('/\\$allowedOps\\s*=\\s*\\[[^\\]]*kills[^\\]]*resurrects[^\\]]*\\]/', $hof);
+        self::assertMatchesRegularExpression('/array_key_exists\\(\\$catRequest,\\s*\\$seencats\\)/', $modules);
+        self::assertMatchesRegularExpression('/rawurlencode\\(\\$cat\\)/', $modules);
     }
 }

--- a/user.php
+++ b/user.php
@@ -45,11 +45,15 @@ if ($op == "lasthit") {
 Header::pageHeader("User Editor");
 
 $sort = Http::get('sort');
-$petition = Http::get("returnpetition");
-$returnpetition = "";
-if ($petition != "") {
-    $returnpetition = "&returnpetition=$petition";
-}
+$petitionRequest = Http::get("returnpetition");
+/**
+ * Lotgd\Http returns raw payloads; accept only positive integer petition IDs
+ * before embedding into user editor navigation links.
+ */
+$petition = is_string($petitionRequest) && ctype_digit($petitionRequest) && (int) $petitionRequest > 0
+    ? (int) $petitionRequest
+    : null;
+$returnpetition = $petition === null ? "" : "&returnpetition=$petition";
 
 $gentime = 0;
 $gentimecount = 0;
@@ -98,9 +102,18 @@ if ($op == "search" || $op == "") {
 }
 
 
-$m = Http::get("module");
-if ($m) {
-    $m = "&module=$m&subop=module";
+/**
+ * Lotgd\Http values are raw; module slugs must pass the module-name sanitizer
+ * and be URL-encoded before composing links.
+ */
+$moduleRequest = Http::get("module");
+$moduleSlug = is_string($moduleRequest) ? modulename_sanitize($moduleRequest) : '';
+if ($moduleSlug !== '') {
+    Http::set('module', $moduleSlug, true);
+}
+$m = '';
+if ($moduleSlug !== '') {
+    $m = '&module=' . rawurlencode($moduleSlug) . '&subop=module';
 }
 $output->rawOutput("<form action='user.php?op=search$m' method='POST'>");
 $output->output("Search by any field below: ");

--- a/viewpetition.php
+++ b/viewpetition.php
@@ -57,6 +57,11 @@ $op = Http::get("op") ?? "";
 $idRequest = Http::get("id");
 $id = is_string($idRequest) && ctype_digit($idRequest) && (int) $idRequest > 0 ? (int) $idRequest : null;
 $idParam = $id === null ? '' : (string) $id;
+$invalidViewRequest = $op === 'view' && $id === null;
+if ($invalidViewRequest) {
+    // Normalize invalid view requests back to the petition list state.
+    $op = '';
+}
 $connection = Database::getDoctrineConnection();
 $insertCommentary = (string) Http::post('insertcommentary');
 if (!empty(trim($insertCommentary)) && $id !== null) {
@@ -88,6 +93,9 @@ if (!empty(trim($insertCommentary)) && $id !== null) {
 //}
 Header::pageHeader("Petition Viewer");
 if ($op == "") {
+    if ($invalidViewRequest) {
+        $output->output("`\$Invalid petition id supplied. Showing petition list instead.`0");
+    }
     $sql = "DELETE FROM " . Database::prefix("petitions") . " WHERE status=2 AND closedate<'" . date("Y-m-d H:i:s", strtotime("-7 days")) . "'";
     Database::query($sql);
     /**

--- a/viewpetition.php
+++ b/viewpetition.php
@@ -13,6 +13,7 @@ use Lotgd\Nav;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Settings;
+use Doctrine\DBAL\ParameterType;
 
 // translator ready
 // addnews ready
@@ -49,12 +50,30 @@ $statuses = HookHandler::hook("petition-status", $statuses);
 $statuses = Translator::translateInline($statuses);
 
 $op = Http::get("op") ?? "";
-$id = Http::get("id") ?? "";
+/**
+ * Lotgd\Http returns raw request payloads; normalize petition IDs before
+ * using them in SQL statements or nav URLs.
+ */
+$idRequest = Http::get("id");
+$id = is_string($idRequest) && ctype_digit($idRequest) && (int) $idRequest > 0 ? (int) $idRequest : null;
+$idParam = $id === null ? '' : (string) $id;
+$connection = Database::getDoctrineConnection();
 $insertCommentary = (string) Http::post('insertcommentary');
-if (!empty(trim($insertCommentary))) {
+if (!empty(trim($insertCommentary)) && $id !== null) {
     /* Update the bug if someone adds comments as well */
-    $sql = "UPDATE " . Database::prefix("petitions") . " SET closeuserid='{$session['user']['acctid']}',closedate='" . date("Y-m-d H:i:s") . "' WHERE petitionid='$id'";
-    Database::query($sql);
+    $connection->executeStatement(
+        "UPDATE " . Database::prefix("petitions") . " SET closeuserid = :closeuserid, closedate = :closedate WHERE petitionid = :petitionid",
+        [
+            'closeuserid' => (int) $session['user']['acctid'],
+            'closedate' => date("Y-m-d H:i:s"),
+            'petitionid' => $id,
+        ],
+        [
+            'closeuserid' => ParameterType::INTEGER,
+            'closedate' => ParameterType::STRING,
+            'petitionid' => ParameterType::INTEGER,
+        ]
+    );
 }
 
 // Eric decide he didn't want petitions to be manually deleted
@@ -71,15 +90,35 @@ Header::pageHeader("Petition Viewer");
 if ($op == "") {
     $sql = "DELETE FROM " . Database::prefix("petitions") . " WHERE status=2 AND closedate<'" . date("Y-m-d H:i:s", strtotime("-7 days")) . "'";
     Database::query($sql);
-    $setstat = Http::get("setstat");
+    /**
+     * Status transitions are enum-like values; narrow to known status keys.
+     */
+    $setstatRequest = Http::get("setstat");
+    $setstat = is_string($setstatRequest) && ctype_digit($setstatRequest) ? (int) $setstatRequest : null;
+    $statusKeys = array_map('intval', array_keys($statuses));
     invalidatedatacache("petition_counts");
-    if ($setstat != "") {
-        $sql = "SELECT status FROM " . Database::prefix("petitions") . " WHERE petitionid='$id'";
-        $result = Database::query($sql);
-        $row = Database::fetchAssoc($result);
-        if ($row['status'] != $setstat) {
-            $sql = "UPDATE " . Database::prefix("petitions") . " SET status='$setstat',closeuserid='{$session['user']['acctid']}',closedate='" . date("Y-m-d H:i:s") . "' WHERE petitionid='$id'";
-            Database::query($sql);
+    if ($setstat !== null && in_array($setstat, $statusKeys, true) && $id !== null) {
+        $row = $connection->executeQuery(
+            "SELECT status FROM " . Database::prefix("petitions") . " WHERE petitionid = :petitionid",
+            ['petitionid' => $id],
+            ['petitionid' => ParameterType::INTEGER]
+        )->fetchAssociative();
+        if ($row && (int) $row['status'] !== $setstat) {
+            $connection->executeStatement(
+                "UPDATE " . Database::prefix("petitions") . " SET status = :status, closeuserid = :closeuserid, closedate = :closedate WHERE petitionid = :petitionid",
+                [
+                    'status' => $setstat,
+                    'closeuserid' => (int) $session['user']['acctid'],
+                    'closedate' => date("Y-m-d H:i:s"),
+                    'petitionid' => $id,
+                ],
+                [
+                    'status' => ParameterType::INTEGER,
+                    'closeuserid' => ParameterType::INTEGER,
+                    'closedate' => ParameterType::STRING,
+                    'petitionid' => ParameterType::INTEGER,
+                ]
+            );
         }
     }
     $sort = "";
@@ -270,14 +309,14 @@ if ($op == "") {
     $output->output("`iClosed`i petitions are for you have dealt with an issue, these will auto delete when they have been closed for 7 days.");
     HookHandler::hook("petitions-descriptions", array());
     $output->rawOutput("</li></ul>");
-} elseif ($op == "view") {
+} elseif ($op == "view" && $id !== null) {
     Nav::add("Petitions");
     Nav::add("Details");
     $viewpageinfo = (int)Http::get("viewpageinfo");
     if ($viewpageinfo == 1) {
-        Nav::add("Hide Details", "viewpetition.php?op=view&id=$id");
+        Nav::add("Hide Details", "viewpetition.php?op=view&id=$idParam");
     } else {
-        Nav::add("D?Show Details", "viewpetition.php?op=view&id=$id&viewpageinfo=1");
+        Nav::add("D?Show Details", "viewpetition.php?op=view&id=$idParam&viewpageinfo=1");
     }
     Nav::add("Navigation");
     Nav::add("V?Petition Viewer", "viewpetition.php");
@@ -293,13 +332,15 @@ if ($op == "") {
         }
         Nav::add(
             array("%s?Mark %s", substr($plain, 0, 1), $val),
-            "viewpetition.php?setstat=$key&id=$id"
+            "viewpetition.php?setstat=$key&id=$idParam"
         );
     }
 
-    $sql = "SELECT " . Database::prefix("accounts") . ".name," .  Database::prefix("accounts") . ".login," .  Database::prefix("accounts") . ".acctid," .  "author,date,closedate,status,petitionid,ip,body,pageinfo," .  "accts.name AS closer FROM " .  Database::prefix("petitions") . " LEFT JOIN " .  Database::prefix("accounts ") . "ON " .  Database::prefix("accounts") . ".acctid=author LEFT JOIN " .  Database::prefix("accounts") . " AS accts ON accts.acctid=" .  "closeuserid WHERE petitionid='$id' ORDER BY date ASC";
-    $result = Database::query($sql);
-    $row = Database::fetchAssoc($result);
+    $row = $connection->executeQuery(
+        "SELECT " . Database::prefix("accounts") . ".name," .  Database::prefix("accounts") . ".login," .  Database::prefix("accounts") . ".acctid," .  "author,date,closedate,status,petitionid,ip,body,pageinfo," .  "accts.name AS closer FROM " .  Database::prefix("petitions") . " LEFT JOIN " .  Database::prefix("accounts ") . "ON " .  Database::prefix("accounts") . ".acctid=author LEFT JOIN " .  Database::prefix("accounts") . " AS accts ON accts.acctid=" .  "closeuserid WHERE petitionid = :petitionid ORDER BY date ASC",
+        ['petitionid' => $id],
+        ['petitionid' => ParameterType::INTEGER]
+    )->fetchAssociative();
     Nav::add("User Ops");
     if (isset($row['login'])) {
         Nav::add("View User Biography", "bio.php?char=" . $row['acctid']
@@ -307,7 +348,7 @@ if ($op == "") {
     }
     if ($row['acctid'] > 0 && $session['user']['superuser'] & SU_EDIT_USERS) {
         Nav::add("User Ops");
-        Nav::add("R?Edit User Record", "user.php?op=edit&userid={$row['acctid']}&returnpetition=$id");
+        Nav::add("R?Edit User Record", "user.php?op=edit&userid={$row['acctid']}&returnpetition=$idParam");
     }
     if ($row['acctid'] > 0 && $session['user']['superuser'] & SU_EDIT_DONATIONS) {
         Nav::add("User Ops");
@@ -364,7 +405,7 @@ if ($op == "") {
             }
         }
     }
-    Commentary::commentDisplay("`n`@Commentary:`0`n", "pet-$id", "Add information", 200);
+    Commentary::commentDisplay("`n`@Commentary:`0`n", "pet-$idParam", "Add information", 200);
     if ($viewpageinfo) {
         $output->output("`n`n`@Page Info:`&`n");
         $row['pageinfo'] = stripslashes($row['pageinfo']);
@@ -375,11 +416,13 @@ if ($op == "") {
     }
 }
 
-if ($id && $op != "") {
-    $prevsql = "SELECT p1.petitionid, p1.status FROM " . Database::prefix("petitions") . " AS p1, " . Database::prefix("petitions") . " AS p2
-			WHERE p1.petitionid<'$id' AND p2.petitionid='$id' AND p1.status=p2.status ORDER BY p1.petitionid DESC LIMIT 1";
-    $prevresult = Database::query($prevsql);
-    $prevrow = Database::fetchAssoc($prevresult);
+if ($id !== null && $op != "") {
+    $prevrow = $connection->executeQuery(
+        "SELECT p1.petitionid, p1.status FROM " . Database::prefix("petitions") . " AS p1, " . Database::prefix("petitions") . " AS p2
+			WHERE p1.petitionid < :petitionid AND p2.petitionid = :petitionid AND p1.status = p2.status ORDER BY p1.petitionid DESC LIMIT 1",
+        ['petitionid' => $id],
+        ['petitionid' => ParameterType::INTEGER]
+    )->fetchAssociative();
     if ($prevrow) {
         $previd = $prevrow['petitionid'];
         $s = $prevrow['status'];
@@ -387,10 +430,12 @@ if ($id && $op != "") {
         Nav::add("Petitions");
         Nav::add(array("Previous %s",$status), "viewpetition.php?op=view&id=$previd");
     }
-    $nextsql = "SELECT p1.petitionid, p1.status FROM " . Database::prefix("petitions") . " AS p1, " . Database::prefix("petitions") . " AS p2
-			WHERE p1.petitionid>'$id' AND p2.petitionid='$id' AND p1.status=p2.status ORDER BY p1.petitionid ASC LIMIT 1";
-    $nextresult = Database::query($nextsql);
-    $nextrow = Database::fetchAssoc($nextresult);
+    $nextrow = $connection->executeQuery(
+        "SELECT p1.petitionid, p1.status FROM " . Database::prefix("petitions") . " AS p1, " . Database::prefix("petitions") . " AS p2
+			WHERE p1.petitionid > :petitionid AND p2.petitionid = :petitionid AND p1.status = p2.status ORDER BY p1.petitionid ASC LIMIT 1",
+        ['petitionid' => $id],
+        ['petitionid' => ParameterType::INTEGER]
+    )->fetchAssociative();
     if ($nextrow) {
         $nextid = $nextrow['petitionid'];
         $s = $nextrow['status'];


### PR DESCRIPTION
### Motivation
- Harden handling of raw request values from `Lotgd\Http` by normalizing, validating, and constraining inputs before reuse in SQL, navigation URLs, or cache keys.
- Reduce the risk of injection and malformed navigation targets by URL-encoding and whitelisting request-driven parameters.

### Description
- Validate and normalize various `Http::get()` values across multiple pages: `healer.php` (`return` token), `hof.php` (`op`/`subop` enum), `modules.php` (`cat`), `pages/user/user_edit.php` and `user.php` (`returnpetition`), `stables.php` (`id` mount id), and `viewpetition.php` (`id` petition id and `setstat`).
- Use whitelists and type checks (e.g. `ctype_digit`, `basename(parse_url(...))`, `array_key_exists`) and apply `rawurlencode()` or a module-name sanitizer before composing nav/query links.
- Replace raw SQL usage with prepared statements via Doctrine DBAL and typed parameters for mount and petition queries/updates in `stables.php` and `viewpetition.php`, and add `use Doctrine\DBAL\ParameterType` where needed.
- Ensure nav and form URLs embed safe, encoded values and adjust logic to skip operations when required normalized inputs are absent.
- Add `tests/Security/RequestNormalizationRegressionTest.php` to assert presence of the new normalization, encoding, and prepared-query patterns.

### Testing
- Added `RequestNormalizationRegressionTest` PHPUnit test file and ran the test suite; the new test and the full PHPUnit suite passed locally.
- Verified that updated files contain the expected prepared-query and encoding patterns via the regression tests, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c515e509d08329920f66084e396998)