### PR TITLE
refactor: enforce exact SQL addslashes baseline entries

### DIFF
--- a/src/Lotgd/QA/SqlAddslashesUsageCheck.php
+++ b/src/Lotgd/QA/SqlAddslashesUsageCheck.php
@@ -12,6 +12,12 @@ namespace Lotgd\QA;
  *  - Global/pre-escaped values must not be used for SQL construction.
  *  - Legacy compatibility wrappers may still expose escaped values, but core
  *    paths must not rely on that behavior.
+ *
+ * Baseline maintenance:
+ *  - Adding a baseline entry requires a justification in metadata (`reason`)
+ *    plus traceability fields (`owner`, `target_removal_version`).
+ *  - Baseline removals are preferred whenever a call site is migrated to
+ *    parameterized DBAL queries.
  */
 final class SqlAddslashesUsageCheck
 {
@@ -46,34 +52,67 @@ final class SqlAddslashesUsageCheck
     ];
 
     /**
-     * Temporary baseline for known legacy usages.
+     * Exact baseline for known legacy SQL addslashes() usage.
      *
-     * Keep this list narrow and remove entries as call sites are migrated.
+     * Entry key format: "{relative_file_path}:{line_number}".
+     * Hash algorithm: sha256 of the normalized source line returned by
+     * self::normalizeLineForBaseline().
      *
-     * @var array<string,list<string>>
+     * @var array<string,array{
+     *     hash: string,
+     *     reason: string,
+     *     owner: string,
+     *     target_removal_version: string
+     * }>
      */
