### PR TITLE
fix: parameterize module SQL sinks and enforce addslashes() QA policy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,14 +28,14 @@
             "Lotgd\\Tests\\Stubs\\": "tests/Stubs/"
         }
     },
-  "scripts": {
-    "qa:http-wrappers": "php scripts/check-legacy-http-wrappers.php",
-    "qa:sql-addslashes": "php scripts/check-sql-addslashes.php",
-    "static": [
-      "@qa:http-wrappers",
-      "@qa:sql-addslashes",
-      "phpstan analyse --configuration phpstan.neon --memory-limit=512M"
-    ],
+    "scripts": {
+        "qa:http-wrappers": "php scripts/check-legacy-http-wrappers.php",
+        "qa:sql-addslashes": "php scripts/check-sql-addslashes.php",
+        "static": [
+            "@qa:http-wrappers",
+            "@qa:sql-addslashes",
+            "phpstan analyse --configuration phpstan.neon --memory-limit=512M"
+        ],
         "test": "phpunit --configuration phpunit.xml",
         "lint": "phpcs .",
         "lint:fix": "phpcbf ."

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,10 @@
     },
   "scripts": {
     "qa:http-wrappers": "php scripts/check-legacy-http-wrappers.php",
+    "qa:sql-addslashes": "php scripts/check-sql-addslashes.php",
     "static": [
       "@qa:http-wrappers",
+      "@qa:sql-addslashes",
       "phpstan analyse --configuration phpstan.neon --memory-limit=512M"
     ],
         "test": "phpunit --configuration phpunit.xml",

--- a/docs/Deprecations.md
+++ b/docs/Deprecations.md
@@ -51,6 +51,13 @@ This project aims to preserve legacy compatibility while moving to a modern stac
   - Migration: Replace legacy helper calls with `Lotgd\Http::get()` / `Lotgd\Http::post()` and use bound DBAL parameters instead of SQL string concatenation.
   - QA enforcement: `composer static` now runs a policy gate that fails when new wrapper usage appears in core/refactored paths.
 
+### Security Guidelines for Input and SQL (Core Paths)
+
+- **No global pre-escaping of superglobals**: do not rely on `addslashes()` wrappers around `$_GET`, `$_POST`, or compatibility helpers as an SQL safety boundary.
+- **Validate/cast at input boundaries**: normalize user input as it enters a feature (for example `int`, `bool`, constrained enum/string), and keep those typed values through the call chain.
+- **Parameterized SQL is mandatory for new/updated code**: use Doctrine DBAL `executeQuery()` / `executeStatement()` with explicit parameter arrays and types at the query sink.
+- **Legacy wrapper escape semantics are compatibility-only**: `lib/http.php` retained behavior is for legacy module compatibility and must not be used as justification for SQL string concatenation in core/refactored paths.
+
 ### Upgrade Guidance (1.3.x → 2.0)
 
 See `UPGRADING.md` for the full process. Key points:

--- a/lib/http.php
+++ b/lib/http.php
@@ -12,6 +12,10 @@ use Lotgd\Http;
  * addslashes()-escaped scalar values. Core/refactored code must use
  * Lotgd\Http directly, which intentionally returns raw values.
  *
+ * Security note: this helper is legacy-compatibility behavior only and is not
+ * an SQL-safety boundary. Core code must validate/cast input and bind DBAL
+ * parameters at the query sink.
+ *
  * @param mixed $value
  *
  * @return mixed

--- a/scripts/check-sql-addslashes.php
+++ b/scripts/check-sql-addslashes.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Lotgd\QA\SqlAddslashesUsageCheck;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$checker = new SqlAddslashesUsageCheck();
+exit($checker->run(dirname(__DIR__)));

--- a/src/Lotgd/Accounts.php
+++ b/src/Lotgd/Accounts.php
@@ -127,35 +127,53 @@ class Accounts
                     $em->flush();
                 }
             } else {
-                $sql = '';
+                $conn   = Database::getDoctrineConnection();
+                $sets   = [];
+                $params = [];
+
                 foreach ($session['user'] as $key => $val) {
+                    if ($key === 'acctid') {
+                        continue;
+                    }
                     if (is_array($val)) {
                         $val = serialize($val);
                     }
                     if ($baseaccount[$key] != $val) {
-                        if (is_string($val)) {
-                            $escapedVal = addslashes($val);
-                        } else {
-                            $escapedVal = $val;
-                        }
-                        $sql .= "$key='" . $escapedVal . "', ";
+                        $sets[]       = "$key = :$key";
+                        $params[$key] = $val;
                     }
                 }
+
                 // Always update laston due to output moving to separate table
-                $sql .= "laston='" . date('Y-m-d H:i:s') . "', ";
-                $sql  = substr($sql, 0, strlen($sql) - 2);
-                $sql  = 'UPDATE ' . Database::prefix('accounts') . ' SET ' . $sql .
-                    ' WHERE acctid = ' . $session['user']['acctid'];
-                Database::query($sql);
+                $sets[]           = 'laston = :laston';
+                $params['laston'] = date('Y-m-d H:i:s');
+
+                if ($sets) {
+                    $params['acctid'] = $session['user']['acctid'];
+                    $conn->executeStatement(
+                        'UPDATE ' . Database::prefix('accounts') . ' SET '
+                            . implode(', ', $sets)
+                            . ' WHERE acctid = :acctid',
+                        $params
+                    );
+                }
             }
             if (isset($session['output']) && $session['output']) {
-                $sql_output = 'UPDATE ' . Database::prefix('accounts_output') .
-                    " SET output='" . addslashes(gzcompress($session['output'], 1)) . "' WHERE acctid={$session['user']['acctid']};";
-                Database::query($sql_output);
-                if (Database::affectedRows() < 1) {
-                    $sql_output = 'REPLACE INTO ' . Database::prefix('accounts_output') .
-                        " VALUES ({$session['user']['acctid']},'" . addslashes(gzcompress($session['output'], 1)) . "');";
-                    Database::query($sql_output);
+                $conn       = Database::getDoctrineConnection();
+                $table      = Database::prefix('accounts_output');
+                $compressed = gzcompress($session['output'], 1);
+                $acctid     = $session['user']['acctid'];
+
+                $affected = $conn->executeStatement(
+                    'UPDATE ' . $table . ' SET output = :output WHERE acctid = :acctid',
+                    ['output' => $compressed, 'acctid' => $acctid]
+                );
+
+                if ($affected < 1) {
+                    $conn->executeStatement(
+                        'REPLACE INTO ' . $table . ' (acctid, output) VALUES (:acctid, :output)',
+                        ['acctid' => $acctid, 'output' => $compressed]
+                    );
                 }
             }
             unset($session['bufflist']);

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -771,8 +771,18 @@ class Modules
          */
         $objid = (int) $objid;
 
-        $sql = 'DELETE FROM ' . Database::prefix('module_objprefs') . " WHERE objtype='$objtype' AND objid='$objid'";
-        Database::query($sql);
+        $sql = 'DELETE FROM ' . Database::prefix('module_objprefs') . ' WHERE objtype = :objtype AND objid = :objid';
+        Database::executeStatement(
+            $sql,
+            [
+                'objtype' => $objtype,
+                'objid'   => $objid,
+            ],
+            [
+                'objtype' => ParameterType::STRING,
+                'objid'   => ParameterType::INTEGER,
+            ]
+        );
         DataCache::getInstance()->massinvalidate("objpref-$objtype-$objid");
     }
 

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -762,6 +762,15 @@ class Modules
      */
     public static function deleteObjPrefs(string $objtype, $objid): void
     {
+        /**
+         * Normalize object IDs the same way as getObjPref()/setObjPref() so
+         * DataCache invalidation keys remain consistent across numeric-string
+         * caller inputs (for example "001" versus 1).
+         *
+         * @var int $objid
+         */
+        $objid = (int) $objid;
+
         $sql = 'DELETE FROM ' . Database::prefix('module_objprefs') . " WHERE objtype='$objtype' AND objid='$objid'";
         Database::query($sql);
         DataCache::getInstance()->massinvalidate("objpref-$objtype-$objid");

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Lotgd;
 
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Types\Types;
 use Lotgd\Settings;
 use Lotgd\MySQL\Database;
 use Lotgd\Backtrace;
@@ -691,12 +692,12 @@ class Modules
                 'UPDATE ' . Database::prefix('module_settings')
                 . ' SET value = value + :value WHERE modulename = :module AND setting = :setting',
                 [
-                    'value' => (string) $value,
+                    'value' => $value,
                     'module' => $module,
                     'setting' => $name,
                 ],
                 [
-                    'value' => ParameterType::STRING,
+                    'value' => Types::FLOAT,
                     'module' => ParameterType::STRING,
                     'setting' => ParameterType::STRING,
                 ]
@@ -784,7 +785,7 @@ class Modules
          * Keep the legacy objpref cache behavior so repeated reads can be served
          * from DataCache, while SQL safety is enforced at the DBAL query sink.
          *
-         * @var array{found:bool,value?:string}|false $cachedValue
+         * @var array{found:bool,value?:string|null}|false $cachedValue
          */
         $cachedValue = $cache->datacache($cacheKey, 86400);
         if (is_array($cachedValue) && array_key_exists('found', $cachedValue)) {
@@ -810,8 +811,10 @@ class Modules
         $row = $result->fetchAssociative();
 
         if ($row !== false) {
-            $cache->updatedatacache($cacheKey, ['found' => true, 'value' => (string) $row['value']]);
-            return $row['value'];
+            /** @var string|null $rawValue */
+            $rawValue = $row['value'];
+            $cache->updatedatacache($cacheKey, ['found' => true, 'value' => $rawValue]);
+            return $rawValue;
         }
 
         $cache->updatedatacache($cacheKey, ['found' => false]);
@@ -883,14 +886,14 @@ class Modules
             . ' SET value = value + :value WHERE modulename = :module AND setting = :setting'
             . ' AND objtype = :objtype AND objid = :objid',
             [
-                'value' => (string) $value,
+                'value' => $value,
                 'module' => $module,
                 'setting' => $name,
                 'objtype' => $objtype,
                 'objid' => $objid,
             ],
             [
-                'value' => ParameterType::STRING,
+                'value' => Types::FLOAT,
                 'module' => ParameterType::STRING,
                 'setting' => ParameterType::STRING,
                 'objtype' => ParameterType::STRING,

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use Doctrine\DBAL\ParameterType;
 use Lotgd\Settings;
 use Lotgd\MySQL\Database;
 use Lotgd\Backtrace;
@@ -168,14 +169,35 @@ class Modules
                             }
                         }
                         $keys = '|' . implode('|', array_keys($info)) . '|';
-                        $sql  = 'UPDATE ' . Database::prefix('modules') .
-                            " SET moduleauthor='" . addslashes((string) ($info['author'] ?? '')) .
-                            "', category='" . addslashes((string) ($info['category'] ?? '')) .
-                            "', formalname='" . addslashes((string) ($info['name'] ?? '')) .
-                            "', description='" . addslashes((string) ($info['description'] ?? '')) .
-                            "', filemoddate='$filemoddate', infokeys='$keys',version='" . addslashes((string) ($info['version'] ?? '')) .
-                            "',download='" . addslashes((string) ($info['download'] ?? '')) . "' WHERE modulename='$moduleName'";
-                        Database::query($sql);
+                        $sql = 'UPDATE ' . Database::prefix('modules')
+                            . ' SET moduleauthor = :moduleauthor, category = :category, formalname = :formalname,'
+                            . ' description = :description, filemoddate = :filemoddate, infokeys = :infokeys,'
+                            . ' version = :version, download = :download WHERE modulename = :modulename';
+                        Database::getDoctrineConnection()->executeStatement(
+                            $sql,
+                            [
+                                'moduleauthor' => (string) ($info['author'] ?? ''),
+                                'category' => (string) ($info['category'] ?? ''),
+                                'formalname' => (string) ($info['name'] ?? ''),
+                                'description' => (string) ($info['description'] ?? ''),
+                                'filemoddate' => $filemoddate,
+                                'infokeys' => $keys,
+                                'version' => (string) ($info['version'] ?? ''),
+                                'download' => (string) ($info['download'] ?? ''),
+                                'modulename' => $moduleName,
+                            ],
+                            [
+                                'moduleauthor' => ParameterType::STRING,
+                                'category' => ParameterType::STRING,
+                                'formalname' => ParameterType::STRING,
+                                'description' => ParameterType::STRING,
+                                'filemoddate' => ParameterType::STRING,
+                                'infokeys' => ParameterType::STRING,
+                                'version' => ParameterType::STRING,
+                                'download' => ParameterType::STRING,
+                                'modulename' => ParameterType::STRING,
+                            ]
+                        );
                         $output->debug($sql);
                         $sql = 'UNLOCK TABLES';
                         Database::query($sql);
@@ -611,16 +633,37 @@ class Modules
 
         self::loadModuleSettings($module);
 
+        $conn = Database::getDoctrineConnection();
         if (isset($module_settings[$module][$name])) {
-            $sql = 'UPDATE ' . Database::prefix('module_settings')
-                . " SET value='" . addslashes((string) $value)
-                . "' WHERE modulename='$module' AND setting='" . addslashes($name) . "'";
-            Database::query($sql);
+            $conn->executeStatement(
+                'UPDATE ' . Database::prefix('module_settings')
+                . ' SET value = :value WHERE modulename = :module AND setting = :setting',
+                [
+                    'value' => (string) $value,
+                    'module' => $module,
+                    'setting' => $name,
+                ],
+                [
+                    'value' => ParameterType::STRING,
+                    'module' => ParameterType::STRING,
+                    'setting' => ParameterType::STRING,
+                ]
+            );
         } else {
-            $sql = 'INSERT INTO ' . Database::prefix('module_settings')
-                . " (modulename,setting,value) VALUES ('$module','" . addslashes($name)
-                . "','" . addslashes((string) $value) . "')";
-            Database::query($sql);
+            $conn->executeStatement(
+                'INSERT INTO ' . Database::prefix('module_settings')
+                . ' (modulename, setting, value) VALUES (:module, :setting, :value)',
+                [
+                    'module' => $module,
+                    'setting' => $name,
+                    'value' => (string) $value,
+                ],
+                [
+                    'module' => ParameterType::STRING,
+                    'setting' => ParameterType::STRING,
+                    'value' => ParameterType::STRING,
+                ]
+            );
         }
 
         DataCache::getInstance()->invalidatedatacache("modulesettings-$module");
@@ -642,15 +685,37 @@ class Modules
 
         self::loadModuleSettings($module);
 
+        $conn = Database::getDoctrineConnection();
         if (isset($module_settings[$module][$name])) {
-            $sql = 'UPDATE ' . Database::prefix('module_settings')
-                . " SET value=value+$value WHERE modulename='$module' AND setting='" . addslashes($name) . "'";
-            Database::query($sql);
+            $conn->executeStatement(
+                'UPDATE ' . Database::prefix('module_settings')
+                . ' SET value = value + :value WHERE modulename = :module AND setting = :setting',
+                [
+                    'value' => (string) $value,
+                    'module' => $module,
+                    'setting' => $name,
+                ],
+                [
+                    'value' => ParameterType::STRING,
+                    'module' => ParameterType::STRING,
+                    'setting' => ParameterType::STRING,
+                ]
+            );
         } else {
-            $sql = 'INSERT INTO ' . Database::prefix('module_settings')
-                . " (modulename,setting,value) VALUES ('$module','" . addslashes($name)
-                . "','" . addslashes($value) . "')";
-            Database::query($sql);
+            $conn->executeStatement(
+                'INSERT INTO ' . Database::prefix('module_settings')
+                . ' (modulename, setting, value) VALUES (:module, :setting, :value)',
+                [
+                    'module' => $module,
+                    'setting' => $name,
+                    'value' => (string) $value,
+                ],
+                [
+                    'module' => ParameterType::STRING,
+                    'setting' => ParameterType::STRING,
+                    'value' => ParameterType::STRING,
+                ]
+            );
         }
 
         DataCache::getInstance()->invalidatedatacache("modulesettings-$module");
@@ -710,12 +775,25 @@ class Modules
             $module = ModuleManager::getMostRecentModule();
         }
 
