### PR TITLE
fix: switch IPN canonical paylog lookup to MAX(payid) semantics

### DIFF
--- a/src/Lotgd/Payment/IpnPaymentProcessor.php
+++ b/src/Lotgd/Payment/IpnPaymentProcessor.php
@@ -13,7 +13,7 @@ use Throwable;
  *
  *
  * Legacy duplicate handling policy:
- * - Canonical row is the *oldest* paylog row for a txnid (`MIN(payid)`).
+ * - Canonical row is the *newest* paylog row for a txnid (`MAX(payid)`).
  * - Only the canonical row may be credited.
  * - Crediting is gated by a transactional claim on `processed = 0`.
  * - Credit and `processed=1` are guarded in one transaction using a conditional
@@ -298,14 +298,14 @@ final class IpnPaymentProcessor
     /**
      * Resolve the canonical paylog identifier for an already-existing transaction.
      *
-     * Canonical policy is always `MIN(payid)` so retries can safely resume against
-     * the same deterministic row even when legacy duplicate txnid rows exist.
+     * Canonical policy is always `MAX(payid)` so retries consistently bind to the
+     * latest persisted duplicate row in legacy datasets.
      */
     private function resolveCanonicalPaylogId(string $txnid, IpnProcessingResult $result): int
     {
         try {
             $row = $this->connection->fetchAssociative(
-                "SELECT MIN(payid) AS payid FROM {$this->paylogTable} WHERE txnid = :txnid",
+                "SELECT MAX(payid) AS payid FROM {$this->paylogTable} WHERE txnid = :txnid",
                 ['txnid' => $txnid],
                 ['txnid' => ParameterType::STRING]
             );
@@ -351,8 +351,8 @@ final class IpnPaymentProcessor
     /**
      * Resolve the canonical paylog row for a transaction ID.
      *
-     * Policy: canonical = `MIN(payid)` to preserve legacy-first processing order.
-     * This deterministic choice prevents older duplicate rows from being bypassed.
+     * Policy: canonical = `MAX(payid)` to preserve latest-row processing order.
+     * This deterministic choice keeps duplicate retries pinned to the newest row.
      *
      * @return array{payid:int,processed:int}|null
      */
@@ -363,7 +363,7 @@ final class IpnPaymentProcessor
                 "SELECT payid, processed
                  FROM {$this->paylogTable}
                  WHERE payid = (
-                    SELECT MIN(payid)
+                    SELECT MAX(payid)
                     FROM {$this->paylogTable}
                     WHERE txnid = :txnid
                  )",

--- a/tests/Payment/IpnPaymentProcessorTest.php
+++ b/tests/Payment/IpnPaymentProcessorTest.php
@@ -248,7 +248,7 @@ final class IpnPaymentProcessorTest extends TestCase
         $connection = $this->createConnectionMock();
         $connection->expects(self::exactly(2))
             ->method('fetchAssociative')
-            ->willReturnOnConsecutiveCalls(['acctid' => 13], ['payid' => 100, 'processed' => 0]);
+            ->willReturnOnConsecutiveCalls(['acctid' => 13], ['payid' => 102, 'processed' => 0]);
         $connection->expects(self::once())->method('lastInsertId')->willReturn(101);
         $connection->expects(self::never())->method('beginTransaction');
         $connection->expects(self::exactly(2))
@@ -296,7 +296,7 @@ final class IpnPaymentProcessorTest extends TestCase
         $connection = $this->createConnectionMock();
         $connection->expects(self::exactly(2))
             ->method('fetchAssociative')
-            ->willReturnOnConsecutiveCalls(['acctid' => 13], ['payid' => 200, 'processed' => 0]);
+            ->willReturnOnConsecutiveCalls(['acctid' => 13], ['payid' => 202, 'processed' => 0]);
         $connection->expects(self::once())->method('lastInsertId')->willReturn(201);
         $connection->expects(self::never())->method('beginTransaction');
         $connection->expects(self::exactly(2))


### PR DESCRIPTION
### Motivation
- Align canonical-duplicate handling to newest-row semantics so duplicate `txnid` retries and guarded credit flow consistently bind to the latest persisted paylog row.

### Description
- Updated class-level and method PHPDoc in `src/Lotgd/Payment/IpnPaymentProcessor.php` to state canonical policy is `MAX(payid)`.
- Replaced `MIN(payid)` with `MAX(payid)` in `resolveCanonicalPaylogId()` and `resolveCanonicalPaylogRow()` queries so canonical selection uses the highest `payid`.
- Adjusted assertions in `tests/Payment/IpnPaymentProcessorTest.php` that assumed oldest-row semantics to match the newest-row canonical behavior.

### Testing
- Ran `php -l` on modified files and there were no syntax errors.
- Executed `vendor/bin/phpunit tests/Payment/IpnPaymentProcessorTest.php` and the targeted test file passed (12 tests, all green).
- Ran full test suite with `composer test` which completed successfully (663 tests) with existing warnings/notices unrelated to this change.
- Ran static analysis with `composer static` which reported no blocking issues.
- Security review: `txnid` remains a bound parameter with explicit `ParameterType::STRING`, all DB access uses DBAL prepared/typed bindings, no `addslashes` patterns were introduced, no authorization or CSRF surface changes were made, and existing error/warning logging paths were preserved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c711bf1a5c8329b58aec3dfc339334)