-    private const ALLOWED_SQL_ADDSLASHES_PATTERNS = [
-        'pages/clan/applicant_new.php' => ['$clanname = addslashes($clanname);'],
-        'pages/clan/clan_motd.php' => [
-            "clanmotd='\" . addslashes(\$clanmotd)",
-            "clandesc='\" . addslashes(mb_substr(stripslashes(\$clandesc)",
+    private const LEGACY_SQL_ADDSLASHES_BASELINE = [
+        'pages/clan/applicant_new.php:28' => [
+            'hash' => '03502d5628a6cd419d213941ec533826328d4d5260c888a6b0bd0b4817c95cd2',
+            'reason' => 'Legacy clan application workflow still escapes clan names pre-DBAL migration.',
+            'owner' => 'core-legacy-maintainers',
+            'target_removal_version' => '3.0.0',
         ],
-        'pages/clan/clan_withdraw.php' => ["subject='\" . addslashes(serialize(\$withdraw_subj))"],
-        'src/Lotgd/Accounts.php' => [
-            "\" SET output='\" . addslashes(gzcompress(\$session['output'], 1))",
-            "VALUES ({\$session['user']['acctid']},'\" . addslashes(gzcompress(\$session['output'], 1))",
+        'pages/clan/clan_motd.php:28' => [
+            'hash' => '7c0b62faa5c75bde868acc4e5e380f5ee2c583ce5ca903b28ff61aedcc54af29',
+            'reason' => 'Legacy clan MOTD update path still uses interpolated SQL string construction.',
+            'owner' => 'core-legacy-maintainers',
+            'target_removal_version' => '3.0.0',
         ],
-        'src/Lotgd/PlayerFunctions.php' => [
-            "addslashes(implode(',', \$players))",
+        'pages/clan/clan_motd.php:42' => [
+            'hash' => 'cc73112aa7f7e0327d0f5b2d56498219afa252bce010af1bd8595f18daecf631',
+            'reason' => 'Legacy clan description update path remains pre-DBAL and escaped inline.',
+            'owner' => 'core-legacy-maintainers',
+            'target_removal_version' => '3.0.0',
         ],
-        'src/Lotgd/Translator.php' => [
-            "VALUES ('\" .  addslashes(\$indata) . \"', '\"",
+        'pages/clan/clan_withdraw.php:55' => [
+            'hash' => '814d0b822836c513c98c315bab7ba4a9c35014c0de20dd707a0d5a6ef6e44f93',
+            'reason' => 'Legacy serialized withdrawal subject is still injected into raw SQL.',
+            'owner' => 'core-legacy-maintainers',
+            'target_removal_version' => '3.0.0',
         ],
-        'src/Lotgd/Motd.php' => [
-            '$body = addslashes(serialize($data));',
+        'src/Lotgd/Motd.php:305' => [
+            'hash' => '864ec7fed5f8965ea8cd9b0df737e7351526d91e6c671c2a58a9378ae59e5b20',
+            'reason' => 'MOTD poll payload is serialized and escaped before legacy persistence flow.',
+            'owner' => 'core-legacy-maintainers',
+            'target_removal_version' => '3.0.0',
         ],
-        'src/Lotgd/Pvp.php' => [
-            '$loc = addslashes($location);',
+        'src/Lotgd/PlayerFunctions.php:269' => [
+            'hash' => '9a9e396bb26a75acea49a054ddd88aac4109bb9458e4dec32a0900e037a01b8c',
+            'reason' => 'Legacy IN-clause account list is still assembled as a raw SQL string.',
+            'owner' => 'core-legacy-maintainers',
+            'target_removal_version' => '3.0.0',
+        ],
+        'src/Lotgd/Pvp.php:309' => [
+            'hash' => '210cbfa91dd74d70e294d4ecfa25693c871df1b063e1dc0501b8062dc0af379b',
+            'reason' => 'PVP location storage still assigns escaped values before SQL assignment.',
+            'owner' => 'core-legacy-maintainers',
+            'target_removal_version' => '3.0.0',
+        ],
+        'src/Lotgd/Translator.php:167' => [
+            'hash' => '64a1ec84cf168bb732d1ea1f29dea281bd15584cf2406a50f83544d51963d9d5',
+            'reason' => 'Translator fallback inserts untranslated text via legacy interpolated SQL.',
+            'owner' => 'core-legacy-maintainers',
+            'target_removal_version' => '3.0.0',
         ],
     ];
 
@@ -171,7 +210,7 @@ final class SqlAddslashesUsageCheck
             }
 
             $lineText = trim($lines[$lineNumber - 1] ?? '');
-            if ($this->isKnownLegacyViolation($relativePath, $lineText)) {
+            if ($this->isKnownLegacyViolation($relativePath, $lineNumber, $lineText)) {
                 continue;
             }
             $violations[] = sprintf('%s:%d:%s', $relativePath, $lineNumber, $lineText);
@@ -180,16 +219,22 @@ final class SqlAddslashesUsageCheck
         return $violations;
     }
 
-    private function isKnownLegacyViolation(string $relativePath, string $lineText): bool
+    private function isKnownLegacyViolation(string $relativePath, int $lineNumber, string $lineText): bool
     {
-        $knownPatterns = self::ALLOWED_SQL_ADDSLASHES_PATTERNS[$relativePath] ?? [];
-        foreach ($knownPatterns as $knownPattern) {
-            if (str_contains($lineText, $knownPattern)) {
-                return true;
-            }
+        $baselineKey = sprintf('%s:%d', $relativePath, $lineNumber);
+        $baseline = self::LEGACY_SQL_ADDSLASHES_BASELINE[$baselineKey] ?? null;
+        if ($baseline === null) {
+            return false;
         }
 
-        return false;
+        $lineHash = hash('sha256', $this->normalizeLineForBaseline($lineText));
+        return hash_equals($baseline['hash'], $lineHash);
+    }
+
+    private function normalizeLineForBaseline(string $lineText): string
+    {
+        $trimmed = trim($lineText);
+        return (string) preg_replace('/\s+/', ' ', $trimmed);
     }
 
     /**

--- a/tests/QA/SqlAddslashesUsageCheckTest.php
+++ b/tests/QA/SqlAddslashesUsageCheckTest.php
@@ -57,13 +57,54 @@ final class SqlAddslashesUsageCheckTest extends TestCase
         mkdir($root . '/src/Lotgd', 0777, true);
         file_put_contents(
             $root . '/src/Lotgd/PlayerFunctions.php',
-            "<?php\n\$sql = 'SELECT acctid FROM accounts WHERE acctid IN (' . addslashes(implode(',', \$players)) . ')';\n"
+            $this->buildLegacyPlayerFunctionsFixture(
+                269,
+                "\$sql = 'SELECT acctid,laston,loggedin FROM ' . Database::prefix('accounts') . ' WHERE acctid IN (' . addslashes(implode(',', \$players)) . ')';"
+            )
         );
 
         $checker = new SqlAddslashesUsageCheck();
         $violations = $checker->collectViolations($root);
 
         $this->assertSame([], $violations);
+    }
+
+    public function testCheckerFlagsSimilarButNewLegacyLikeLine(): void
+    {
+        $root = $this->createFixtureRoot();
+        mkdir($root . '/src/Lotgd', 0777, true);
+        file_put_contents(
+            $root . '/src/Lotgd/PlayerFunctions.php',
+            $this->buildLegacyPlayerFunctionsFixture(
+                269,
+                "\$sql = 'SELECT acctid,laston,loggedin FROM ' . Database::prefix('accounts') . ' WHERE acctid IN (' . addslashes(implode(',', \$players)) . ') ORDER BY acctid';"
+            )
+        );
+
+        $checker = new SqlAddslashesUsageCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('src/Lotgd/PlayerFunctions.php:269:', $violations[0]);
+    }
+
+    public function testCheckerIgnoresOnlyExactBaselineEntry(): void
+    {
+        $root = $this->createFixtureRoot();
+        mkdir($root . '/src/Lotgd', 0777, true);
+        file_put_contents(
+            $root . '/src/Lotgd/PlayerFunctions.php',
+            $this->buildLegacyPlayerFunctionsFixture(
+                270,
+                "\$sql = 'SELECT acctid,laston,loggedin FROM ' . Database::prefix('accounts') . ' WHERE acctid IN (' . addslashes(implode(',', \$players)) . ')';"
+            )
+        );
+
+        $checker = new SqlAddslashesUsageCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('src/Lotgd/PlayerFunctions.php:270:', $violations[0]);
     }
 
     public function testCheckerFlagsSplitSqlConstructionUsingEscapedTemporaryVariable(): void
@@ -96,6 +137,17 @@ PHP
         $this->fixtureRoots[] = $root;
 
         return $root;
+    }
+
+    private function buildLegacyPlayerFunctionsFixture(int $lineNumber, string $line): string
+    {
+        $phpLines = ['<?php'];
+        while (count($phpLines) < ($lineNumber - 1)) {
+            $phpLines[] = '$placeholder = null;';
+        }
+        $phpLines[] = $line;
+
+        return implode("\n", $phpLines) . "\n";
     }
 
     private function removeDirectoryRecursively(string $path): void


### PR DESCRIPTION
### Motivation

- Prevent accidental suppression of new/modified addslashes() uses by replacing substring allowlists with an exact, auditable baseline keyed by `file:line` and the normalized-line hash.
- Make remaining legacy exceptions traceable and timeboxed by attaching metadata (`reason`, `owner`, `target_removal_version`) to each baseline entry.

### Description

- Replaced the substring-based `ALLOWED_SQL_ADDSLASHES_PATTERNS` with `LEGACY_SQL_ADDSLASHES_BASELINE`, an exact `file:line` keyed map whose entries include a `sha256` `hash` and metadata fields `reason`, `owner`, and `target_removal_version` in `src/Lotgd/QA/SqlAddslashesUsageCheck.php`.
- Changed `isKnownLegacyViolation()` to `isKnownLegacyViolation(string $relativePath, int $lineNumber, string $lineText)` and require exact key + hash equality using `normalizeLineForBaseline()` and `hash_equals()` instead of `str_contains`.
- Added a short "Baseline maintenance" section to the class docblock documenting that adding an entry requires justification and that removals are preferred when migrating to parameterized DBAL.
- Extended `tests/QA/SqlAddslashesUsageCheckTest.php` with two cases that prove similar-but-new lines are flagged and that only exact baseline entries are ignored, and added a helper `buildLegacyPlayerFunctionsFixture()` for deterministic line placement.

### Testing

- Ran syntax checks with `php -l` on the modified files and they reported no syntax errors.
- Executed the checker unit tests with `vendor/bin/phpunit tests/QA/SqlAddslashesUsageCheckTest.php` which passed (`6 tests, 10 assertions`).
- Ran the full test suite with `composer test` which completed successfully (tests passed, existing repository warnings/notices remained but are unrelated to this change).
- Ran static analysis with `composer static` which reported the SQL addslashes check as passing and finished without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c79a3578c083299c6291bae07eecb8)