### PR TITLE
chore: raise PHPStan memory limit for static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
             "Lotgd\\Tests\\Stubs\\": "tests/Stubs/"
         }
     },
-    "scripts": {
-        "qa:http-wrappers": "php scripts/check-legacy-http-wrappers.php",
-        "static": [
-            "@qa:http-wrappers",
-            "phpstan analyse --configuration phpstan.neon"
-        ],
+  "scripts": {
+    "qa:http-wrappers": "php scripts/check-legacy-http-wrappers.php",
+    "static": [
+      "@qa:http-wrappers",
+      "phpstan analyse --configuration phpstan.neon --memory-limit=512M"
+    ],
         "test": "phpunit --configuration phpunit.xml",
         "lint": "phpcs .",
         "lint:fix": "phpcbf ."


### PR DESCRIPTION
## Summary
- updated the Composer `static` script to run PHPStan with `--memory-limit=512M`
- keeps the existing `phpstan.neon` configuration unchanged
- resolves crashes from the default `128M` memory cap in parallel workers

## Why
`composer static` was failing with:
- `PHPStan process crashed because it reached configured PHP memory limit: 128M`

Setting an explicit memory limit in the script makes static analysis more reliable across environments where CLI memory defaults are low.

## Validation
- `composer validate --no-check-publish` passes (with existing non-blocking warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6d4ec98cc8329a75f92eebd63e10b)