-        $sql = 'SELECT value FROM ' . Database::prefix('module_objprefs')
-            . " WHERE modulename='$module' AND objtype='$type' AND setting='" . addslashes($name) . "' AND objid='$objid'";
-        $result = Database::queryCached($sql, "objpref-$type-$objid-$name-$module", 86400);
+        $result = Database::getDoctrineConnection()->executeQuery(
+            'SELECT value FROM ' . Database::prefix('module_objprefs')
+            . ' WHERE modulename = :module AND objtype = :objtype AND setting = :setting AND objid = :objid',
+            [
+                'module' => $module,
+                'objtype' => $type,
+                'setting' => $name,
+                'objid' => (string) $objid,
+            ],
+            [
+                'module' => ParameterType::STRING,
+                'objtype' => ParameterType::STRING,
+                'setting' => ParameterType::STRING,
+                'objid' => ParameterType::STRING,
+            ]
+        );
+        $row = $result->fetchAssociative();
 
-        if (Database::numRows($result) > 0) {
-            $row = Database::fetchAssoc($result);
+        if ($row !== false) {
             return $row['value'];
         }
 
@@ -744,9 +822,24 @@ class Modules
             $module = ModuleManager::getMostRecentModule();
         }
 
-        $sql = 'REPLACE INTO ' . Database::prefix('module_objprefs')
-            . "(modulename,objtype,setting,objid,value) VALUES ('$module', '$objtype', '$name', '$objid', '" . addslashes((string)$value) . "')";
-        Database::query($sql);
+        Database::getDoctrineConnection()->executeStatement(
+            'REPLACE INTO ' . Database::prefix('module_objprefs')
+            . ' (modulename, objtype, setting, objid, value) VALUES (:module, :objtype, :setting, :objid, :value)',
+            [
+                'module' => $module,
+                'objtype' => $objtype,
+                'setting' => $name,
+                'objid' => (string) $objid,
+                'value' => (string) $value,
+            ],
+            [
+                'module' => ParameterType::STRING,
+                'objtype' => ParameterType::STRING,
+                'setting' => ParameterType::STRING,
+                'objid' => ParameterType::STRING,
+                'value' => ParameterType::STRING,
+            ]
+        );
         DataCache::getInstance()->invalidatedatacache("objpref-$objtype-$objid-$name-$module");
     }
 
