### PR TITLE
chore(ci): update workflow action majors for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PHP_VERSION: '8.3'
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ env.PHP_VERSION }}
           tools: composer
       - name: Cache Composer files
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.composer/cache/files
           key: ${{ runner.os }}-php-${{ env.PHP_VERSION }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,11 @@ on:
 jobs:
   package:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Extract version


### PR DESCRIPTION
### Motivation
- Update GitHub Actions usage to remain compatible with the platform's upcoming Node.js runtime changes and the Node 20 deprecation/removal timeline. 
- Ensure CI and release workflows will be validated early against the Node 24 runtime by enabling the forced env flag for JavaScript actions.

### Description
- Bump `actions/checkout` from `v4` to `v5` in both `.github/workflows/ci.yml` and `.github/workflows/release.yml` to use a newer major that supports Node 24 runtime changes. 
- Bump `actions/cache` from `v4` to `v5` in `.github/workflows/ci.yml` to keep the composer cache step compatible. 
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the job environment in both CI and release workflows for early validation of JavaScript actions against Node 24.

### Testing
- Ran `composer test`, which completed successfully overall but reported warnings (8), deprecations (2), and PHPUnit notices (22). 
- Ran `composer static`, which passed with no static analysis errors. 
- Executed the release packaging commands locally which produced `dist/lotgd-0.0.0-test.tar.gz` and `dist/lotgd-0.0.0-test.zip` as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c79a41dd9083299fd816da377b5deb)