### PR TITLE
feat(installer): add security defaults and admin recommendations module

### DIFF
--- a/install/data/recommended_modules.php
+++ b/install/data/recommended_modules.php
@@ -61,6 +61,8 @@ $recommended_modules = array(
     "strategyhut",
     "thieves",
     "tutor",
+    "twofactorauth",
     "tynan",
     "waterfall",
+    "admin_recommendations",
 );

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -30,6 +30,40 @@ use Symfony\Component\Console\Input\ArrayInput;
 class Installer
 {
     /**
+     * Canonical dbconnect.php defaults used for fresh installs and migrations.
+     *
+     * Keep these defaults aligned with RuntimeHardening::buildOptions() so
+     * operators receive predictable behavior after installation.
+     *
+     * @var array<string, mixed>
+     */
+    private const DBCONNECT_DEFAULTS = [
+        'DB_HOST' => '',
+        'DB_USER' => '',
+        'DB_PASS' => '',
+        'DB_NAME' => '',
+        'DB_PREFIX' => '',
+        'DB_USEDATACACHE' => 0,
+        'DB_DATACACHEPATH' => '',
+        'SESSION_COOKIE_PATH' => '/',
+        'SESSION_COOKIE_DOMAIN' => '',
+        'SESSION_COOKIE_SAMESITE' => 'Lax',
+        'SESSION_COOKIE_SECURE_AUTO' => true,
+        'SESSION_COOKIE_SECURE_FORCE' => false,
+        'SECURITY_HEADERS_ENABLED' => true,
+        'SECURITY_FRAME_OPTIONS' => 'SAMEORIGIN',
+        'SECURITY_REFERRER_POLICY' => 'strict-origin-when-cross-origin',
+        'SECURITY_USE_CSP_FRAME_ANCESTORS' => false,
+        'SECURITY_CSP_FRAME_ANCESTORS' => "'self'",
+        'SECURITY_HSTS_ENABLED' => false,
+        'SECURITY_HSTS_MAX_AGE' => 31536000,
+        'SECURITY_HSTS_INCLUDE_SUBDOMAINS' => false,
+        'SECURITY_HSTS_PRELOAD' => false,
+        'SECURITY_TRUST_FORWARDED_PROTO' => false,
+        'SECURITY_TRUSTED_PROXIES' => '',
+    ];
+
+    /**
      * Counter for unique HTML tip identifiers used by the tip() helper.
      *
      * @var int
@@ -828,18 +862,11 @@ class Installer
             $this->output->output("`@`c`bWriting your dbconnect.php file`b`c");
             $this->output->output("`2I'm attempting to write a file named 'dbconnect.php' to your site root.");
             $this->output->output("This file tells LoGD how to connect to the database, and is necessary to continue installation.`n");
-            $dbconnect =
-                "<?php\n"
-                . "//This file automatically created by installer.php on " . date("M d, Y h:i a") . "\n"
-                . "return [\n"
-                . "    'DB_HOST' => '{$session['dbinfo']['DB_HOST']}',\n"
-                . "    'DB_USER' => '{$session['dbinfo']['DB_USER']}',\n"
-                . "    'DB_PASS' => '{$session['dbinfo']['DB_PASS']}',\n"
-                . "    'DB_NAME' => '{$session['dbinfo']['DB_NAME']}',\n"
-                . "    'DB_PREFIX' => '{$session['dbinfo']['DB_PREFIX']}',\n"
-                . "    'DB_USEDATACACHE' => " . ((int)$session['dbinfo']['DB_USEDATACACHE']) . ",\n"
-                . "    'DB_DATACACHEPATH' => '{$session['dbinfo']['DB_DATACACHEPATH']}',\n"
-                . "];\n";
+            $dbconnect = $this->buildDbconnectContents(
+                $this->normalizeDbconnectAssignments(
+                    $this->getSessionDbinfoOverrides($session['dbinfo'] ?? [])
+                )
+            );
             $failure = false;
             $dir = dirname($dbconnectPath);
 
@@ -1768,19 +1795,11 @@ class Installer
      *
      * @param array<string, mixed> $assignments
      *
-     * @return array{DB_HOST: string, DB_USER: string, DB_PASS: string, DB_NAME: string, DB_PREFIX: string, DB_USEDATACACHE: int, DB_DATACACHEPATH: string}
+     * @return array<string, mixed>
      */
     private function normalizeDbconnectAssignments(array $assignments): array
     {
-        $normalized = [
-            'DB_HOST' => '',
-            'DB_USER' => '',
-            'DB_PASS' => '',
-            'DB_NAME' => '',
-            'DB_PREFIX' => '',
-            'DB_USEDATACACHE' => 0,
-            'DB_DATACACHEPATH' => '',
-        ];
+        $normalized = self::DBCONNECT_DEFAULTS;
 
         foreach ($normalized as $key => $default) {
             if (! array_key_exists($key, $assignments)) {
@@ -1792,8 +1811,21 @@ class Installer
                 case 'DB_USEDATACACHE':
                     $normalized[$key] = (int) $value;
                     break;
+                case 'SECURITY_HSTS_MAX_AGE':
+                    $normalized[$key] = max(0, (int) $value);
+                    break;
                 case 'DB_PREFIX':
                     $normalized[$key] = $this->normalizePrefixValue($value);
+                    break;
+                case 'SESSION_COOKIE_SECURE_AUTO':
+                case 'SESSION_COOKIE_SECURE_FORCE':
+                case 'SECURITY_HEADERS_ENABLED':
+                case 'SECURITY_USE_CSP_FRAME_ANCESTORS':
+                case 'SECURITY_HSTS_ENABLED':
+                case 'SECURITY_HSTS_INCLUDE_SUBDOMAINS':
+                case 'SECURITY_HSTS_PRELOAD':
+                case 'SECURITY_TRUST_FORWARDED_PROTO':
+                    $normalized[$key] = $this->normalizeBoolean($value);
                     break;
                 default:
                     $normalized[$key] = (string) $value;
@@ -1814,7 +1846,31 @@ class Installer
     private function getSessionDbinfoOverrides(array $sessionDbinfo): array
     {
         $overrides = [];
-        $keys = ['DB_HOST', 'DB_USER', 'DB_PASS', 'DB_NAME', 'DB_PREFIX', 'DB_USEDATACACHE', 'DB_DATACACHEPATH'];
+        $keys = [
+            'DB_HOST',
+            'DB_USER',
+            'DB_PASS',
+            'DB_NAME',
+            'DB_PREFIX',
+            'DB_USEDATACACHE',
+            'DB_DATACACHEPATH',
+            'SESSION_COOKIE_PATH',
+            'SESSION_COOKIE_DOMAIN',
+            'SESSION_COOKIE_SAMESITE',
+            'SESSION_COOKIE_SECURE_AUTO',
+            'SESSION_COOKIE_SECURE_FORCE',
+            'SECURITY_HEADERS_ENABLED',
+            'SECURITY_FRAME_OPTIONS',
+            'SECURITY_REFERRER_POLICY',
+            'SECURITY_USE_CSP_FRAME_ANCESTORS',
+            'SECURITY_CSP_FRAME_ANCESTORS',
+            'SECURITY_HSTS_ENABLED',
+            'SECURITY_HSTS_MAX_AGE',
+            'SECURITY_HSTS_INCLUDE_SUBDOMAINS',
+            'SECURITY_HSTS_PRELOAD',
+            'SECURITY_TRUST_FORWARDED_PROTO',
+            'SECURITY_TRUSTED_PROXIES',
+        ];
 
         foreach ($keys as $key) {
             if (! array_key_exists($key, $sessionDbinfo)) {
@@ -1826,8 +1882,21 @@ class Installer
                 case 'DB_USEDATACACHE':
                     $overrides[$key] = (int) $value;
                     break;
+                case 'SECURITY_HSTS_MAX_AGE':
+                    $overrides[$key] = max(0, (int) $value);
+                    break;
                 case 'DB_PREFIX':
                     $overrides[$key] = $this->normalizePrefixValue($value);
+                    break;
+                case 'SESSION_COOKIE_SECURE_AUTO':
+                case 'SESSION_COOKIE_SECURE_FORCE':
+                case 'SECURITY_HEADERS_ENABLED':
+                case 'SECURITY_USE_CSP_FRAME_ANCESTORS':
+                case 'SECURITY_HSTS_ENABLED':
+                case 'SECURITY_HSTS_INCLUDE_SUBDOMAINS':
+                case 'SECURITY_HSTS_PRELOAD':
+                case 'SECURITY_TRUST_FORWARDED_PROTO':
+                    $overrides[$key] = $this->normalizeBoolean($value);
                     break;
                 default:
                     $overrides[$key] = (string) $value;
@@ -1850,6 +1919,8 @@ class Installer
             "<?php",
             '',
             "//This file automatically created by installer.php on " . date("M d, Y h:i a"),
+            '// Runtime hardening defaults are intentionally explicit below so',
+            '// admins can review and tune cookie/header behavior in one place.',
             'return [',
             "    'DB_HOST' => " . var_export($data['DB_HOST'], true) . ',',
             "    'DB_USER' => " . var_export($data['DB_USER'], true) . ',',
@@ -1858,6 +1929,26 @@ class Installer
             "    'DB_PREFIX' => " . var_export($data['DB_PREFIX'], true) . ',',
             "    'DB_USEDATACACHE' => " . (int) $data['DB_USEDATACACHE'] . ',',
             "    'DB_DATACACHEPATH' => " . var_export($data['DB_DATACACHEPATH'], true) . ',',
+            '',
+            "    'SESSION_COOKIE_PATH' => " . var_export($data['SESSION_COOKIE_PATH'], true) . ',',
+            "    'SESSION_COOKIE_DOMAIN' => " . var_export($data['SESSION_COOKIE_DOMAIN'], true) . ',',
+            "    'SESSION_COOKIE_SAMESITE' => " . var_export($data['SESSION_COOKIE_SAMESITE'], true) . ',',
+            "    'SESSION_COOKIE_SECURE_AUTO' => " . var_export($data['SESSION_COOKIE_SECURE_AUTO'], true) . ',',
+            "    'SESSION_COOKIE_SECURE_FORCE' => " . var_export($data['SESSION_COOKIE_SECURE_FORCE'], true) . ',',
+            '',
+            "    'SECURITY_HEADERS_ENABLED' => " . var_export($data['SECURITY_HEADERS_ENABLED'], true) . ',',
+            "    'SECURITY_FRAME_OPTIONS' => " . var_export($data['SECURITY_FRAME_OPTIONS'], true) . ',',
+            "    'SECURITY_REFERRER_POLICY' => " . var_export($data['SECURITY_REFERRER_POLICY'], true) . ',',
+            "    'SECURITY_USE_CSP_FRAME_ANCESTORS' => " . var_export($data['SECURITY_USE_CSP_FRAME_ANCESTORS'], true) . ',',
+            "    'SECURITY_CSP_FRAME_ANCESTORS' => " . var_export($data['SECURITY_CSP_FRAME_ANCESTORS'], true) . ',',
+            '',
+            "    'SECURITY_HSTS_ENABLED' => " . var_export($data['SECURITY_HSTS_ENABLED'], true) . ',',
+            "    'SECURITY_HSTS_MAX_AGE' => " . (int) $data['SECURITY_HSTS_MAX_AGE'] . ',',
+            "    'SECURITY_HSTS_INCLUDE_SUBDOMAINS' => " . var_export($data['SECURITY_HSTS_INCLUDE_SUBDOMAINS'], true) . ',',
+            "    'SECURITY_HSTS_PRELOAD' => " . var_export($data['SECURITY_HSTS_PRELOAD'], true) . ',',
+            '',
+            "    'SECURITY_TRUST_FORWARDED_PROTO' => " . var_export($data['SECURITY_TRUST_FORWARDED_PROTO'], true) . ',',
+            "    'SECURITY_TRUSTED_PROXIES' => " . var_export($data['SECURITY_TRUSTED_PROXIES'], true) . ',',
             '];',
             '',
         ];
@@ -1920,6 +2011,26 @@ class Installer
         $this->output->output("`2Replace its contents with the following configuration:`n`n`&");
         $this->output->rawOutput("<blockquote><pre>" . htmlentities($contents, ENT_COMPAT, $this->getSetting('charset', 'UTF-8')) . "</pre></blockquote>");
         $this->output->output("`2After saving the file, rerun this step to continue.`n");
+    }
+
+    /**
+     * Normalize values commonly submitted as booleans in installer payloads.
+     */
+    private function normalizeBoolean(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (int) $value !== 0;
+        }
+
+        return in_array(
+            strtolower(trim((string) $value)),
+            ['1', 'true', 'yes', 'on'],
+            true
+        );
     }
 
     /**

--- a/modules/admin_recommendations.php
+++ b/modules/admin_recommendations.php
@@ -160,19 +160,46 @@ function admin_recommendations_collect(): array
  */
 function admin_recommendations_load_dbconnect(): array
 {
+    global $hardeningConfig;
+
+    // Prefer the configuration already loaded by common.php to avoid
+    // re-executing dbconnect.php and to support legacy/global formats.
+    if (isset($hardeningConfig) && is_array($hardeningConfig)) {
+        return $hardeningConfig;
+    }
+
     $dbconnectPath = dirname(__DIR__) . '/dbconnect.php';
     if (!file_exists($dbconnectPath)) {
         return [];
     }
 
+    $config       = [];
+    $bufferLevel  = ob_get_level();
+
     try {
+        ob_start();
         /** @psalm-suppress UnresolvableInclude */
-        $config = require $dbconnectPath;
+        $config = require_once $dbconnectPath;
+        ob_end_clean();
     } catch (\Throwable) {
+        // Ensure no partial output escapes if dbconnect.php misbehaves.
+        while (ob_get_level() > $bufferLevel) {
+            ob_end_clean();
+        }
+
         return [];
     }
 
-    return is_array($config) ? $config : [];
+    if (is_array($config)) {
+        return $config;
+    }
+
+    // Legacy dbconnect.php may populate $hardeningConfig via globals.
+    if (isset($hardeningConfig) && is_array($hardeningConfig)) {
+        return $hardeningConfig;
+    }
+
+    return [];
 }
 
 /**

--- a/modules/admin_recommendations.php
+++ b/modules/admin_recommendations.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+use Lotgd\Output;
+use Lotgd\Settings;
+use Lotgd\Translator;
+
+/**
+ * Surface operational security recommendations to superusers in the Grotto.
+ *
+ * This module intentionally keeps checks lightweight and read-only. It only
+ * evaluates runtime/configuration state and prints short guidance messages.
+ */
+function admin_recommendations_getmoduleinfo(): array
+{
+    return [
+        'name' => 'Admin Recommendations',
+        'version' => '1.0.0',
+        'author' => 'NB-Core',
+        'category' => 'Administrative',
+        'download' => 'core_module',
+        'settings' => [
+            'Admin Recommendations,title',
+            'show_footer_summary' => 'Show recommendation summary in superuser footer,bool|1',
+        ],
+    ];
+}
+
+/**
+ * Register the footer-superuser hook so recommendations appear in the Grotto.
+ */
+function admin_recommendations_install(): bool
+{
+    module_addhook('footer-superuser');
+
+    return true;
+}
+
+function admin_recommendations_uninstall(): bool
+{
+    return true;
+}
+
+/**
+ * Render a concise recommendation list for superusers.
+ *
+ * @param string               $hookname Hook currently being processed.
+ * @param array<string, mixed> $args     Existing hook arguments.
+ *
+ * @return array<string, mixed>
+ */
+function admin_recommendations_dohook(string $hookname, array $args): array
+{
+    global $session;
+
+    if ($hookname !== 'footer-superuser') {
+        return $args;
+    }
+
+    if ((int) get_module_setting('show_footer_summary') !== 1) {
+        return $args;
+    }
+
+    if (!isset($session['user']['superuser']) || ((int) $session['user']['superuser'] & SU_EDIT_CONFIG) !== SU_EDIT_CONFIG) {
+        return $args;
+    }
+
+    Translator::tlschema('module_admin_recommendations');
+
+    $recommendations = admin_recommendations_collect();
+    if ($recommendations === []) {
+        Translator::tlschema();
+
+        return $args;
+    }
+
+    $output = Output::getInstance();
+    $output->output('`n`n`b`^%s`0`b`n', Translator::translateInline('Admin Recommendations'));
+    $output->output('`2%s`0`n', Translator::translateInline('Quick security/configuration checks found:'));
+    foreach ($recommendations as $recommendation) {
+        $output->output("`n`\$- `2%s`0", $recommendation);
+    }
+    $output->output("`n");
+
+    Translator::tlschema();
+
+    return $args;
+}
+
+/**
+ * Build a compact recommendation list from dbconnect settings and runtime state.
+ *
+ * @return list<string>
+ */
+function admin_recommendations_collect(): array
+{
+    $settings = Settings::getInstance();
+    $recommendations = [];
+    $config = admin_recommendations_load_dbconnect();
+
+    $securityHeadersEnabled = admin_recommendations_to_bool($config['SECURITY_HEADERS_ENABLED'] ?? true);
+    if (!$securityHeadersEnabled) {
+        $recommendations[] = Translator::translateInline(
+            "SECURITY_HEADERS_ENABLED is disabled. Re-enable baseline security headers in dbconnect.php."
+        );
+    }
+
+    $hstsEnabled = admin_recommendations_to_bool($config['SECURITY_HSTS_ENABLED'] ?? false);
+    if (!$hstsEnabled) {
+        $recommendations[] = Translator::translateInline(
+            "HSTS is disabled (SECURITY_HSTS_ENABLED=false). Enable it once HTTPS/proxy setup is verified."
+        );
+    }
+
+    $trustForwardedProto = admin_recommendations_to_bool($config['SECURITY_TRUST_FORWARDED_PROTO'] ?? false);
+    $forwardedProtoPresent = isset($_SERVER['HTTP_X_FORWARDED_PROTO']) || isset($_SERVER['HTTP_FORWARDED']);
+    if ($forwardedProtoPresent && !$trustForwardedProto) {
+        $recommendations[] = Translator::translateInline(
+            "Reverse-proxy headers are present, but SECURITY_TRUST_FORWARDED_PROTO is false. Enable it and set SECURITY_TRUSTED_PROXIES."
+        );
+    }
+
+    if ($trustForwardedProto && trim((string) ($config['SECURITY_TRUSTED_PROXIES'] ?? '')) === '') {
+        $recommendations[] = Translator::translateInline(
+            "SECURITY_TRUST_FORWARDED_PROTO is enabled but SECURITY_TRUSTED_PROXIES is empty. Add your proxy IP allowlist."
+        );
+    }
+
+    if (!is_module_installed('twofactorauth') || !is_module_active('twofactorauth')) {
+        $recommendations[] = Translator::translateInline(
+            "Two-factor authentication module is not active. Install and activate 'twofactorauth' for admin/player account hardening."
+        );
+    }
+
+    $datacacheEnabled = (int) ($config['DB_USEDATACACHE'] ?? 0) === 1;
+    if ($datacacheEnabled) {
+        $datacachePath = trim((string) ($config['DB_DATACACHEPATH'] ?? ''));
+        if ($datacachePath === '' || !is_dir($datacachePath) || !is_writable($datacachePath)) {
+            $recommendations[] = Translator::translateInline(
+                "Data cache is enabled but DB_DATACACHEPATH is missing/not writable. Fix the path or disable DB_USEDATACACHE."
+            );
+        }
+    }
+
+    $serverUrl = trim((string) $settings->getSetting('serverurl', ''));
+    if ($serverUrl !== '' && stripos($serverUrl, 'https://') !== 0) {
+        $recommendations[] = Translator::translateInline(
+            "serverurl does not start with https://. Set a canonical HTTPS URL in game settings."
+        );
+    }
+
+    return $recommendations;
+}
+
+/**
+ * Read dbconnect.php in array mode and gracefully handle legacy/non-array files.
+ *
+ * @return array<string, mixed>
+ */
+function admin_recommendations_load_dbconnect(): array
+{
+    $dbconnectPath = dirname(__DIR__) . '/dbconnect.php';
+    if (!file_exists($dbconnectPath)) {
+        return [];
+    }
+
+    try {
+        /** @psalm-suppress UnresolvableInclude */
+        $config = require $dbconnectPath;
+    } catch (\Throwable) {
+        return [];
+    }
+
+    return is_array($config) ? $config : [];
+}
+
+/**
+ * Normalize typical bool-like config inputs ("1", "true", etc.) to bool.
+ */
+function admin_recommendations_to_bool(mixed $value): bool
+{
+    if (is_bool($value)) {
+        return $value;
+    }
+
+    if (is_numeric($value)) {
+        return (int) $value !== 0;
+    }
+
+    return in_array(strtolower(trim((string) $value)), ['1', 'true', 'yes', 'on'], true);
+}

--- a/tests/Installer/Stage6Test.php
+++ b/tests/Installer/Stage6Test.php
@@ -121,7 +121,7 @@ final class Stage6Test extends TestCase
         $this->assertFileExists($this->dbconnectPath);
 
         $contents = file_get_contents($this->dbconnectPath);
-        $this->assertMatchesRegularExpression('/^<\?php\n\/\/This file automatically created by installer\\.php on .+\nreturn \[\n/s', $contents);
+        $this->assertMatchesRegularExpression('/^<\?php\n(?:\n)?\/\/This file automatically created by installer\\.php on .+\n(?:\/\/.*\n)*return \[\n/s', $contents);
         $this->assertStringContainsString("'DB_HOST' => 'localhost'", $contents);
         $this->assertStringContainsString("'DB_USER' => 'installer'", $contents);
         $this->assertStringContainsString("'DB_PASS' => 'password'", $contents);


### PR DESCRIPTION
## Summary
- Extend installer-generated `dbconnect.php` output with explicit runtime hardening defaults (`SESSION_COOKIE_*` and `SECURITY_*` keys) for fresh installs and legacy-file normalization.
- Refactor stage 6 initial file creation to reuse canonical `buildDbconnectContents()` output, avoiding drift between first-write and update paths.
- Add a new core module `admin_recommendations` that hooks `footer-superuser` and emits concise operational security recommendations (HSTS/proxy trust config, 2FA activation, datacache path validity, canonical HTTPS server URL).
- Mark `twofactorauth` and `admin_recommendations` as recommended modules during installer module selection.
- Update installer stage-6 test regex to allow the new generated comment lines.

## Why
Admins were missing actionable visibility on hardening setup and blank installs did not surface the runtime security knobs in `dbconnect.php`, making HSTS/proxy/cookie setup easy to miss.

## Security review note
This change touches installer config generation and superuser-facing recommendations.

- **Input validation boundary**: module checks only read trusted local config/runtime values and server env; no new untrusted write paths were added.
- **CSRF coverage**: no new state-changing endpoints/forms were introduced.
- **SQL safety**: no SQL query changes were introduced.
- **Authorization checks**: recommendations render only for users with `SU_EDIT_CONFIG` on `footer-superuser`.
- **Security logging**: no security-critical state changes are performed; no new logs required.

## Testing
- `php -l install/lib/Installer.php`
- `php -l modules/admin_recommendations.php`
- `php -l install/data/recommended_modules.php`
- `vendor/bin/phpunit tests/Installer/Stage6Test.php tests/Installer/Stage9Test.php --colors=never`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c77f0edb188329acad82d2f90bd473)