### PR TITLE
fix: add canonical idempotency guard for IPN donation crediting

### DIFF
--- a/src/Lotgd/Payment/IpnPaymentProcessor.php
+++ b/src/Lotgd/Payment/IpnPaymentProcessor.php
@@ -14,7 +14,8 @@ use Throwable;
  *
  * Legacy duplicate handling policy:
  * - Canonical row is the *oldest* paylog row for a txnid (`MIN(payid)`).
- * - Only the processor instance that inserted/owns that canonical row may credit points.
+ * - Only the canonical row may be credited.
+ * - Crediting is gated by a transactional claim on `processed = 0`.
  * - Credit and `processed=1` are guarded in one transaction using a conditional
  *   `UPDATE ... WHERE payid = :payid AND processed = 0`, which emulates row-lock
  *   claim semantics on platforms without portable `SELECT ... FOR UPDATE` support.
@@ -185,11 +186,14 @@ final class IpnPaymentProcessor
     }
 
     /**
-     * Persist paylog with an atomic "insert-if-not-exists" guard for auditability.
+     * Persist paylog with a single-statement, best-effort "insert-if-not-exists" guard for auditability.
      *
      * This method intentionally does not fail hard when the row already exists because
-     * legacy datasets may already contain duplicate txnid rows; canonical-row ownership
-     * checks are applied later before any crediting is attempted.
+     * legacy datasets may already contain duplicate txnid rows; canonical-row
+     * validation and guarded claim checks are applied later before any crediting is attempted.
+     *
+     * Note: without a DB-level unique constraint on txnid, this guard does not fully
+     * prevent concurrent duplicate inserts; canonical claim logic is the true idempotency gate.
      *
      * When a duplicate txnid is detected, this method resolves and stores the canonical
      * payid so downstream guarded processing can still claim/process resumable rows.

--- a/src/Lotgd/Payment/IpnPaymentProcessor.php
+++ b/src/Lotgd/Payment/IpnPaymentProcessor.php
@@ -11,9 +11,13 @@ use Throwable;
 /**
  * Handles database-side IPN persistence and crediting in a testable, stepwise workflow.
  *
- * Note: this flow is intentionally not wrapped in a single DB transaction because
- * legacy behavior expects paylog persistence and follow-up updates to remain visible
- * even if later steps fail.
+ *
+ * Legacy duplicate handling policy:
+ * - Canonical row is the *oldest* paylog row for a txnid (`MIN(payid)`).
+ * - Only the processor instance that inserted/owns that canonical row may credit points.
+ * - Credit and `processed=1` are guarded in one transaction using a conditional
+ *   `UPDATE ... WHERE payid = :payid AND processed = 0`, which emulates row-lock
+ *   claim semantics on platforms without portable `SELECT ... FOR UPDATE` support.
  */
 final class IpnPaymentProcessor
 {
@@ -58,6 +62,29 @@ final class IpnPaymentProcessor
         }
         $this->updatePaylogAccountId($result);
 
+        $canonicalRow = $this->resolveCanonicalPaylogRow($txnid, $result);
+        if ($canonicalRow === null) {
+            return $result;
+        }
+
+        // Legacy-safe idempotency policy:
+        // only the instance that inserted the canonical paylog row may perform crediting.
+        if ($result->paylogId !== $canonicalRow['payid']) {
+            $result->duplicateTransaction = true;
+            $result->warnings[] = sprintf(
+                'Skipped non-canonical paylog row for txnid (%s); canonical payid is %d.',
+                $txnid,
+                $canonicalRow['payid']
+            );
+            return $result;
+        }
+
+        if ($canonicalRow['processed'] !== 0) {
+            $result->duplicateTransaction = true;
+            $result->warnings[] = sprintf('Transaction (%s) was already processed.', $txnid);
+            return $result;
+        }
+
         $pointsPerCurrencyUnit = (float) ($payload['pointsPerCurrencyUnit'] ?? 0.0);
         $adjusted = $adjustDonation([
             'points' => $result->donationAmount * $pointsPerCurrencyUnit,
@@ -79,28 +106,7 @@ final class IpnPaymentProcessor
             }
         }
 