@@ -761,14 +854,45 @@ class Modules
             $module = ModuleManager::getMostRecentModule();
         }
 
-        $sql = 'UPDATE ' . Database::prefix('module_objprefs')
-            . " SET value=value+$value WHERE modulename='$module' AND setting='" . addslashes($name)
-            . "' AND objtype='" . addslashes($objtype) . "' AND objid=$objid;";
-        $result = Database::query($sql);
-        if (Database::affectedRows() == 0) {
-            $sql = 'INSERT INTO ' . Database::prefix('module_objprefs')
-                . "(modulename,objtype,setting,objid,value) VALUES ('$module', '$objtype', '$name', '$objid', '" . addslashes((string)$value) . "')";
-            Database::query($sql);
+        $conn = Database::getDoctrineConnection();
+        $affected = $conn->executeStatement(
+            'UPDATE ' . Database::prefix('module_objprefs')
+            . ' SET value = value + :value WHERE modulename = :module AND setting = :setting'
+            . ' AND objtype = :objtype AND objid = :objid',
+            [
+                'value' => (string) $value,
+                'module' => $module,
+                'setting' => $name,
+                'objtype' => $objtype,
+                'objid' => (string) $objid,
+            ],
+            [
+                'value' => ParameterType::STRING,
+                'module' => ParameterType::STRING,
+                'setting' => ParameterType::STRING,
+                'objtype' => ParameterType::STRING,
+                'objid' => ParameterType::STRING,
+            ]
+        );
+        if ($affected === 0) {
+            $conn->executeStatement(
+                'INSERT INTO ' . Database::prefix('module_objprefs')
+                . ' (modulename, objtype, setting, objid, value) VALUES (:module, :objtype, :setting, :objid, :value)',
+                [
+                    'module' => $module,
+                    'objtype' => $objtype,
+                    'setting' => $name,
+                    'objid' => (string) $objid,
+                    'value' => (string) $value,
+                ],
+                [
+                    'module' => ParameterType::STRING,
+                    'objtype' => ParameterType::STRING,
+                    'setting' => ParameterType::STRING,
+                    'objid' => ParameterType::STRING,
+                    'value' => ParameterType::STRING,
+                ]
+            );
         }
 
         DataCache::getInstance()->invalidatedatacache("objpref-$objtype-$objid-$name-$module");
@@ -891,15 +1015,41 @@ class Modules
             return;
         }
 
