### PR TITLE
fix: harden legacy superuser/account SQL writes with typed DBAL bindings

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -205,16 +205,17 @@ Recent 2.x updates switched several superuser and security-sensitive endpoints t
 - `moderate.php` (comment delete / restore writes, moderation inserts, dynamic `IN` list binding with `ArrayParameterType::INTEGER`).
 - `payment.php` (IPN duplicate check, account donation credit update, and paylog persistence writes).
 - `badword.php` (good/nasty word list rewrite operations).
-- `masters.php` (training master insert/update writes).
+- `masters.php` (training master insert/update/delete writes).
 - `titleedit.php` (title insert/update/delete and account title reset updates).
+- `creatures.php` (creature insert/update/delete writes with typed DBAL parameters).
+- `referers.php` (cleanup delete + site rebuild updates now use typed parameter binding).
+- `paylog.php` (process date backfill update is bound through DBAL).
+- `configuration.php` (account location mass updates for village/inn rename flows).
+- `create.php` (validation/forgot-password/email-change account writes now use bound parameters).
 - Previously migrated: `deathmessages.php`, `taunt.php`, `untranslated.php`.
 
 **Pending superuser pages still using legacy string-built writes (track for next waves):**
-- `creatures.php`
-- `referers.php`
-- `paylog.php`
-- `configuration.php`
-- `create.php`
+- None currently tracked in this hardening wave.
 
 If you maintain custom overrides of any migrated page, update those overrides to match bound-parameter execution semantics (including explicit type maps and DBAL array binding for dynamic `IN` clauses).
 

--- a/configuration.php
+++ b/configuration.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Lotgd\MySQL\Database;
+use Doctrine\DBAL\ParameterType;
 use Lotgd\Translator;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
