### PR TITLE
Passkey hardening

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -204,6 +204,22 @@ $result = $conn->executeQuery($sql, ['login' => $login]);
 
 `executeQuery()` returns a `Result` object for `SELECT` statements, while `executeStatement()` returns the affected row count for `INSERT`, `UPDATE`, or `DELETE` queries. See [docs/Doctrine.md#prepared-statements](docs/Doctrine.md#prepared-statements) and the official [Doctrine DBAL prepared statement guide](https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/data-retrieval-and-manipulation.html#prepared-statements) for more details.
 
+### HTTP API Policy and Deprecation Timeline
+
+To keep request handling explicit and secure during the 2.x modernization:
+
+- **Core/refactored code policy (effective now in 2.x):**
+  - Use `Lotgd\Http` (`Http::get()`, `Http::post()`, `Http::allGet()`, `Http::allPost()`) as the only HTTP API.
+  - Do not introduce `httpget()` / `httppost()` in core/refactored paths.
+- **Legacy compatibility policy (2.x only):**
+  - `lib/http.php` wrappers remain for legacy/module compatibility.
+  - Those wrappers intentionally preserve legacy escaped behaviour.
+- **Planned major-version change (3.0 target):**
+  - Escaped wrapper semantics are scheduled for retirement in the next major version.
+  - Legacy wrappers will either be removed or aligned to raw `Lotgd\Http` semantics; module maintainers should migrate to `Lotgd\Http` and bound DBAL parameters before upgrading to 3.0.
+
+As of this policy, static QA enforcement runs during `composer static` and fails when `httpget()` / `httppost()` usage appears in core/refactored paths.
+
 ---
 
 ## 8. After Upgrade

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -172,6 +172,10 @@ The 2.x branch is already aligned with Doctrine DBAL 4 result APIs and parameter
 
 If you maintain custom modules, update any legacy calls to `Database::fetchAssoc()` loops by switching to the DBAL `Result` APIs and named parameters as shown in the refactoring examples above.
 
+### Superuser endpoint hardening update
+
+Recent 2.x updates switched the superuser editors in `deathmessages.php`, `taunt.php`, and `untranslated.php` to explicit Doctrine parameter binding for write operations (and filtered untranslated lookups). These endpoints now rely on `executeStatement()` / `executeQuery()` with typed bound parameters instead of legacy wrapper escaping behavior. If you maintain custom overrides of these pages, update them to match bound-parameter execution semantics.
+
 ### Refactoring Legacy SQL to Prepared Statements
 
 Legacy database calls often used `Lotgd\MySQL\Database::query()` together with manual escaping via `addslashes`. When upgrading, migrate those calls to Doctrine DBAL prepared statements obtained through `Lotgd\MySQL\Database::getDoctrineConnection()`. The following example shows how to convert a legacy lookup:

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,11 @@
         }
     },
     "scripts": {
-        "static": "phpstan analyse --configuration phpstan.neon",
+        "qa:http-wrappers": "php scripts/check-legacy-http-wrappers.php",
+        "static": [
+            "@qa:http-wrappers",
+            "phpstan analyse --configuration phpstan.neon"
+        ],
         "test": "phpunit --configuration phpunit.xml",
         "lint": "phpcs .",
         "lint:fix": "phpcbf ."

--- a/deathmessages.php
+++ b/deathmessages.php
@@ -157,7 +157,20 @@ function deathmessages_normalize_optional_int(mixed $value): ?int
         return null;
     }
 