-        try {
-            $affected = $this->connection->executeStatement(
-                "UPDATE {$this->accountsTable} SET donation = donation + :points WHERE acctid = :acctid",
-                [
-                    'points' => $points,
-                    'acctid' => $result->accountId,
-                ],
-                [
-                    'points' => ParameterType::INTEGER,
-                    'acctid' => ParameterType::INTEGER,
-                ]
-            );
-        } catch (Throwable $exception) {
-            $result->errors[] = 'Failed to credit donation points: ' . $exception->getMessage();
-            return $result;
-        }
-
-        if ($affected > 0) {
-            $result->processed = 1;
-            $result->credited = true;
-            $this->updatePaylogProcessedState($result);
-        }
+        $this->creditCanonicalRowInGuardedFlow($result, $points, $txnid);
 
         return $result;
     }
@@ -179,7 +185,11 @@ final class IpnPaymentProcessor
     }
 
     /**
-     * Persist paylog with an atomic "insert-if-not-exists" guard to avoid check/insert races.
+     * Persist paylog with an atomic "insert-if-not-exists" guard for auditability.
+     *
+     * This method intentionally does not fail hard when the row already exists because
+     * legacy datasets may already contain duplicate txnid rows; canonical-row ownership
+     * checks are applied later before any crediting is attempted.
      */
     private function insertPaylogIfNew(array $post, array $payload, IpnProcessingResult $result): bool
     {
@@ -244,7 +254,7 @@ final class IpnPaymentProcessor
             if ($inserted === 0) {
                 $result->duplicateTransaction = true;
                 $result->warnings[] = sprintf('Already logged this transaction ID (%s)', $txnid);
-                return false;
+                return true;
             }
             $result->paylogInserted = true;
             $result->paylogId = (int) $this->connection->lastInsertId();
@@ -253,7 +263,7 @@ final class IpnPaymentProcessor
             if ($this->isDuplicateTransactionError($exception)) {
                 $result->duplicateTransaction = true;
                 $result->warnings[] = sprintf('Already logged this transaction ID (%s)', $txnid);
-                return false;
+                return true;
             }
 
             $result->errors[] = 'Failed to persist payment log: ' . $exception->getMessage();
@@ -288,28 +298,113 @@ final class IpnPaymentProcessor
     }
 
     /**
-     * Mark paylog row as processed once donation points are successfully credited.
+     * Resolve the canonical paylog row for a transaction ID.
+     *
+     * Policy: canonical = `MIN(payid)` to preserve legacy-first processing order.
+     * This deterministic choice prevents older duplicate rows from being bypassed.
+     *
+     * @return array{payid:int,processed:int}|null
      */