+        $conn = Database::getDoctrineConnection();
         if (isset($module_prefs[$uid][$module][$name])) {
-            $sql = 'UPDATE ' . Database::prefix('module_userprefs')
-                . " SET value='" . addslashes((string) $value)
-                . "' WHERE modulename='$module' AND setting='$name' AND userid='$uid'";
-            Database::query($sql);
+            $conn->executeStatement(
+                'UPDATE ' . Database::prefix('module_userprefs')
+                . ' SET value = :value WHERE modulename = :module AND setting = :setting AND userid = :userid',
+                [
+                    'value' => (string) $value,
+                    'module' => $module,
+                    'setting' => $name,
+                    'userid' => (int) $uid,
+                ],
+                [
+                    'value' => ParameterType::STRING,
+                    'module' => ParameterType::STRING,
+                    'setting' => ParameterType::STRING,
+                    'userid' => ParameterType::INTEGER,
+                ]
+            );
         } else {
-            $sql = 'INSERT INTO ' . Database::prefix('module_userprefs')
-                . " (modulename,setting,userid,value) VALUES ('$module','$name','$uid','" . addslashes((string) $value) . "')";
-            Database::query($sql);
+            $conn->executeStatement(
+                'INSERT INTO ' . Database::prefix('module_userprefs')
+                . ' (modulename, setting, userid, value) VALUES (:module, :setting, :userid, :value)',
+                [
+                    'module' => $module,
+                    'setting' => $name,
+                    'userid' => (int) $uid,
+                    'value' => (string) $value,
+                ],
+                [
+                    'module' => ParameterType::STRING,
+                    'setting' => ParameterType::STRING,
+                    'userid' => ParameterType::INTEGER,
+                    'value' => ParameterType::STRING,
+                ]
+            );
         }
 
         $module_prefs[$uid][$module][$name] = $value;
@@ -1103,9 +1253,20 @@ class Modules
 
         self::dropEventHook($type);
 
-        $sql = 'INSERT INTO ' . Database::prefix('module_event_hooks')
-            . " (modulename, event_type, event_chance) VALUES ('" . $module . "', '$type', '" . addslashes($chance) . "')";
-        Database::query($sql);
+        Database::getDoctrineConnection()->executeStatement(
+            'INSERT INTO ' . Database::prefix('module_event_hooks')
+            . ' (modulename, event_type, event_chance) VALUES (:module, :eventType, :eventChance)',
+            [
+                'module' => $module,
+                'eventType' => $type,
+                'eventChance' => $chance,
+            ],
+            [
+                'module' => ParameterType::STRING,
+                'eventType' => ParameterType::STRING,
+                'eventChance' => ParameterType::STRING,
+            ]
+        );
         DataCache::getInstance()->invalidatedatacache("event-$type-0");
         DataCache::getInstance()->invalidatedatacache("event-$type-1");
     }
@@ -1120,9 +1281,18 @@ class Modules
     {
         $module = ModuleManager::getMostRecentModule();
 
-        $sql = 'DELETE FROM ' . Database::prefix('module_event_hooks')
-            . " WHERE modulename='$module' AND event_type='" . addslashes($type) . "'";
-        Database::query($sql);
+        Database::getDoctrineConnection()->executeStatement(
+            'DELETE FROM ' . Database::prefix('module_event_hooks')
+            . ' WHERE modulename = :module AND event_type = :eventType',
+            [
+                'module' => $module,
+                'eventType' => $type,
+            ],
+            [
+                'module' => ParameterType::STRING,
+                'eventType' => ParameterType::STRING,
+            ]
+        );
         DataCache::getInstance()->invalidatedatacache("event-$type-0");
         DataCache::getInstance()->invalidatedatacache("event-$type-1");
     }
@@ -1138,10 +1308,20 @@ class Modules
             $functioncall = $module . '_dohook';
         }
 
-        $sql = 'DELETE FROM ' . Database::prefix('module_hooks')
-            . " WHERE modulename='$module' AND location='" . addslashes($hookname)
-            . "' AND hook_callback='" . addslashes($functioncall) . "'";
-        Database::query($sql);
+        Database::getDoctrineConnection()->executeStatement(
+            'DELETE FROM ' . Database::prefix('module_hooks')
+            . ' WHERE modulename = :module AND location = :location AND hook_callback = :callback',
+            [
+                'module' => $module,
+                'location' => $hookname,
+                'callback' => (string) $functioncall,
+            ],
+            [
+                'module' => ParameterType::STRING,
+                'location' => ParameterType::STRING,
+                'callback' => ParameterType::STRING,
+            ]
+        );
         DataCache::getInstance()->invalidatedatacache("hook-$hookname");
         DataCache::getInstance()->invalidatedatacache('module_prepare');
     }
@@ -1170,10 +1350,25 @@ class Modules
             $whenactive = '';
         }
 
-        $sql = 'REPLACE INTO ' . Database::prefix('module_hooks')
-            . " (modulename,location,hook_callback,whenactive,priority) VALUES ('$module','" . addslashes($hookname)
-            . "','" . addslashes($functioncall) . "','" . addslashes($whenactive) . "','" . $priority . "')";
-        Database::query($sql);
+        Database::getDoctrineConnection()->executeStatement(
+            'REPLACE INTO ' . Database::prefix('module_hooks')
+            . ' (modulename, location, hook_callback, whenactive, priority)'
+            . ' VALUES (:module, :location, :callback, :whenactive, :priority)',
+            [
+                'module' => $module,
+                'location' => $hookname,
+                'callback' => (string) $functioncall,
+                'whenactive' => (string) $whenactive,
+                'priority' => $priority,
+            ],
+            [
+                'module' => ParameterType::STRING,
+                'location' => ParameterType::STRING,
+                'callback' => ParameterType::STRING,
+                'whenactive' => ParameterType::STRING,
+                'priority' => ParameterType::INTEGER,
+            ]
+        );
         DataCache::getInstance()->invalidatedatacache("hook-$hookname");
         DataCache::getInstance()->invalidatedatacache('module_prepare');
     }

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -772,7 +772,7 @@ class Modules
         $objid = (int) $objid;
 
         $sql = 'DELETE FROM ' . Database::prefix('module_objprefs') . ' WHERE objtype = :objtype AND objid = :objid';