-    return (int) $value;
+    // Only accept positive integer values represented as digits-only strings.
+    $valueString = (string) $value;
+
+    if ($valueString === '' || ! ctype_digit($valueString)) {
+        return null;
+    }
+
+    $intValue = (int) $valueString;
+
+    if ($intValue <= 0) {
+        return null;
+    }
+
+    return $intValue;
 }
 
 /**

--- a/deathmessages.php
+++ b/deathmessages.php
@@ -32,17 +32,19 @@ SuAccess::check(SU_EDIT_CREATURES);
 Header::pageHeader("Deathmessage Editor");
 SuperuserNav::render();
 $op = Http::get('op');
-$deathmessageid = Http::get('deathmessageid');
+$deathmessageidRequest = Http::get('deathmessageid');
+$deathmessageid = deathmessages_normalize_optional_int($deathmessageidRequest);
+$deathmessageidParam = $deathmessageid === null ? '' : (string) $deathmessageid;
 switch ($op) {
     case "edit":
         Nav::add("Deathmessages");
         Nav::add("Return to the Deathmessage editor", "deathmessages.php");
-        $output->rawOutput("<form action='deathmessages.php?op=save&deathmessageid=$deathmessageid' method='POST'>", true);
-        Nav::add("", "deathmessages.php?op=save&deathmessageid=$deathmessageid");
-        if ($deathmessageid != "") {
+        $output->rawOutput("<form action='deathmessages.php?op=save&deathmessageid=" . rawurlencode($deathmessageidParam) . "' method='POST'>", true);
+        Nav::add("", "deathmessages.php?op=save&deathmessageid=" . rawurlencode($deathmessageidParam));
+        if ($deathmessageid !== null) {
             $result = $connection->executeQuery(
                 "SELECT * FROM " . Database::prefix("deathmessages") . " WHERE deathmessageid = :deathmessageid",
-                ['deathmessageid' => (int) $deathmessageid],
+                ['deathmessageid' => $deathmessageid],
                 ['deathmessageid' => ParameterType::INTEGER]
             );
             $row = Database::fetchAssoc($result);
@@ -80,20 +82,25 @@ switch ($op) {
         $output->rawOutput("</form>");
         break;
     case "del":
+        if ($deathmessageid === null) {
+            $op = "";
+            Http::set("op", "");
+            break;
+        }
         $connection->executeStatement(
             "DELETE FROM " . Database::prefix("deathmessages") . " WHERE deathmessageid = :deathmessageid",
-            ['deathmessageid' => (int) $deathmessageid],
+            ['deathmessageid' => $deathmessageid],
             ['deathmessageid' => ParameterType::INTEGER]
         );
         $op = "";
         Http::set("op", "");
         break;
     case "save":
-        $deathmessage = Http::post('deathmessage');
+        $deathmessage = deathmessages_normalize_text(Http::post('deathmessage'));
         $forest = (int) Http::post('forest');
         $graveyard = (int) Http::post('graveyard');
         $taunt = (int) Http::post('taunt');
-        if ($deathmessageid != "") {
+        if ($deathmessageid !== null) {
             $connection->executeStatement(
                 "UPDATE " . Database::prefix("deathmessages") . " SET deathmessage = :deathmessage, taunt = :taunt, forest = :forest, graveyard = :graveyard, editor = :editor WHERE deathmessageid = :deathmessageid",
                 [
@@ -102,7 +109,7 @@ switch ($op) {
                     'forest' => $forest,
                     'graveyard' => $graveyard,
                     'editor' => (string) $session['user']['login'],
-                    'deathmessageid' => (int) $deathmessageid,
+                    'deathmessageid' => $deathmessageid,
                 ],
                 [
                     'deathmessage' => ParameterType::STRING,
@@ -135,6 +142,39 @@ switch ($op) {
         $op = "";
         Http::set("op", "");
         break;
+}
+
+/**
+ * Normalise request values expected to be optional integer identifiers.
+ */
+function deathmessages_normalize_optional_int(mixed $value): ?int
+{
+    if ($value === '' || $value === null || is_array($value)) {
+        return null;
+    }
+
+    if (! is_scalar($value)) {
+        return null;
+    }
+
+    return (int) $value;
+}
+
+/**
+ * Normalise request values to a safe string payload for DBAL string binding.
+ */
+function deathmessages_normalize_text(mixed $value): string
+{
+    // Preserve legacy coercion behavior while rejecting array/object payloads.
+    if ($value === false || $value === null || is_array($value)) {
+        return '';
+    }
+
+    if (is_string($value)) {
+        return $value;
+    }
+
+    return is_scalar($value) ? (string) $value : '';
 }
 if ($op == "") {
     $output->output("`i`\$Note: These messages are NEWS messages the user will trigger when he/she dies in the forest or graveyard.`0`i`n`n");

--- a/deathmessages.php
+++ b/deathmessages.php
@@ -12,6 +12,7 @@ use Lotgd\Nav;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Settings;
+use Doctrine\DBAL\ParameterType;
 
 // addnews ready
 // mail ready
@@ -22,6 +23,7 @@ require_once __DIR__ . "/common.php";
 
 $settings = Settings::getInstance();
 $output = Output::getInstance();
+$connection = Database::getDoctrineConnection();
 
 Translator::getInstance()->setSchema("deathmessage");
 
@@ -38,8 +40,11 @@ switch ($op) {
         $output->rawOutput("<form action='deathmessages.php?op=save&deathmessageid=$deathmessageid' method='POST'>", true);
         Nav::add("", "deathmessages.php?op=save&deathmessageid=$deathmessageid");
         if ($deathmessageid != "") {
-            $sql = "SELECT * FROM " . Database::prefix("deathmessages") . " WHERE deathmessageid=\"$deathmessageid\"";
-            $result = Database::query($sql);
+            $result = $connection->executeQuery(
+                "SELECT * FROM " . Database::prefix("deathmessages") . " WHERE deathmessageid = :deathmessageid",
+                ['deathmessageid' => (int) $deathmessageid],
+                ['deathmessageid' => ParameterType::INTEGER]
+            );
             $row = Database::fetchAssoc($result);
             $badguy = array(
                 'creaturename' => '`2The Nasty Rabbit',
@@ -75,8 +80,11 @@ switch ($op) {
         $output->rawOutput("</form>");
         break;
     case "del":
-        $sql = "DELETE FROM " . Database::prefix("deathmessages") . " WHERE deathmessageid=\"$deathmessageid\"";
-        Database::query($sql);
+        $connection->executeStatement(
+            "DELETE FROM " . Database::prefix("deathmessages") . " WHERE deathmessageid = :deathmessageid",
+            ['deathmessageid' => (int) $deathmessageid],
+            ['deathmessageid' => ParameterType::INTEGER]
+        );
         $op = "";
         Http::set("op", "");
         break;
@@ -86,11 +94,44 @@ switch ($op) {
         $graveyard = (int) Http::post('graveyard');
         $taunt = (int) Http::post('taunt');
         if ($deathmessageid != "") {
-            $sql = "UPDATE " . Database::prefix("deathmessages") . " SET deathmessage=\"$deathmessage\",taunt=$taunt,forest=$forest,graveyard=$graveyard,editor=\"" . addslashes($session['user']['login']) . "\" WHERE deathmessageid=\"$deathmessageid\"";
+            $connection->executeStatement(
+                "UPDATE " . Database::prefix("deathmessages") . " SET deathmessage = :deathmessage, taunt = :taunt, forest = :forest, graveyard = :graveyard, editor = :editor WHERE deathmessageid = :deathmessageid",
+                [
+                    'deathmessage' => $deathmessage,
+                    'taunt' => $taunt,
+                    'forest' => $forest,
+                    'graveyard' => $graveyard,
+                    'editor' => (string) $session['user']['login'],
+                    'deathmessageid' => (int) $deathmessageid,
+                ],
+                [
+                    'deathmessage' => ParameterType::STRING,
+                    'taunt' => ParameterType::INTEGER,
+                    'forest' => ParameterType::INTEGER,
+                    'graveyard' => ParameterType::INTEGER,
+                    'editor' => ParameterType::STRING,
+                    'deathmessageid' => ParameterType::INTEGER,
+                ]
+            );
         } else {
-            $sql = "INSERT INTO " . Database::prefix("deathmessages") . " (deathmessage,taunt,forest,graveyard,editor) VALUES (\"$deathmessage\",$taunt,$forest,$graveyard,\"" . addslashes($session['user']['login']) . "\")";
+            $connection->executeStatement(
+                "INSERT INTO " . Database::prefix("deathmessages") . " (deathmessage, taunt, forest, graveyard, editor) VALUES (:deathmessage, :taunt, :forest, :graveyard, :editor)",
+                [
+                    'deathmessage' => $deathmessage,
+                    'taunt' => $taunt,
+                    'forest' => $forest,
+                    'graveyard' => $graveyard,
+                    'editor' => (string) $session['user']['login'],
+                ],
+                [
+                    'deathmessage' => ParameterType::STRING,
+                    'taunt' => ParameterType::INTEGER,
+                    'forest' => ParameterType::INTEGER,
+                    'graveyard' => ParameterType::INTEGER,
+                    'editor' => ParameterType::STRING,
+                ]
+            );
         }
-        Database::query($sql);
         $op = "";
         Http::set("op", "");
         break;

--- a/deathmessages.php
+++ b/deathmessages.php
@@ -35,6 +35,7 @@ $op = Http::get('op');
 $deathmessageidRequest = Http::get('deathmessageid');
 $deathmessageid = deathmessages_normalize_optional_int($deathmessageidRequest);
 $deathmessageidParam = $deathmessageid === null ? '' : (string) $deathmessageid;
+$commentaryPage = deathmessages_normalize_optional_int(Http::get('c'));
 switch ($op) {
     case "edit":
         Nav::add("Deathmessages");
@@ -146,6 +147,9 @@ switch ($op) {
 
 /**
  * Normalise request values expected to be optional integer identifiers.
+ *
+ * Lotgd\Http now exposes raw request payloads, so we must explicitly narrow
+ * values such as c/deathmessageid before building navigation URLs.
  */
 function deathmessages_normalize_optional_int(mixed $value): ?int
 {
@@ -209,7 +213,7 @@ if ($op == "") {
         $edit = Translator::translateInline("Edit");
         $del = Translator::translateInline("Del");
         $conf = Translator::translateInline("Are you sure you wish to delete this deathmessage?");
-        $id = $row['deathmessageid'];
+        $id = (int) $row['deathmessageid'];
         $output->rawOutput("[ <a href='deathmessages.php?op=edit&deathmessageid=$id'>$edit</a> | <a href='deathmessages.php?op=del&deathmessageid=$id' onClick='return confirm(\"$conf\");'>$del</a> ]");
         Nav::add("", "deathmessages.php?op=edit&deathmessageid=$id");
         Nav::add("", "deathmessages.php?op=del&deathmessageid=$id");
@@ -225,7 +229,8 @@ if ($op == "") {
         $output->outputNotl("%s", $row['editor']);
         $output->rawOutput("</td></tr>");
     }
-    Nav::add("", "deathmessages.php?c=" . Http::get('c'));
+    $commentaryPageParam = $commentaryPage === null ? '' : (string) (int) $commentaryPage;
+    Nav::add("", "deathmessages.php?c=$commentaryPageParam");
     $output->rawOutput("</table>");
     Nav::add("Deathmessages");
     Nav::add("Add a new deathmessage", "deathmessages.php?op=edit");

--- a/docs/Deprecations.md
+++ b/docs/Deprecations.md
@@ -38,6 +38,13 @@ This project aims to preserve legacy compatibility while moving to a modern stac
   - Replacement: `Lotgd\PlayerSearch::legacyLookup()` and other `PlayerSearch` helpers
   - Migration: Inject or instantiate `PlayerSearch` directly and call `legacyLookup()` (or a more specific finder), removing usage of the legacy array/SQL wrapper.
 
+- Legacy HTTP wrappers `httpget()` / `httppost()` in core/refactored paths
+  - Status: Deprecated in 2.x for core and refactored modules (legacy compatibility only)
+  - Policy: `Lotgd\Http` is the only allowed HTTP API in core/refactored code; legacy wrappers are reserved for legacy/module compatibility paths.
+  - Behaviour note: `lib/http.php` wrappers intentionally preserve escaped legacy semantics for compatibility, while `Lotgd\Http` returns raw request values for typed and parameterized handling.
+  - Migration: Replace legacy helper calls with `Lotgd\Http::get()` / `Lotgd\Http::post()` and use bound DBAL parameters instead of SQL string concatenation.
+  - QA enforcement: `composer static` now runs a policy gate that fails when new wrapper usage appears in core/refactored paths.
+
 ### Upgrade Guidance (1.3.x → 2.0)
 
 See `UPGRADING.md` for the full process. Key points:
@@ -47,4 +54,3 @@ See `UPGRADING.md` for the full process. Key points:
 
 ### Contact
 Open an issue if you need a longer grace period or migration examples for a specific API.
-

--- a/docs/Doctrine.md
+++ b/docs/Doctrine.md
@@ -64,6 +64,16 @@ values based on the parameter type if you supply a third argument to
 See the official [Doctrine DBAL prepared statements documentation](https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/data-retrieval-and-manipulation.html#prepared-statements)
 for more background.
 
+
+## Legacy Request SQL Refactor Checklist
+
+When converting legacy request-driven SQL to DBAL in place:
+
+1. Keep the SQL semantics unchanged (same table, predicates, grouping, ordering).
+2. Use named placeholders instead of concatenating request values.
+3. Pass an explicit `$types` array (`ParameterType::STRING` / `ParameterType::INTEGER`) for request values.
+4. Add/adjust regression tests with quote-containing payloads to ensure values stay in params, not SQL text.
+
 ## Running Migrations
 
 Schema migrations reside in the `migrations/` directory and are configured

--- a/healer.php
+++ b/healer.php
@@ -26,8 +26,15 @@ Translator::getInstance()->setSchema("healer");
 
 $config = unserialize($session['user']['donationconfig']);
 
-$return = Http::get("return");
-$returnline = $return > "" ? "&return=$return" : "";
+/**
+ * Lotgd\Http returns raw input; keep return target as an internal route token
+ * from a strict allow-list before reusing it in nav/query links.
+ */
+$returnRequest = Http::get("return");
+$returnToken = is_string($returnRequest) ? basename(parse_url($returnRequest, PHP_URL_PATH) ?? '') : '';
+$allowedReturnTokens = ['forest.php', 'village.php'];
+$return = in_array($returnToken, $allowedReturnTokens, true) ? $returnToken : '';
+$returnline = $return !== '' ? '&return=' . rawurlencode($return) : "";
 
 Header::pageHeader("Healer's Hut");
 $output->output("`#`b`cHealer's Hut`c`b`n");

--- a/hof.php
+++ b/hof.php
@@ -37,14 +37,14 @@ VillageNav::render();
 
 $playersperpage = 50;
 
-$op = Http::get('op');
-if ($op == "") {
-    $op = "kills";
-}
-$subop = Http::get('subop');
-if ($subop == "") {
-    $subop = "most";
-}
+/**
+ * Lotgd\Http yields raw values; whitelist operation enums before nav reuse.
+ */
+$opRequest = Http::get('op');
+$allowedOps = ['kills', 'money', 'gems', 'charm', 'tough', 'resurrects', 'days'];
+$op = is_string($opRequest) && in_array($opRequest, $allowedOps, true) ? $opRequest : 'kills';
+$subopRequest = Http::get('subop');
+$subop = is_string($subopRequest) && in_array($subopRequest, ['most', 'least'], true) ? $subopRequest : 'most';
 
 $sql = "SELECT count(acctid) AS c FROM " . Database::prefix("accounts") . " WHERE $standardwhere";
 $extra = "";

--- a/lib/http.php
+++ b/lib/http.php
@@ -5,13 +5,39 @@
 // mail ready
 use Lotgd\Http;
 
+/**
+ * Legacy compatibility escape helper for lib/http.php wrappers.
+ *
+ * The legacy wrappers intentionally preserve historical behaviour by returning
+ * addslashes()-escaped scalar values. Core/refactored code must use
+ * Lotgd\Http directly, which intentionally returns raw values.
+ *
+ * @param mixed $value
+ *
+ * @return mixed
+ */
+function legacy_http_escape(mixed $value): mixed
+{
+    if (is_string($value)) {
+        return addslashes($value);
+    }
+
+    if (is_array($value)) {
+        foreach ($value as $key => $item) {
+            $value[$key] = legacy_http_escape($item);
+        }
+    }
+
+    return $value;
+}
+
 function httpget($var)
 {
-    return Http::get($var);
+    return legacy_http_escape(Http::get($var));
 }
 function httpallget()
 {
-    return Http::allGet();
+    return legacy_http_escape(Http::allGet());
 }
 function httpset($var, $val, $force = false)
 {
@@ -19,7 +45,7 @@ function httpset($var, $val, $force = false)
 }
 function httppost($var)
 {
-    return Http::post($var);
+    return legacy_http_escape(Http::post($var));
 }
 function httppostisset($var)
 {
@@ -31,9 +57,11 @@ function httppostset($var, $val, $sub = false)
 }
 function httpallpost()
 {
-    return Http::allPost();
+    return legacy_http_escape(Http::allPost());
 }
 function postparse($verify = false, $subval = false)
 {
-    return Http::postParse($verify, $subval);
+    [$columns, $placeholders, $parameters] = Http::postParse($verify, $subval);
+
+    return [$columns, $placeholders, legacy_http_escape($parameters)];
 }

--- a/modules.php
+++ b/modules.php
@@ -138,10 +138,19 @@ foreach ($seencats as $cat => $count) {
     if ($subnav !== '') {
             Nav::addSubHeader($subnav);
     }
-        Nav::add(array(" ?%s - (%s modules)", $category, $count), "modules.php?cat=$cat");
+        Nav::add(
+            array(" ?%s - (%s modules)", $category, $count),
+            "modules.php?cat=" . rawurlencode($cat)
+        );
 }
 
-$cat = Http::get('cat');
+/**
+ * Lotgd\Http values are raw; constrain category to known categories and
+ * URL-encode when composing links/forms/nav entries.
+ */
+$catRequest = Http::get('cat');
+$cat = is_string($catRequest) && array_key_exists($catRequest, $seencats) ? $catRequest : '';
+$catQuery = rawurlencode($cat);
 if ($op == "") {
     if ($cat) {
         $sortby = Http::get('sortby');
@@ -168,21 +177,21 @@ if ($op == "") {
         $installstr = Translator::translateInline("by %s");
         $active = Translator::translateInline("`@Active`0");
         $inactive = Translator::translateInline("`\$Inactive`0");
-        $output->rawOutput("<form action='modules.php?op=mass&cat=$cat' method='POST'>");
-        Nav::add("", "modules.php?op=mass&cat=$cat");
+        $output->rawOutput("<form action='modules.php?op=mass&cat=$catQuery' method='POST'>");
+        Nav::add("", "modules.php?op=mass&cat=$catQuery");
         $installedCaption = Translator::translateInline("Installed modules table");
         $output->rawOutput("<div class='table-responsive'>");
         $output->rawOutput("<table class='table table-striped table-hover js-modules-table'>");
         $output->rawOutput("<caption class='visually-hidden'>{$installedCaption}</caption>");
         $output->rawOutput("<thead>");
         $selectAllLabel = Translator::translateInline("Select all");
-        $output->rawOutput("<tr class='table-secondary'><th scope='col'><input type='checkbox' class='js-select-all' aria-label='{$selectAllLabel}'></th><th scope='col'>$ops</th><th scope='col'><a href='modules.php?cat=$cat&sortby=active&order=" . ($sortby == "active" ? !$order : 1) . "'>$status</a></th><th scope='col'><a href='modules.php?cat=$cat&sortby=formalname&order=" . ($sortby == "formalname" ? !$order : 1) . "'>$mname</a></th><th scope='col'><a href='modules.php?cat=$cat&sortby=moduleauthor&order=" . ($sortby == "moduleauthor" ? !$order : 1) . "'>$mauth</a></th><th scope='col'><a href='modules.php?cat=$cat&sortby=installdate&order=" . ($sortby == "installdate" ? !$order : 0) . "'>$inon</a></th></tr>");
+        $output->rawOutput("<tr class='table-secondary'><th scope='col'><input type='checkbox' class='js-select-all' aria-label='{$selectAllLabel}'></th><th scope='col'>$ops</th><th scope='col'><a href='modules.php?cat=$catQuery&sortby=active&order=" . ($sortby == "active" ? !$order : 1) . "'>$status</a></th><th scope='col'><a href='modules.php?cat=$catQuery&sortby=formalname&order=" . ($sortby == "formalname" ? !$order : 1) . "'>$mname</a></th><th scope='col'><a href='modules.php?cat=$catQuery&sortby=moduleauthor&order=" . ($sortby == "moduleauthor" ? !$order : 1) . "'>$mauth</a></th><th scope='col'><a href='modules.php?cat=$catQuery&sortby=installdate&order=" . ($sortby == "installdate" ? !$order : 0) . "'>$inon</a></th></tr>");
         $output->rawOutput("</thead>");
         $output->rawOutput("<tbody>");
-        Nav::add("", "modules.php?cat=$cat&sortby=active&order=" . ($sortby == "active" ? !$order : 1));
-        Nav::add("", "modules.php?cat=$cat&sortby=formalname&order=" . ($sortby == "formalname" ? !$order : 1));
-        Nav::add("", "modules.php?cat=$cat&sortby=moduleauthor&order=" . ($sortby == "moduleauthor" ? !$order : 1));
-        Nav::add("", "modules.php?cat=$cat&sortby=installdate&order=" . ($sortby == "installdate" ? $order : 0));
+        Nav::add("", "modules.php?cat=$catQuery&sortby=active&order=" . ($sortby == "active" ? !$order : 1));
+        Nav::add("", "modules.php?cat=$catQuery&sortby=formalname&order=" . ($sortby == "formalname" ? !$order : 1));
+        Nav::add("", "modules.php?cat=$catQuery&sortby=moduleauthor&order=" . ($sortby == "moduleauthor" ? !$order : 1));
+        Nav::add("", "modules.php?cat=$catQuery&sortby=installdate&order=" . ($sortby == "installdate" ? $order : 0));
                 $rows = ModuleManager::listInstalled($cat, $sortby, (bool)$order);
         if (count($rows) == 0) {
                 $output->rawOutput("<tr class='table-light'><td colspan='6' class='text-center'>");
@@ -197,28 +206,28 @@ if ($op == "") {
             $output->rawOutput("<input type='checkbox' name='module[]' value=\"{$row['modulename']}\">");
             $output->rawOutput("</td><td class='text-nowrap align-top'>[ ");
             if ($row['active']) {
-                $output->rawOutput("<a href='modules.php?op=deactivate&module={$row['modulename']}&cat=$cat'>");
+                $output->rawOutput("<a href='modules.php?op=deactivate&module={$row['modulename']}&cat=$catQuery'>");
                 $output->outputNotl($deactivate);
                 $output->rawOutput("</a>");
-                Nav::add("", "modules.php?op=deactivate&module={$row['modulename']}&cat=$cat");
+                Nav::add("", "modules.php?op=deactivate&module={$row['modulename']}&cat=$catQuery");
             } else {
-                $output->rawOutput("<a href='modules.php?op=activate&module={$row['modulename']}&cat=$cat'>");
+                $output->rawOutput("<a href='modules.php?op=activate&module={$row['modulename']}&cat=$catQuery'>");
                 $output->outputNotl($activate);
                 $output->rawOutput("</a>");
-                Nav::add("", "modules.php?op=activate&module={$row['modulename']}&cat=$cat");
+                Nav::add("", "modules.php?op=activate&module={$row['modulename']}&cat=$catQuery");
             }
-            $output->rawOutput(" |<a href='modules.php?op=uninstall&module={$row['modulename']}&cat=$cat' onClick='return confirm(\"$uninstallconfirm\");'>");
+            $output->rawOutput(" |<a href='modules.php?op=uninstall&module={$row['modulename']}&cat=$catQuery' onClick='return confirm(\"$uninstallconfirm\");'>");
             $output->outputNotl($uninstall);
             $output->rawOutput("</a>");
-            Nav::add("", "modules.php?op=uninstall&module={$row['modulename']}&cat=$cat");
-            $output->rawOutput(" | <a href='modules.php?op=reinstall&module={$row['modulename']}&cat=$cat'>");
+            Nav::add("", "modules.php?op=uninstall&module={$row['modulename']}&cat=$catQuery");
+            $output->rawOutput(" | <a href='modules.php?op=reinstall&module={$row['modulename']}&cat=$catQuery'>");
             $output->outputNotl($reinstall);
             $output->rawOutput("</a>");
-            Nav::add("", "modules.php?op=reinstall&module={$row['modulename']}&cat=$cat");
-            $output->rawOutput(" | <a href='modules.php?op=remove&module={$row['modulename']}&cat=$cat' onClick='return confirm(\"$removeconfirm\");'>");
+            Nav::add("", "modules.php?op=reinstall&module={$row['modulename']}&cat=$catQuery");
+            $output->rawOutput(" | <a href='modules.php?op=remove&module={$row['modulename']}&cat=$catQuery' onClick='return confirm(\"$removeconfirm\");'>");
             $output->outputNotl($remove);
             $output->rawOutput("</a>");
-            Nav::add("", "modules.php?op=remove&module={$row['modulename']}&cat=$cat");
+            Nav::add("", "modules.php?op=remove&module={$row['modulename']}&cat=$catQuery");
 
             if ($session['user']['superuser'] & SU_EDIT_CONFIG) {
                 if (strstr($row['infokeys'], "|settings|")) {
@@ -277,8 +286,8 @@ if ($op == "") {
         $mauth = Translator::translateInline("Module Author");
         $categ = Translator::translateInline("Category");
         $fname = Translator::translateInline("Filename");
-        $output->rawOutput("<form action='modules.php?op=mass&cat=$cat' method='POST'>");
-        Nav::add("", "modules.php?op=mass&cat=$cat");
+        $output->rawOutput("<form action='modules.php?op=mass&cat=$catQuery' method='POST'>");
+        Nav::add("", "modules.php?op=mass&cat=$catQuery");
         $uninstalledCaption = Translator::translateInline("Uninstalled modules table");
         $output->rawOutput("<div class='table-responsive'>");
         $output->rawOutput("<table class='table table-striped table-hover js-uninstalled-modules-table'>");

--- a/pages/bans/case_setupban.php
+++ b/pages/bans/case_setupban.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\ParameterType;
 
 $output = Output::getInstance();
 $settings = Settings::getInstance();
+$charset = $settings->getSetting('charset', 'UTF-8');
 
 $sql = 'SELECT name,lastip,uniqueid FROM ' . Database::prefix('accounts') . ' WHERE acctid=' . (int) $userid;
 $result = Database::query($sql);
@@ -69,7 +70,11 @@ if (isset($row['name']) && !empty($row['name'])) {
             $row['lastip'],
             $row['name'],
             $row['gentimecount'],
-            DateTime::relTime(strtotime($row['laston']))
+            (
+                isset($row['laston']) && is_string($row['laston']) && $row['laston'] !== ''
+                    ? DateTime::relTime(strtotime($row['laston']))
+                    : Translator::translateInline('unknown')
+            )
         );
     }
     $sameIdResult->free();
@@ -99,7 +104,9 @@ if (isset($row['name']) && !empty($row['name'])) {
             if (!$hasRows) {
                 $hasRows = true;
                 $output->output("IP Filter: %s ", $thisip);
-                $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
+                $thisIpJson = json_encode($thisip, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+                $onClick = "document.getElementById('ip').value={$thisIpJson}; document.getElementById('ipradio').checked = true; return false";
+                $output->rawOutput("<a href='#' onClick=\"" . HTMLEntities($onClick, ENT_QUOTES, $charset) . "\">");
                 $output->output("Use this filter");
                 $output->rawOutput("</a>");
                 $output->outputNotl("`n");
@@ -112,7 +119,11 @@ if (isset($row['name']) && !empty($row['name'])) {
                     $row['uniqueid'],
                     $row['name'],
                     $row['gentimecount'],
-                    DateTime::relTime(strtotime($row['laston']))
+                    (
+                        isset($row['laston']) && is_string($row['laston']) && $row['laston'] !== ''
+                            ? DateTime::relTime(strtotime($row['laston']))
+                            : Translator::translateInline('unknown')
+                    )
                 );
         }
         $similarIpResult->free();

--- a/pages/bans/case_setupban.php
+++ b/pages/bans/case_setupban.php
@@ -9,6 +9,7 @@ use Lotgd\Http;
 use Lotgd\Output;
 use Lotgd\Settings;
 use Lotgd\DateTime;
+use Doctrine\DBAL\ParameterType;
 
 $output = Output::getInstance();
 $settings = Settings::getInstance();
@@ -47,14 +48,18 @@ $output->rawOutput("</form>");
 $output->output("For an IP ban, enter the beginning part of the IP you wish to ban if you wish to ban a range, or simply a full IP to ban a single IP`n`n");
 Nav::add("", "bans.php?op=saveban");
 if (isset($row['name']) && !empty($row['name'])) {
+    $conn = Database::getDoctrineConnection();
     $id = $row['uniqueid'];
     $ip = $row['lastip'];
     $name = $row['name'];
     $output->output("`0To help locate similar users to `@%s`0, here are some other users who are close:`n", $name);
     $output->output("`bSame ID (%s):`b`n", $id);
-    $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . Database::prefix("accounts") . " WHERE uniqueid='" . addslashes($id) . "' ORDER BY lastip";
-    $result = Database::query($sql);
-    while ($row = Database::fetchAssoc($result)) {
+    $sameIdRows = $conn->fetchAllAssociative(
+        'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE uniqueid = :uniqueid ORDER BY lastip',
+        ['uniqueid' => $id],
+        ['uniqueid' => ParameterType::STRING]
+    );
+    foreach ($sameIdRows as $row) {
         $output->output(
             "`0* (%s) `%%s`0 - %s hits, last: %s`n",
             $row['lastip'],
@@ -72,16 +77,25 @@ if (isset($row['name']) && !empty($row['name'])) {
             break;
         }
         $thisip = substr($ip, 0, $x);
-        $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . Database::prefix("accounts") . " WHERE lastip LIKE '$thisip%' AND NOT (lastip LIKE '$oip') ORDER BY uniqueid";
-        //$output->output("$sql`n");
-        $result = Database::query($sql);
-        if (Database::numRows($result) > 0) {
+        $similarIpRows = $conn->fetchAllAssociative(
+            'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE lastip LIKE :thisIp AND NOT (lastip LIKE :oldIp) ORDER BY uniqueid',
+            [
+                'thisIp' => $thisip . '%',
+                'oldIp' => $oip,
+            ],
+            [
+                'thisIp' => ParameterType::STRING,
+                'oldIp' => ParameterType::STRING,
+            ]
+        );
+
+        if (count($similarIpRows) > 0) {
             $output->output("IP Filter: %s ", $thisip);
             $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
             $output->output("Use this filter");
             $output->rawOutput("</a>");
             $output->outputNotl("`n");
-            while ($row = Database::fetchAssoc($result)) {
+            foreach ($similarIpRows as $row) {
                 $output->output("&nbsp;&nbsp;", true);
                 $output->output(
                     "(%s) [%s] `%%s`0 - %s hits, last: %s`n",

--- a/pages/bans/case_setupban.php
+++ b/pages/bans/case_setupban.php
@@ -54,12 +54,16 @@ if (isset($row['name']) && !empty($row['name'])) {
     $name = $row['name'];
     $output->output("`0To help locate similar users to `@%s`0, here are some other users who are close:`n", $name);
     $output->output("`bSame ID (%s):`b`n", $id);
-    $sameIdRows = $conn->fetchAllAssociative(
+    /**
+     * Stream rows instead of materialising all matches in memory.
+     * This keeps legacy broad filters safer on large account tables.
+     */
+    $sameIdResult = $conn->executeQuery(
         'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE uniqueid = :uniqueid ORDER BY lastip',
         ['uniqueid' => $id],
         ['uniqueid' => ParameterType::STRING]
     );
-    foreach ($sameIdRows as $row) {
+    while (($row = $sameIdResult->fetchAssociative()) !== false) {
         $output->output(
             "`0* (%s) `%%s`0 - %s hits, last: %s`n",
             $row['lastip'],
@@ -68,6 +72,7 @@ if (isset($row['name']) && !empty($row['name'])) {
             DateTime::relTime(strtotime($row['laston']))
         );
     }
+    $sameIdResult->free();
     $output->outputNotl("`n");
         $oip = "";
     $dots = 0;
@@ -77,7 +82,7 @@ if (isset($row['name']) && !empty($row['name'])) {
             break;
         }
         $thisip = substr($ip, 0, $x);
-        $similarIpRows = $conn->fetchAllAssociative(
+        $similarIpResult = $conn->executeQuery(
             'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE lastip LIKE :thisIp AND NOT (lastip LIKE :oldIp) ORDER BY uniqueid',
             [
                 'thisIp' => $thisip . '%',
@@ -89,13 +94,17 @@ if (isset($row['name']) && !empty($row['name'])) {
             ]
         );
 
-        if (count($similarIpRows) > 0) {
-            $output->output("IP Filter: %s ", $thisip);
-            $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
-            $output->output("Use this filter");
-            $output->rawOutput("</a>");
-            $output->outputNotl("`n");
-            foreach ($similarIpRows as $row) {
+        $hasRows = false;
+        while (($row = $similarIpResult->fetchAssociative()) !== false) {
+            if (!$hasRows) {
+                $hasRows = true;
+                $output->output("IP Filter: %s ", $thisip);
+                $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
+                $output->output("Use this filter");
+                $output->rawOutput("</a>");
+                $output->outputNotl("`n");
+            }
+
                 $output->output("&nbsp;&nbsp;", true);
                 $output->output(
                     "(%s) [%s] `%%s`0 - %s hits, last: %s`n",
@@ -105,7 +114,10 @@ if (isset($row['name']) && !empty($row['name'])) {
                     $row['gentimecount'],
                     DateTime::relTime(strtotime($row['laston']))
                 );
-            }
+        }
+        $similarIpResult->free();
+
+        if ($hasRows) {
             $output->outputNotl("`n");
         }
         if (substr($ip, $x - 1, 1) == ".") {

--- a/pages/petition/petition_default.php
+++ b/pages/petition/petition_default.php
@@ -150,9 +150,12 @@ if (count($post) > 0 && (string) Http::post('abuse') !== 'yes') {
         $abuse = (string) Http::post('abuse');
     }
     if ($abuse === 'yes') {
+        $abusePlayer = petition_normalize_optional_int(Http::post('abuseplayer'));
+        $abusePlayerValue = $abusePlayer === null ? '' : (string) (int) $abusePlayer;
+        $abusePlayerAttr = htmlentities($abusePlayerValue, ENT_COMPAT, $settings->getSetting("charset", "UTF-8"));
         $output->rawOutput("<textarea name='description' cols='55' rows='7' class='input'></textarea>");
         $output->rawOutput("<input type='hidden' name='abuse' value=\"" . Stripslashes::deep($problem) . "\"><br><hr><pre>" . stripslashes(rawurldecode($problem)) . "</pre><hr><br>");
-        $output->rawOutput("<input type='hidden' name='abuseplayer' value=\"" . (string) Http::post('abuseplayer') . "\">");
+        $output->rawOutput("<input type='hidden' name='abuseplayer' value=\"$abusePlayerAttr\">");
     } else {
         $output->rawOutput("<textarea name='description' cols='55' rows='7' class='input'>" . Stripslashes::deep(($problem)) . "</textarea>");
     }
@@ -164,4 +167,27 @@ if (count($post) > 0 && (string) Http::post('abuse') !== 'yes') {
     $output->output("Petitions about game mechanics will more than likely not be answered unless they have something to do with a bug.");
     $output->output("Remember, if you are not signed in, and do not provide an email address, we have no way to contact you.");
     $output->rawOutput("</form>");
+}
+
+/**
+ * Normalise optional integer request values before rendering into HTML.
+ *
+ * Lotgd\Http now returns raw payloads, so abuseplayer must be narrowed to an
+ * integer identifier before writing into hidden input attributes.
+ */
+function petition_normalize_optional_int(mixed $value): ?int
+{
+    if ($value === '' || $value === null || is_array($value) || ! is_scalar($value)) {
+        return null;
+    }
+
+    $valueString = (string) $value;
+
+    if ($valueString === '' || ! ctype_digit($valueString)) {
+        return null;
+    }
+
+    $intValue = (int) $valueString;
+
+    return $intValue > 0 ? $intValue : null;
 }

--- a/pages/user/user_debuglog.php
+++ b/pages/user/user_debuglog.php
@@ -6,6 +6,7 @@ use Lotgd\Nav;
 use Lotgd\Translator;
 use Lotgd\MySQL\Database;
 use Lotgd\Sanitize;
+use Lotgd\Http;
 
 if ($petition != "") {
     Nav::add("Navigation");
@@ -43,7 +44,7 @@ $row = Database::fetchAssoc($result);
 $max += $row['c'];
 
 
-$start = (int)httpget('start');
+$start = (int) Http::get('start');
 
 $sql = "(
                         SELECT {$debuglog}.*,

--- a/pages/user/user_delban.php
+++ b/pages/user/user_delban.php
@@ -8,11 +8,14 @@ use Lotgd\Http;
 use Doctrine\DBAL\ParameterType;
 
 $conn = Database::getDoctrineConnection();
+$ipFilter = (string) (Http::get('ipfilter') ?: '');
+$uniqueId = (string) (Http::get('uniqueid') ?: '');
+
 $conn->executeStatement(
     'DELETE FROM ' . Database::prefix('bans') . ' WHERE ipfilter = :ip AND uniqueid = :id',
     [
-        'ip' => Http::get('ipfilter'),
-        'id' => Http::get('uniqueid'),
+        'ip' => $ipFilter,
+        'id' => $uniqueId,
     ],
     [
         'ip' => ParameterType::STRING,

--- a/pages/user/user_delban.php
+++ b/pages/user/user_delban.php
@@ -4,7 +4,19 @@ declare(strict_types=1);
 
 use Lotgd\Redirect;
 use Lotgd\MySQL\Database;
+use Lotgd\Http;
+use Doctrine\DBAL\ParameterType;
 
-$sql = "DELETE FROM " . Database::prefix("bans") . " WHERE ipfilter = '" . httpget("ipfilter") . "' AND uniqueid = '" . httpget("uniqueid") . "'";
-Database::query($sql);
+$conn = Database::getDoctrineConnection();
+$conn->executeStatement(
+    'DELETE FROM ' . Database::prefix('bans') . ' WHERE ipfilter = :ip AND uniqueid = :id',
+    [
+        'ip' => Http::get('ipfilter'),
+        'id' => Http::get('uniqueid'),
+    ],
+    [
+        'ip' => ParameterType::STRING,
+        'id' => ParameterType::STRING,
+    ]
+);
 Redirect::redirect('bans.php?op=removeban');

--- a/pages/user/user_delban.php
+++ b/pages/user/user_delban.php
@@ -8,8 +8,15 @@ use Lotgd\Http;
 use Doctrine\DBAL\ParameterType;
 
 $conn = Database::getDoctrineConnection();
-$ipFilter = (string) (Http::get('ipfilter') ?: '');
-$uniqueId = (string) (Http::get('uniqueid') ?: '');
+$ipFilterRaw = Http::get('ipfilter');
+$uniqueIdRaw = Http::get('uniqueid');
+
+/**
+ * Normalize only missing values (false) to empty strings.
+ * Keep valid falsy string values (e.g. "0") unchanged.
+ */
+$ipFilter = $ipFilterRaw === false ? '' : (string) $ipFilterRaw;
+$uniqueId = $uniqueIdRaw === false ? '' : (string) $uniqueIdRaw;
 
 $conn->executeStatement(
     'DELETE FROM ' . Database::prefix('bans') . ' WHERE ipfilter = :ip AND uniqueid = :id',

--- a/pages/user/user_edit.php
+++ b/pages/user/user_edit.php
@@ -17,10 +17,15 @@ $row = Database::fetchAssoc($result);
 $output = Output::getInstance();
 $settings = Settings::getInstance();
 $charset = $settings->getSetting('charset', 'UTF-8');
-$petition = Http::get('returnpetition');
-if ($petition != "") {
-    $returnpetition = "&returnpetition=$petition";
-}
+/**
+ * Lotgd\Http returns raw payloads, so normalize returnpetition as optional int
+ * before embedding it back into operation/nav URLs.
+ */
+$petitionRequest = Http::get('returnpetition');
+$petition = is_string($petitionRequest) && ctype_digit($petitionRequest) && (int) $petitionRequest > 0
+    ? (int) $petitionRequest
+    : null;
+$returnpetition = $petition === null ? '' : "&returnpetition=$petition";
 if ($petition != "") {
     Nav::add("Navigation");
     Nav::add("Return to the petition", "viewpetition.php?op=view&id=$petition");

--- a/pages/user/user_edit.php
+++ b/pages/user/user_edit.php
@@ -26,7 +26,7 @@ $petition = is_string($petitionRequest) && ctype_digit($petitionRequest) && (int
     ? (int) $petitionRequest
     : null;
 $returnpetition = $petition === null ? '' : "&returnpetition=$petition";
-if ($petition != "") {
+if ($petition !== null) {
     Nav::add("Navigation");
     Nav::add("Return to the petition", "viewpetition.php?op=view&id=$petition");
 }

--- a/pages/user/user_save.php
+++ b/pages/user/user_save.php
@@ -207,7 +207,7 @@ foreach ($post as $key => $val) {
         }
     }
 }
-$petition = httpget("returnpetition");
+$petition = (string) Http::get('returnpetition');
 if ($petition != "") {
     Nav::add("", "viewpetition.php?op=view&id=$petition");
 }

--- a/pages/user/user_savemodule.php
+++ b/pages/user/user_savemodule.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
+use Lotgd\Http;
+use Doctrine\DBAL\ParameterType;
 
 //save module settings.
-$userid = (int)httpget('userid');
-$module = httpget('module');
-$post = httpallpost();
+$userid = (int) Http::get('userid');
+$module = (string) Http::get('module');
+$post = Http::allPost();
 $post = modulehook("validateprefs", $post, true, $module);
 if (isset($post['validation_error']) && $post['validation_error']) {
     Translator::getInstance()->setSchema("module-$module");
@@ -17,15 +19,25 @@ if (isset($post['validation_error']) && $post['validation_error']) {
     Translator::getInstance()->setSchema();
     $output->output("Unable to change settings: `\$%s`0", $post['validation_error']);
 } else {
+    $conn = Database::getDoctrineConnection();
     $output->outputNotl("`n");
     foreach ($post as $key => $val) {
         $output->output("`\$Setting '`2%s`\$' to '`2%s`\$'`n", $key, htmlspecialchars($val, ENT_QUOTES, 'UTF-8'));
-        $sql = "REPLACE INTO " . Database::prefix("module_userprefs") .
-            " (modulename,userid,setting,value) VALUES ('" .
-            Database::escape($module) . "',$userid,'" .
-            Database::escape($key) . "','" .
-            Database::escape($val) . "')";
-        Database::query($sql);
+        $conn->executeStatement(
+            'REPLACE INTO ' . Database::prefix('module_userprefs') . ' (modulename,userid,setting,value) VALUES (:module,:userid,:setting,:value)',
+            [
+                'module' => $module,
+                'userid' => $userid,
+                'setting' => $key,
+                'value' => (string) $val,
+            ],
+            [
+                'module' => ParameterType::STRING,
+                'userid' => ParameterType::INTEGER,
+                'setting' => ParameterType::STRING,
+                'value' => ParameterType::STRING,
+            ]
+        );
     }
     $output->output("`^Preferences for module %s saved.`n", $module);
 }

--- a/pages/user/user_setupban.php
+++ b/pages/user/user_setupban.php
@@ -101,7 +101,11 @@ if ($row['name'] != "") {
             $row['lastip'],
             $row['name'],
             $row['gentimecount'],
-            reltime(strtotime($row['laston']))
+            (
+                isset($row['laston']) && is_string($row['laston']) && $row['laston'] !== ''
+                    ? reltime(strtotime($row['laston']))
+                    : Translator::translateInline('unknown')
+            )
         );
     }
     $sameIdResult->free();
@@ -131,7 +135,9 @@ if ($row['name'] != "") {
             if (!$hasRows) {
                 $hasRows = true;
                 $output->output("• IP Filter: %s ", $thisip);
-                $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
+                $thisIpJson = json_encode($thisip, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+                $onClick = "document.getElementById('ip').value={$thisIpJson}; document.getElementById('ipradio').checked = true; return false";
+                $output->rawOutput("<a href='#' onClick=\"" . HTMLEntities($onClick, ENT_QUOTES, $charset) . "\">");
                 $output->output("Use this filter");
                 $output->rawOutput("</a>");
                 $output->outputNotl("`n");
@@ -144,7 +150,11 @@ if ($row['name'] != "") {
                     $row['uniqueid'],
                     $row['name'],
                     $row['gentimecount'],
-                    reltime(strtotime($row['laston']))
+                    (
+                        isset($row['laston']) && is_string($row['laston']) && $row['laston'] !== ''
+                            ? reltime(strtotime($row['laston']))
+                            : Translator::translateInline('unknown')
+                    )
                 );
         }
         $similarIpResult->free();

--- a/pages/user/user_setupban.php
+++ b/pages/user/user_setupban.php
@@ -9,6 +9,7 @@ use Lotgd\Output;
 use Lotgd\Settings;
 use Lotgd\Http;
 use Lotgd\Sanitize;
+use Doctrine\DBAL\ParameterType;
 
 global $session;
 
@@ -79,14 +80,18 @@ $output->rawOutput("</form>");
 $output->output("For an IP ban, enter the beginning part of the IP you wish to ban if you wish to ban a range, or simply a full IP to ban a single IP`n`n");
 Nav::add("", "user.php?op=saveban");
 if ($row['name'] != "") {
+    $conn = Database::getDoctrineConnection();
     $id = $row['uniqueid'];
     $ip = $row['lastip'];
     $name = $row['name'];
     $output->output("`0To help locate similar users to `@%s`0, here are some other users who are close:`n", $name);
     $output->output("`bSame ID (%s):`b`n", $id);
-    $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . Database::prefix("accounts") . " WHERE uniqueid='" . addslashes($id) . "' ORDER BY lastip";
-    $result = Database::query($sql);
-    while ($row = Database::fetchAssoc($result)) {
+    $sameIdRows = $conn->fetchAllAssociative(
+        'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE uniqueid = :uniqueid ORDER BY lastip',
+        ['uniqueid' => $id],
+        ['uniqueid' => ParameterType::STRING]
+    );
+    foreach ($sameIdRows as $row) {
         $output->output(
             "`0• (%s) `%%s`0 - %s hits, last: %s`n",
             $row['lastip'],
@@ -104,16 +109,25 @@ if ($row['name'] != "") {
             break;
         }
         $thisip = substr($ip, 0, $x);
-        $sql = "SELECT name, lastip, uniqueid, laston, gentimecount FROM " . Database::prefix("accounts") . " WHERE lastip LIKE '$thisip%' AND NOT (lastip LIKE '$oip') ORDER BY uniqueid";
-        //$output->output("$sql`n");
-        $result = Database::query($sql);
-        if (Database::numRows($result) > 0) {
+        $similarIpRows = $conn->fetchAllAssociative(
+            'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE lastip LIKE :thisIp AND NOT (lastip LIKE :oldIp) ORDER BY uniqueid',
+            [
+                'thisIp' => $thisip . '%',
+                'oldIp' => $oip,
+            ],
+            [
+                'thisIp' => ParameterType::STRING,
+                'oldIp' => ParameterType::STRING,
+            ]
+        );
+
+        if (count($similarIpRows) > 0) {
             $output->output("• IP Filter: %s ", $thisip);
             $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
             $output->output("Use this filter");
             $output->rawOutput("</a>");
             $output->outputNotl("`n");
-            while ($row = Database::fetchAssoc($result)) {
+            foreach ($similarIpRows as $row) {
                 $output->output("&nbsp;&nbsp;", true);
                 $output->output(
                     "• (%s) [%s] `%%s`0 - %s hits, last: %s`n",

--- a/pages/user/user_setupban.php
+++ b/pages/user/user_setupban.php
@@ -86,12 +86,16 @@ if ($row['name'] != "") {
     $name = $row['name'];
     $output->output("`0To help locate similar users to `@%s`0, here are some other users who are close:`n", $name);
     $output->output("`bSame ID (%s):`b`n", $id);
-    $sameIdRows = $conn->fetchAllAssociative(
+    /**
+     * Stream rows instead of fetching everything at once so broad matches
+     * remain predictable on larger installs.
+     */
+    $sameIdResult = $conn->executeQuery(
         'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE uniqueid = :uniqueid ORDER BY lastip',
         ['uniqueid' => $id],
         ['uniqueid' => ParameterType::STRING]
     );
-    foreach ($sameIdRows as $row) {
+    while (($row = $sameIdResult->fetchAssociative()) !== false) {
         $output->output(
             "`0• (%s) `%%s`0 - %s hits, last: %s`n",
             $row['lastip'],
@@ -100,6 +104,7 @@ if ($row['name'] != "") {
             reltime(strtotime($row['laston']))
         );
     }
+    $sameIdResult->free();
     $output->outputNotl("`n");
         $oip = "";
     $dots = 0;
@@ -109,7 +114,7 @@ if ($row['name'] != "") {
             break;
         }
         $thisip = substr($ip, 0, $x);
-        $similarIpRows = $conn->fetchAllAssociative(
+        $similarIpResult = $conn->executeQuery(
             'SELECT name, lastip, uniqueid, laston, gentimecount FROM ' . Database::prefix('accounts') . ' WHERE lastip LIKE :thisIp AND NOT (lastip LIKE :oldIp) ORDER BY uniqueid',
             [
                 'thisIp' => $thisip . '%',
@@ -121,13 +126,17 @@ if ($row['name'] != "") {
             ]
         );
 
-        if (count($similarIpRows) > 0) {
-            $output->output("• IP Filter: %s ", $thisip);
-            $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
-            $output->output("Use this filter");
-            $output->rawOutput("</a>");
-            $output->outputNotl("`n");
-            foreach ($similarIpRows as $row) {
+        $hasRows = false;
+        while (($row = $similarIpResult->fetchAssociative()) !== false) {
+            if (!$hasRows) {
+                $hasRows = true;
+                $output->output("• IP Filter: %s ", $thisip);
+                $output->rawOutput("<a href='#' onClick=\"document.getElementById('ip').value='$thisip'; document.getElementById('ipradio').checked = true; return false\">");
+                $output->output("Use this filter");
+                $output->rawOutput("</a>");
+                $output->outputNotl("`n");
+            }
+
                 $output->output("&nbsp;&nbsp;", true);
                 $output->output(
                     "• (%s) [%s] `%%s`0 - %s hits, last: %s`n",
@@ -137,7 +146,10 @@ if ($row['name'] != "") {
                     $row['gentimecount'],
                     reltime(strtotime($row['laston']))
                 );
-            }
+        }
+        $similarIpResult->free();
+
+        if ($hasRows) {
             $output->outputNotl("`n");
         }
         if (substr($ip, $x - 1, 1) == ".") {

--- a/scripts/check-legacy-http-wrappers.php
+++ b/scripts/check-legacy-http-wrappers.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Lotgd\QA\LegacyHttpWrapperUsageCheck;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$checker = new LegacyHttpWrapperUsageCheck();
+exit($checker->run(dirname(__DIR__)));
+

--- a/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
+++ b/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
@@ -92,7 +92,7 @@ final class LegacyHttpWrapperUsageCheck
     private function isWhitelistedPath(string $relativePath): bool
     {
         foreach (self::ALLOWED_PATHS as $allowedPath) {
-            if (str_starts_with($relativePath, $allowedPath)) {
+            if ($relativePath === $allowedPath) {
                 return true;
             }
         }
@@ -111,7 +111,7 @@ final class LegacyHttpWrapperUsageCheck
         }
 
         $tokens = token_get_all($contents);
-        $lines = file($absolutePath, FILE_IGNORE_NEW_LINES) ?: [];
+        $lines = preg_split("/\r\n|\n|\r/", $contents) ?: [];
         $violations = [];
 
         foreach ($tokens as $index => $token) {

--- a/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
+++ b/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\QA;
+
+/**
+ * Detects legacy httpget()/httppost() helper usage in core/refactored code.
+ *
+ * Policy:
+ *  - Core/refactored code must use Lotgd\Http directly.
+ *  - Legacy wrappers are permitted only in explicitly whitelisted paths.
+ */
+final class LegacyHttpWrapperUsageCheck
+{
+    /**
+     * @var list<string>
+     */
+    private const DISALLOWED_PATTERNS = [
+        '/\bhttpget\s*\(/i',
+        '/\bhttppost\s*\(/i',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const SCAN_ROOTS = [
+        'pages',
+        'src',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const ALLOWED_ROOTS = [
+        'lib/',
+        'modules/',
+        'install/',
+        'tests/',
+        'vendor/',
+        'src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php',
+    ];
+
+    /**
+     * @return list<string> Human-readable violations in "file:line:text" format.
+     */
+    public function collectViolations(string $repositoryRoot): array
+    {
+        $violations = [];
+
+        foreach (self::SCAN_ROOTS as $relativeRoot) {
+            $absoluteRoot = rtrim($repositoryRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relativeRoot;
+            if (!is_dir($absoluteRoot)) {
+                continue;
+            }
+
+            $directoryIterator = new \RecursiveDirectoryIterator($absoluteRoot, \FilesystemIterator::SKIP_DOTS);
+            $iterator = new \RecursiveIteratorIterator($directoryIterator);
+
+            foreach ($iterator as $file) {
+                if (!($file instanceof \SplFileInfo) || $file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $relativePath = str_replace('\\', '/', substr($file->getPathname(), strlen(rtrim($repositoryRoot, DIRECTORY_SEPARATOR)) + 1));
+                if ($this->isWhitelistedPath($relativePath)) {
+                    continue;
+                }
+
+                $lines = file($file->getPathname(), FILE_IGNORE_NEW_LINES);
+                if ($lines === false) {
+                    continue;
+                }
+
+                foreach ($lines as $lineNumber => $line) {
+                    $trimmed = ltrim($line);
+                    if (str_starts_with($trimmed, '//') || str_starts_with($trimmed, '#')) {
+                        continue;
+                    }
+
+                    foreach (self::DISALLOWED_PATTERNS as $pattern) {
+                        if (preg_match($pattern, $line) === 1) {
+                            $violations[] = sprintf(
+                                '%s:%d:%s',
+                                $relativePath,
+                                $lineNumber + 1,
+                                trim($line)
+                            );
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        sort($violations);
+
+        return $violations;
+    }
+
+    public function run(string $repositoryRoot): int
+    {
+        $violations = $this->collectViolations($repositoryRoot);
+        if ($violations === []) {
+            echo "Legacy HTTP wrapper usage check passed.\n";
+            return 0;
+        }
+
+        fwrite(STDERR, "Legacy HTTP wrapper usage detected in core/refactored paths.\n");
+        fwrite(STDERR, "Use Lotgd\\\\Http::* in core paths and keep httpget()/httppost() for legacy compatibility paths only.\n");
+        foreach ($violations as $violation) {
+            fwrite(STDERR, " - {$violation}\n");
+        }
+
+        return 1;
+    }
+
+    private function isWhitelistedPath(string $relativePath): bool
+    {
+        foreach (self::ALLOWED_ROOTS as $allowedRoot) {
+            if (str_starts_with($relativePath, $allowedRoot)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
+++ b/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
@@ -32,12 +32,8 @@ final class LegacyHttpWrapperUsageCheck
     /**
      * @var list<string>
      */
-    private const ALLOWED_ROOTS = [
-        'lib/',
-        'modules/',
-        'install/',
-        'tests/',
-        'vendor/',
+    private const ALLOWED_PATHS = [
+        // Self-exclusion so policy text/examples in this checker are not flagged.
         'src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php',
     ];
 
@@ -95,8 +91,8 @@ final class LegacyHttpWrapperUsageCheck
 
     private function isWhitelistedPath(string $relativePath): bool
     {
-        foreach (self::ALLOWED_ROOTS as $allowedRoot) {
-            if (str_starts_with($relativePath, $allowedRoot)) {
+        foreach (self::ALLOWED_PATHS as $allowedPath) {
+            if (str_starts_with($relativePath, $allowedPath)) {
                 return true;
             }
         }

--- a/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
+++ b/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php
@@ -16,9 +16,9 @@ final class LegacyHttpWrapperUsageCheck
     /**
      * @var list<string>
      */
-    private const DISALLOWED_PATTERNS = [
-        '/\bhttpget\s*\(/i',
-        '/\bhttppost\s*\(/i',
+    private const DISALLOWED_FUNCTIONS = [
+        'httpget',
+        'httppost',
     ];
 
     /**
@@ -67,29 +67,7 @@ final class LegacyHttpWrapperUsageCheck
                     continue;
                 }
 
-                $lines = file($file->getPathname(), FILE_IGNORE_NEW_LINES);
-                if ($lines === false) {
-                    continue;
-                }
-
-                foreach ($lines as $lineNumber => $line) {
-                    $trimmed = ltrim($line);
-                    if (str_starts_with($trimmed, '//') || str_starts_with($trimmed, '#')) {
-                        continue;
-                    }
-
-                    foreach (self::DISALLOWED_PATTERNS as $pattern) {
-                        if (preg_match($pattern, $line) === 1) {
-                            $violations[] = sprintf(
-                                '%s:%d:%s',
-                                $relativePath,
-                                $lineNumber + 1,
-                                trim($line)
-                            );
-                            break;
-                        }
-                    }
-                }
+                $violations = array_merge($violations, $this->collectFileViolations($file->getPathname(), $relativePath));
             }
         }
 
@@ -124,5 +102,93 @@ final class LegacyHttpWrapperUsageCheck
         }
 
         return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectFileViolations(string $absolutePath, string $relativePath): array
+    {
+        $contents = file_get_contents($absolutePath);
+        if ($contents === false) {
+            return [];
+        }
+
+        $tokens = token_get_all($contents);
+        $lines = file($absolutePath, FILE_IGNORE_NEW_LINES) ?: [];
+        $violations = [];
+
+        foreach ($tokens as $index => $token) {
+            if (!is_array($token) || $token[0] !== T_STRING) {
+                continue;
+            }
+
+            $functionName = strtolower($token[1]);
+            if (!in_array($functionName, self::DISALLOWED_FUNCTIONS, true)) {
+                continue;
+            }
+
+            if (!$this->isFunctionCallToken($tokens, $index)) {
+                continue;
+            }
+
+            $lineNumber = (int) $token[2];
+            $lineText = trim($lines[$lineNumber - 1] ?? '');
+            $violations[] = sprintf('%s:%d:%s', $relativePath, $lineNumber, $lineText);
+        }
+
+        return $violations;
+    }
+
+    /**
+     * @param list<array<int, int|string>|string> $tokens
+     */
+    private function isFunctionCallToken(array $tokens, int $index): bool
+    {
+        $previousToken = $this->findPreviousSignificantToken($tokens, $index);
+        if (is_array($previousToken) && in_array($previousToken[0], [T_FUNCTION, T_FN, T_OBJECT_OPERATOR, T_DOUBLE_COLON], true)) {
+            return false;
+        }
+        if ($previousToken === '->' || $previousToken === '::') {
+            return false;
+        }
+
+        $nextToken = $this->findNextSignificantToken($tokens, $index);
+        return $nextToken === '(';
+    }
+
+    /**
+     * @param list<array<int, int|string>|string> $tokens
+     */
+    private function findPreviousSignificantToken(array $tokens, int $index): array|string|null
+    {
+        for ($i = $index - 1; $i >= 0; $i--) {
+            $token = $tokens[$i];
+            if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            return $token;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<array<int, int|string>|string> $tokens
+     */
+    private function findNextSignificantToken(array $tokens, int $index): array|string|null
+    {
+        $count = count($tokens);
+        for ($i = $index + 1; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            return $token;
+        }
+
+        return null;
     }
 }

--- a/stables.php
+++ b/stables.php
@@ -19,6 +19,7 @@ use Lotgd\Sanitize;
 use Lotgd\DebugLog;
 use Lotgd\DateTime;
 use Lotgd\Random;
+use Lotgd\DataCache;
 use Doctrine\DBAL\ParameterType;
 
 // translator ready
@@ -121,6 +122,37 @@ if (in_array((string) $op, ['examine', 'buymount', 'confirmbuy'], true) && $id =
     $op = "";
 }
 
+/**
+ * Fetch mount data by normalized mount id with datacache fallback.
+ *
+ * Lotgd\Http request values are normalized before reaching this helper, so the
+ * cache key and bound parameter stay stable and safe.
+ *
+ * @return array<string, mixed>|false
+ */
+function stables_load_mount_by_id(int $mountId): array|false
+{
+    $cache = DataCache::getInstance();
+    $cacheKey = "mountdata-$mountId";
+    $cached = $cache->datacache($cacheKey, 3600);
+    if (is_array($cached) && array_key_exists('mountid', $cached)) {
+        return $cached;
+    }
+
+    $row = Database::getDoctrineConnection()->executeQuery(
+        "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid = :mountid",
+        ['mountid' => $mountId],
+        ['mountid' => ParameterType::INTEGER]
+    )->fetchAssociative();
+
+    if (!is_array($row)) {
+        return false;
+    }
+
+    $cache->updatedatacache($cacheKey, $row);
+    return $row;
+}
+
 
 if ($op == "") {
     DateTime::checkDay();
@@ -135,12 +167,8 @@ if ($op == "") {
     $translator->setSchema();
     HookHandler::hook("stables-desc");
 } elseif ($op == "examine") {
-    $result = Database::getDoctrineConnection()->executeQuery(
-        "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid = :mountid",
-        ['mountid' => $id],
-        ['mountid' => ParameterType::INTEGER]
-    );
-    if (Database::numRows($result) <= 0) {
+    $mount = stables_load_mount_by_id((int) $id);
+    if ($mount === false) {
         $translator->setSchema($schemas['nosuchbeast']);
         $output->output('%s', $texts['nosuchbeast']);
         $translator->setSchema();
@@ -150,7 +178,6 @@ if ($op == "") {
         $translator->setSchema($schemas['finebeast']);
         $output->output('%s', $texts['finebeast'][$t]);
         $translator->setSchema();
-        $mount = Database::fetchAssoc($result);
         $mount = HookHandler::hook("mount-modifycosts", $mount);
         $output->output("`7Creature: `&%s`0`n", $mount['mountname']);
         $output->output("`7Description: `&%s`0`n", $mount['mountdesc']);
@@ -176,17 +203,12 @@ if ($op == "") {
     }
 }
 if ($op == 'confirmbuy') {
-    $result = Database::getDoctrineConnection()->executeQuery(
-        "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid = :mountid",
-        ['mountid' => $id],
-        ['mountid' => ParameterType::INTEGER]
-    );
-    if (Database::numRows($result) <= 0) {
+    $mount = stables_load_mount_by_id((int) $id);
+    if ($mount === false) {
         $translator->setSchema($schemas['nosuchbeast']);
         $output->output('%s', $texts['nosuchbeast']);
         $translator->setSchema();
     } else {
-        $mount = Database::fetchAssoc($result);
         $mount = HookHandler::hook("mount-modifycosts", $mount);
         if (
             ($session['user']['gold'] + $repaygold) < $mount['mountcostgold'] ||

--- a/stables.php
+++ b/stables.php
@@ -19,6 +19,7 @@ use Lotgd\Sanitize;
 use Lotgd\DebugLog;
 use Lotgd\DateTime;
 use Lotgd\Random;
+use Doctrine\DBAL\ParameterType;
 
 // translator ready
 // addnews ready
@@ -110,7 +111,15 @@ if ($playerMount) {
 $confirm = 0;
 
 $op = Http::get('op');
-$id = Http::get('id');
+/**
+ * Lotgd\Http returns raw request payloads; mount ids must be normalized
+ * before SQL and cache-key usage.
+ */
+$idRequest = Http::get('id');
+$id = is_string($idRequest) && ctype_digit($idRequest) && (int) $idRequest > 0 ? (int) $idRequest : null;
+if (in_array((string) $op, ['examine', 'buymount', 'confirmbuy'], true) && $id === null) {
+    $op = "";
+}
 
 
 if ($op == "") {
@@ -126,8 +135,11 @@ if ($op == "") {
     $translator->setSchema();
     HookHandler::hook("stables-desc");
 } elseif ($op == "examine") {
-    $sql = "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid='$id'";
-    $result = Database::queryCached($sql, "mountdata-$id", 3600);
+    $result = Database::getDoctrineConnection()->executeQuery(
+        "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid = :mountid",
+        ['mountid' => $id],
+        ['mountid' => ParameterType::INTEGER]
+    );
     if (Database::numRows($result) <= 0) {
         $translator->setSchema($schemas['nosuchbeast']);
         $output->output('%s', $texts['nosuchbeast']);
@@ -164,8 +176,11 @@ if ($op == "") {
     }
 }
 if ($op == 'confirmbuy') {
-    $sql = "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid='$id'";
-    $result = Database::queryCached($sql, "mountdata-$id", 3600);
+    $result = Database::getDoctrineConnection()->executeQuery(
+        "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid = :mountid",
+        ['mountid' => $id],
+        ['mountid' => ParameterType::INTEGER]
+    );
     if (Database::numRows($result) <= 0) {
         $translator->setSchema($schemas['nosuchbeast']);
         $output->output('%s', $texts['nosuchbeast']);

--- a/superuser.php
+++ b/superuser.php
@@ -14,6 +14,7 @@ use Lotgd\Page\Footer;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Sanitize;
+use Doctrine\DBAL\ParameterType;
 
 // translator ready
 // addnews ready
@@ -38,8 +39,14 @@ if ($op == "keepalive") {
     echo '<html><meta http-equiv="Refresh" content="30;url=' . PhpGenericEnvironment::getRequestUri() . '"></html><body>' . date("Y-m-d H:i:s") . "</body></html>";
     exit();
 } elseif ($op == "newsdelete") {
-    $sql = "DELETE FROM " . Database::prefix("news") . " WHERE newsid='" . Http::get('newsid') . "'";
-    Database::query($sql);
+    $newsIdRequest = Http::get('newsid');
+    // Preserve legacy behavior by treating request payload as a string while binding it safely.
+    $newsId = is_string($newsIdRequest) ? $newsIdRequest : (string) $newsIdRequest;
+    Database::getDoctrineConnection()->executeStatement(
+        "DELETE FROM " . Database::prefix("news") . " WHERE newsid = :newsid",
+        ['newsid' => $newsId],
+        ['newsid' => ParameterType::STRING]
+    );
     $return = Http::get('return');
     $return = Sanitize::cmdSanitize($return);
     $return = basename($return);

--- a/taunt.php
+++ b/taunt.php
@@ -32,16 +32,18 @@ SuAccess::check(SU_EDIT_CREATURES);
 Header::pageHeader("Taunt Editor");
 SuperuserNav::render();
 $op = Http::get('op');
-$tauntid = Http::get('tauntid');
+$tauntidRequest = Http::get('tauntid');
+$tauntid = taunt_normalize_optional_int($tauntidRequest);
+$tauntidParam = $tauntid === null ? '' : (string) $tauntid;
 if ($op == "edit") {
     Nav::add("Taunts");
     Nav::add("Return to the taunt editor", "taunt.php");
-    $output->rawOutput("<form action='taunt.php?op=save&tauntid=$tauntid' method='POST'>", true);
-    Nav::add("", "taunt.php?op=save&tauntid=$tauntid");
-    if ($tauntid != "") {
+    $output->rawOutput("<form action='taunt.php?op=save&tauntid=" . rawurlencode($tauntidParam) . "' method='POST'>", true);
+    Nav::add("", "taunt.php?op=save&tauntid=" . rawurlencode($tauntidParam));
+    if ($tauntid !== null) {
         $result = $connection->executeQuery(
             "SELECT * FROM " . Database::prefix("taunts") . " WHERE tauntid = :tauntid",
-            ['tauntid' => (int) $tauntid],
+            ['tauntid' => $tauntid],
             ['tauntid' => ParameterType::INTEGER]
         );
         $row = Database::fetchAssoc($result);
@@ -71,22 +73,27 @@ if ($op == "edit") {
     $output->rawOutput("<input type='submit' class='button' value='$save'>");
     $output->rawOutput("</form>");
 } elseif ($op == "del") {
-    $connection->executeStatement(
-        "DELETE FROM " . Database::prefix("taunts") . " WHERE tauntid = :tauntid",
-        ['tauntid' => (int) $tauntid],
-        ['tauntid' => ParameterType::INTEGER]
-    );
-    $op = "";
-    Http::set("op", "");
+    if ($tauntid === null) {
+        $op = "";
+        Http::set("op", "");
+    } else {
+        $connection->executeStatement(
+            "DELETE FROM " . Database::prefix("taunts") . " WHERE tauntid = :tauntid",
+            ['tauntid' => $tauntid],
+            ['tauntid' => ParameterType::INTEGER]
+        );
+        $op = "";
+        Http::set("op", "");
+    }
 } elseif ($op == "save") {
-    $taunt = Http::post('taunt');
-    if ($tauntid != "") {
+    $taunt = taunt_normalize_text(Http::post('taunt'));
+    if ($tauntid !== null) {
         $connection->executeStatement(
             "UPDATE " . Database::prefix("taunts") . " SET taunt = :taunt, editor = :editor WHERE tauntid = :tauntid",
             [
                 'taunt' => $taunt,
                 'editor' => (string) $session['user']['login'],
-                'tauntid' => (int) $tauntid,
+                'tauntid' => $tauntid,
             ],
             [
                 'taunt' => ParameterType::STRING,
@@ -140,5 +147,38 @@ if ($op == "") {
     $output->rawOutput("</table>");
     Nav::add("Taunts");
     Nav::add("Add a new taunt", "taunt.php?op=edit");
+}
+
+/**
+ * Normalise request values expected to be optional integer identifiers.
+ */
+function taunt_normalize_optional_int(mixed $value): ?int
+{
+    if ($value === '' || $value === null || is_array($value)) {
+        return null;
+    }
+
+    if (! is_scalar($value)) {
+        return null;
+    }
+
+    return (int) $value;
+}
+
+/**
+ * Normalise request values to a safe string payload for DBAL string binding.
+ */
+function taunt_normalize_text(mixed $value): string
+{
+    // Preserve legacy coercion behavior while rejecting array/object payloads.
+    if ($value === false || $value === null || is_array($value)) {
+        return '';
+    }
+
+    if (is_string($value)) {
+        return $value;
+    }
+
+    return is_scalar($value) ? (string) $value : '';
 }
 Footer::pageFooter();

--- a/taunt.php
+++ b/taunt.php
@@ -162,7 +162,24 @@ function taunt_normalize_optional_int(mixed $value): ?int
         return null;
     }
 
-    return (int) $value;
+    // Accept only unsigned integer identifiers (> 0, digits only).
+    if (is_int($value)) {
+        return $value > 0 ? $value : null;
+    }
+
+    if (is_string($value)) {
+        // Reject non-digit strings (e.g. "17foo", "-5", "abc").
+        if (! ctype_digit($value)) {
+            return null;
+        }
+
+        $intValue = (int) $value;
+
+        return $intValue > 0 ? $intValue : null;
+    }
+
+    // Reject other scalar types such as bool and float.
+    return null;
 }
 
 /**

--- a/taunt.php
+++ b/taunt.php
@@ -12,6 +12,7 @@ use Lotgd\Nav;
 use Lotgd\MySQL\Database;
 use Lotgd\Settings;
 use Lotgd\Translator;
+use Doctrine\DBAL\ParameterType;
 
 // addnews ready
 // mail ready
@@ -22,6 +23,7 @@ require_once __DIR__ . "/common.php";
 
 $settings = Settings::getInstance();
 $output = Output::getInstance();
+$connection = Database::getDoctrineConnection();
 
 Translator::getInstance()->setSchema("taunt");
 
@@ -37,8 +39,11 @@ if ($op == "edit") {
     $output->rawOutput("<form action='taunt.php?op=save&tauntid=$tauntid' method='POST'>", true);
     Nav::add("", "taunt.php?op=save&tauntid=$tauntid");
     if ($tauntid != "") {
-        $sql = "SELECT * FROM " . Database::prefix("taunts") . " WHERE tauntid=\"$tauntid\"";
-        $result = Database::query($sql);
+        $result = $connection->executeQuery(
+            "SELECT * FROM " . Database::prefix("taunts") . " WHERE tauntid = :tauntid",
+            ['tauntid' => (int) $tauntid],
+            ['tauntid' => ParameterType::INTEGER]
+        );
         $row = Database::fetchAssoc($result);
         $badguy = array(
             'creaturename' => 'Baron Munchausen',
@@ -66,18 +71,42 @@ if ($op == "edit") {
     $output->rawOutput("<input type='submit' class='button' value='$save'>");
     $output->rawOutput("</form>");
 } elseif ($op == "del") {
-    $sql = "DELETE FROM " . Database::prefix("taunts") . " WHERE tauntid=\"$tauntid\"";
-    Database::query($sql);
+    $connection->executeStatement(
+        "DELETE FROM " . Database::prefix("taunts") . " WHERE tauntid = :tauntid",
+        ['tauntid' => (int) $tauntid],
+        ['tauntid' => ParameterType::INTEGER]
+    );
     $op = "";
     Http::set("op", "");
 } elseif ($op == "save") {
     $taunt = Http::post('taunt');
     if ($tauntid != "") {
-        $sql = "UPDATE " . Database::prefix("taunts") . " SET taunt=\"$taunt\",editor=\"" . addslashes($session['user']['login']) . "\" WHERE tauntid=\"$tauntid\"";
+        $connection->executeStatement(
+            "UPDATE " . Database::prefix("taunts") . " SET taunt = :taunt, editor = :editor WHERE tauntid = :tauntid",
+            [
+                'taunt' => $taunt,
+                'editor' => (string) $session['user']['login'],
+                'tauntid' => (int) $tauntid,
+            ],
+            [
+                'taunt' => ParameterType::STRING,
+                'editor' => ParameterType::STRING,
+                'tauntid' => ParameterType::INTEGER,
+            ]
+        );
     } else {
-        $sql = "INSERT INTO " . Database::prefix("taunts") . " (taunt,editor) VALUES (\"$taunt\",\"" . addslashes($session['user']['login']) . "\")";
+        $connection->executeStatement(
+            "INSERT INTO " . Database::prefix("taunts") . " (taunt, editor) VALUES (:taunt, :editor)",
+            [
+                'taunt' => $taunt,
+                'editor' => (string) $session['user']['login'],
+            ],
+            [
+                'taunt' => ParameterType::STRING,
+                'editor' => ParameterType::STRING,
+            ]
+        );
     }
-    Database::query($sql);
     $op = "";
     Http::set("op", "");
 }

--- a/taunt.php
+++ b/taunt.php
@@ -35,6 +35,7 @@ $op = Http::get('op');
 $tauntidRequest = Http::get('tauntid');
 $tauntid = taunt_normalize_optional_int($tauntidRequest);
 $tauntidParam = $tauntid === null ? '' : (string) $tauntid;
+$commentaryPage = taunt_normalize_optional_int(Http::get('c'));
 if ($op == "edit") {
     Nav::add("Taunts");
     Nav::add("Return to the taunt editor", "taunt.php");
@@ -133,7 +134,7 @@ if ($op == "") {
         $edit = Translator::translateInline("Edit");
         $del = Translator::translateInline("Del");
         $conf = Translator::translateInline("Are you sure you wish to delete this taunt?");
-        $id = $row['tauntid'];
+        $id = (int) $row['tauntid'];
         $output->rawOutput("[ <a href='taunt.php?op=edit&tauntid=$id'>$edit</a> | <a href='taunt.php?op=del&tauntid=$id' onClick='return confirm(\"$conf\");'>$del</a> ]");
         Nav::add("", "taunt.php?op=edit&tauntid=$id");
         Nav::add("", "taunt.php?op=del&tauntid=$id");
@@ -143,7 +144,8 @@ if ($op == "") {
         $output->outputNotl("%s", $row['editor']);
         $output->rawOutput("</td></tr>");
     }
-    Nav::add("", "taunt.php?c=" . Http::get('c'));
+    $commentaryPageParam = $commentaryPage === null ? '' : (string) (int) $commentaryPage;
+    Nav::add("", "taunt.php?c=$commentaryPageParam");
     $output->rawOutput("</table>");
     Nav::add("Taunts");
     Nav::add("Add a new taunt", "taunt.php?op=edit");
@@ -151,6 +153,9 @@ if ($op == "") {
 
 /**
  * Normalise request values expected to be optional integer identifiers.
+ *
+ * Lotgd\Http now exposes raw request payloads, so we must explicitly narrow
+ * values such as c/tauntid before building navigation URLs.
  */
 function taunt_normalize_optional_int(mixed $value): ?int
 {

--- a/tests/Legacy/HighRiskSqlMigrationTest.php
+++ b/tests/Legacy/HighRiskSqlMigrationTest.php
@@ -44,7 +44,7 @@ final class HighRiskSqlMigrationTest extends TestCase
         self::assertStringContainsString('WHERE language = :language GROUP BY uri ORDER BY uri ASC', $content);
         self::assertStringContainsString('WHERE language = :language AND uri = :uri', $content);
         self::assertStringContainsString("'language' => ParameterType::STRING", $content);
-        self::assertStringContainsString("'uri' => ParameterType::STRING", $content);
+        self::assertStringContainsString("'uri'      => ParameterType::STRING", $content);
         self::assertStringNotContainsString('. LANGUAGE .', $content);
     }
 

--- a/tests/Legacy/HighRiskSqlMigrationTest.php
+++ b/tests/Legacy/HighRiskSqlMigrationTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Legacy;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\MySQL\Database;
+use Lotgd\Tests\Stubs\DoctrineConnection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression checks for legacy request-driven SQL hardening.
+ */
+final class HighRiskSqlMigrationTest extends TestCase
+{
+    private DoctrineConnection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \Lotgd\Tests\Stubs\Database::setPrefix('');
+        Database::resetDoctrineConnection();
+        $this->connection = Database::getDoctrineConnection();
+        $this->connection->executeStatements = [];
+        $this->connection->lastFetchAllParams = [];
+        $this->connection->lastFetchAllTypes = [];
+    }
+
+    public function testSuperuserNewsDeleteSqlIsParameterizedInSource(): void
+    {
+        $content = (string) file_get_contents(dirname(__DIR__, 2) . '/superuser.php');
+
+        self::assertStringContainsString('WHERE newsid = :newsid', $content);
+        self::assertStringContainsString("['newsid' => ParameterType::STRING]", $content);
+        self::assertStringNotContainsString("WHERE newsid='" . "' . Http::get('newsid')", $content);
+    }
+
+    public function testTranslatortoolListQueriesUseTypedBoundLanguageAndUriInSource(): void
+    {
+        $content = (string) file_get_contents(dirname(__DIR__, 2) . '/translatortool.php');
+
+        self::assertStringContainsString('WHERE language = :language GROUP BY uri ORDER BY uri ASC', $content);
+        self::assertStringContainsString('WHERE language = :language AND uri = :uri', $content);
+        self::assertStringContainsString("'language' => ParameterType::STRING", $content);
+        self::assertStringContainsString("'uri'      => ParameterType::STRING", $content);
+        self::assertStringNotContainsString("WHERE language='" . LANGUAGE . "'", $content);
+    }
+
+    public function testQuoteContainingPayloadsRemainBoundParameters(): void
+    {
+        $newsPayload = "7' OR '1'='1";
+        $uriPayload = "quest's/intro\"line";
+
+        $this->connection->executeStatement(
+            'DELETE FROM news WHERE newsid = :newsid',
+            ['newsid' => $newsPayload],
+            ['newsid' => ParameterType::STRING]
+        );
+
+        $delete = $this->connection->executeStatements[0] ?? null;
+        self::assertNotNull($delete);
+        self::assertSame(['newsid' => $newsPayload], $delete['params']);
+        self::assertStringNotContainsString($newsPayload, $delete['sql']);
+
+        $this->connection->fetchAllAssociative(
+            'SELECT * FROM translations WHERE language = :language AND uri = :uri',
+            [
+                'language' => 'en',
+                'uri'      => $uriPayload,
+            ],
+            [
+                'language' => ParameterType::STRING,
+                'uri'      => ParameterType::STRING,
+            ]
+        );
+
+        self::assertSame(['language' => 'en', 'uri' => $uriPayload], $this->connection->lastFetchAllParams);
+        self::assertSame(
+            ['language' => ParameterType::STRING, 'uri' => ParameterType::STRING],
+            $this->connection->lastFetchAllTypes
+        );
+    }
+}

--- a/tests/Legacy/HighRiskSqlMigrationTest.php
+++ b/tests/Legacy/HighRiskSqlMigrationTest.php
@@ -44,8 +44,8 @@ final class HighRiskSqlMigrationTest extends TestCase
         self::assertStringContainsString('WHERE language = :language GROUP BY uri ORDER BY uri ASC', $content);
         self::assertStringContainsString('WHERE language = :language AND uri = :uri', $content);
         self::assertStringContainsString("'language' => ParameterType::STRING", $content);
-        self::assertStringContainsString("'uri'      => ParameterType::STRING", $content);
-        self::assertStringNotContainsString("WHERE language='" . LANGUAGE . "'", $content);
+        self::assertStringContainsString("'uri' => ParameterType::STRING", $content);
+        self::assertStringNotContainsString('. LANGUAGE .', $content);
     }
 
     public function testQuoteContainingPayloadsRemainBoundParameters(): void

--- a/tests/LegacyHttpWrapperCompatibilityTest.php
+++ b/tests/LegacyHttpWrapperCompatibilityTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+final class LegacyHttpWrapperCompatibilityTest extends TestCase
+{
+    public function testLegacyWrappersEscapeButLotgdHttpReturnsRawValues(): void
+    {
+        $payload = $this->runIsolatedPhp(<<<'PHP'
+$_GET['id'] = "ab'c";
+$_POST['title'] = 'x"y';
+echo json_encode([
+    'legacy_get' => httpget('id'),
+    'legacy_post' => httppost('title'),
+    'raw_get' => \Lotgd\Http::get('id'),
+    'raw_post' => \Lotgd\Http::post('title'),
+], JSON_THROW_ON_ERROR);
+PHP);
+
+        $this->assertSame("ab\\'c", $payload['legacy_get'] ?? null);
+        $this->assertSame('x\\"y', $payload['legacy_post'] ?? null);
+        $this->assertSame("ab'c", $payload['raw_get'] ?? null);
+        $this->assertSame('x"y', $payload['raw_post'] ?? null);
+    }
+
+    public function testLegacyPostParseEscapesOnlyLegacyWrapperOutput(): void
+    {
+        $payload = $this->runIsolatedPhp(<<<'PHP'
+$_POST = ['title' => "O'Reilly"];
+[, , $rawParameters] = \Lotgd\Http::postParse();
+[, , $legacyParameters] = postparse();
+echo json_encode([
+    'raw' => $rawParameters,
+    'legacy' => $legacyParameters,
+], JSON_THROW_ON_ERROR);
+PHP);
+
+        $this->assertSame(["O'Reilly"], $payload['raw'] ?? null);
+        $this->assertSame(["O\\'Reilly"], $payload['legacy'] ?? null);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function runIsolatedPhp(string $snippet): array
+    {
+        $root = dirname(__DIR__);
+        $bootstrap = sprintf(
+            "require %s;\nrequire %s;\n",
+            var_export($root . '/autoload.php', true),
+            var_export($root . '/lib/http.php', true)
+        );
+
+        $code = $bootstrap . "\n" . $snippet;
+        $command = sprintf('%s -r %s', escapeshellarg(PHP_BINARY), escapeshellarg($code));
+        $output = shell_exec($command);
+
+        $this->assertNotFalse($output, 'Isolated php process did not produce output.');
+
+        /** @var array<string,mixed> $decoded */
+        $decoded = json_decode((string) $output, true, 512, JSON_THROW_ON_ERROR);
+        return $decoded;
+    }
+}

--- a/tests/LegacyHttpWrapperCompatibilityTest.php
+++ b/tests/LegacyHttpWrapperCompatibilityTest.php
@@ -59,7 +59,8 @@ PHP);
         $command = sprintf('%s -r %s', escapeshellarg(PHP_BINARY), escapeshellarg($code));
         $output = shell_exec($command);
 
-        $this->assertNotFalse($output, 'Isolated php process did not produce output.');
+        $this->assertNotNull($output, 'Isolated php process did not produce output.');
+        $this->assertIsString($output);
 
         /** @var array<string,mixed> $decoded */
         $decoded = json_decode((string) $output, true, 512, JSON_THROW_ON_ERROR);

--- a/tests/Petition/PetitionSubmitTest.php
+++ b/tests/Petition/PetitionSubmitTest.php
@@ -61,6 +61,8 @@ namespace Lotgd\Tests\Petition {
     use Lotgd\Tests\Stubs\DoctrineConnection;
     use PHPUnit\Framework\TestCase;
 
+    #[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+    #[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
     final class PetitionSubmitTest extends TestCase
     {
         private DoctrineConnection $connection;
@@ -198,6 +200,65 @@ namespace Lotgd\Tests\Petition {
             self::assertSame(ParameterType::STRING, $insertTypes['pageinfo'] ?? null);
             self::assertSame(ParameterType::STRING, $insertTypes['ip'] ?? null);
             self::assertSame(ParameterType::STRING, $insertTypes['cookie'] ?? null);
+        }
+
+        public function testAbusePlayerHiddenFieldIsNormalizedAndEscaped(): void
+        {
+            global $session, $settings, $output;
+
+            $session = [
+                'user' => [
+                    'acctid'       => 42,
+                    'password'     => 'hunter2',
+                    'superuser'    => 0,
+                    'name'         => 'TestUser',
+                    'emailaddress' => 'tester@example.com',
+                    'loggedin'     => true,
+                ],
+            ];
+            $settings = Settings::getInstance();
+            $GLOBALS['settings'] = $settings;
+
+            $output = new class {
+                public array $buffer = [];
+
+                public function output(string $format, mixed ...$args): void
+                {
+                    $this->buffer[] = vsprintf($format, $args);
+                }
+
+                public function outputNotl(string $format, mixed ...$args): void
+                {
+                    $this->buffer[] = vsprintf($format, $args);
+                }
+
+                public function rawOutput(string $text): void
+                {
+                    $this->buffer[] = $text;
+                }
+            };
+
+            $_GET = [];
+            $_POST = [
+                'problem' => 'Mail abuse report',
+                'abuse' => 'yes',
+                'abuseplayer' => "17\"><script>alert(1)</script>",
+            ];
+            $_COOKIE = [];
+            $_SERVER = [];
+
+            $include = static function (): void {
+                global $session, $settings, $output, $_POST, $_SERVER, $_COOKIE;
+
+                require __DIR__ . '/../../pages/petition/petition_default.php';
+            };
+            \Closure::bind($include, null, null)();
+
+            $rendered = implode("\n", $output->buffer);
+            self::assertStringContainsString('name=\'abuseplayer\' value="', $rendered);
+            self::assertStringContainsString('name=\'abuseplayer\' value=""', $rendered);
+            self::assertStringNotContainsString('<script>', $rendered);
+            self::assertStringNotContainsString('abuseplayer\' value="17', $rendered);
         }
     }
 }

--- a/tests/QA/LegacyHttpWrapperUsageCheckTest.php
+++ b/tests/QA/LegacyHttpWrapperUsageCheckTest.php
@@ -24,8 +24,8 @@ final class LegacyHttpWrapperUsageCheckTest extends TestCase
     public function testCheckerAllowsLegacyHttpWrappersInWhitelistedLegacyPaths(): void
     {
         $root = $this->createFixtureRoot();
-        file_put_contents($root . '/modules/example.php', "<?php\n\$a = httpget('foo');\n");
-        file_put_contents($root . '/lib/example.php', "<?php\n\$a = httppost('bar');\n");
+        mkdir($root . '/src/Lotgd/QA', 0777, true);
+        file_put_contents($root . '/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php', "<?php\n\$a = httpget('foo');\n");
 
         $checker = new LegacyHttpWrapperUsageCheck();
         $violations = $checker->collectViolations($root);
@@ -58,8 +58,6 @@ PHP
         $root = sys_get_temp_dir() . '/lotgd-http-check-' . uniqid('', true);
         mkdir($root . '/pages', 0777, true);
         mkdir($root . '/src', 0777, true);
-        mkdir($root . '/lib', 0777, true);
-        mkdir($root . '/modules', 0777, true);
 
         return $root;
     }

--- a/tests/QA/LegacyHttpWrapperUsageCheckTest.php
+++ b/tests/QA/LegacyHttpWrapperUsageCheckTest.php
@@ -33,6 +33,26 @@ final class LegacyHttpWrapperUsageCheckTest extends TestCase
         $this->assertSame([], $violations);
     }
 
+    public function testCheckerIgnoresMentionsInsideCommentsAndStrings(): void
+    {
+        $root = $this->createFixtureRoot();
+        file_put_contents(
+            $root . '/pages/docs-example.php',
+            <<<'PHP'
+<?php
+/**
+ * Example docs mentioning httpget('foo') for migration notes.
+ */
+$message = "Use httppost('bar') in legacy wrappers only.";
+PHP
+        );
+
+        $checker = new LegacyHttpWrapperUsageCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertSame([], $violations);
+    }
+
     private function createFixtureRoot(): string
     {
         $root = sys_get_temp_dir() . '/lotgd-http-check-' . uniqid('', true);
@@ -44,4 +64,3 @@ final class LegacyHttpWrapperUsageCheckTest extends TestCase
         return $root;
     }
 }
-

--- a/tests/QA/LegacyHttpWrapperUsageCheckTest.php
+++ b/tests/QA/LegacyHttpWrapperUsageCheckTest.php
@@ -9,6 +9,19 @@ use PHPUnit\Framework\TestCase;
 
 final class LegacyHttpWrapperUsageCheckTest extends TestCase
 {
+    /**
+     * @var list<string>
+     */
+    private array $fixtureRoots = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->fixtureRoots as $root) {
+            $this->removeDirectoryRecursively($root);
+        }
+        $this->fixtureRoots = [];
+    }
+
     public function testCheckerFlagsLegacyHttpWrappersInCorePaths(): void
     {
         $root = $this->createFixtureRoot();
@@ -58,7 +71,36 @@ PHP
         $root = sys_get_temp_dir() . '/lotgd-http-check-' . uniqid('', true);
         mkdir($root . '/pages', 0777, true);
         mkdir($root . '/src', 0777, true);
+        $this->fixtureRoots[] = $root;
 
         return $root;
+    }
+
+    private function removeDirectoryRecursively(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $items = scandir($path);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $current = $path . DIRECTORY_SEPARATOR . $item;
+            if (is_dir($current)) {
+                $this->removeDirectoryRecursively($current);
+                continue;
+            }
+
+            @unlink($current);
+        }
+
+        @rmdir($path);
     }
 }

--- a/tests/QA/LegacyHttpWrapperUsageCheckTest.php
+++ b/tests/QA/LegacyHttpWrapperUsageCheckTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\QA;
+
+use Lotgd\QA\LegacyHttpWrapperUsageCheck;
+use PHPUnit\Framework\TestCase;
+
+final class LegacyHttpWrapperUsageCheckTest extends TestCase
+{
+    public function testCheckerFlagsLegacyHttpWrappersInCorePaths(): void
+    {
+        $root = $this->createFixtureRoot();
+        file_put_contents($root . '/pages/example.php', "<?php\n\$a = httpget('foo');\n\$b = \\Lotgd\\Http::get('bar');\n");
+
+        $checker = new LegacyHttpWrapperUsageCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertNotEmpty($violations);
+        $this->assertStringContainsString('pages/example.php:2:', $violations[0]);
+    }
+
+    public function testCheckerAllowsLegacyHttpWrappersInWhitelistedLegacyPaths(): void
+    {
+        $root = $this->createFixtureRoot();
+        file_put_contents($root . '/modules/example.php', "<?php\n\$a = httpget('foo');\n");
+        file_put_contents($root . '/lib/example.php', "<?php\n\$a = httppost('bar');\n");
+
+        $checker = new LegacyHttpWrapperUsageCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertSame([], $violations);
+    }
+
+    private function createFixtureRoot(): string
+    {
+        $root = sys_get_temp_dir() . '/lotgd-http-check-' . uniqid('', true);
+        mkdir($root . '/pages', 0777, true);
+        mkdir($root . '/src', 0777, true);
+        mkdir($root . '/lib', 0777, true);
+        mkdir($root . '/modules', 0777, true);
+
+        return $root;
+    }
+}
+

--- a/tests/QA/LegacyHttpWrapperUsageCheckTest.php
+++ b/tests/QA/LegacyHttpWrapperUsageCheckTest.php
@@ -46,6 +46,19 @@ final class LegacyHttpWrapperUsageCheckTest extends TestCase
         $this->assertSame([], $violations);
     }
 
+    public function testCheckerDoesNotWhitelistPrefixMatchedFilenames(): void
+    {
+        $root = $this->createFixtureRoot();
+        mkdir($root . '/src/Lotgd/QA', 0777, true);
+        file_put_contents($root . '/src/Lotgd/QA/LegacyHttpWrapperUsageCheck.php.bypass.php', "<?php\n\$a = httpget('foo');\n");
+
+        $checker = new LegacyHttpWrapperUsageCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('LegacyHttpWrapperUsageCheck.php.bypass.php', $violations[0]);
+    }
+
     public function testCheckerIgnoresMentionsInsideCommentsAndStrings(): void
     {
         $root = $this->createFixtureRoot();

--- a/tests/Security/DeathmessagesParameterBindingRegressionTest.php
+++ b/tests/Security/DeathmessagesParameterBindingRegressionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Security;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\MySQL\Database;
+use Lotgd\Tests\Stubs\DoctrineBootstrap;
+use Lotgd\Tests\Stubs\DoctrineConnection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security regression coverage for deathmessage parameter binding.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+final class DeathmessagesParameterBindingRegressionTest extends TestCase
+{
+    private DoctrineConnection $connection;
+
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
+
+        DoctrineBootstrap::$conn = null;
+        Database::resetDoctrineConnection();
+        // Avoid leaking prefix changes into unrelated suites.
+        Database::setPrefix('');
+
+        $this->connection = Database::getDoctrineConnection();
+        $this->connection->executeStatements = [];
+    }
+
+    protected function tearDown(): void
+    {
+        DoctrineBootstrap::$conn = null;
+        Database::resetDoctrineConnection();
+        Database::setPrefix('');
+        parent::tearDown();
+    }
+
+    public function testSourceUsesPreparedStatementsWithExplicitTypes(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/deathmessages.php');
+
+        self::assertStringContainsString('executeStatement(', $source);
+        self::assertStringContainsString('executeQuery(', $source);
+        self::assertStringContainsString('WHERE deathmessageid = :deathmessageid', $source);
+        self::assertStringContainsString('deathmessageid = :deathmessageid', $source);
+        self::assertStringContainsString('deathmessage = :deathmessage', $source);
+        self::assertStringContainsString('ParameterType::INTEGER', $source);
+        self::assertStringContainsString('ParameterType::STRING', $source);
+        self::assertStringNotContainsString('addslashes($session[\'user\'][\'login\'])', $source);
+    }
+
+    public function testPayloadRoundtripIsPreservedInBoundParameters(): void
+    {
+        $payload = "Death '\" \\\\ Ω漢字";
+
+        $this->connection->executeStatement(
+            'UPDATE ' . Database::prefix('deathmessages') . ' SET deathmessage = :deathmessage, taunt = :taunt, forest = :forest, graveyard = :graveyard, editor = :editor WHERE deathmessageid = :deathmessageid',
+            [
+                'deathmessage' => $payload,
+                'taunt' => 1,
+                'forest' => 0,
+                'graveyard' => 1,
+                'editor' => "Admin '\" \\\\ Ω",
+                'deathmessageid' => 17,
+            ],
+            [
+                'deathmessage' => ParameterType::STRING,
+                'taunt' => ParameterType::INTEGER,
+                'forest' => ParameterType::INTEGER,
+                'graveyard' => ParameterType::INTEGER,
+                'editor' => ParameterType::STRING,
+                'deathmessageid' => ParameterType::INTEGER,
+            ]
+        );
+
+        $statement = $this->connection->executeStatements[0] ?? null;
+        self::assertNotNull($statement);
+        self::assertStringNotContainsString($payload, $statement['sql']);
+        self::assertSame($payload, $statement['params']['deathmessage']);
+        self::assertSame(ParameterType::STRING, $statement['types']['deathmessage']);
+        self::assertSame(ParameterType::INTEGER, $statement['types']['deathmessageid']);
+    }
+}

--- a/tests/Security/DeathmessagesParameterBindingRegressionTest.php
+++ b/tests/Security/DeathmessagesParameterBindingRegressionTest.php
@@ -50,6 +50,8 @@ final class DeathmessagesParameterBindingRegressionTest extends TestCase
         self::assertStringContainsString('executeStatement(', $source);
         self::assertStringContainsString('executeQuery(', $source);
         self::assertStringContainsString('WHERE deathmessageid = :deathmessageid', $source);
+        self::assertStringContainsString('deathmessages_normalize_text(Http::post(\'deathmessage\'))', $source);
+        self::assertStringContainsString('rawurlencode($deathmessageidParam)', $source);
         self::assertStringContainsString('deathmessageid = :deathmessageid', $source);
         self::assertStringContainsString('deathmessage = :deathmessage', $source);
         self::assertStringContainsString('ParameterType::INTEGER', $source);

--- a/tests/Security/DeathmessagesParameterBindingRegressionTest.php
+++ b/tests/Security/DeathmessagesParameterBindingRegressionTest.php
@@ -52,11 +52,16 @@ final class DeathmessagesParameterBindingRegressionTest extends TestCase
         self::assertStringContainsString('WHERE deathmessageid = :deathmessageid', $source);
         self::assertStringContainsString('deathmessages_normalize_text(Http::post(\'deathmessage\'))', $source);
         self::assertStringContainsString('rawurlencode($deathmessageidParam)', $source);
+        self::assertStringContainsString('deathmessages_normalize_optional_int(Http::get(\'c\'))', $source);
+        self::assertStringContainsString('Nav::add("", "deathmessages.php?c=$commentaryPageParam");', $source);
+        self::assertStringNotContainsString('Nav::add("", "deathmessages.php?c=" . Http::get(\'c\'));', $source);
         self::assertStringContainsString('deathmessageid = :deathmessageid', $source);
         self::assertStringContainsString('deathmessage = :deathmessage', $source);
         self::assertStringContainsString('ParameterType::INTEGER', $source);
         self::assertStringContainsString('ParameterType::STRING', $source);
         self::assertStringNotContainsString('addslashes($session[\'user\'][\'login\'])', $source);
+        self::assertStringContainsString('ctype_digit($valueString)', $source);
+        self::assertStringContainsString('$intValue <= 0', $source);
     }
 
     public function testPayloadRoundtripIsPreservedInBoundParameters(): void

--- a/tests/Security/RequestNormalizationRegressionTest.php
+++ b/tests/Security/RequestNormalizationRegressionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+
+final class RequestNormalizationRegressionTest extends TestCase
+{
+    public function testViewpetitionUsesTypedBindingsForRequestDrivenPetitionIdQueries(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../viewpetition.php');
+        self::assertIsString($source);
+        self::assertStringContainsString('WHERE petitionid = :petitionid', $source);
+        self::assertStringContainsString("'petitionid' => ParameterType::INTEGER", $source);
+        self::assertStringNotContainsString("petitionid='$id'", $source);
+    }
+
+    public function testStablesUsesPreparedStatementForMountLookup(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../stables.php');
+        self::assertIsString($source);
+        self::assertStringContainsString('WHERE mountid = :mountid', $source);
+        self::assertStringContainsString("'mountid' => ParameterType::INTEGER", $source);
+        self::assertStringNotContainsString("mountid='$id'", $source);
+    }
+
+    public function testNavCompositionUsesNormalizedOrEncodedQueryComponents(): void
+    {
+        $healer = file_get_contents(__DIR__ . '/../../healer.php');
+        $user = file_get_contents(__DIR__ . '/../../user.php');
+        $userEdit = file_get_contents(__DIR__ . '/../../pages/user/user_edit.php');
+        $hof = file_get_contents(__DIR__ . '/../../hof.php');
+        $modules = file_get_contents(__DIR__ . '/../../modules.php');
+
+        self::assertIsString($healer);
+        self::assertIsString($user);
+        self::assertIsString($userEdit);
+        self::assertIsString($hof);
+        self::assertIsString($modules);
+
+        self::assertStringContainsString("rawurlencode(\$return)", $healer);
+        self::assertStringContainsString('modulename_sanitize($moduleRequest)', $user);
+        self::assertStringContainsString("rawurlencode(\$moduleSlug)", $user);
+        self::assertStringContainsString("ctype_digit(\$petitionRequest)", $userEdit);
+        self::assertStringContainsString("\$allowedOps = ['kills', 'money', 'gems', 'charm', 'tough', 'resurrects', 'days'];", $hof);
+        self::assertStringContainsString("array_key_exists(\$catRequest, \$seencats)", $modules);
+        self::assertStringContainsString("rawurlencode(\$cat)", $modules);
+    }
+}

--- a/tests/Security/RequestNormalizationRegressionTest.php
+++ b/tests/Security/RequestNormalizationRegressionTest.php
@@ -12,18 +12,19 @@ final class RequestNormalizationRegressionTest extends TestCase
     {
         $source = file_get_contents(__DIR__ . '/../../viewpetition.php');
         self::assertIsString($source);
-        self::assertStringContainsString('WHERE petitionid = :petitionid', $source);
-        self::assertStringContainsString("'petitionid' => ParameterType::INTEGER", $source);
-        self::assertStringNotContainsString("petitionid='$id'", $source);
+        $nonCommentSource = (string) preg_replace('/^\\s*\\/\\/.*$/m', '', $source);
+        self::assertMatchesRegularExpression('/WHERE\\s+petitionid\\s*=\\s*:petitionid/i', $source);
+        self::assertMatchesRegularExpression('/[\'"]petitionid[\'"]\\s*=>\\s*ParameterType::INTEGER/', $source);
+        self::assertDoesNotMatchRegularExpression('/petitionid\\s*=\\s*[\'"]\\$id[\'"]/', $nonCommentSource);
     }
 
     public function testStablesUsesPreparedStatementForMountLookup(): void
     {
         $source = file_get_contents(__DIR__ . '/../../stables.php');
         self::assertIsString($source);
-        self::assertStringContainsString('WHERE mountid = :mountid', $source);
-        self::assertStringContainsString("'mountid' => ParameterType::INTEGER", $source);
-        self::assertStringNotContainsString("mountid='$id'", $source);
+        self::assertMatchesRegularExpression('/WHERE\\s+mountid\\s*=\\s*:mountid/i', $source);
+        self::assertMatchesRegularExpression('/[\'"]mountid[\'"]\\s*=>\\s*ParameterType::INTEGER/', $source);
+        self::assertDoesNotMatchRegularExpression('/mountid\\s*=\\s*[\'"]\\$id[\'"]/', $source);
     }
 
     public function testNavCompositionUsesNormalizedOrEncodedQueryComponents(): void
@@ -40,12 +41,12 @@ final class RequestNormalizationRegressionTest extends TestCase
         self::assertIsString($hof);
         self::assertIsString($modules);
 
-        self::assertStringContainsString("rawurlencode(\$return)", $healer);
-        self::assertStringContainsString('modulename_sanitize($moduleRequest)', $user);
-        self::assertStringContainsString("rawurlencode(\$moduleSlug)", $user);
-        self::assertStringContainsString("ctype_digit(\$petitionRequest)", $userEdit);
-        self::assertStringContainsString("\$allowedOps = ['kills', 'money', 'gems', 'charm', 'tough', 'resurrects', 'days'];", $hof);
-        self::assertStringContainsString("array_key_exists(\$catRequest, \$seencats)", $modules);
-        self::assertStringContainsString("rawurlencode(\$cat)", $modules);
+        self::assertMatchesRegularExpression('/rawurlencode\\(\\$return\\)/', $healer);
+        self::assertMatchesRegularExpression('/modulename_sanitize\\(\\$moduleRequest\\)/', $user);
+        self::assertMatchesRegularExpression('/rawurlencode\\(\\$moduleSlug\\)/', $user);
+        self::assertMatchesRegularExpression('/ctype_digit\\(\\$petitionRequest\\)/', $userEdit);
+        self::assertMatchesRegularExpression('/\\$allowedOps\\s*=\\s*\\[[^\\]]*kills[^\\]]*resurrects[^\\]]*\\]/', $hof);
+        self::assertMatchesRegularExpression('/array_key_exists\\(\\$catRequest,\\s*\\$seencats\\)/', $modules);
+        self::assertMatchesRegularExpression('/rawurlencode\\(\\$cat\\)/', $modules);
     }
 }

--- a/tests/Security/TauntParameterBindingRegressionTest.php
+++ b/tests/Security/TauntParameterBindingRegressionTest.php
@@ -50,6 +50,8 @@ final class TauntParameterBindingRegressionTest extends TestCase
         self::assertStringContainsString('executeStatement(', $source);
         self::assertStringContainsString('executeQuery(', $source);
         self::assertStringContainsString('WHERE tauntid = :tauntid', $source);
+        self::assertStringContainsString('taunt_normalize_text(Http::post(\'taunt\'))', $source);
+        self::assertStringContainsString('rawurlencode($tauntidParam)', $source);
         self::assertStringContainsString('tauntid = :tauntid', $source);
         self::assertStringContainsString('taunt = :taunt', $source);
         self::assertStringContainsString('editor = :editor', $source);

--- a/tests/Security/TauntParameterBindingRegressionTest.php
+++ b/tests/Security/TauntParameterBindingRegressionTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Security;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\MySQL\Database;
+use Lotgd\Tests\Stubs\DoctrineBootstrap;
+use Lotgd\Tests\Stubs\DoctrineConnection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security regression coverage for taunt parameter binding.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+final class TauntParameterBindingRegressionTest extends TestCase
+{
+    private DoctrineConnection $connection;
+
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
+
+        DoctrineBootstrap::$conn = null;
+        Database::resetDoctrineConnection();
+        // Avoid leaking prefix changes into unrelated suites.
+        Database::setPrefix('');
+
+        $this->connection = Database::getDoctrineConnection();
+        $this->connection->executeStatements = [];
+    }
+
+    protected function tearDown(): void
+    {
+        DoctrineBootstrap::$conn = null;
+        Database::resetDoctrineConnection();
+        Database::setPrefix('');
+        parent::tearDown();
+    }
+
+    public function testSourceUsesPreparedStatementsWithTypedParams(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/taunt.php');
+
+        self::assertStringContainsString('executeStatement(', $source);
+        self::assertStringContainsString('executeQuery(', $source);
+        self::assertStringContainsString('WHERE tauntid = :tauntid', $source);
+        self::assertStringContainsString('tauntid = :tauntid', $source);
+        self::assertStringContainsString('taunt = :taunt', $source);
+        self::assertStringContainsString('editor = :editor', $source);
+        self::assertStringContainsString('ParameterType::INTEGER', $source);
+        self::assertStringContainsString('ParameterType::STRING', $source);
+        self::assertStringNotContainsString('addslashes($session[\'user\'][\'login\'])', $source);
+    }
+
+    public function testPayloadRoundtripIsPreservedInInsertBoundParameters(): void
+    {
+        $payload = "Taunt '\" \\\\ Ω漢字";
+        $editor = "Admin '\" \\\\ Ω";
+
+        $this->connection->executeStatement(
+            'INSERT INTO ' . Database::prefix('taunts') . ' (taunt, editor) VALUES (:taunt, :editor)',
+            [
+                'taunt' => $payload,
+                'editor' => $editor,
+            ],
+            [
+                'taunt' => ParameterType::STRING,
+                'editor' => ParameterType::STRING,
+            ]
+        );
+
+        $statement = $this->connection->executeStatements[0] ?? null;
+        self::assertNotNull($statement);
+        self::assertStringNotContainsString($payload, $statement['sql']);
+        self::assertSame($payload, $statement['params']['taunt']);
+        self::assertSame($editor, $statement['params']['editor']);
+        self::assertSame(ParameterType::STRING, $statement['types']['taunt']);
+    }
+}

--- a/tests/Security/TauntParameterBindingRegressionTest.php
+++ b/tests/Security/TauntParameterBindingRegressionTest.php
@@ -52,12 +52,17 @@ final class TauntParameterBindingRegressionTest extends TestCase
         self::assertStringContainsString('WHERE tauntid = :tauntid', $source);
         self::assertStringContainsString('taunt_normalize_text(Http::post(\'taunt\'))', $source);
         self::assertStringContainsString('rawurlencode($tauntidParam)', $source);
+        self::assertStringContainsString('taunt_normalize_optional_int(Http::get(\'c\'))', $source);
+        self::assertStringContainsString('Nav::add("", "taunt.php?c=$commentaryPageParam");', $source);
+        self::assertStringNotContainsString('Nav::add("", "taunt.php?c=" . Http::get(\'c\'));', $source);
         self::assertStringContainsString('tauntid = :tauntid', $source);
         self::assertStringContainsString('taunt = :taunt', $source);
         self::assertStringContainsString('editor = :editor', $source);
         self::assertStringContainsString('ParameterType::INTEGER', $source);
         self::assertStringContainsString('ParameterType::STRING', $source);
         self::assertStringNotContainsString('addslashes($session[\'user\'][\'login\'])', $source);
+        self::assertStringContainsString('! ctype_digit($value)', $source);
+        self::assertStringContainsString('$intValue > 0 ? $intValue : null;', $source);
     }
 
     public function testPayloadRoundtripIsPreservedInInsertBoundParameters(): void

--- a/tests/Security/UntranslatedParameterBindingRegressionTest.php
+++ b/tests/Security/UntranslatedParameterBindingRegressionTest.php
@@ -58,6 +58,10 @@ final class UntranslatedParameterBindingRegressionTest extends TestCase
         self::assertStringContainsString('strlen($cacheNamespace) > Sanitize::URI_MAX_LENGTH', $source);
         self::assertStringContainsString('$cacheNamespace = sha1($cacheNamespace);', $source);
         self::assertStringContainsString('ParameterType::STRING', $source);
+        self::assertGreaterThanOrEqual(
+            2,
+            substr_count($source, 'invalidatedatacache(untranslated_translation_cache_key((string) $namespace, (string) $language));')
+        );
     }
 
     public function testQuotedMultibytePayloadRemainsBoundAndSqlShapeUnchanged(): void

--- a/tests/Security/UntranslatedParameterBindingRegressionTest.php
+++ b/tests/Security/UntranslatedParameterBindingRegressionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Security;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\MySQL\Database;
+use Lotgd\Tests\Stubs\DoctrineBootstrap;
+use Lotgd\Tests\Stubs\DoctrineConnection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security regression coverage for untranslated page parameter binding.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+final class UntranslatedParameterBindingRegressionTest extends TestCase
+{
+    private DoctrineConnection $connection;
+
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
+
+        DoctrineBootstrap::$conn = null;
+        Database::resetDoctrineConnection();
+        // Avoid leaking prefix changes into unrelated suites.
+        Database::setPrefix('');
+
+        $this->connection = Database::getDoctrineConnection();
+        $this->connection->executeStatements = [];
+        $this->connection->queries = [];
+        $this->connection->executeQueryParams = [];
+        $this->connection->executeQueryTypes = [];
+    }
+
+    protected function tearDown(): void
+    {
+        DoctrineBootstrap::$conn = null;
+        Database::resetDoctrineConnection();
+        Database::setPrefix('');
+        parent::tearDown();
+    }
+
+    public function testSourceUsesBoundParamsForLanguageAndNamespaceFilters(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/untranslated.php');
+
+        self::assertStringContainsString('WHERE language = :language', $source);
+        self::assertStringContainsString('AND namespace = :namespace', $source);
+        self::assertStringContainsString('INSERT INTO " . Database::prefix("translations") . "', $source);
+        self::assertStringContainsString('DELETE FROM " . Database::prefix("untranslated") . "', $source);
+        self::assertStringContainsString('invalidatedatacache(untranslated_translation_cache_key((string) $namespace, (string) $language));', $source);
+        self::assertStringContainsString('strlen($cacheNamespace) > Sanitize::URI_MAX_LENGTH', $source);
+        self::assertStringContainsString('$cacheNamespace = sha1($cacheNamespace);', $source);
+        self::assertStringContainsString('ParameterType::STRING', $source);
+    }
+
+    public function testQuotedMultibytePayloadRemainsBoundAndSqlShapeUnchanged(): void
+    {
+        $language = "en'\"\\Ω";
+        $namespace = "core/forest'\"\\漢字";
+        $intext = "Source '\" \\\\ Ω漢字";
+        $outtext = "Target '\" \\\\ Ω漢字";
+
+        $this->connection->executeQuery(
+            'SELECT * FROM ' . Database::prefix('untranslated') . ' WHERE language = :language AND namespace = :namespace',
+            [
+                'language' => $language,
+                'namespace' => $namespace,
+            ],
+            [
+                'language' => ParameterType::STRING,
+                'namespace' => ParameterType::STRING,
+            ]
+        );
+
+        $this->connection->executeStatement(
+            'INSERT INTO ' . Database::prefix('translations') . ' (language, uri, intext, outtext, author, version) VALUES (:language, :namespace, :intext, :outtext, :author, :version)',
+            [
+                'language' => $language,
+                'namespace' => $namespace,
+                'intext' => $intext,
+                'outtext' => $outtext,
+                'author' => "Editor '\" \\\\ Ω",
+                'version' => '2.0.0',
+            ],
+            [
+                'language' => ParameterType::STRING,
+                'namespace' => ParameterType::STRING,
+                'intext' => ParameterType::STRING,
+                'outtext' => ParameterType::STRING,
+                'author' => ParameterType::STRING,
+                'version' => ParameterType::STRING,
+            ]
+        );
+
+        $selectSql = $this->connection->queries[0] ?? '';
+        self::assertStringNotContainsString($language, $selectSql);
+        self::assertStringNotContainsString($namespace, $selectSql);
+
+        $insert = $this->connection->executeStatements[0] ?? null;
+        self::assertNotNull($insert);
+        self::assertStringNotContainsString($intext, $insert['sql']);
+        self::assertSame($intext, $insert['params']['intext']);
+        self::assertSame($outtext, $insert['params']['outtext']);
+    }
+}

--- a/tests/User/UserLegacyHttpMigrationTest.php
+++ b/tests/User/UserLegacyHttpMigrationTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    if (!function_exists('modulehook')) {
+        /**
+         * Minimal modulehook shim for isolated page include tests.
+         *
+         * @param array<mixed> $args
+         * @return array<mixed>
+         */
+        function modulehook(string $hookname, array $args = [], bool $allowinactive = false, string $modulename = ''): array
+        {
+            return $args;
+        }
+    }
+
+    if (!function_exists('httpset')) {
+        function httpset(string $var, mixed $value, bool $force = false): void
+        {
+        }
+    }
+}
+
+namespace Lotgd {
+    if (!class_exists(__NAMESPACE__ . '\\Redirect', false)) {
+        class Redirect
+        {
+            public static function redirect(string $location, string|bool $reason = false): void
+            {
+            }
+        }
+    }
+}
+
+namespace Lotgd\Tests\User {
+
+    use Doctrine\DBAL\ParameterType;
+    use Lotgd\MySQL\Database;
+    use Lotgd\Tests\Stubs\DoctrineBootstrap;
+    use PHPUnit\Framework\TestCase;
+
+    final class UserLegacyHttpMigrationTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
+            Database::$doctrineConnection = null;
+            Database::$instance = null;
+            DoctrineBootstrap::$conn = null;
+            Database::$mockResults = [];
+            $_GET = [];
+            $_POST = [];
+            $GLOBALS['output'] = new class {
+                public function outputNotl(string $format, mixed ...$args): void
+                {
+                }
+
+                public function output(string $format, mixed ...$args): void
+                {
+                }
+            };
+        }
+
+        public function testUserDelbanUsesRawHttpAndTypedBoundParameters(): void
+        {
+            $_GET['ipfilter'] = "10.0.0.1' OR 1=1 --";
+            $_GET['uniqueid'] = 'abc"xyz';
+
+            $include = static function (): void {
+                require __DIR__ . '/../../pages/user/user_delban.php';
+            };
+            $include();
+
+            $conn = Database::getDoctrineConnection();
+            $statement = $conn->executeStatements[0] ?? null;
+            $this->assertIsArray($statement);
+            $this->assertSame($_GET['ipfilter'], $statement['params']['ip'] ?? null);
+            $this->assertSame($_GET['uniqueid'], $statement['params']['id'] ?? null);
+            $this->assertSame(ParameterType::STRING, $statement['types']['ip'] ?? null);
+            $this->assertSame(ParameterType::STRING, $statement['types']['id'] ?? null);
+        }
+
+        public function testUserSavemoduleUsesHttpClassAndParameterizedReplace(): void
+        {
+            $_GET['userid'] = '42';
+            $_GET['module'] = 'samplemodule';
+            $_POST = ['display_name' => "O'Reilly"];
+
+            $include = static function (): void {
+                $output = $GLOBALS['output'];
+                require __DIR__ . '/../../pages/user/user_savemodule.php';
+            };
+            $include();
+
+            $conn = Database::getDoctrineConnection();
+            $statement = $conn->executeStatements[0] ?? null;
+            $this->assertIsArray($statement);
+            $this->assertStringContainsString('VALUES (:module,:userid,:setting,:value)', $statement['sql']);
+            $this->assertSame("O'Reilly", $statement['params']['value'] ?? null);
+            $this->assertSame(ParameterType::INTEGER, $statement['types']['userid'] ?? null);
+        }
+    }
+}

--- a/tests/User/UserLegacyHttpMigrationTest.php
+++ b/tests/User/UserLegacyHttpMigrationTest.php
@@ -101,5 +101,22 @@ namespace Lotgd\Tests\User {
             $this->assertSame("O'Reilly", $statement['params']['value'] ?? null);
             $this->assertSame(ParameterType::INTEGER, $statement['types']['userid'] ?? null);
         }
+
+        public function testUserDelbanPreservesZeroStringParameters(): void
+        {
+            $_GET['ipfilter'] = '0';
+            $_GET['uniqueid'] = '0';
+
+            $include = static function (): void {
+                require __DIR__ . '/../../pages/user/user_delban.php';
+            };
+            $include();
+
+            $conn = Database::getDoctrineConnection();
+            $statement = $conn->executeStatements[0] ?? null;
+            $this->assertIsArray($statement);
+            $this->assertSame('0', $statement['params']['ip'] ?? null);
+            $this->assertSame('0', $statement['params']['id'] ?? null);
+        }
     }
 }

--- a/tests/User/UserLegacyHttpMigrationTest.php
+++ b/tests/User/UserLegacyHttpMigrationTest.php
@@ -14,7 +14,7 @@ final class UserLegacyHttpMigrationTest extends TestCase
 $_GET['ipfilter'] = "10.0.0.1' OR 1=1 --";
 $_GET['uniqueid'] = 'abc"xyz';
 
-require __DIR__ . '/tests/User/isolated_user_delban.php';
+require LOTGD_TEST_ROOT . '/tests/User/isolated_user_delban.php';
 PHP);
 
         $statement = $payload['statement'] ?? null;
@@ -31,7 +31,7 @@ PHP);
 $_GET['ipfilter'] = '0';
 $_GET['uniqueid'] = '0';
 
-require __DIR__ . '/tests/User/isolated_user_delban.php';
+require LOTGD_TEST_ROOT . '/tests/User/isolated_user_delban.php';
 PHP);
 
         $statement = $payload['statement'] ?? null;
@@ -47,7 +47,7 @@ $_GET['userid'] = '42';
 $_GET['module'] = 'samplemodule';
 $_POST = ['display_name' => "O'Reilly"];
 
-require __DIR__ . '/tests/User/isolated_user_savemodule.php';
+require LOTGD_TEST_ROOT . '/tests/User/isolated_user_savemodule.php';
 PHP);
 
         $statement = $payload['statement'] ?? null;

--- a/tests/User/UserLegacyHttpMigrationTest.php
+++ b/tests/User/UserLegacyHttpMigrationTest.php
@@ -2,121 +2,85 @@
 
 declare(strict_types=1);
 
-namespace {
-    if (!function_exists('modulehook')) {
-        /**
-         * Minimal modulehook shim for isolated page include tests.
-         *
-         * @param array<mixed> $args
-         * @return array<mixed>
-         */
-        function modulehook(string $hookname, array $args = [], bool $allowinactive = false, string $modulename = ''): array
-        {
-            return $args;
-        }
-    }
+namespace Lotgd\Tests\User;
 
-    if (!function_exists('httpset')) {
-        function httpset(string $var, mixed $value, bool $force = false): void
-        {
-        }
-    }
-}
+use PHPUnit\Framework\TestCase;
 
-namespace Lotgd {
-    if (!class_exists(__NAMESPACE__ . '\\Redirect', false)) {
-        class Redirect
-        {
-            public static function redirect(string $location, string|bool $reason = false): void
-            {
-            }
-        }
-    }
-}
-
-namespace Lotgd\Tests\User {
-
-    use Doctrine\DBAL\ParameterType;
-    use Lotgd\MySQL\Database;
-    use Lotgd\Tests\Stubs\DoctrineBootstrap;
-    use PHPUnit\Framework\TestCase;
-
-    final class UserLegacyHttpMigrationTest extends TestCase
+final class UserLegacyHttpMigrationTest extends TestCase
+{
+    public function testUserDelbanUsesRawHttpAndTypedBoundParameters(): void
     {
-        protected function setUp(): void
-        {
-            require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
-            Database::$doctrineConnection = null;
-            Database::$instance = null;
-            DoctrineBootstrap::$conn = null;
-            Database::$mockResults = [];
-            $_GET = [];
-            $_POST = [];
-            $GLOBALS['output'] = new class {
-                public function outputNotl(string $format, mixed ...$args): void
-                {
-                }
+        $payload = $this->runIsolatedPageScript(<<<'PHP'
+$_GET['ipfilter'] = "10.0.0.1' OR 1=1 --";
+$_GET['uniqueid'] = 'abc"xyz';
 
-                public function output(string $format, mixed ...$args): void
-                {
-                }
-            };
-        }
+require __DIR__ . '/tests/User/isolated_user_delban.php';
+PHP);
 
-        public function testUserDelbanUsesRawHttpAndTypedBoundParameters(): void
-        {
-            $_GET['ipfilter'] = "10.0.0.1' OR 1=1 --";
-            $_GET['uniqueid'] = 'abc"xyz';
+        $statement = $payload['statement'] ?? null;
+        $this->assertIsArray($statement);
+        $this->assertSame("10.0.0.1' OR 1=1 --", $statement['params']['ip'] ?? null);
+        $this->assertSame('abc"xyz', $statement['params']['id'] ?? null);
+        $this->assertSame('STRING', $statement['types']['ip'] ?? null);
+        $this->assertSame('STRING', $statement['types']['id'] ?? null);
+    }
 
-            $include = static function (): void {
-                require __DIR__ . '/../../pages/user/user_delban.php';
-            };
-            $include();
+    public function testUserDelbanPreservesZeroStringParameters(): void
+    {
+        $payload = $this->runIsolatedPageScript(<<<'PHP'
+$_GET['ipfilter'] = '0';
+$_GET['uniqueid'] = '0';
 
-            $conn = Database::getDoctrineConnection();
-            $statement = $conn->executeStatements[0] ?? null;
-            $this->assertIsArray($statement);
-            $this->assertSame($_GET['ipfilter'], $statement['params']['ip'] ?? null);
-            $this->assertSame($_GET['uniqueid'], $statement['params']['id'] ?? null);
-            $this->assertSame(ParameterType::STRING, $statement['types']['ip'] ?? null);
-            $this->assertSame(ParameterType::STRING, $statement['types']['id'] ?? null);
-        }
+require __DIR__ . '/tests/User/isolated_user_delban.php';
+PHP);
 
-        public function testUserSavemoduleUsesHttpClassAndParameterizedReplace(): void
-        {
-            $_GET['userid'] = '42';
-            $_GET['module'] = 'samplemodule';
-            $_POST = ['display_name' => "O'Reilly"];
+        $statement = $payload['statement'] ?? null;
+        $this->assertIsArray($statement);
+        $this->assertSame('0', $statement['params']['ip'] ?? null);
+        $this->assertSame('0', $statement['params']['id'] ?? null);
+    }
 
-            $include = static function (): void {
-                $output = $GLOBALS['output'];
-                require __DIR__ . '/../../pages/user/user_savemodule.php';
-            };
-            $include();
+    public function testUserSavemoduleUsesHttpClassAndParameterizedReplace(): void
+    {
+        $payload = $this->runIsolatedPageScript(<<<'PHP'
+$_GET['userid'] = '42';
+$_GET['module'] = 'samplemodule';
+$_POST = ['display_name' => "O'Reilly"];
 
-            $conn = Database::getDoctrineConnection();
-            $statement = $conn->executeStatements[0] ?? null;
-            $this->assertIsArray($statement);
-            $this->assertStringContainsString('VALUES (:module,:userid,:setting,:value)', $statement['sql']);
-            $this->assertSame("O'Reilly", $statement['params']['value'] ?? null);
-            $this->assertSame(ParameterType::INTEGER, $statement['types']['userid'] ?? null);
-        }
+require __DIR__ . '/tests/User/isolated_user_savemodule.php';
+PHP);
 
-        public function testUserDelbanPreservesZeroStringParameters(): void
-        {
-            $_GET['ipfilter'] = '0';
-            $_GET['uniqueid'] = '0';
+        $statement = $payload['statement'] ?? null;
+        $this->assertIsArray($statement);
+        $this->assertStringContainsString('VALUES (:module,:userid,:setting,:value)', $statement['sql'] ?? '');
+        $this->assertSame("O'Reilly", $statement['params']['value'] ?? null);
+        $this->assertSame('INTEGER', $statement['types']['userid'] ?? null);
+    }
 
-            $include = static function (): void {
-                require __DIR__ . '/../../pages/user/user_delban.php';
-            };
-            $include();
+    /**
+     * Execute page-inclusion tests in an isolated PHP process so test-only
+     * function/class shims cannot leak into the main PHPUnit process.
+     *
+     * @return array<string,mixed>
+     */
+    private function runIsolatedPageScript(string $snippet): array
+    {
+        $root = dirname(__DIR__, 2);
+        $bootstrap = sprintf(
+            "define('LOTGD_TEST_ROOT', %s);\nrequire %s;\n",
+            var_export($root, true),
+            var_export($root . '/tests/bootstrap.php', true)
+        );
 
-            $conn = Database::getDoctrineConnection();
-            $statement = $conn->executeStatements[0] ?? null;
-            $this->assertIsArray($statement);
-            $this->assertSame('0', $statement['params']['ip'] ?? null);
-            $this->assertSame('0', $statement['params']['id'] ?? null);
-        }
+        $code = $bootstrap . $snippet;
+        $command = sprintf('%s -r %s', escapeshellarg(PHP_BINARY), escapeshellarg($code));
+        $output = shell_exec($command);
+
+        $this->assertNotNull($output, 'Isolated page script produced no output.');
+        $this->assertIsString($output);
+
+        /** @var array<string,mixed> $decoded */
+        $decoded = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+        return $decoded;
     }
 }

--- a/tests/User/isolated_user_delban.php
+++ b/tests/User/isolated_user_delban.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd {
+    if (!class_exists(__NAMESPACE__ . '\\Redirect', false)) {
+        class Redirect
+        {
+            public static function redirect(string $location, string|bool $reason = false): void
+            {
+            }
+        }
+    }
+}
+
+namespace {
+    use Lotgd\MySQL\Database;
+    Database::$doctrineConnection = null;
+    Database::$instance = null;
+    Database::$mockResults = [];
+
+    require LOTGD_TEST_ROOT . '/pages/user/user_delban.php';
+
+    $conn = Database::getDoctrineConnection();
+    $statement = $conn->executeStatements[0] ?? null;
+    $normalize = static function (mixed $value) use (&$normalize): mixed {
+        if ($value instanceof \UnitEnum) {
+            return $value->name;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $key => $item) {
+                $value[$key] = $normalize($item);
+            }
+        }
+
+        return $value;
+    };
+
+    echo json_encode(['statement' => $normalize($statement)], JSON_THROW_ON_ERROR);
+}

--- a/tests/User/isolated_user_savemodule.php
+++ b/tests/User/isolated_user_savemodule.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    use Lotgd\MySQL\Database;
+    use Lotgd\Translator;
+
+    if (!function_exists('modulehook')) {
+        /**
+         * Test shim for module validation hooks.
+         *
+         * @param array<mixed> $args
+         * @return array<mixed>
+         */
+        function modulehook(string $hookname, array $args = [], bool $allowinactive = false, string $modulename = ''): array
+        {
+            return $args;
+        }
+    }
+
+    if (!function_exists('httpset')) {
+        function httpset(string $var, mixed $value, bool $force = false): void
+        {
+        }
+    }
+
+    $output = new class {
+        public function outputNotl(string $format, mixed ...$args): void
+        {
+        }
+
+        public function output(string $format, mixed ...$args): void
+        {
+        }
+    };
+
+    Database::$doctrineConnection = null;
+    Database::$instance = null;
+    Database::$mockResults = [];
+    Translator::enableTranslation(false);
+
+    require LOTGD_TEST_ROOT . '/pages/user/user_savemodule.php';
+
+    $conn = Database::getDoctrineConnection();
+    $statement = $conn->executeStatements[0] ?? null;
+    $normalize = static function (mixed $value) use (&$normalize): mixed {
+        if ($value instanceof \UnitEnum) {
+            return $value->name;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $key => $item) {
+                $value[$key] = $normalize($item);
+            }
+        }
+
+        return $value;
+    };
+
+    echo json_encode(['statement' => $normalize($statement)], JSON_THROW_ON_ERROR);
+}

--- a/translatortool.php
+++ b/translatortool.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\ParameterType;
 use Lotgd\MySQL\Database;
 use Lotgd\DataCache;
 use Lotgd\Sanitize;
@@ -255,15 +256,20 @@ if ($op == "") {
     }
 } elseif ($op == "list") {
     popup_header("Translation List");
-    $sql = "SELECT uri,count(*) AS c FROM " . Database::prefix("translations") . " WHERE language='" . LANGUAGE . "' GROUP BY uri ORDER BY uri ASC";
-    $result = Database::query($sql);
+    // Keep LANGUAGE explicit while ensuring the DBAL layer receives a typed bound parameter.
+    $language = (string) LANGUAGE;
+    $rows = Database::getDoctrineConnection()->fetchAllAssociative(
+        'SELECT uri,count(*) AS c FROM ' . Database::prefix('translations') . ' WHERE language = :language GROUP BY uri ORDER BY uri ASC',
+        ['language' => $language],
+        ['language' => ParameterType::STRING]
+    );
     $output->outputNotl("<form action='translatortool.php' method='GET'>", true);
     $output->outputNotl("<input type='hidden' name='op' value='list'>", true);
         $output->outputNotl("<label for='u'>", true);
         $output->output("Known Namespaces:");
         $output->outputNotl("</label>", true);
         $output->outputNotl("<select name='u' id='u'>", true);
-    while ($row = Database::fetchAssoc($result)) {
+    foreach ($rows as $row) {
         $output->outputNotl("<option value=\"" . htmlentities($row['uri']) . "\">" . htmlentities($row['uri'], ENT_COMPAT, $settings->getSetting('charset', 'UTF-8')) . " ({$row['c']})</option>", true);
     }
     $output->outputNotl("</select>", true);
@@ -278,11 +284,22 @@ if ($op == "") {
     $norows = Translator::translateInline("No rows found");
     $output->outputNotl("<table border='0' cellpadding='2' cellspacing='0'>", true);
     $output->outputNotl("<tr class='trhead'><td>$ops</td><td>$from</td><td>$to</td><td>$version</td><td>$author</td></tr>", true);
-    $sql = "SELECT * FROM " . Database::prefix("translations") . " WHERE language='" . LANGUAGE . "' AND uri='" . (string) Http::get('u') . "'";
-    $result = Database::query($sql);
-    if (Database::numRows($result) > 0) {
+    $uriRequest = Http::get('u');
+    $uri = is_string($uriRequest) ? $uriRequest : (string) $uriRequest;
+    $translations = Database::getDoctrineConnection()->fetchAllAssociative(
+        'SELECT * FROM ' . Database::prefix('translations') . ' WHERE language = :language AND uri = :uri',
+        [
+            'language' => $language,
+            'uri'      => $uri,
+        ],
+        [
+            'language' => ParameterType::STRING,
+            'uri'      => ParameterType::STRING,
+        ]
+    );
+    if (count($translations) > 0) {
         $i = 0;
-        while ($row = Database::fetchAssoc($result)) {
+        foreach ($translations as $row) {
             $i++;
             $output->outputNotl("<tr class='" . ($i % 2 ? "trlight" : "trdark") . "'><td>", true);
             $edit = Translator::translateInline("Edit");

--- a/untranslated.php
+++ b/untranslated.php
@@ -12,6 +12,8 @@ use Lotgd\MySQL\Database;
 use Lotgd\Translator;
 use Lotgd\Settings;
 use Lotgd\Random;
+use Lotgd\Sanitize;
+use Doctrine\DBAL\ParameterType;
 
 // translator ready
 // addnews ready
@@ -30,6 +32,7 @@ require_once __DIR__ . "/common.php";
 
 $settings = Settings::getInstance();
 $output = Output::getInstance();
+$connection = Database::getDoctrineConnection();
 
 SuAccess::check(SU_IS_TRANSLATOR);
 
@@ -58,10 +61,38 @@ if ($op == "list") {
         if ($outtext <> "") {
             $login = $session['user']['login'];
             $language = $session['user']['prefs']['language'];
-            $sql = "INSERT INTO " . Database::prefix("translations") . " (language,uri,intext,outtext,author,version) VALUES" . " ('$language','$namespace','$intext','$outtext','$login','$logd_version')";
-            Database::query($sql);
-            $sql = "DELETE FROM " . Database::prefix("untranslated") . " WHERE intext = '$intext' AND language = '$language' AND namespace = '$namespace'";
-            Database::query($sql);
+            $connection->executeStatement(
+                "INSERT INTO " . Database::prefix("translations") . " (language, uri, intext, outtext, author, version) VALUES (:language, :namespace, :intext, :outtext, :author, :version)",
+                [
+                    'language' => (string) $language,
+                    'namespace' => (string) $namespace,
+                    'intext' => (string) $intext,
+                    'outtext' => (string) $outtext,
+                    'author' => (string) $login,
+                    'version' => (string) $logd_version,
+                ],
+                [
+                    'language' => ParameterType::STRING,
+                    'namespace' => ParameterType::STRING,
+                    'intext' => ParameterType::STRING,
+                    'outtext' => ParameterType::STRING,
+                    'author' => ParameterType::STRING,
+                    'version' => ParameterType::STRING,
+                ]
+            );
+            $connection->executeStatement(
+                "DELETE FROM " . Database::prefix("untranslated") . " WHERE intext = :intext AND language = :language AND namespace = :namespace",
+                [
+                    'intext' => (string) $intext,
+                    'language' => (string) $language,
+                    'namespace' => (string) $namespace,
+                ],
+                [
+                    'intext' => ParameterType::STRING,
+                    'language' => ParameterType::STRING,
+                    'namespace' => ParameterType::STRING,
+                ]
+            );
         }
     }
 
@@ -73,8 +104,11 @@ if ($op == "list") {
         Nav::add("", "untranslated.php?op=list");
     }
 
-    $sql = "SELECT namespace,count(*) AS c FROM " . Database::prefix("untranslated") . " WHERE language='" . $session['user']['prefs']['language'] . "' GROUP BY namespace ORDER BY namespace ASC";
-    $result = Database::query($sql);
+    $result = $connection->executeQuery(
+        "SELECT namespace, count(*) AS c FROM " . Database::prefix("untranslated") . " WHERE language = :language GROUP BY namespace ORDER BY namespace ASC",
+        ['language' => (string) $session['user']['prefs']['language']],
+        ['language' => ParameterType::STRING]
+    );
     $output->rawOutput("<input type='hidden' name='op' value='list'>");
         $output->rawOutput("<label for='ns'>");
         $output->output("Known Namespaces:");
@@ -98,8 +132,17 @@ if ($op == "list") {
     } else {
         $output->rawOutput("<table border='0' cellpadding='2' cellspacing='0'>");
         $output->rawOutput("<tr class='trhead'><td>" . Translator::translateInline("Ops") . "</td><td>" . Translator::translateInline("Text") . "</td></tr>");
-        $sql = "SELECT * FROM " . Database::prefix("untranslated") . " WHERE language='" . $session['user']['prefs']['language'] . "' AND namespace='" . $namespace . "'";
-        $result = Database::query($sql);
+        $result = $connection->executeQuery(
+            "SELECT * FROM " . Database::prefix("untranslated") . " WHERE language = :language AND namespace = :namespace",
+            [
+                'language' => (string) $session['user']['prefs']['language'],
+                'namespace' => (string) $namespace,
+            ],
+            [
+                'language' => ParameterType::STRING,
+                'namespace' => ParameterType::STRING,
+            ]
+        );
         if (Database::numRows($result) > 0) {
             $i = 0;
             while ($row = Database::fetchAssoc($result)) {
@@ -126,19 +169,50 @@ if ($op == "list") {
         $language = Http::post('language');
         if ($outtext <> "") {
             $login = $session['user']['login'];
-            $sql = "INSERT INTO " . Database::prefix("translations") . " (language,uri,intext,outtext,author,version) VALUES" . " ('$language','$namespace','$intext','$outtext','$login','$logd_version')";
-            Database::query($sql);
-            $sql = "DELETE FROM " . Database::prefix("untranslated") . " WHERE intext = '$intext' AND language = '$language' AND namespace = '$namespace'";
-            Database::query($sql);
-            invalidatedatacache("translations-" . $namespace . "-" . $language);
+            $connection->executeStatement(
+                "INSERT INTO " . Database::prefix("translations") . " (language, uri, intext, outtext, author, version) VALUES (:language, :namespace, :intext, :outtext, :author, :version)",
+                [
+                    'language' => (string) $language,
+                    'namespace' => (string) $namespace,
+                    'intext' => (string) $intext,
+                    'outtext' => (string) $outtext,
+                    'author' => (string) $login,
+                    'version' => (string) $logd_version,
+                ],
+                [
+                    'language' => ParameterType::STRING,
+                    'namespace' => ParameterType::STRING,
+                    'intext' => ParameterType::STRING,
+                    'outtext' => ParameterType::STRING,
+                    'author' => ParameterType::STRING,
+                    'version' => ParameterType::STRING,
+                ]
+            );
+            $connection->executeStatement(
+                "DELETE FROM " . Database::prefix("untranslated") . " WHERE intext = :intext AND language = :language AND namespace = :namespace",
+                [
+                    'intext' => (string) $intext,
+                    'language' => (string) $language,
+                    'namespace' => (string) $namespace,
+                ],
+                [
+                    'intext' => ParameterType::STRING,
+                    'language' => ParameterType::STRING,
+                    'namespace' => ParameterType::STRING,
+                ]
+            );
+            invalidatedatacache(untranslated_translation_cache_key((string) $namespace, (string) $language));
         }
     }
 
     $sql = "SELECT count(intext) AS count FROM " . Database::prefix("untranslated");
     $count = Database::fetchAssoc(Database::query($sql));
     if ($count['count'] > 0) {
-        $sql = "SELECT * FROM " . Database::prefix("untranslated") . " WHERE language = '" . $session['user']['prefs']['language'] . "' ORDER BY rand(" . Random::eRand() . ") LIMIT 1";
-        $result = Database::query($sql);
+        $result = $connection->executeQuery(
+            "SELECT * FROM " . Database::prefix("untranslated") . " WHERE language = :language ORDER BY rand(" . Random::eRand() . ") LIMIT 1",
+            ['language' => (string) $session['user']['prefs']['language']],
+            ['language' => ParameterType::STRING]
+        );
         if (Database::numRows($result) == 1) {
             $row = Database::fetchAssoc($result);
             $row['intext'] = stripslashes($row['intext']);
@@ -180,3 +254,21 @@ Nav::add("N?Translate by Namespace", "untranslated.php?op=list");
 Nav::add("Navigation");
 SuperuserNav::render();
 Footer::pageFooter();
+
+/**
+ * Build the cache key used by translation loading/invalidation.
+ *
+ * Translator::translateLoadNamespace() hashes namespaces longer than
+ * Sanitize::URI_MAX_LENGTH before writing cache entries. We mirror the same
+ * rule here so invalidation always targets the exact key previously used.
+ */
+function untranslated_translation_cache_key(string $namespace, string $language): string
+{
+    // Keep cache-key generation behavior aligned with Translator.
+    $cacheNamespace = $namespace;
+    if (strlen($cacheNamespace) > Sanitize::URI_MAX_LENGTH) {
+        $cacheNamespace = sha1($cacheNamespace);
+    }
+
+    return 'translations-' . $cacheNamespace . '-' . $language;
+}

--- a/untranslated.php
+++ b/untranslated.php
@@ -93,6 +93,7 @@ if ($op == "list") {
                     'namespace' => ParameterType::STRING,
                 ]
             );
+            invalidatedatacache(untranslated_translation_cache_key((string) $namespace, (string) $language));
         }
     }
 

--- a/user.php
+++ b/user.php
@@ -45,11 +45,15 @@ if ($op == "lasthit") {
 Header::pageHeader("User Editor");
 
 $sort = Http::get('sort');
-$petition = Http::get("returnpetition");
-$returnpetition = "";
-if ($petition != "") {
-    $returnpetition = "&returnpetition=$petition";
-}
+$petitionRequest = Http::get("returnpetition");
+/**
+ * Lotgd\Http returns raw payloads; accept only positive integer petition IDs
+ * before embedding into user editor navigation links.
+ */
+$petition = is_string($petitionRequest) && ctype_digit($petitionRequest) && (int) $petitionRequest > 0
+    ? (int) $petitionRequest
+    : null;
+$returnpetition = $petition === null ? "" : "&returnpetition=$petition";
 
 $gentime = 0;
 $gentimecount = 0;
@@ -98,9 +102,18 @@ if ($op == "search" || $op == "") {
 }
 
 
-$m = Http::get("module");
-if ($m) {
-    $m = "&module=$m&subop=module";
+/**
+ * Lotgd\Http values are raw; module slugs must pass the module-name sanitizer
+ * and be URL-encoded before composing links.
+ */
+$moduleRequest = Http::get("module");
+$moduleSlug = is_string($moduleRequest) ? modulename_sanitize($moduleRequest) : '';
+if ($moduleSlug !== '') {
+    Http::set('module', $moduleSlug, true);
+}
+$m = '';
+if ($moduleSlug !== '') {
+    $m = '&module=' . rawurlencode($moduleSlug) . '&subop=module';
 }
 $output->rawOutput("<form action='user.php?op=search$m' method='POST'>");
 $output->output("Search by any field below: ");

--- a/viewpetition.php
+++ b/viewpetition.php
@@ -57,6 +57,11 @@ $op = Http::get("op") ?? "";
 $idRequest = Http::get("id");
 $id = is_string($idRequest) && ctype_digit($idRequest) && (int) $idRequest > 0 ? (int) $idRequest : null;
 $idParam = $id === null ? '' : (string) $id;
+$invalidViewRequest = $op === 'view' && $id === null;
+if ($invalidViewRequest) {
+    // Normalize invalid view requests back to the petition list state.
+    $op = '';
+}
 $connection = Database::getDoctrineConnection();
 $insertCommentary = (string) Http::post('insertcommentary');
 if (!empty(trim($insertCommentary)) && $id !== null) {
@@ -88,6 +93,9 @@ if (!empty(trim($insertCommentary)) && $id !== null) {
 //}
 Header::pageHeader("Petition Viewer");
 if ($op == "") {
+    if ($invalidViewRequest) {
+        $output->output("`\$Invalid petition id supplied. Showing petition list instead.`0");
+    }
     $sql = "DELETE FROM " . Database::prefix("petitions") . " WHERE status=2 AND closedate<'" . date("Y-m-d H:i:s", strtotime("-7 days")) . "'";
     Database::query($sql);
     /**

--- a/viewpetition.php
+++ b/viewpetition.php
@@ -13,6 +13,7 @@ use Lotgd\Nav;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Settings;
+use Doctrine\DBAL\ParameterType;
 
 // translator ready
 // addnews ready
@@ -49,12 +50,30 @@ $statuses = HookHandler::hook("petition-status", $statuses);
 $statuses = Translator::translateInline($statuses);
 
 $op = Http::get("op") ?? "";
-$id = Http::get("id") ?? "";
+/**
+ * Lotgd\Http returns raw request payloads; normalize petition IDs before
+ * using them in SQL statements or nav URLs.
+ */
+$idRequest = Http::get("id");
+$id = is_string($idRequest) && ctype_digit($idRequest) && (int) $idRequest > 0 ? (int) $idRequest : null;
+$idParam = $id === null ? '' : (string) $id;
+$connection = Database::getDoctrineConnection();
 $insertCommentary = (string) Http::post('insertcommentary');
-if (!empty(trim($insertCommentary))) {
+if (!empty(trim($insertCommentary)) && $id !== null) {
     /* Update the bug if someone adds comments as well */
-    $sql = "UPDATE " . Database::prefix("petitions") . " SET closeuserid='{$session['user']['acctid']}',closedate='" . date("Y-m-d H:i:s") . "' WHERE petitionid='$id'";
-    Database::query($sql);
+    $connection->executeStatement(
+        "UPDATE " . Database::prefix("petitions") . " SET closeuserid = :closeuserid, closedate = :closedate WHERE petitionid = :petitionid",
+        [
+            'closeuserid' => (int) $session['user']['acctid'],
+            'closedate' => date("Y-m-d H:i:s"),
+            'petitionid' => $id,
+        ],
+        [
+            'closeuserid' => ParameterType::INTEGER,
+            'closedate' => ParameterType::STRING,
+            'petitionid' => ParameterType::INTEGER,
+        ]
+    );
 }
 
 // Eric decide he didn't want petitions to be manually deleted
@@ -71,15 +90,35 @@ Header::pageHeader("Petition Viewer");
 if ($op == "") {
     $sql = "DELETE FROM " . Database::prefix("petitions") . " WHERE status=2 AND closedate<'" . date("Y-m-d H:i:s", strtotime("-7 days")) . "'";
     Database::query($sql);
-    $setstat = Http::get("setstat");
+    /**
+     * Status transitions are enum-like values; narrow to known status keys.
+     */
+    $setstatRequest = Http::get("setstat");
+    $setstat = is_string($setstatRequest) && ctype_digit($setstatRequest) ? (int) $setstatRequest : null;
+    $statusKeys = array_map('intval', array_keys($statuses));
     invalidatedatacache("petition_counts");
-    if ($setstat != "") {
-        $sql = "SELECT status FROM " . Database::prefix("petitions") . " WHERE petitionid='$id'";
-        $result = Database::query($sql);
-        $row = Database::fetchAssoc($result);
-        if ($row['status'] != $setstat) {
-            $sql = "UPDATE " . Database::prefix("petitions") . " SET status='$setstat',closeuserid='{$session['user']['acctid']}',closedate='" . date("Y-m-d H:i:s") . "' WHERE petitionid='$id'";
-            Database::query($sql);
+    if ($setstat !== null && in_array($setstat, $statusKeys, true) && $id !== null) {
+        $row = $connection->executeQuery(
+            "SELECT status FROM " . Database::prefix("petitions") . " WHERE petitionid = :petitionid",
+            ['petitionid' => $id],
+            ['petitionid' => ParameterType::INTEGER]
+        )->fetchAssociative();
+        if ($row && (int) $row['status'] !== $setstat) {
+            $connection->executeStatement(
+                "UPDATE " . Database::prefix("petitions") . " SET status = :status, closeuserid = :closeuserid, closedate = :closedate WHERE petitionid = :petitionid",
+                [
+                    'status' => $setstat,
+                    'closeuserid' => (int) $session['user']['acctid'],
+                    'closedate' => date("Y-m-d H:i:s"),
+                    'petitionid' => $id,
+                ],
+                [
+                    'status' => ParameterType::INTEGER,
+                    'closeuserid' => ParameterType::INTEGER,
+                    'closedate' => ParameterType::STRING,
+                    'petitionid' => ParameterType::INTEGER,
+                ]
+            );
         }
     }
     $sort = "";
@@ -270,14 +309,14 @@ if ($op == "") {
     $output->output("`iClosed`i petitions are for you have dealt with an issue, these will auto delete when they have been closed for 7 days.");
     HookHandler::hook("petitions-descriptions", array());
     $output->rawOutput("</li></ul>");
-} elseif ($op == "view") {
+} elseif ($op == "view" && $id !== null) {
     Nav::add("Petitions");
     Nav::add("Details");
     $viewpageinfo = (int)Http::get("viewpageinfo");
     if ($viewpageinfo == 1) {
-        Nav::add("Hide Details", "viewpetition.php?op=view&id=$id");
+        Nav::add("Hide Details", "viewpetition.php?op=view&id=$idParam");
     } else {
-        Nav::add("D?Show Details", "viewpetition.php?op=view&id=$id&viewpageinfo=1");
+        Nav::add("D?Show Details", "viewpetition.php?op=view&id=$idParam&viewpageinfo=1");
     }
     Nav::add("Navigation");
     Nav::add("V?Petition Viewer", "viewpetition.php");
@@ -293,13 +332,15 @@ if ($op == "") {
         }
         Nav::add(
             array("%s?Mark %s", substr($plain, 0, 1), $val),
-            "viewpetition.php?setstat=$key&id=$id"
+            "viewpetition.php?setstat=$key&id=$idParam"
         );
     }
 
-    $sql = "SELECT " . Database::prefix("accounts") . ".name," .  Database::prefix("accounts") . ".login," .  Database::prefix("accounts") . ".acctid," .  "author,date,closedate,status,petitionid,ip,body,pageinfo," .  "accts.name AS closer FROM " .  Database::prefix("petitions") . " LEFT JOIN " .  Database::prefix("accounts ") . "ON " .  Database::prefix("accounts") . ".acctid=author LEFT JOIN " .  Database::prefix("accounts") . " AS accts ON accts.acctid=" .  "closeuserid WHERE petitionid='$id' ORDER BY date ASC";
-    $result = Database::query($sql);
-    $row = Database::fetchAssoc($result);
+    $row = $connection->executeQuery(
+        "SELECT " . Database::prefix("accounts") . ".name," .  Database::prefix("accounts") . ".login," .  Database::prefix("accounts") . ".acctid," .  "author,date,closedate,status,petitionid,ip,body,pageinfo," .  "accts.name AS closer FROM " .  Database::prefix("petitions") . " LEFT JOIN " .  Database::prefix("accounts ") . "ON " .  Database::prefix("accounts") . ".acctid=author LEFT JOIN " .  Database::prefix("accounts") . " AS accts ON accts.acctid=" .  "closeuserid WHERE petitionid = :petitionid ORDER BY date ASC",
+        ['petitionid' => $id],
+        ['petitionid' => ParameterType::INTEGER]
+    )->fetchAssociative();
     Nav::add("User Ops");
     if (isset($row['login'])) {
         Nav::add("View User Biography", "bio.php?char=" . $row['acctid']
@@ -307,7 +348,7 @@ if ($op == "") {
     }
     if ($row['acctid'] > 0 && $session['user']['superuser'] & SU_EDIT_USERS) {
         Nav::add("User Ops");
-        Nav::add("R?Edit User Record", "user.php?op=edit&userid={$row['acctid']}&returnpetition=$id");
+        Nav::add("R?Edit User Record", "user.php?op=edit&userid={$row['acctid']}&returnpetition=$idParam");
     }
     if ($row['acctid'] > 0 && $session['user']['superuser'] & SU_EDIT_DONATIONS) {
         Nav::add("User Ops");
@@ -364,7 +405,7 @@ if ($op == "") {
             }
         }
     }
-    Commentary::commentDisplay("`n`@Commentary:`0`n", "pet-$id", "Add information", 200);
+    Commentary::commentDisplay("`n`@Commentary:`0`n", "pet-$idParam", "Add information", 200);
     if ($viewpageinfo) {
         $output->output("`n`n`@Page Info:`&`n");
         $row['pageinfo'] = stripslashes($row['pageinfo']);
@@ -375,11 +416,13 @@ if ($op == "") {
     }
 }
 
-if ($id && $op != "") {
-    $prevsql = "SELECT p1.petitionid, p1.status FROM " . Database::prefix("petitions") . " AS p1, " . Database::prefix("petitions") . " AS p2
-			WHERE p1.petitionid<'$id' AND p2.petitionid='$id' AND p1.status=p2.status ORDER BY p1.petitionid DESC LIMIT 1";
-    $prevresult = Database::query($prevsql);
-    $prevrow = Database::fetchAssoc($prevresult);
+if ($id !== null && $op != "") {
+    $prevrow = $connection->executeQuery(
+        "SELECT p1.petitionid, p1.status FROM " . Database::prefix("petitions") . " AS p1, " . Database::prefix("petitions") . " AS p2
+			WHERE p1.petitionid < :petitionid AND p2.petitionid = :petitionid AND p1.status = p2.status ORDER BY p1.petitionid DESC LIMIT 1",
+        ['petitionid' => $id],
+        ['petitionid' => ParameterType::INTEGER]
+    )->fetchAssociative();
     if ($prevrow) {
         $previd = $prevrow['petitionid'];
         $s = $prevrow['status'];
@@ -387,10 +430,12 @@ if ($id && $op != "") {
         Nav::add("Petitions");
         Nav::add(array("Previous %s",$status), "viewpetition.php?op=view&id=$previd");
     }
-    $nextsql = "SELECT p1.petitionid, p1.status FROM " . Database::prefix("petitions") . " AS p1, " . Database::prefix("petitions") . " AS p2
-			WHERE p1.petitionid>'$id' AND p2.petitionid='$id' AND p1.status=p2.status ORDER BY p1.petitionid ASC LIMIT 1";
-    $nextresult = Database::query($nextsql);
-    $nextrow = Database::fetchAssoc($nextresult);
+    $nextrow = $connection->executeQuery(
+        "SELECT p1.petitionid, p1.status FROM " . Database::prefix("petitions") . " AS p1, " . Database::prefix("petitions") . " AS p2
+			WHERE p1.petitionid > :petitionid AND p2.petitionid = :petitionid AND p1.status = p2.status ORDER BY p1.petitionid ASC LIMIT 1",
+        ['petitionid' => $id],
+        ['petitionid' => ParameterType::INTEGER]
+    )->fetchAssociative();
     if ($nextrow) {
         $nextid = $nextrow['petitionid'];
         $s = $nextrow['status'];


### PR DESCRIPTION
This pull request focuses on hardening superuser/editor endpoints by migrating legacy SQL queries to use Doctrine DBAL with explicit parameter binding, and introduces stricter input normalization and HTTP API policies. It also updates documentation and static analysis to enforce these new standards, ensuring safer handling of user-supplied data and preparing for future deprecation of legacy HTTP wrappers.

**Superuser endpoint and SQL hardening:**
- Refactored `deathmessages.php` to use Doctrine DBAL's `executeQuery()`/`executeStatement()` with explicit parameter binding and type enforcement, replacing legacy SQL concatenation and manual escaping. Added normalization helpers for integer and text inputs to ensure only valid data is used in queries. [[1]](diffhunk://#diff-80acced3d784fd5a545b3d46c9ea6967d61fb11f67d95370a168aaf76d2736deR15) [[2]](diffhunk://#diff-80acced3d784fd5a545b3d46c9ea6967d61fb11f67d95370a168aaf76d2736deR26) [[3]](diffhunk://#diff-80acced3d784fd5a545b3d46c9ea6967d61fb11f67d95370a168aaf76d2736deL33-R50) [[4]](diffhunk://#diff-80acced3d784fd5a545b3d46c9ea6967d61fb11f67d95370a168aaf76d2736deL78-R195) [[5]](diffhunk://#diff-80acced3d784fd5a545b3d46c9ea6967d61fb11f67d95370a168aaf76d2736deL118-R216) [[6]](diffhunk://#diff-80acced3d784fd5a545b3d46c9ea6967d61fb11f67d95370a168aaf76d2736deL134-R233)
- Updated navigation and query parameter handling in `modules.php`, `healer.php`, and `hof.php` to strictly validate and encode user-supplied inputs before use, preventing injection or navigation issues. [[1]](diffhunk://#diff-052becfd97db02aeb6ff0a66a227114793a6e0efc2cefb5a726c2c9839fd54e7L141-R153) [[2]](diffhunk://#diff-d45648ee09b2529d4ca02cac8d7ddc4e8ca8f767696b5f96cd5bfd695f76ea28L29-R37) [[3]](diffhunk://#diff-a80fb5d8ff71266396ae4406aef7fc5f8c08e274c5efc0aa1e43237ab73c3337L40-R47)

**HTTP API modernization and legacy wrapper policy:**
- Introduced a documented policy in `UPGRADING.md` and `docs/Deprecations.md` mandating the use of `Lotgd\Http` for all new/refactored code, deprecating legacy `httpget()`/`httppost()` wrappers in core paths. Legacy wrappers are now strictly for compatibility and retain their historical escaping behavior. [[1]](diffhunk://#diff-f411a5009131db5a6c7242b49ca78488f2d274ef9e5e5f4de9262a42108a5386R211-R226) [[2]](diffhunk://#diff-9a6ebf64a6c6db9ab8c93aed4c2c34a52d47b00e518ff0d3d0e54512fbbafc4cR41-R47)
- Added a `legacy_http_escape()` helper in `lib/http.php` to ensure legacy wrappers escape values as before, while `Lotgd\Http` provides raw request data for typed handling. [[1]](diffhunk://#diff-d72d4461185d7f0291db0bbf4efa2cb25267a5dc95db7960188b21f0af9ba58bR8-R48) [[2]](diffhunk://#diff-d72d4461185d7f0291db0bbf4efa2cb25267a5dc95db7960188b21f0af9ba58bL34-R66)

**Quality assurance and enforcement:**
- Modified `composer.json` to include a static QA check (`qa:http-wrappers`) that fails builds if legacy HTTP wrappers are used in refactored/core code, enforcing the new HTTP API policy.

**Documentation and migration guidance:**
- Expanded upgrade and migration documentation in `UPGRADING.md` and `docs/Doctrine.md` with checklists and examples for converting legacy SQL and handling request-driven queries safely with DBAL and input normalization. [[1]](diffhunk://#diff-f411a5009131db5a6c7242b49ca78488f2d274ef9e5e5f4de9262a42108a5386R175-R178) [[2]](diffhunk://#diff-68e4964f70eb57776e093a6efb7fe95c6f959db125fc04cd4d6c2eefab54ae91R67-R76)

These changes collectively improve security, maintainability, and future-proofing of the codebase as part of the 2.x modernization effort.