### PR TITLE
docs: add security review checklist, secure baseline, operator hardening, and deprecation milestone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,17 @@ Before opening a PR:
 
 Recommended commit convention: follow Conventional Commits (`feat:`, `fix:`, `perf:`, `docs:`, `refactor:`, `chore:`) to improve release notes.
 
+
+## Security Review Checklist
+
+For any PR touching **authentication, session handling, admin/superuser flows, async endpoints, or SQL execution**, include a short security review note in the PR description that confirms all of the following:
+
+- Input validation boundary is defined (where untrusted input enters and where it is validated/cast).
+- CSRF coverage is present for all state-changing requests.
+- Prepared statements are used for SQL writes/reads; do not introduce new `addslashes`-based SQL patterns.
+- Authorization checks exist for superuser and module-privileged actions.
+- Security-relevant outcomes are logged (for example: auth failures, privilege changes, denied admin actions, suspicious async activity).
+
 These rules apply to all directories unless a more specific file overrides them.
 
 ## Compatibility & Deprecations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,3 +34,11 @@ Good-faith security research is welcome. Please avoid impacting production playe
 ## Recognition
 
 With your permission, verified reporters are thanked in the release notes. The project does not operate a bug bounty or provide monetary rewards.
+
+## Secure coding baseline
+
+When changing security-sensitive code paths, align implementation and review notes with these project references:
+
+- Doctrine prepared statements baseline: [docs/Doctrine.md#prepared-statements](docs/Doctrine.md#prepared-statements)
+- Async authentication and rate-limit guidance: [AGENTS.md#async--jaxon](AGENTS.md#async--jaxon) and [docs/PasskeyService.md#async-boundary](docs/PasskeyService.md#async-boundary)
+- Session, header, and cookie expectations: [docs/PasskeyService.md#security-model-and-boundaries](docs/PasskeyService.md#security-model-and-boundaries), [UPGRADING.md#6-configuration-changes](UPGRADING.md#6-configuration-changes), and [UPGRADING.md#8-after-upgrade](UPGRADING.md#8-after-upgrade)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -271,3 +271,14 @@ As of this policy, static QA enforcement runs during `composer static` and fails
 ---
 
 👉 See also [CHANGELOG.md](CHANGELOG.md) for detailed release notes.
+
+---
+
+## 11. Operator Hardening Checklist
+
+After upgrade and smoke tests, run this operator-focused hardening pass:
+
+- Verify HTTPS termination correctness end-to-end (TLS at edge/proxy, forwarded scheme handling, and no mixed-content/login downgrade paths).
+- Re-check cache path permissions (`DB_DATACACHEPATH` and Twig cache path) and confirm directories are writable by the runtime user only as needed.
+- Verify cookie and session behavior in production-like conditions (secure transport, expected login/session persistence, logout invalidation, and async/session continuity).
+- Run post-upgrade admin endpoint smoke checks (superuser login, key admin pages, and at least one state-changing admin action with expected auth/CSRF behavior).

--- a/docs/Deprecations.md
+++ b/docs/Deprecations.md
@@ -29,6 +29,12 @@ This project aims to preserve legacy compatibility while moving to a modern stac
   - Replacement: `Database::getDoctrineConnection()` with `Result::fetchAssociative()` / `fetchAllAssociative()`  
   - Migration: Replace wrapper loops with DBAL results and explicit parameter typing.
 
+- Legacy SQL string concatenation in core paths
+  - Status: Deprecated milestone **2026-03-27** (core paths only)
+  - 2.x compatibility: Existing module wrappers and legacy module code paths remain supported in 2.x for backward compatibility.
+  - Replacement: Doctrine DBAL prepared statements via `Database::getDoctrineConnection()` (or equivalent Doctrine abstractions).
+  - Removal target: Next major release (3.0) for core/refactored paths; module maintainers should migrate before upgrading.
+
 - Custom Ajax endpoints not using Jaxon
   - Status: Deprecated
   - Replacement: Jaxon-based async calls under `async/`


### PR DESCRIPTION
### Motivation

- Make security expectations explicit for PRs that touch authentication, sessions, admin/superuser flows, async endpoints, or SQL execution so reviews catch common mistakes early. 
- Surface implementation guidance and links to project references (Doctrine prepared statements, async auth/rate limits, session/header/cookie expectations) in the canonical security document. 
- Provide an operator-focused post-upgrade hardening checklist to reduce deployment misconfiguration risk. 
- Announce a dated deprecation milestone for unsafe legacy SQL concatenation in core paths to encourage migration to prepared statements.

### Description

- Add a compact **Security Review Checklist** to `AGENTS.md` that requires PR descriptions touching sensitive areas to confirm `input validation` boundaries, `CSRF` coverage, `prepared statements` usage (no new `addslashes` patterns), `authorization` checks, and `security-relevant` logging. 
- Add a **Secure coding baseline** section to `SECURITY.md` linking to `docs/Doctrine.md#prepared-statements`, `AGENTS.md#async--jaxon`, and `docs/PasskeyService.md` topics about session/header/cookie expectations. 
- Append an **Operator Hardening Checklist** to `UPGRADING.md` with steps for verifying `HTTPS` termination, cache path permissions (`DB_DATACACHEPATH` and Twig cache), cookie/session behavior, and post-upgrade admin endpoint smoke checks. 
- Insert a dated deprecation milestone (2026-03-27) in `docs/Deprecations.md` for legacy SQL string concatenation in core paths while retaining 2.x module-wrapper compatibility and targeting removal in the next major release.

### Testing

- Ran `git diff --check` to validate whitespace and diff hygiene, which returned clean results. 
- Ran `git status --short` to confirm the intended files were staged and committed, which showed the four modified docs files. 
- Changes are documentation-only and do not modify runtime code paths, so no unit tests or static-analysis changes were necessary for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c660a6d69c83299a5f08154fb9561a)