-        Database::executeStatement(
+        Database::getDoctrineConnection()->executeStatement(
             $sql,
             [
                 'objtype' => $objtype,

--- a/src/Lotgd/Modules.php
+++ b/src/Lotgd/Modules.php
@@ -775,6 +775,22 @@ class Modules
             $module = ModuleManager::getMostRecentModule();
         }
 
+        /** @var int $objid */
+        $objid = (int) $objid;
+        $cacheKey = "objpref-$type-$objid-$name-$module";
+        $cache = DataCache::getInstance();
+
+        /**
+         * Keep the legacy objpref cache behavior so repeated reads can be served
+         * from DataCache, while SQL safety is enforced at the DBAL query sink.
+         *
+         * @var array{found:bool,value?:string}|false $cachedValue
+         */
+        $cachedValue = $cache->datacache($cacheKey, 86400);
+        if (is_array($cachedValue) && array_key_exists('found', $cachedValue)) {
+            return $cachedValue['found'] ? ($cachedValue['value'] ?? null) : null;
+        }
+
         $result = Database::getDoctrineConnection()->executeQuery(
             'SELECT value FROM ' . Database::prefix('module_objprefs')
             . ' WHERE modulename = :module AND objtype = :objtype AND setting = :setting AND objid = :objid',
@@ -782,20 +798,23 @@ class Modules
                 'module' => $module,
                 'objtype' => $type,
                 'setting' => $name,
-                'objid' => (string) $objid,
+                'objid' => $objid,
             ],
             [
                 'module' => ParameterType::STRING,
                 'objtype' => ParameterType::STRING,
                 'setting' => ParameterType::STRING,
-                'objid' => ParameterType::STRING,
+                'objid' => ParameterType::INTEGER,
             ]
         );
         $row = $result->fetchAssociative();
 
         if ($row !== false) {
+            $cache->updatedatacache($cacheKey, ['found' => true, 'value' => (string) $row['value']]);
             return $row['value'];
         }
+
+        $cache->updatedatacache($cacheKey, ['found' => false]);
 
         $info = self::getModuleInfo($module);
         if (isset($info['prefs-' . $type][$name])) {
@@ -821,6 +840,8 @@ class Modules
         if ($module === null) {
             $module = ModuleManager::getMostRecentModule();
         }
+        /** @var int $objid */
+        $objid = (int) $objid;
 
         Database::getDoctrineConnection()->executeStatement(
             'REPLACE INTO ' . Database::prefix('module_objprefs')
@@ -829,14 +850,14 @@ class Modules
                 'module' => $module,
                 'objtype' => $objtype,
                 'setting' => $name,
-                'objid' => (string) $objid,
+                'objid' => $objid,
                 'value' => (string) $value,
             ],
             [
                 'module' => ParameterType::STRING,
                 'objtype' => ParameterType::STRING,
                 'setting' => ParameterType::STRING,
-                'objid' => ParameterType::STRING,
+                'objid' => ParameterType::INTEGER,
                 'value' => ParameterType::STRING,
             ]
         );
@@ -853,6 +874,8 @@ class Modules
         if ($module === null) {
             $module = ModuleManager::getMostRecentModule();
         }
+        /** @var int $objid */
+        $objid = (int) $objid;
 
         $conn = Database::getDoctrineConnection();
         $affected = $conn->executeStatement(
@@ -864,14 +887,14 @@ class Modules
                 'module' => $module,
                 'setting' => $name,
                 'objtype' => $objtype,
-                'objid' => (string) $objid,
+                'objid' => $objid,
             ],
             [
                 'value' => ParameterType::STRING,
                 'module' => ParameterType::STRING,
                 'setting' => ParameterType::STRING,
                 'objtype' => ParameterType::STRING,
-                'objid' => ParameterType::STRING,
+                'objid' => ParameterType::INTEGER,
             ]
         );
         if ($affected === 0) {
@@ -882,14 +905,14 @@ class Modules
                     'module' => $module,
                     'objtype' => $objtype,
                     'setting' => $name,
-                    'objid' => (string) $objid,
+                    'objid' => $objid,
                     'value' => (string) $value,
                 ],
                 [
                     'module' => ParameterType::STRING,
                     'objtype' => ParameterType::STRING,
                     'setting' => ParameterType::STRING,
-                    'objid' => ParameterType::STRING,
+                    'objid' => ParameterType::INTEGER,
                     'value' => ParameterType::STRING,
                 ]
             );