@@ -126,10 +127,19 @@ switch ($type_setting) {
                 $villageName = is_string($rawVillageName) ? stripslashes($rawVillageName) : '';
                 if ($villageName !== '' && $villageName != $settings->getSetting('villagename', LOCATION_FIELDS)) {
                     $output->debug("Updating village name -- moving players");
-                    $sql = "UPDATE " . Database::prefix("accounts") . " SET location='" .
-                        addslashes($villageName) . "' WHERE location='" .
-                        addslashes($settings->getSetting('villagename', LOCATION_FIELDS)) . "'";
-                    Database::query($sql);
+                    $conn = Database::getDoctrineConnection();
+                    $accountsTable = Database::prefix('accounts');
+                    $conn->executeStatement(
+                        "UPDATE {$accountsTable} SET location = :newLocation WHERE location = :oldLocation",
+                        [
+                            'newLocation' => $villageName,
+                            'oldLocation' => $settings->getSetting('villagename', LOCATION_FIELDS),
+                        ],
+                        [
+                            'newLocation' => ParameterType::STRING,
+                            'oldLocation' => ParameterType::STRING,
+                        ]
+                    );
                     if ($session['user']['location'] == $settings->getSetting('villagename', LOCATION_FIELDS)) {
                         $session['user']['location'] = $villageName;
                     }
@@ -138,10 +148,19 @@ switch ($type_setting) {
                 $innName = is_string($rawInnName) ? stripslashes($rawInnName) : '';
                 if ($innName !== '' && $innName != $settings->getSetting('innname', LOCATION_INN)) {
                     $output->debug("Updating inn name -- moving players");
-                    $sql = "UPDATE " . Database::prefix("accounts") . " SET location='" .
-                        addslashes($innName) . "' WHERE location='" .
-                        addslashes($settings->getSetting('innname', LOCATION_INN)) . "'";
-                    Database::query($sql);
+                    $conn = Database::getDoctrineConnection();
+                    $accountsTable = Database::prefix('accounts');
+                    $conn->executeStatement(
+                        "UPDATE {$accountsTable} SET location = :newLocation WHERE location = :oldLocation",
+                        [
+                            'newLocation' => $innName,
+                            'oldLocation' => $settings->getSetting('innname', LOCATION_INN),
+                        ],
+                        [
+                            'newLocation' => ParameterType::STRING,
+                            'oldLocation' => ParameterType::STRING,
+                        ]
+                    );
                     if ($session['user']['location'] == $settings->getSetting('innname', LOCATION_INN)) {
                         $session['user']['location'] = $innName;
                     }

--- a/create.php
+++ b/create.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Lotgd\MySQL\Database;
+use Doctrine\DBAL\ParameterType;
 use Lotgd\Translator;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
@@ -64,12 +65,23 @@ if ($op == 'val' || $op == 'forgotval') {
 
 if ($op == "forgotval") {
     $id = Http::get('id');
+    $conn = Database::getDoctrineConnection();
+    $accountsTable = Database::prefix('accounts');
     $sql = "SELECT acctid,login,superuser,password,name,replaceemail,emailaddress,emailvalidation FROM " . Database::prefix("accounts") . " WHERE forgottenpassword='" . Database::escape($id) . "' AND forgottenpassword!=''";
     $result = Database::query($sql);
     if (Database::numRows($result) > 0) {
         $row = Database::fetchAssoc($result);
-        $sql = "UPDATE " . Database::prefix("accounts") . " SET forgottenpassword='' WHERE forgottenpassword='$id';";
-        Database::query($sql);
+        $conn->executeStatement(
+            "UPDATE {$accountsTable} SET forgottenpassword = :forgottenpassword WHERE forgottenpassword = :id",
+            [
+                'forgottenpassword' => '',
+                'id' => (string) $id,
+            ],
+            [
+                'forgottenpassword' => ParameterType::STRING,
+                'id' => ParameterType::STRING,
+            ]
+        );
         $output->output("`#`cYour login request has been validated.  You may now log in.`c`0");
         $output->rawOutput("<form action='login.php' method='POST'>");
         $output->rawOutput("<input name='name' value=\"{$row['login']}\" type='hidden'>");
@@ -89,8 +101,17 @@ if ($op == "forgotval") {
         }
         //rare case: we have somebody who deleted his first validation email and then requests a forgotten PW...
         if ($row['emailvalidation'] != "" && substr($row['emailvalidation'], 0, 1) != "x") {
-            $sql = "UPDATE " . Database::prefix('accounts') . " SET emailvalidation='' WHERE acctid=" . $row['acctid'];
-            Database::query($sql);
+            $conn->executeStatement(
+                "UPDATE {$accountsTable} SET emailvalidation = :emailvalidation WHERE acctid = :acctid",
+                [
+                    'emailvalidation' => '',
+                    'acctid' => (int) $row['acctid'],
+                ],
+                [
+                    'emailvalidation' => ParameterType::STRING,
+                    'acctid' => ParameterType::INTEGER,
+                ]
+            );
         }
     } else {
         $output->output("`#Your request could not be verified.`n`n");
@@ -99,6 +120,8 @@ if ($op == "forgotval") {
     }
 } elseif ($op == "val") {
     $id = Http::get('id');
+    $conn = Database::getDoctrineConnection();
+    $accountsTable = Database::prefix('accounts');
     $sql = "SELECT acctid,login,superuser,password,name,replaceemail,emailaddress FROM " . Database::prefix("accounts") . " WHERE emailvalidation='" . Database::escape($id) . "' AND emailvalidation!=''";
     $result = Database::query($sql);
     if (Database::numRows($result) > 0) {
@@ -107,8 +130,23 @@ if ($op == "forgotval") {
             $replace_array = explode("|", $row['replaceemail']);
             $replaceemail = $replace_array[0]; //1==date
             //note: remove any forgotten password request!
-            $sql = "UPDATE " . Database::prefix("accounts") . " SET emailaddress='" . $replaceemail . "', replaceemail='',forgottenpassword='' WHERE emailvalidation='$id';";
-            Database::query($sql);
+            $conn->executeStatement(
+                "UPDATE {$accountsTable}
+                    SET emailaddress = :replaceemail, replaceemail = :replaceemailReset, forgottenpassword = :forgottenpassword
+                    WHERE emailvalidation = :id",
+                [
+                    'replaceemail' => $replaceemail,
+                    'replaceemailReset' => '',
+                    'forgottenpassword' => '',
+                    'id' => (string) $id,
+                ],
+                [
+                    'replaceemail' => ParameterType::STRING,
+                    'replaceemailReset' => ParameterType::STRING,
+                    'forgottenpassword' => ParameterType::STRING,
+                    'id' => ParameterType::STRING,
+                ]
+            );
             $output->output("`#`c Email changed successfully!`c`0`n");
                         DebugLog::add("Email change request validated by link from " . $row['emailaddress'] . " to " . $replaceemail, $row['acctid'], $row['acctid'], "Email");
             //If a superuser changes email, we want to know about it... at least those who can ee it anyway, the user editors...
@@ -130,8 +168,17 @@ if ($op == "forgotval") {
                 }
             }
         }
-        $sql = "UPDATE " . Database::prefix("accounts") . " SET emailvalidation='' WHERE emailvalidation='$id';";
-        Database::query($sql);
+        $conn->executeStatement(
+            "UPDATE {$accountsTable} SET emailvalidation = :emailvalidation WHERE emailvalidation = :id",
+            [
+                'emailvalidation' => '',
+                'id' => (string) $id,
+            ],
+            [
+                'emailvalidation' => ParameterType::STRING,
+                'id' => ParameterType::STRING,
+            ]
+        );
         $output->output("`#`cYour email has been validated.  You may now log in.`c`0");
         $output->output(
             "Your email has been validated, your login name is `^%s`0.`n`n",
@@ -174,8 +221,19 @@ if ($op == "forgot") {
             if (trim($row['emailaddress']) != "") {
                 if ($row['forgottenpassword'] == "") {
                     $row['forgottenpassword'] = substr("x" . md5(date("Y-m-d H:i:s") . $row['password']), 0, 32);
-                    $sql = "UPDATE " . Database::prefix("accounts") . " SET forgottenpassword='{$row['forgottenpassword']}' where login='{$row['login']}'";
-                    Database::query($sql);
+                    $conn = Database::getDoctrineConnection();
+                    $accountsTable = Database::prefix('accounts');
+                    $conn->executeStatement(
+                        "UPDATE {$accountsTable} SET forgottenpassword = :forgottenpassword WHERE login = :login",
+                        [
+                            'forgottenpassword' => (string) $row['forgottenpassword'],
+                            'login' => (string) $row['login'],
+                        ],
+                        [
+                            'forgottenpassword' => ParameterType::STRING,
+                            'login' => ParameterType::STRING,
+                        ]
+                    );
                 }
 
                 $subj = translate_mail($settings_extended->getSetting('forgottenpasswordmailsubject'), $row['acctid']);

--- a/creatures.php
+++ b/creatures.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Lotgd\MySQL\Database;
+use Doctrine\DBAL\ParameterType;
 use Lotgd\Translator;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
@@ -81,11 +82,21 @@ if ($op == "save") {
     if ($subop == "") {
         $post = httpallpost();
         $lev = (int)Http::post('creaturelevel');
+        $conn = Database::getDoctrineConnection();
+        $creaturesTable = Database::prefix('creatures');
         if ($id) {
-            $sql = "";
+            $setClauses = [];
+            $params = [];
+            $types = [];
             foreach ($post as $key => $val) {
-                if (substr($key, 0, 8) == "creature") {
-                    $sql .= "$key = '$val', ";
+                if (!is_string($key) || !is_scalar($val)) {
+                    continue;
+                }
+                if (substr($key, 0, 8) == "creature" && preg_match('/^creature[a-z0-9_]+$/i', $key) === 1) {
+                    $paramKey = 'set_' . $key;
+                    $setClauses[] = "{$key} = :{$paramKey}";
+                    $params[$paramKey] = (string) $val;
+                    $types[$paramKey] = ParameterType::STRING;
                 }
             }
             foreach ($creaturestats[$lev] as $key => $val) {
@@ -93,40 +104,64 @@ if ($op == "save") {
                     continue;
                 }
                 if ($key != "creaturelevel" && substr($key, 0, 8) == "creature") {
-                    $sql .= "$key = \"" . addslashes($val) . "\", ";
+                    $paramKey = 'default_' . $key;
+                    $setClauses[] = "{$key} = :{$paramKey}";
+                    $params[$paramKey] = (string) $val;
+                    $types[$paramKey] = ParameterType::STRING;
                 }
             }
-            $sql .= " forest='$forest', ";
-            $sql .= " graveyard='$grave', ";
-            $sql .= " createdby='" . $session['user']['login'] . "' ";
-            $sql = "UPDATE " . Database::prefix("creatures") . " SET " . $sql . " WHERE creatureid='$id'";
-            $result = Database::query($sql) or $output->output("`\$" . Database::error(LINK) . "`0`n`#$sql`0`n");
+            $setClauses[] = 'forest = :forest';
+            $setClauses[] = 'graveyard = :graveyard';
+            $setClauses[] = 'createdby = :createdby';
+            $params['forest'] = $forest;
+            $params['graveyard'] = $grave;
+            $params['createdby'] = (string) $session['user']['login'];
+            $params['id'] = (int) $id;
+            $types['forest'] = ParameterType::INTEGER;
+            $types['graveyard'] = ParameterType::INTEGER;
+            $types['createdby'] = ParameterType::STRING;
+            $types['id'] = ParameterType::INTEGER;
+
+            $sql = "UPDATE {$creaturesTable} SET " . implode(', ', $setClauses) . " WHERE creatureid = :id";
+            $result = $conn->executeStatement($sql, $params, $types) > 0;
         } else {
             $cols = array();
-            $vals = array();
+            $params = [];
+            $types = [];
 
             foreach ($post as $key => $val) {
-                if (substr($key, 0, 8) == "creature") {
-                    array_push($cols, $key);
-                    array_push($vals, $val);
+                if (!is_string($key) || !is_scalar($val)) {
+                    continue;
+                }
+                if (substr($key, 0, 8) == "creature" && preg_match('/^creature[a-z0-9_]+$/i', $key) === 1) {
+                    $cols[] = $key;
+                    $params[$key] = (string) $val;
+                    $types[$key] = ParameterType::STRING;
                 }
             }
-            array_push($cols, "forest");
-            array_push($vals, $forest);
-            array_push($cols, "graveyard");
-            array_push($vals, $grave);
+            $cols[] = "forest";
+            $params['forest'] = $forest;
+            $types['forest'] = ParameterType::INTEGER;
+            $cols[] = "graveyard";
+            $params['graveyard'] = $grave;
+            $types['graveyard'] = ParameterType::INTEGER;
             reset($creaturestats[$lev]);
             foreach ($creaturestats[$lev] as $key => $val) {
                 if ($post[$key] != "") {
                     continue;
                 }
                 if ($key != "creaturelevel" && substr($key, 0, 8) == "creature") {
-                    array_push($cols, $key);
-                    array_push($vals, $val);
+                    $cols[] = $key;
+                    $params[$key] = (string) $val;
+                    $types[$key] = ParameterType::STRING;
                 }
             }
-            $sql = "INSERT INTO " . Database::prefix("creatures") . " (" . join(",", $cols) . ",createdby) VALUES (\"" . join("\",\"", $vals) . "\",\"" . addslashes($session['user']['login']) . "\")";
-            $result = Database::query($sql);
+            $cols[] = 'createdby';
+            $params['createdby'] = (string) $session['user']['login'];
+            $types['createdby'] = ParameterType::STRING;
+            $placeholders = array_map(static fn (string $column): string => ':' . $column, $cols);
+            $sql = "INSERT INTO {$creaturesTable} (" . implode(',', $cols) . ") VALUES (" . implode(',', $placeholders) . ")";
+            $result = $conn->executeStatement($sql, $params, $types) > 0;
             $id = Database::insertId();
         }
         if ($result) {
@@ -152,9 +187,14 @@ if ($op == "save") {
 $op = Http::get('op');
 $id = Http::get('creatureid');
 if ($op == "del") {
-    $sql = "DELETE FROM " . Database::prefix("creatures") . " WHERE creatureid = '$id'";
-    Database::query($sql);
-    if (Database::affectedRows() > 0) {
+    $conn = Database::getDoctrineConnection();
+    $creaturesTable = Database::prefix('creatures');
+    $affectedRows = $conn->executeStatement(
+        "DELETE FROM {$creaturesTable} WHERE creatureid = :id",
+        ['id' => (int) $id],
+        ['id' => ParameterType::INTEGER]
+    );
+    if ($affectedRows > 0) {
         $output->output("Creature deleted`n`n");
         module_delete_objprefs('creatures', $id);
     } else {

--- a/creatures.php
+++ b/creatures.php
@@ -123,7 +123,7 @@ if ($op == "save") {
             $types['id'] = ParameterType::INTEGER;
 
             $sql = "UPDATE {$creaturesTable} SET " . implode(', ', $setClauses) . " WHERE creatureid = :id";
-            $result = $conn->executeStatement($sql, $params, $types) > 0;
+            $result = $conn->executeStatement($sql, $params, $types) >= 0;
         } else {
             $cols = array();
             $params = [];

--- a/masters.php
+++ b/masters.php
@@ -37,12 +37,16 @@ SuperuserNav::render();
 if ($op == "del") {
     $conn = Database::getDoctrineConnection();
     $mastersTable = Database::prefix('masters');
-    $conn->executeStatement(
+    $affectedRows = $conn->executeStatement(
         "DELETE FROM {$mastersTable} WHERE creatureid = :id",
         ['id' => $id],
         ['id' => ParameterType::INTEGER]
     );
-    $output->output("`^Master deleted.`0");
+    if ($affectedRows > 0) {
+        $output->output("`^Master deleted.`0");
+    } else {
+        $output->output("`\$No master found for the given id.`0");
+    }
     $op = "";
     Http::set("op", "");
 } elseif ($op == "save") {

--- a/masters.php
+++ b/masters.php
@@ -35,8 +35,13 @@ Header::pageHeader("Masters Editor");
 SuperuserNav::render();
 
 if ($op == "del") {
-    $sql = "DELETE FROM " . Database::prefix("masters") . " WHERE creatureid=$id";
-    Database::query($sql);
+    $conn = Database::getDoctrineConnection();
+    $mastersTable = Database::prefix('masters');
+    $conn->executeStatement(
+        "DELETE FROM {$mastersTable} WHERE creatureid = :id",
+        ['id' => $id],
+        ['id' => ParameterType::INTEGER]
+    );
     $output->output("`^Master deleted.`0");
     $op = "";
     Http::set("op", "");

--- a/paylog.php
+++ b/paylog.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Lotgd\MySQL\Database;
+use Doctrine\DBAL\ParameterType;
 use Lotgd\Translator;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
@@ -77,6 +78,8 @@ HookHandler::hook("paylog", array());
 $op = (string) Http::get('op');
 $currency = $settings->getSetting('paypalcurrency', 'USD');
 if ($op == "") {
+    $conn = Database::getDoctrineConnection();
+    $paylogTable = Database::prefix('paylog');
     Nav::add('Actions');
     Nav::add('Refresh', 'paylog.php');
     $sql = "SELECT info,txnid FROM " . Database::prefix("paylog") . " WHERE processdate='" . DATETIME_DATEMIN . "'";
@@ -92,8 +95,17 @@ if ($op == "") {
         if ($normalized['paymentDate'] !== null) {
             $timestamp = strtotime($normalized['paymentDate']);
             if ($timestamp !== false) {
-                $sql = "UPDATE " . Database::prefix('paylog') . " SET processdate='" . date("Y-m-d H:i:s", $timestamp) . "' WHERE txnid='" . addslashes($row['txnid']) . "'";
-                Database::query($sql);
+                $conn->executeStatement(
+                    "UPDATE {$paylogTable} SET processdate = :processdate WHERE txnid = :txnid",
+                    [
+                        'processdate' => date("Y-m-d H:i:s", $timestamp),
+                        'txnid' => (string) $row['txnid'],
+                    ],
+                    [
+                        'processdate' => ParameterType::STRING,
+                        'txnid' => ParameterType::STRING,
+                    ]
+                );
             }
         }
     }

--- a/referers.php
+++ b/referers.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Lotgd\MySQL\Database;
+use Doctrine\DBAL\ParameterType;
 use Lotgd\Translator;
 use Lotgd\SuAccess;
 use Lotgd\Nav\SuperuserNav;
@@ -29,8 +30,14 @@ Translator::getInstance()->setSchema("referers");
 
 SuAccess::check(SU_EDIT_CONFIG);
 
-$sql = "DELETE FROM " . Database::prefix("referers") . " WHERE last<'" . date("Y-m-d H:i:s", strtotime("-" . $settings->getSetting('expirecontent', 180) . " days")) . "'";
-Database::query($sql);
+$conn = Database::getDoctrineConnection();
+$referersTable = Database::prefix('referers');
+$cutoffDate = date("Y-m-d H:i:s", strtotime("-" . $settings->getSetting('expirecontent', 180) . " days"));
+$conn->executeStatement(
+    "DELETE FROM {$referersTable} WHERE last < :cutoff",
+    ['cutoff' => $cutoffDate],
+    ['cutoff' => ParameterType::STRING]
+);
 $op = Http::get('op');
 
 if ($op == "rebuild") {
@@ -41,8 +48,17 @@ if ($op == "rebuild") {
         if (strpos($site, "/")) {
             $site = substr($site, 0, strpos($site, "/"));
         }
-        $sql = "UPDATE " . Database::prefix("referers") . " SET site='" . addslashes($site) . "' WHERE refererid='{$row['refererid']}'";
-        Database::query($sql);
+        $conn->executeStatement(
+            "UPDATE {$referersTable} SET site = :site WHERE refererid = :refererid",
+            [
+                'site' => $site,
+                'refererid' => (int) $row['refererid'],
+            ],
+            [
+                'site' => ParameterType::STRING,
+                'refererid' => ParameterType::INTEGER,
+            ]
+        );
     }
 }
 SuperuserNav::render();

--- a/tests/Security/SuperuserEndpointHardeningWave2RegressionTest.php
+++ b/tests/Security/SuperuserEndpointHardeningWave2RegressionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression coverage for the second superuser/account SQL hardening wave.
+ *
+ * This suite intentionally verifies source-level hardening signals so we can
+ * detect accidental reintroduction of string-built writes in legacy endpoints.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+final class SuperuserEndpointHardeningWave2RegressionTest extends TestCase
+{
+    public function testMastersDeleteUsesBoundIntegerParameterAndDelGuard(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/masters.php');
+
+        self::assertStringContainsString('if ($op == "del")', $source);
+        self::assertStringContainsString('DELETE FROM {$mastersTable} WHERE creatureid = :id', $source);
+        self::assertStringContainsString("'id' => ParameterType::INTEGER", $source);
+    }
+
+    public function testCreaturesWritesUseExecuteStatementAndBoundDeleteId(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/creatures.php');
+
+        self::assertStringContainsString('if ($subop == "")', $source);
+        self::assertStringContainsString('UPDATE {$creaturesTable} SET ', $source);
+        self::assertStringContainsString('INSERT INTO {$creaturesTable}', $source);
+        self::assertStringContainsString('DELETE FROM {$creaturesTable} WHERE creatureid = :id', $source);
+        self::assertStringContainsString("'id' => ParameterType::INTEGER", $source);
+    }
+
+    public function testReferersCleanupAndRebuildWritesAreParameterized(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/referers.php');
+
+        self::assertStringContainsString('if ($op == "rebuild")', $source);
+        self::assertStringContainsString('DELETE FROM {$referersTable} WHERE last < :cutoff', $source);
+        self::assertStringContainsString('UPDATE {$referersTable} SET site = :site WHERE refererid = :refererid', $source);
+        self::assertStringContainsString("'refererid' => ParameterType::INTEGER", $source);
+    }
+
+    public function testPaylogBackfillUpdateUsesBoundParamsBehindPaymentDateGuard(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/paylog.php');
+
+        self::assertStringContainsString("if (\$normalized['paymentDate'] !== null)", $source);
+        self::assertStringContainsString('UPDATE {$paylogTable} SET processdate = :processdate WHERE txnid = :txnid', $source);
+        self::assertStringContainsString("'txnid' => ParameterType::STRING", $source);
+    }
+
+    public function testConfigurationRenameMassUpdatesUseNamedParametersWithGuards(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/configuration.php');
+
+        self::assertStringContainsString("if (\$villageName !== '' && \$villageName != \$settings->getSetting('villagename', LOCATION_FIELDS))", $source);
+        self::assertStringContainsString("if (\$innName !== '' && \$innName != \$settings->getSetting('innname', LOCATION_INN))", $source);
+        self::assertStringContainsString('UPDATE {$accountsTable} SET location = :newLocation WHERE location = :oldLocation', $source);
+        self::assertStringContainsString("'newLocation' => ParameterType::STRING", $source);
+    }
+
+    public function testCreateValidationAndForgotPasswordWritesUseBoundParams(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/create.php');
+
+        self::assertStringContainsString('if ($op == "forgotval")', $source);
+        self::assertStringContainsString('if ($op == "forgot")', $source);
+        self::assertStringContainsString("if (\$row['replaceemail'] != '')", $source);
+        self::assertStringContainsString('SET emailaddress = :replaceemail, replaceemail = :replaceemailReset, forgottenpassword = :forgottenpassword', $source);
+        self::assertStringContainsString('SET forgottenpassword = :forgottenpassword WHERE login = :login', $source);
+        self::assertStringContainsString("'acctid' => ParameterType::INTEGER", $source);
+    }
+}


### PR DESCRIPTION
### Motivation

- Remove legacy string-interpolated SQL writes in several superuser and account flows to prevent injection risks and align with Doctrine DBAL typed-parameter practices.
- Ensure consistency with the DBAL 4 migration guidance and the project policy of using `executeStatement()` with explicit parameter types for write operations.
- Add targeted regression checks to prevent accidental reintroduction of string-built writes in these sensitive endpoints.

### Description

- Replaced interpolated/`addslashes`-based write queries with Doctrine DBAL `executeStatement()` using named parameters and explicit `ParameterType` typing in `masters.php`, `creatures.php`, `referers.php`, `paylog.php`, `configuration.php`, and `create.php`.
- `creatures.php` now builds `UPDATE` and `INSERT` statements with explicit parameter maps and types (string/int) and the `DELETE` path uses a bound `:id` with `ParameterType::INTEGER` rather than string concatenation.
- Replaced `referers.php` cleanup `DELETE` and per-row `UPDATE site` writes with parameterized statements and removed `addslashes` usage for those write paths, and migrated `paylog.php` processdate backfill to typed parameters.
- Synchronized the “Superuser endpoint hardening update” section of `UPGRADING.md` to reflect the newly migrated pages, and added `tests/Security/SuperuserEndpointHardeningWave2RegressionTest.php` to assert source-level presence of the new DBAL bindings.
- Security review: untrusted input is still obtained via `Http::get()`/`Http::post()` but is now passed as bound parameters with explicit DBAL types; CSRF/authorization behavior was not changed; prepared statements replace `addslashes`-style writes; existing security logging remains unchanged.

### Testing

- Ran syntax checks with `php -l` on changed files and the new test file and received `No syntax errors detected` for all files checked.
- Executed focused regression tests with `composer test -- --filter 'SuperuserEndpointHardeningWave2RegressionTest|SuperuserEndpointHardeningWaveRegressionTest'` and observed the filtered suites pass (9 tests, 40 assertions) with `OK`.
- Ran static analysis with `composer static` and it completed with `No errors` reported for the checks run.
- Ran the full test suite via `composer test`, which completed successfully but reported non-failing issues (`OK, but there were issues!` with warnings/deprecations/notices); the migration-specific regression tests passed and the repository static checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a0fe67f88329961c2c0a0e38f18b)