-    private function updatePaylogProcessedState(IpnProcessingResult $result): void
+    private function resolveCanonicalPaylogRow(string $txnid, IpnProcessingResult $result): ?array
     {
-        if ($result->paylogId <= 0) {
+        try {
+            $row = $this->connection->fetchAssociative(
+                "SELECT payid, processed
+                 FROM {$this->paylogTable}
+                 WHERE payid = (
+                    SELECT MIN(payid)
+                    FROM {$this->paylogTable}
+                    WHERE txnid = :txnid
+                 )",
+                ['txnid' => $txnid],
+                ['txnid' => ParameterType::STRING]
+            );
+        } catch (Throwable $exception) {
+            $result->errors[] = 'Failed to resolve canonical paylog row: ' . $exception->getMessage();
+            return null;
+        }
+
+        if (! is_array($row)) {
+            $result->errors[] = sprintf('Missing paylog row for transaction ID (%s).', $txnid);
+            return null;
+        }
+
+        return [
+            'payid' => (int) ($row['payid'] ?? 0),
+            'processed' => (int) ($row['processed'] ?? 0),
+        ];
+    }
+
+    /**
+     * Execute donation crediting in one guarded transaction.
+     *
+     * Guard order:
+     * 1) claim canonical paylog row via `processed = 0` conditional update,
+     * 2) credit account donation points,
+     * 3) commit both changes together.
+     *
+     * The conditional claim emulates row-lock ownership on engines where portable
+     * `SELECT ... FOR UPDATE` is not available.
+     */
+    private function creditCanonicalRowInGuardedFlow(IpnProcessingResult $result, int $points, string $txnid): void
+    {
+        if ($result->paylogId <= 0 || $result->accountId <= 0) {
             return;
         }
 
         try {
-            $this->connection->executeStatement(
-                "UPDATE {$this->paylogTable} SET processed = :processed WHERE payid = :payid",
+            $this->connection->beginTransaction();
+
+            $claimed = $this->connection->executeStatement(
+                "UPDATE {$this->paylogTable}
+                 SET processed = :processed
+                 WHERE payid = :payid
+                 AND processed = :unprocessed",
                 [
                     'processed' => 1,
                     'payid' => $result->paylogId,
+                    'unprocessed' => 0,
                 ],
                 [
                     'processed' => ParameterType::INTEGER,
                     'payid' => ParameterType::INTEGER,
+                    'unprocessed' => ParameterType::INTEGER,
                 ]
             );
+
+            if ($claimed === 0) {
+                $this->connection->rollBack();
+                $result->duplicateTransaction = true;
+                $result->warnings[] = sprintf('Transaction (%s) was already processed.', $txnid);
+                return;
+            }
+
+            $affected = $this->connection->executeStatement(
+                "UPDATE {$this->accountsTable} SET donation = donation + :points WHERE acctid = :acctid",
+                [
+                    'points' => $points,
+                    'acctid' => $result->accountId,
+                ],
+                [
+                    'points' => ParameterType::INTEGER,
+                    'acctid' => ParameterType::INTEGER,
+                ]
+            );
+
+            if ($affected <= 0) {
+                $this->connection->rollBack();
+                return;
+            }
+
+            $this->connection->commit();
+            $result->processed = 1;
+            $result->credited = true;
         } catch (Throwable $exception) {
-            $result->errors[] = 'Failed to update paylog processed state: ' . $exception->getMessage();
+            if ($this->connection->isTransactionActive()) {
+                $this->connection->rollBack();
+            }
+
+            $result->errors[] = 'Failed to credit donation points: ' . $exception->getMessage();
         }
     }
 

--- a/src/Lotgd/Payment/IpnPaymentProcessor.php
+++ b/src/Lotgd/Payment/IpnPaymentProcessor.php
@@ -190,6 +190,9 @@ final class IpnPaymentProcessor
      * This method intentionally does not fail hard when the row already exists because
      * legacy datasets may already contain duplicate txnid rows; canonical-row ownership
      * checks are applied later before any crediting is attempted.
+     *
+     * When a duplicate txnid is detected, this method resolves and stores the canonical
+     * payid so downstream guarded processing can still claim/process resumable rows.
      */
     private function insertPaylogIfNew(array $post, array $payload, IpnProcessingResult $result): bool
     {
@@ -254,6 +257,7 @@ final class IpnPaymentProcessor
             if ($inserted === 0) {
                 $result->duplicateTransaction = true;
                 $result->warnings[] = sprintf('Already logged this transaction ID (%s)', $txnid);
+                $result->paylogId = $this->resolveCanonicalPaylogId($txnid, $result);
                 return true;
             }
             $result->paylogInserted = true;
@@ -263,12 +267,35 @@ final class IpnPaymentProcessor
             if ($this->isDuplicateTransactionError($exception)) {
                 $result->duplicateTransaction = true;
                 $result->warnings[] = sprintf('Already logged this transaction ID (%s)', $txnid);
+                $result->paylogId = $this->resolveCanonicalPaylogId($txnid, $result);
                 return true;
             }
 
             $result->errors[] = 'Failed to persist payment log: ' . $exception->getMessage();
             return false;
         }
+    }
+
+    /**
+     * Resolve the canonical paylog identifier for an already-existing transaction.
+     *
+     * Canonical policy is always `MIN(payid)` so retries can safely resume against
+     * the same deterministic row even when legacy duplicate txnid rows exist.
+     */
+    private function resolveCanonicalPaylogId(string $txnid, IpnProcessingResult $result): int
+    {
+        try {
+            $row = $this->connection->fetchAssociative(
+                "SELECT MIN(payid) AS payid FROM {$this->paylogTable} WHERE txnid = :txnid",
+                ['txnid' => $txnid],
+                ['txnid' => ParameterType::STRING]
+            );
+        } catch (Throwable $exception) {
+            $result->errors[] = 'Failed to resolve existing paylog row: ' . $exception->getMessage();
+            return 0;
+        }
+
+        return (int) ($row['payid'] ?? 0);
     }
 
     /**

--- a/src/Lotgd/Payment/IpnPaymentProcessor.php
+++ b/src/Lotgd/Payment/IpnPaymentProcessor.php
@@ -314,7 +314,12 @@ final class IpnPaymentProcessor
             return 0;
         }
 
-        return (int) ($row['payid'] ?? 0);
+        if (!is_array($row) || !array_key_exists('payid', $row) || $row['payid'] === null) {
+            $result->errors[] = 'Failed to resolve canonical paylog id: no existing paylog row found for transaction.';
+            return 0;
+        }
+
+        return (int) $row['payid'];
     }
 
     /**

--- a/src/Lotgd/Payment/IpnPaymentProcessor.php
+++ b/src/Lotgd/Payment/IpnPaymentProcessor.php
@@ -69,7 +69,8 @@ final class IpnPaymentProcessor
         }
 
         // Legacy-safe idempotency policy:
-        // only the instance that inserted the canonical paylog row may perform crediting.
+        // only the canonical row may be credited, and only after the
+        // transactional `processed = 0` claim succeeds in guarded flow.
         if ($result->paylogId !== $canonicalRow['payid']) {
             $result->duplicateTransaction = true;
             $result->warnings[] = sprintf(
@@ -262,6 +263,13 @@ final class IpnPaymentProcessor
                 $result->duplicateTransaction = true;
                 $result->warnings[] = sprintf('Already logged this transaction ID (%s)', $txnid);
                 $result->paylogId = $this->resolveCanonicalPaylogId($txnid, $result);
+                if ($result->paylogId <= 0) {
+                    $result->errors[] = sprintf(
+                        'Unable to continue duplicate transaction processing because canonical paylog row was not resolved (%s).',
+                        $txnid
+                    );
+                    return false;
+                }
                 return true;
             }
             $result->paylogInserted = true;
@@ -272,6 +280,13 @@ final class IpnPaymentProcessor
                 $result->duplicateTransaction = true;
                 $result->warnings[] = sprintf('Already logged this transaction ID (%s)', $txnid);
                 $result->paylogId = $this->resolveCanonicalPaylogId($txnid, $result);
+                if ($result->paylogId <= 0) {
+                    $result->errors[] = sprintf(
+                        'Unable to continue duplicate transaction processing because canonical paylog row was not resolved (%s).',
+                        $txnid
+                    );
+                    return false;
+                }
                 return true;
             }
 

--- a/tests/Payment/IpnPaymentProcessorTest.php
+++ b/tests/Payment/IpnPaymentProcessorTest.php
@@ -11,7 +11,7 @@ use RuntimeException;
 
 final class IpnPaymentProcessorTest extends TestCase
 {
-    public function testDuplicateTransactionReturnsNoSecondCredit(): void
+    public function testDuplicateTransactionWithMissingAccountSkipsCrediting(): void
     {
         $connection = $this->createConnectionMock();
         $connection->expects(self::exactly(2))

--- a/tests/Payment/IpnPaymentProcessorTest.php
+++ b/tests/Payment/IpnPaymentProcessorTest.php
@@ -14,7 +14,10 @@ final class IpnPaymentProcessorTest extends TestCase
     public function testDuplicateTransactionReturnsNoSecondCredit(): void
     {
         $connection = $this->createConnectionMock();
-        $connection->expects(self::never())->method('fetchAssociative');
+        $connection->expects(self::once())
+            ->method('fetchAssociative')
+            ->willReturn(false);
+        $connection->expects(self::never())->method('beginTransaction');
         $connection->expects(self::never())->method('lastInsertId');
         $connection->expects(self::once())
             ->method('executeStatement')
@@ -37,10 +40,13 @@ final class IpnPaymentProcessorTest extends TestCase
     public function testFirstDeliveryCreditsOnceAndLogsOnce(): void
     {
         $connection = $this->createConnectionMock();
-        $connection->expects(self::once())
+        $connection->expects(self::exactly(2))
             ->method('fetchAssociative')
-            ->willReturn(['acctid' => 13]);
+            ->willReturnOnConsecutiveCalls(['acctid' => 13], ['payid' => 501, 'processed' => 0]);
         $connection->expects(self::once())->method('lastInsertId')->willReturn(501);
+        $connection->expects(self::once())->method('beginTransaction');
+        $connection->expects(self::once())->method('commit');
+        $connection->expects(self::never())->method('rollBack');
 
         $calls = 0;
         $statements = [];
@@ -72,26 +78,30 @@ final class IpnPaymentProcessorTest extends TestCase
         self::assertStringContainsString('UPDATE paylog SET acctid', $statements[1]['sql']);
         self::assertArrayHasKey('acctid', $statements[1]['params']);
         self::assertArrayHasKey('payid', $statements[1]['params']);
-        self::assertStringContainsString('UPDATE accounts SET donation', $statements[2]['sql']);
-        self::assertArrayHasKey('points', $statements[2]['params']);
-        self::assertArrayHasKey('acctid', $statements[2]['params']);
-        self::assertStringContainsString('UPDATE paylog SET processed', $statements[3]['sql']);
-        self::assertArrayHasKey('processed', $statements[3]['params']);
+        self::assertStringContainsString('UPDATE paylog', $statements[2]['sql']);
+        self::assertArrayHasKey('processed', $statements[2]['params']);
+        self::assertStringContainsString('UPDATE accounts SET donation', $statements[3]['sql']);
+        self::assertArrayHasKey('points', $statements[3]['params']);
+        self::assertArrayHasKey('acctid', $statements[3]['params']);
     }
 
     public function testCreditWriteFailureAddsErrorAndDoesNotFatal(): void
     {
         $connection = $this->createConnectionMock();
-        $connection->expects(self::once())
+        $connection->expects(self::exactly(2))
             ->method('fetchAssociative')
-            ->willReturn(['acctid' => 2]);
+            ->willReturnOnConsecutiveCalls(['acctid' => 2], ['payid' => 502, 'processed' => 0]);
         $connection->expects(self::once())->method('lastInsertId')->willReturn(502);
+        $connection->expects(self::once())->method('beginTransaction');
+        $connection->expects(self::once())->method('isTransactionActive')->willReturn(true);
+        $connection->expects(self::once())->method('rollBack');
+        $connection->expects(self::never())->method('commit');
 
         $calls = 0;
         $connection->method('executeStatement')
             ->willReturnCallback(static function (string $sql, array $params = [], array $types = []) use (&$calls): int {
                 $calls++;
-                if ($calls === 3) {
+                if ($calls === 4) {
                     throw new RuntimeException('write failed');
                 }
 
@@ -116,6 +126,7 @@ final class IpnPaymentProcessorTest extends TestCase
         $connection->expects(self::once())
             ->method('fetchAssociative')
             ->willReturn(false);
+        $connection->expects(self::never())->method('beginTransaction');
         $connection->expects(self::once())->method('lastInsertId')->willReturn(503);
         $connection->expects(self::once())->method('executeStatement')->willReturn(1);
 
@@ -159,10 +170,13 @@ final class IpnPaymentProcessorTest extends TestCase
     public function testReversalUsesFeeAdjustedDonationAmountForPointCalculation(): void
     {
         $connection = $this->createConnectionMock();
-        $connection->expects(self::once())
+        $connection->expects(self::exactly(2))
             ->method('fetchAssociative')
-            ->willReturn(['acctid' => 13]);
+            ->willReturnOnConsecutiveCalls(['acctid' => 13], ['payid' => 504, 'processed' => 0]);
         $connection->expects(self::once())->method('lastInsertId')->willReturn(504);
+        $connection->expects(self::once())->method('beginTransaction');
+        $connection->expects(self::once())->method('commit');
+        $connection->expects(self::never())->method('rollBack');
         $connection->expects(self::exactly(4))->method('executeStatement')->willReturn(1);
 
         $processor = new IpnPaymentProcessor($connection, 'accounts', 'paylog');
@@ -184,7 +198,7 @@ final class IpnPaymentProcessorTest extends TestCase
     {
         return $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['fetchAssociative', 'executeStatement', 'lastInsertId'])
+            ->onlyMethods(['fetchAssociative', 'executeStatement', 'lastInsertId', 'beginTransaction', 'commit', 'rollBack', 'isTransactionActive'])
             ->getMock();
     }
 
@@ -208,6 +222,7 @@ final class IpnPaymentProcessorTest extends TestCase
     {
         $connection = $this->createConnectionMock();
         $connection->expects(self::once())->method('lastInsertId')->willReturn(505);
+        $connection->expects(self::never())->method('beginTransaction');
         $connection->expects(self::once())->method('executeStatement')->willReturn(1);
         $connection->expects(self::never())->method('fetchAssociative');
 
@@ -225,5 +240,77 @@ final class IpnPaymentProcessorTest extends TestCase
         self::assertSame(0, $result->accountId);
         self::assertTrue($result->paylogInserted);
         self::assertFalse($result->credited);
+    }
+
+    public function testLegacyDuplicateRowsOnlyCanonicalOwnerMayCredit(): void
+    {
+        $connection = $this->createConnectionMock();
+        $connection->expects(self::exactly(2))
+            ->method('fetchAssociative')
+            ->willReturnOnConsecutiveCalls(['acctid' => 13], ['payid' => 100, 'processed' => 0]);
+        $connection->expects(self::once())->method('lastInsertId')->willReturn(101);
+        $connection->expects(self::never())->method('beginTransaction');
+        $connection->expects(self::exactly(2))
+            ->method('executeStatement')
+            ->willReturnOnConsecutiveCalls(1, 1);
+
+        $processor = new IpnPaymentProcessor($connection, 'accounts', 'paylog');
+        $result = $processor->processVerifiedPayment(
+            ['foo' => 'bar'],
+            $this->buildPayload(),
+            static fn (array $data): array => $data
+        );
+
+        self::assertFalse($result->credited);
+        self::assertTrue($result->duplicateTransaction);
+        self::assertStringContainsString('non-canonical', implode("\n", $result->warnings));
+    }
+
+    public function testSecondProcessingAttemptOnSameCanonicalRowSkipsCredit(): void
+    {
+        $connection = $this->createConnectionMock();
+        $connection->expects(self::exactly(2))
+            ->method('fetchAssociative')
+            ->willReturnOnConsecutiveCalls(['acctid' => 13], ['payid' => 777, 'processed' => 1]);
+        $connection->expects(self::once())->method('lastInsertId')->willReturn(777);
+        $connection->expects(self::never())->method('beginTransaction');
+        $connection->expects(self::exactly(2))
+            ->method('executeStatement')
+            ->willReturnOnConsecutiveCalls(1, 1);
+
+        $processor = new IpnPaymentProcessor($connection, 'accounts', 'paylog');
+        $result = $processor->processVerifiedPayment(
+            ['foo' => 'bar'],
+            $this->buildPayload(),
+            static fn (array $data): array => $data
+        );
+
+        self::assertFalse($result->credited);
+        self::assertTrue($result->duplicateTransaction);
+        self::assertStringContainsString('already processed', implode("\n", $result->warnings));
+    }
+
+    public function testNonCanonicalRowAttemptMustNotCredit(): void
+    {
+        $connection = $this->createConnectionMock();
+        $connection->expects(self::exactly(2))
+            ->method('fetchAssociative')
+            ->willReturnOnConsecutiveCalls(['acctid' => 13], ['payid' => 200, 'processed' => 0]);
+        $connection->expects(self::once())->method('lastInsertId')->willReturn(201);
+        $connection->expects(self::never())->method('beginTransaction');
+        $connection->expects(self::exactly(2))
+            ->method('executeStatement')
+            ->willReturnOnConsecutiveCalls(1, 1);
+
+        $processor = new IpnPaymentProcessor($connection, 'accounts', 'paylog');
+        $result = $processor->processVerifiedPayment(
+            ['foo' => 'bar'],
+            $this->buildPayload(),
+            static fn (array $data): array => $data
+        );
+
+        self::assertFalse($result->credited);
+        self::assertSame(0, $result->processed);
+        self::assertTrue($result->duplicateTransaction);
     }
 }

--- a/tests/Payment/IpnPaymentProcessorTest.php
+++ b/tests/Payment/IpnPaymentProcessorTest.php
@@ -351,4 +351,28 @@ final class IpnPaymentProcessorTest extends TestCase
         self::assertSame(1, $result->processed);
         self::assertSame(300, $result->paylogId);
     }
+
+    public function testDuplicateDeliveryFailsWhenCanonicalPaylogCannotBeResolved(): void
+    {
+        $connection = $this->createConnectionMock();
+        $connection->expects(self::once())
+            ->method('fetchAssociative')
+            ->willReturn(false);
+        $connection->expects(self::never())->method('lastInsertId');
+        $connection->expects(self::never())->method('beginTransaction');
+        $connection->expects(self::once())
+            ->method('executeStatement')
+            ->willReturn(0);
+
+        $processor = new IpnPaymentProcessor($connection, 'accounts', 'paylog');
+        $result = $processor->processVerifiedPayment(
+            ['foo' => 'bar'],
+            $this->buildPayload(),
+            static fn (array $data): array => $data
+        );
+
+        self::assertFalse($result->credited);
+        self::assertSame(0, $result->paylogId);
+        self::assertStringContainsString('Unable to continue duplicate transaction processing', implode("\n", $result->errors));
+    }
 }

--- a/tests/Payment/IpnPaymentProcessorTest.php
+++ b/tests/Payment/IpnPaymentProcessorTest.php
@@ -14,9 +14,9 @@ final class IpnPaymentProcessorTest extends TestCase
     public function testDuplicateTransactionReturnsNoSecondCredit(): void
     {
         $connection = $this->createConnectionMock();
-        $connection->expects(self::once())
+        $connection->expects(self::exactly(2))
             ->method('fetchAssociative')
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls(['payid' => 900], false);
         $connection->expects(self::never())->method('beginTransaction');
         $connection->expects(self::never())->method('lastInsertId');
         $connection->expects(self::once())
@@ -35,6 +35,7 @@ final class IpnPaymentProcessorTest extends TestCase
         self::assertFalse($result->paylogInserted);
         self::assertFalse($result->credited);
         self::assertNotEmpty($result->warnings);
+        self::assertSame(900, $result->paylogId);
     }
 
     public function testFirstDeliveryCreditsOnceAndLogsOnce(): void
@@ -312,5 +313,42 @@ final class IpnPaymentProcessorTest extends TestCase
         self::assertFalse($result->credited);
         self::assertSame(0, $result->processed);
         self::assertTrue($result->duplicateTransaction);
+    }
+
+    public function testDuplicateDeliveryCanResumeCanonicalCreditWhenUnprocessed(): void
+    {
+        $connection = $this->createConnectionMock();
+        $connection->expects(self::exactly(3))
+            ->method('fetchAssociative')
+            ->willReturnOnConsecutiveCalls(
+                ['payid' => 300], // duplicate insert path resolves canonical payid
+                ['acctid' => 13], // account lookup
+                ['payid' => 300, 'processed' => 0] // canonical row state before claim
+            );
+        $connection->expects(self::never())->method('lastInsertId');
+        $connection->expects(self::once())->method('beginTransaction');
+        $connection->expects(self::once())->method('commit');
+        $connection->expects(self::never())->method('rollBack');
+        $connection->expects(self::exactly(4))
+            ->method('executeStatement')
+            ->willReturnOnConsecutiveCalls(
+                0, // insert skipped (duplicate)
+                1, // update paylog acctid using canonical payid
+                1, // claim canonical row processed=0->1
+                1  // credit account donation
+            );
+
+        $processor = new IpnPaymentProcessor($connection, 'accounts', 'paylog');
+        $result = $processor->processVerifiedPayment(
+            ['foo' => 'bar'],
+            $this->buildPayload(),
+            static fn (array $data): array => $data
+        );
+
+        self::assertTrue($result->duplicateTransaction);
+        self::assertFalse($result->paylogInserted);
+        self::assertTrue($result->credited);
+        self::assertSame(1, $result->processed);
+        self::assertSame(300, $result->paylogId);
     }
 }


### PR DESCRIPTION
### Motivation

- Prevent duplicate donation credits caused by legacy datasets containing multiple `paylog` rows with the same `txnid` without requiring a unique DB constraint.
- Provide a legacy-safe, deterministic ownership policy so only one processor instance can claim and credit a canonical row.
- Preserve existing paylog insert/audit behavior while ensuring duplicates never trigger a second credit.

### Description

- Resolve a canonical paylog row using `MIN(payid)` per `txnid` and document this deterministic policy in PHPDoc and inline comments to explain why the oldest row is chosen.
- Add `resolveCanonicalPaylogRow()` and `creditCanonicalRowInGuardedFlow()` which claim the canonical row via a conditional `UPDATE ... WHERE payid = :payid AND processed = 0` inside a transaction and then credit the account only when the claim succeeds.
- Keep the original paylog insert for auditability but make `insertPaylogIfNew()` return safely when duplicates exist so canonical ownership and processing logic run afterwards; this prevents duplicate inserts from causing a second credit.
- Expand `tests/Payment/IpnPaymentProcessorTest.php` to cover duplicate `txnid` rows, second processing attempts on the canonical row, non-canonical-row attempts that must not credit, and updated mock expectations for transactional claim flows; all DB access remains parameterized and typed.

### Testing

- Ran PHP syntax checks with `php -l src/Lotgd/Payment/IpnPaymentProcessor.php` and `php -l tests/Payment/IpnPaymentProcessorTest.php`, both succeeded.
- Ran the targeted unit tests with `./vendor/bin/phpunit tests/Payment/IpnPaymentProcessorTest.php`, which passed (10 tests, 56 assertions).
- Ran the full test suite with `composer test`, which completed successfully (661 tests) and reported existing warnings/notices unrelated to this change.
- Ran static analysis with `composer static`, which reported no blocking findings for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6f89165bc8329a34d173083cf28d1)