--- a/src/Lotgd/QA/SqlAddslashesUsageCheck.php
+++ b/src/Lotgd/QA/SqlAddslashesUsageCheck.php
@@ -195,22 +195,97 @@ final class SqlAddslashesUsageCheck
      */
     private function isSqlContext(array $lines, int $lineNumber): bool
     {
-        $start = max(1, $lineNumber - 2);
-        $end = min(count($lines), $lineNumber + 2);
-        $window = '';
-        for ($line = $start; $line <= $end; $line++) {
-            $window .= ' ' . strtolower($lines[$line - 1] ?? '');
-        }
+        $start = max(1, $lineNumber - 6);
+        $end = min(count($lines), $lineNumber + 12);
+        $windowLines = array_slice($lines, $start - 1, $end - $start + 1);
+        $window = strtolower(implode("\n", $windowLines));
 
-        $keywordsPattern = '/\b(' . implode('|', self::SQL_KEYWORDS) . ')\b/';
-        if (preg_match($keywordsPattern, $window) !== 1) {
+        if (!$this->containsSqlKeywords($window)) {
             return false;
         }
 
-        return str_contains($window, '$sql')
-            || str_contains($window, 'database::query')
-            || str_contains($window, 'executequery(')
-            || str_contains($window, 'executestatement(');
+        $lineText = strtolower($lines[$lineNumber - 1] ?? '');
+        if (
+            $this->containsSqlSinkMarker($window)
+            && (
+                $this->containsSqlKeywords($lineText)
+                || str_contains($lineText, '$sql')
+                || $this->hasDirectNearbySqlLine($lines, $lineNumber)
+            )
+        ) {
+            return true;
+        }
+
+        /**
+         * Catch split SQL building patterns:
+         *   $escaped = addslashes(...);
+         *   ... (several lines later)
+         *   $sql = "... '$escaped' ...";
+         */
+        $assignedVariable = $this->extractAssignedVariable($lines[$lineNumber - 1] ?? '');
+        if ($assignedVariable === null) {
+            return false;
+        }
+
+        foreach ($windowLines as $windowLine) {
+            $normalizedLine = strtolower($windowLine);
+            if (!str_contains($normalizedLine, '$sql')) {
+                continue;
+            }
+            if (!str_contains($windowLine, '$' . $assignedVariable)) {
+                continue;
+            }
+            if ($this->containsSqlKeywords($normalizedLine)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Detect direct SQL assignment/building very close to addslashes().
+     *
+     * @param list<string> $lines
+     */
+    private function hasDirectNearbySqlLine(array $lines, int $lineNumber): bool
+    {
+        $start = max(1, $lineNumber - 1);
+        $end = min(count($lines), $lineNumber + 1);
+        for ($line = $start; $line <= $end; $line++) {
+            $normalizedLine = strtolower($lines[$line - 1] ?? '');
+            if (!str_contains($normalizedLine, '$sql')) {
+                continue;
+            }
+            if ($this->containsSqlKeywords($normalizedLine)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function containsSqlKeywords(string $text): bool
+    {
+        $keywordsPattern = '/\b(' . implode('|', self::SQL_KEYWORDS) . ')\b/';
+        return preg_match($keywordsPattern, $text) === 1;
+    }
+
+    private function containsSqlSinkMarker(string $text): bool
+    {
+        return str_contains($text, '$sql')
+            || str_contains($text, 'database::query')
+            || str_contains($text, 'executequery(')
+            || str_contains($text, 'executestatement(');
+    }
+
+    private function extractAssignedVariable(string $lineText): ?string
+    {
+        if (preg_match('/\$(?<variable>[A-Za-z_]\w*)\s*=\s*.*addslashes\s*\(/i', $lineText, $matches) !== 1) {
+            return null;
+        }
+
+        return $matches['variable'];
     }
 
     /**

--- a/src/Lotgd/QA/SqlAddslashesUsageCheck.php
+++ b/src/Lotgd/QA/SqlAddslashesUsageCheck.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\QA;
+
+/**
+ * Detect addslashes() usage when building SQL in core/refactored code.
+ *
+ * Policy:
+ *  - SQL escaping must be done at the query sink via parameterized DBAL calls.
+ *  - Global/pre-escaped values must not be used for SQL construction.
+ *  - Legacy compatibility wrappers may still expose escaped values, but core
+ *    paths must not rely on that behavior.
+ */
+final class SqlAddslashesUsageCheck
+{
+    /**
+     * @var list<string>
+     */
+    private const SCAN_ROOTS = [
+        'pages',
+        'src',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const SQL_KEYWORDS = [
+        'select',
+        'insert',
+        'update',
+        'delete',
+        'replace',
+        'where',
+        'values',
+        'set',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const ALLOWED_PATHS = [
+        // Self-exclusion so policy examples in this checker are not flagged.
+        'src/Lotgd/QA/SqlAddslashesUsageCheck.php',
+    ];
+
+    /**
+     * Temporary baseline for known legacy usages.
+     *
+     * Keep this list narrow and remove entries as call sites are migrated.
+     *
+     * @var array<string,list<string>>
+     */
+    private const ALLOWED_SQL_ADDSLASHES_PATTERNS = [
+        'pages/clan/applicant_new.php' => ['$clanname = addslashes($clanname);'],
+        'pages/clan/clan_motd.php' => [
+            "clanmotd='\" . addslashes(\$clanmotd)",
+            "clandesc='\" . addslashes(mb_substr(stripslashes(\$clandesc)",
+        ],
+        'pages/clan/clan_withdraw.php' => ["subject='\" . addslashes(serialize(\$withdraw_subj))"],
+        'src/Lotgd/Accounts.php' => [
+            "\" SET output='\" . addslashes(gzcompress(\$session['output'], 1))",
+            "VALUES ({\$session['user']['acctid']},'\" . addslashes(gzcompress(\$session['output'], 1))",
+        ],
+        'src/Lotgd/PlayerFunctions.php' => [
+            "addslashes(implode(',', \$players))",
+        ],
+        'src/Lotgd/Translator.php' => [
+            "VALUES ('\" .  addslashes(\$indata) . \"', '\"",
+        ],
+        'src/Lotgd/Motd.php' => [
+            '$body = addslashes(serialize($data));',
+        ],
+        'src/Lotgd/Pvp.php' => [
+            '$loc = addslashes($location);',
+        ],
+    ];
+
+    /**
+     * @return list<string> Human-readable violations in "file:line:text" format.
+     */
+    public function collectViolations(string $repositoryRoot): array
+    {
+        $violations = [];
+
+        foreach (self::SCAN_ROOTS as $relativeRoot) {
+            $absoluteRoot = rtrim($repositoryRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relativeRoot;
+            if (!is_dir($absoluteRoot)) {
+                continue;
+            }
+
+            $directoryIterator = new \RecursiveDirectoryIterator($absoluteRoot, \FilesystemIterator::SKIP_DOTS);
+            $iterator = new \RecursiveIteratorIterator($directoryIterator);
+
+            foreach ($iterator as $file) {
+                if (!($file instanceof \SplFileInfo) || $file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $relativePath = str_replace('\\', '/', substr($file->getPathname(), strlen(rtrim($repositoryRoot, DIRECTORY_SEPARATOR)) + 1));
+                if ($this->isWhitelistedPath($relativePath)) {
+                    continue;
+                }
+
+                $violations = array_merge($violations, $this->collectFileViolations($file->getPathname(), $relativePath));
+            }
+        }
+
+        sort($violations);
+
+        return $violations;
+    }
+
+    public function run(string $repositoryRoot): int
+    {
+        $violations = $this->collectViolations($repositoryRoot);
+        if ($violations === []) {
+            echo "SQL addslashes() usage check passed.\n";
+            return 0;
+        }
+
+        fwrite(STDERR, "Detected addslashes() usage in SQL-building contexts.\n");
+        fwrite(STDERR, "Use executeQuery()/executeStatement() with bound parameters and explicit types instead.\n");
+        foreach ($violations as $violation) {
+            fwrite(STDERR, " - {$violation}\n");
+        }
+
+        return 1;
+    }
+
+    private function isWhitelistedPath(string $relativePath): bool
+    {
+        foreach (self::ALLOWED_PATHS as $allowedPath) {
+            if ($relativePath === $allowedPath) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectFileViolations(string $absolutePath, string $relativePath): array
+    {
+        $contents = file_get_contents($absolutePath);
+        if ($contents === false) {
+            return [];
+        }
+
+        $tokens = token_get_all($contents);
+        $lines = preg_split("/\r\n|\n|\r/", $contents) ?: [];
+        $violations = [];
+
+        foreach ($tokens as $index => $token) {
+            if (!is_array($token) || $token[0] !== T_STRING || strtolower($token[1]) !== 'addslashes') {
+                continue;
+            }
+
+            if (!$this->isFunctionCallToken($tokens, $index)) {
+                continue;
+            }
+
+            $lineNumber = (int) $token[2];
+            if (!$this->isSqlContext($lines, $lineNumber)) {
+                continue;
+            }
+
+            $lineText = trim($lines[$lineNumber - 1] ?? '');
+            if ($this->isKnownLegacyViolation($relativePath, $lineText)) {
+                continue;
+            }
+            $violations[] = sprintf('%s:%d:%s', $relativePath, $lineNumber, $lineText);
+        }
+
+        return $violations;
+    }
+
+    private function isKnownLegacyViolation(string $relativePath, string $lineText): bool
+    {
+        $knownPatterns = self::ALLOWED_SQL_ADDSLASHES_PATTERNS[$relativePath] ?? [];
+        foreach ($knownPatterns as $knownPattern) {
+            if (str_contains($lineText, $knownPattern)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<string> $lines
+     */
+    private function isSqlContext(array $lines, int $lineNumber): bool
+    {
+        $start = max(1, $lineNumber - 2);
+        $end = min(count($lines), $lineNumber + 2);
+        $window = '';
+        for ($line = $start; $line <= $end; $line++) {
+            $window .= ' ' . strtolower($lines[$line - 1] ?? '');
+        }
+
+        $keywordsPattern = '/\b(' . implode('|', self::SQL_KEYWORDS) . ')\b/';
+        if (preg_match($keywordsPattern, $window) !== 1) {
+            return false;
+        }
+
+        return str_contains($window, '$sql')
+            || str_contains($window, 'database::query')
+            || str_contains($window, 'executequery(')
+            || str_contains($window, 'executestatement(');
+    }
+
+    /**
+     * @param list<array<int, int|string>|string> $tokens
+     */
+    private function isFunctionCallToken(array $tokens, int $index): bool
+    {
+        $previousToken = $this->findPreviousSignificantToken($tokens, $index);
+        if (is_array($previousToken) && in_array($previousToken[0], [T_FUNCTION, T_FN, T_OBJECT_OPERATOR, T_DOUBLE_COLON], true)) {
+            return false;
+        }
+        if ($previousToken === '->' || $previousToken === '::') {
+            return false;
+        }
+
+        $nextToken = $this->findNextSignificantToken($tokens, $index);
+        return $nextToken === '(';
+    }
+
+    /**
+     * @param list<array<int, int|string>|string> $tokens
+     */
+    private function findPreviousSignificantToken(array $tokens, int $index): array|string|null
+    {
+        for ($i = $index - 1; $i >= 0; $i--) {
+            $token = $tokens[$i];
+            if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            return $token;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<array<int, int|string>|string> $tokens
+     */
+    private function findNextSignificantToken(array $tokens, int $index): array|string|null
+    {
+        $count = count($tokens);
+        for ($i = $index + 1; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            return $token;
+        }
+
+        return null;
+    }
+}

--- a/src/Lotgd/QA/SqlAddslashesUsageCheck.php
+++ b/src/Lotgd/QA/SqlAddslashesUsageCheck.php
@@ -237,9 +237,12 @@ final class SqlAddslashesUsageCheck
             if (!str_contains($windowLine, '$' . $assignedVariable)) {
                 continue;
             }
-            if ($this->containsSqlKeywords($normalizedLine)) {
-                return true;
-            }
+            // At this point we know:
+            //  - The surrounding window contains SQL keywords (line 205),
+            //  - This line is part of that window,
+            //  - It references both $sql and the escaped variable.
+            // Treat this as SQL context even if this specific line has no keyword.
+            return true;
         }
 
         return false;

--- a/src/Lotgd/QA/SqlAddslashesUsageCheck.php
+++ b/src/Lotgd/QA/SqlAddslashesUsageCheck.php
@@ -103,7 +103,9 @@ final class SqlAddslashesUsageCheck
                     continue;
                 }
 
-                $violations = array_merge($violations, $this->collectFileViolations($file->getPathname(), $relativePath));
+                foreach ($this->collectFileViolations($file->getPathname(), $relativePath) as $violation) {
+                    $violations[] = $violation;
+                }
             }
         }
 

--- a/tests/Modules/Prefs/ModuleObjPrefsTest.php
+++ b/tests/Modules/Prefs/ModuleObjPrefsTest.php
@@ -54,6 +54,13 @@ namespace Lotgd\Tests\Modules\Prefs {
                 public function executeQuery(string $sql, array $params = [], array $types = []): DoctrineResult
                 {
                     $this->queries[] = $sql;
+                    if (str_contains($sql, 'SELECT value FROM module_objprefs')
+                        && isset($params['objtype'], $params['objid'], $params['setting'], $params['module'])) {
+                        $key = "objpref-{$params['objtype']}-{$params['objid']}-{$params['setting']}-{$params['module']}";
+                        if (isset($this->objprefs[$key])) {
+                            return new DoctrineResult([['value' => $this->objprefs[$key]]]);
+                        }
+                    }
                     return new DoctrineResult([]);
                 }
 
@@ -67,6 +74,38 @@ namespace Lotgd\Tests\Modules\Prefs {
                     ];
                     $this->lastExecuteStatementParams = $params;
                     $this->lastExecuteStatementTypes  = $types;
+
+                    if (str_contains($sql, 'REPLACE INTO module_objprefs') && isset($params['module'], $params['objtype'], $params['setting'], $params['objid'], $params['value'])) {
+                        $key = "objpref-{$params['objtype']}-{$params['objid']}-{$params['setting']}-{$params['module']}";
+                        $this->objprefs[$key]                 = (string) $params['value'];
+                        Database::$queryCacheResults[$key]    = [['value' => (string) $params['value']]];
+                        Database::$affected_rows              = 1;
+                        return 1;
+                    }
+
+                    if (str_contains($sql, 'UPDATE module_objprefs')
+                        && isset($params['module'], $params['setting'], $params['objtype'], $params['objid'], $params['value'])) {
+                        $increment = (float) $params['value'];
+                        $key       = "objpref-{$params['objtype']}-{$params['objid']}-{$params['setting']}-{$params['module']}";
+                        if (isset($this->objprefs[$key])) {
+                            $new                               = (string) ((float) $this->objprefs[$key] + $increment);
+                            $this->objprefs[$key]              = $new;
+                            Database::$queryCacheResults[$key] = [['value' => $new]];
+                            Database::$affected_rows           = 1;
+                            return 1;
+                        }
+                        Database::$affected_rows = 0;
+                        return 0;
+                    }
+
+                    if (str_contains($sql, 'INSERT INTO module_objprefs')
+                        && isset($params['module'], $params['objtype'], $params['setting'], $params['objid'], $params['value'])) {
+                        $key = "objpref-{$params['objtype']}-{$params['objid']}-{$params['setting']}-{$params['module']}";
+                        $this->objprefs[$key]                 = (string) $params['value'];
+                        Database::$queryCacheResults[$key]    = [['value' => (string) $params['value']]];
+                        Database::$affected_rows              = 1;
+                        return 1;
+                    }
 
                     if (preg_match("/REPLACE INTO module_objprefs\\(modulename,objtype,setting,objid,value\\) VALUES \\('(.*?)', '(.*?)', '(.*?)', '(.*?)', '(.*?)'\\)/", $sql, $m)) {
                         $key = "objpref-{$m[2]}-{$m[4]}-{$m[3]}-{$m[1]}";

--- a/tests/Modules/Prefs/ModuleObjPrefsTest.php
+++ b/tests/Modules/Prefs/ModuleObjPrefsTest.php
@@ -137,9 +137,10 @@ namespace Lotgd\Tests\Modules\Prefs {
                         return 1;
                     }
 
-                    if (preg_match("/DELETE FROM module_objprefs WHERE objtype='([^']+)' AND objid='([^']+)'/", $sql, $m)) {
+                    if (str_contains($sql, 'DELETE FROM module_objprefs')
+                        && isset($params['objtype'], $params['objid'])) {
                         foreach (array_keys($this->objprefs) as $key) {
-                            if (str_starts_with($key, "objpref-{$m[1]}-{$m[2]}-")) {
+                            if (str_starts_with($key, "objpref-{$params['objtype']}-{$params['objid']}-")) {
                                 unset($this->objprefs[$key]);
                                 unset(Database::$queryCacheResults[$key]);
                             }

--- a/tests/QA/SqlAddslashesUsageCheckTest.php
+++ b/tests/QA/SqlAddslashesUsageCheckTest.php
@@ -66,6 +66,28 @@ final class SqlAddslashesUsageCheckTest extends TestCase
         $this->assertSame([], $violations);
     }
 
+    public function testCheckerFlagsSplitSqlConstructionUsingEscapedTemporaryVariable(): void
+    {
+        $root = $this->createFixtureRoot();
+        file_put_contents(
+            $root . '/pages/split-sql.php',
+            <<<'PHP'
+<?php
+$escapedName = addslashes($name);
+$audit = 'not sql';
+$flag = true;
+$sql = "UPDATE modules SET formalname='" . $escapedName . "'";
+Database::query($sql);
+PHP
+        );
+
+        $checker = new SqlAddslashesUsageCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('pages/split-sql.php:2:', $violations[0]);
+    }
+
     private function createFixtureRoot(): string
     {
         $root = sys_get_temp_dir() . '/lotgd-sql-addslashes-check-' . uniqid('', true);

--- a/tests/QA/SqlAddslashesUsageCheckTest.php
+++ b/tests/QA/SqlAddslashesUsageCheckTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\QA;
+
+use Lotgd\QA\SqlAddslashesUsageCheck;
+use PHPUnit\Framework\TestCase;
+
+final class SqlAddslashesUsageCheckTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private array $fixtureRoots = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->fixtureRoots as $root) {
+            $this->removeDirectoryRecursively($root);
+        }
+        $this->fixtureRoots = [];
+    }
+
+    public function testCheckerFlagsAddslashesInSqlBuildingContexts(): void
+    {
+        $root = $this->createFixtureRoot();
+        file_put_contents(
+            $root . '/src/example.php',
+            "<?php\n\$sql = \"UPDATE modules SET name='\" . addslashes(\$name) . \"'\";\n"
+        );
+
+        $checker = new SqlAddslashesUsageCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertNotEmpty($violations);
+        $this->assertStringContainsString('src/example.php:2:', $violations[0]);
+    }
+
+    public function testCheckerIgnoresAddslashesOutsideSqlContexts(): void
+    {
+        $root = $this->createFixtureRoot();
+        file_put_contents(
+            $root . '/pages/example.php',
+            "<?php\n\$display = addslashes(\$value);\n\$safe = htmlspecialchars(\$display, ENT_QUOTES);\n"
+        );
+
+        $checker = new SqlAddslashesUsageCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertSame([], $violations);
+    }
+
+    public function testCheckerAllowsDocumentedLegacyBaselinePatterns(): void
+    {
+        $root = $this->createFixtureRoot();
+        mkdir($root . '/src/Lotgd', 0777, true);
+        file_put_contents(
+            $root . '/src/Lotgd/PlayerFunctions.php',
+            "<?php\n\$sql = 'SELECT acctid FROM accounts WHERE acctid IN (' . addslashes(implode(',', \$players)) . ')';\n"
+        );
+
+        $checker = new SqlAddslashesUsageCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertSame([], $violations);
+    }
+
+    private function createFixtureRoot(): string
+    {
+        $root = sys_get_temp_dir() . '/lotgd-sql-addslashes-check-' . uniqid('', true);
+        mkdir($root . '/pages', 0777, true);
+        mkdir($root . '/src', 0777, true);
+        $this->fixtureRoots[] = $root;
+
+        return $root;
+    }
+
+    private function removeDirectoryRecursively(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $items = scandir($path);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $current = $path . DIRECTORY_SEPARATOR . $item;
+            if (is_dir($current)) {
+                $this->removeDirectoryRecursively($current);
+                continue;
+            }
+
+            @unlink($current);
+        }
+
+        @rmdir($path);
+    }
+}


### PR DESCRIPTION
### Motivation

- Eliminate unsafe SQL string concatenation that relied on `addslashes()` by enforcing parameterized queries at the DB sink. 
- Keep legacy module compatibility while moving escaping responsibility to prepared statements and explicit typing. 
- Prevent regressions by adding an automated QA gate that detects `addslashes()` usage in SQL-building contexts under core/refactored paths. 

### Description

- Replaced many ad-hoc SQL strings in `src/Lotgd/Modules.php` with Doctrine DBAL parameterized calls using `Database::getDoctrineConnection()->executeQuery()` / `executeStatement()` and explicit `Doctrine\DBAL\ParameterType` maps for module metadata, module settings, object prefs, user prefs, event hooks, and module hook operations. 
- Added a new QA checker `Lotgd\QA\SqlAddslashesUsageCheck` and a script `scripts/check-sql-addslashes.php` that scans `src/` and `pages/` for `addslashes()` used in SQL contexts and supports a narrow, documented legacy baseline allowlist. 
- Wired the new QA gate into `composer static` via `qa:sql-addslashes` and added `tests/QA/SqlAddslashesUsageCheckTest.php` to assert both positive and negative behavior. 
- Updated test stubs (`tests/Modules/Prefs/ModuleObjPrefsTest.php`) so the parameterized DBAL execution paths are exercised by the unit tests. 
- Documented the security guidance in `docs/Deprecations.md` (no global pre-escaping of superglobals, validation/casting at input boundaries, and mandatory parameterized SQL for new/updated code) and added a clarifying security note to `lib/http.php` while preserving its legacy behavior.

### Testing

- Ran syntax checks with `php -l` on changed files; all checks passed. 
- Executed QA unit tests for the new checker with `phpunit` (`tests/QA/LegacyHttpWrapperUsageCheckTest.php`, `tests/QA/SqlAddslashesUsageCheckTest.php`) and they passed. 
- Ran the affected module prefs unit (`tests/Modules/Prefs/ModuleObjPrefsTest.php`) after adapting stubs and it passed. 
- Ran `composer static` (which now includes the new `qa:sql-addslashes` gate) and `composer test`; the full test run completed successfully (tests passed, with existing benign warnings/notices reported by the suite).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c77f293e4883299724fdd3a694ef08)