### PR TITLE
fix: parameterize registration inserts in create.php

### DIFF
--- a/create.php
+++ b/create.php
@@ -221,6 +221,7 @@ if ($op == "forgot") {
             if (trim($row['emailaddress']) != "") {
                 if ($row['forgottenpassword'] == "") {
                     $row['forgottenpassword'] = substr("x" . md5(date("Y-m-d H:i:s") . $row['password']), 0, 32);
+                    // Keep account bootstrap writes parameterized to avoid SQL interpolation.
                     $conn = Database::getDoctrineConnection();
                     $accountsTable = Database::prefix('accounts');
                     $conn->executeStatement(
@@ -392,13 +393,82 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
                     }
                     $dbpass = PasswordHelper::hash($pass1);
                     $dbpassAlgo = PasswordHelper::ALGO_MODERN;
-                    $allowednavs = addslashes(serialize(['village.php' => true]));
-                    $sql = "INSERT INTO " . Database::prefix("accounts") . "
-                                                (playername,name, superuser, title, password, password_algo, sex, login, laston, uniqueid, lastip, gold, location, emailaddress, emailvalidation, referer, regdate,badguy,allowednavs,restorepage,specialinc,specialmisc,bufflist,dragonpoints,replaceemail,forgottenpassword,prefs,hauntedby,donationconfig,bio,ctitle,companions)
-                                                VALUES
-                                                ('$shortname','$title $shortname', '" . (int) $settings->getSetting('defaultsuperuser', 0) . "', '$title', '$dbpass', '$dbpassAlgo', '$sex', '$shortname', '" . date("Y-m-d H:i:s", strtotime("-1 day")) . "', '" . (Cookies::getLgi() ?? '') . "', '" . $_SERVER['REMOTE_ADDR'] . "', " . (int) $settings->getSetting('newplayerstartgold', 50) . ", '" . addslashes($settings->getSetting('villagename', LOCATION_FIELDS)) . "', '$email', '$emailverification', '$referer', NOW(),'','" . $allowednavs . "', 'village.php','','','',0,'','','','','','','','')";
-                    Database::query($sql);
-                    if (Database::affectedRows() <= 0) {
+                    $allowednavs = serialize(['village.php' => true]);
+                    $conn = Database::getDoctrineConnection();
+                    $accountsTable = Database::prefix('accounts');
+                    $rowsInserted = $conn->executeStatement(
+                        "INSERT INTO {$accountsTable}
+                            (playername, name, superuser, title, password, password_algo, sex, login, laston, uniqueid, lastip, gold, location, emailaddress, emailvalidation, referer, regdate, badguy, allowednavs, restorepage, specialinc, specialmisc, bufflist, dragonpoints, replaceemail, forgottenpassword, prefs, hauntedby, donationconfig, bio, ctitle, companions)
+                        VALUES
+                            (:playername, :name, :superuser, :title, :password, :password_algo, :sex, :login, :laston, :uniqueid, :lastip, :gold, :location, :emailaddress, :emailvalidation, :referer, NOW(), :badguy, :allowednavs, :restorepage, :specialinc, :specialmisc, :bufflist, :dragonpoints, :replaceemail, :forgottenpassword, :prefs, :hauntedby, :donationconfig, :bio, :ctitle, :companions)",
+                        [
+                            'playername' => $shortname,
+                            'name' => "{$title} {$shortname}",
+                            'superuser' => (int) $settings->getSetting('defaultsuperuser', 0),
+                            'title' => $title,
+                            'password' => $dbpass,
+                            'password_algo' => $dbpassAlgo,
+                            'sex' => $sex,
+                            'login' => $shortname,
+                            'laston' => date("Y-m-d H:i:s", strtotime("-1 day")),
+                            'uniqueid' => (string) (Cookies::getLgi() ?? ''),
+                            'lastip' => (string) $_SERVER['REMOTE_ADDR'],
+                            'gold' => (int) $settings->getSetting('newplayerstartgold', 50),
+                            'location' => $settings->getSetting('villagename', LOCATION_FIELDS),
+                            'emailaddress' => $email,
+                            'emailvalidation' => $emailverification,
+                            'referer' => (int) $referer,
+                            'badguy' => '',
+                            'allowednavs' => $allowednavs,
+                            'restorepage' => 'village.php',
+                            'specialinc' => '',
+                            'specialmisc' => '',
+                            'bufflist' => '',
+                            'dragonpoints' => 0,
+                            'replaceemail' => '',
+                            'forgottenpassword' => '',
+                            'prefs' => '',
+                            'hauntedby' => '',
+                            'donationconfig' => '',
+                            'bio' => '',
+                            'ctitle' => '',
+                            'companions' => '',
+                        ],
+                        [
+                            'playername' => ParameterType::STRING,
+                            'name' => ParameterType::STRING,
+                            'superuser' => ParameterType::INTEGER,
+                            'title' => ParameterType::STRING,
+                            'password' => ParameterType::STRING,
+                            'password_algo' => ParameterType::STRING,
+                            'sex' => ParameterType::INTEGER,
+                            'login' => ParameterType::STRING,
+                            'laston' => ParameterType::STRING,
+                            'uniqueid' => ParameterType::STRING,
+                            'lastip' => ParameterType::STRING,
+                            'gold' => ParameterType::INTEGER,
+                            'location' => ParameterType::STRING,
+                            'emailaddress' => ParameterType::STRING,
+                            'emailvalidation' => ParameterType::STRING,
+                            'referer' => ParameterType::INTEGER,
+                            'badguy' => ParameterType::STRING,
+                            'allowednavs' => ParameterType::STRING,
+                            'restorepage' => ParameterType::STRING,
+                            'specialinc' => ParameterType::STRING,
+                            'specialmisc' => ParameterType::STRING,
+                            'bufflist' => ParameterType::STRING,
+                            'dragonpoints' => ParameterType::INTEGER,
+                            'replaceemail' => ParameterType::STRING,
+                            'forgottenpassword' => ParameterType::STRING,
+                            'prefs' => ParameterType::STRING,
+                            'hauntedby' => ParameterType::STRING,
+                            'donationconfig' => ParameterType::STRING,
+                            'bio' => ParameterType::STRING,
+                            'ctitle' => ParameterType::STRING,
+                            'companions' => ParameterType::STRING,
+                        ]
+                    );
+                    if ($rowsInserted <= 0) {
                         $output->output("`\$Error`^: Your account was not created for an unknown reason, please try again. ");
                     } else {
                         $sql = "SELECT acctid FROM " . Database::prefix("accounts") . " WHERE login='$shortname'";
@@ -407,8 +477,19 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
                         $args = Http::allPost();
                         $args['acctid'] = $row['acctid'];
                         //insert output
-                        $sql_output = "INSERT INTO " . Database::prefix("accounts_output") . " VALUES ({$row['acctid']},'');";
-                        Database::query($sql_output);
+                        // Ensure output bootstrap row uses a bound account id as well.
+                        $accountsOutputTable = Database::prefix('accounts_output');
+                        $conn->executeStatement(
+                            "INSERT INTO {$accountsOutputTable} VALUES (:acctid, :output)",
+                            [
+                                'acctid' => (int) $row['acctid'],
+                                'output' => '',
+                            ],
+                            [
+                                'acctid' => ParameterType::INTEGER,
+                                'output' => ParameterType::STRING,
+                            ]
+                        );
                         //end
                         HookHandler::hook("process-create", $args);
                         if ($emailverification != "") {

--- a/create.php
+++ b/create.php
@@ -487,7 +487,7 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
                             ],
                             [
                                 'acctid' => ParameterType::INTEGER,
-                                'output' => ParameterType::STRING,
+                                'output' => ParameterType::LARGE_OBJECT,
                             ]
                         );
                         //end

--- a/create.php
+++ b/create.php
@@ -487,7 +487,7 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
                             ],
                             [
                                 'acctid' => ParameterType::INTEGER,
-                                'output' => ParameterType::LARGE_OBJECT,
+                                'output' => ParameterType::STRING,
                             ]
                         );
                         //end

--- a/create.php
+++ b/create.php
@@ -440,7 +440,7 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
                             'superuser' => ParameterType::INTEGER,
                             'title' => ParameterType::STRING,
                             'password' => ParameterType::STRING,
-                            'password_algo' => ParameterType::STRING,
+                            'password_algo' => ParameterType::INTEGER,
                             'sex' => ParameterType::INTEGER,
                             'login' => ParameterType::STRING,
                             'laston' => ParameterType::STRING,

--- a/create.php
+++ b/create.php
@@ -457,7 +457,7 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
                             'specialinc' => ParameterType::STRING,
                             'specialmisc' => ParameterType::STRING,
                             'bufflist' => ParameterType::STRING,
-                            'dragonpoints' => ParameterType::INTEGER,
+                            'dragonpoints' => ParameterType::STRING,
                             'replaceemail' => ParameterType::STRING,
                             'forgottenpassword' => ParameterType::STRING,
                             'prefs' => ParameterType::STRING,

--- a/tests/Security/SuperuserEndpointHardeningWave2RegressionTest.php
+++ b/tests/Security/SuperuserEndpointHardeningWave2RegressionTest.php
@@ -79,4 +79,27 @@ final class SuperuserEndpointHardeningWave2RegressionTest extends TestCase
         self::assertStringContainsString('SET forgottenpassword = :forgottenpassword WHERE login = :login', $source);
         self::assertStringContainsString("'acctid' => ParameterType::INTEGER", $source);
     }
+
+    public function testCreateRegistrationWritesUseBoundParametersForAccountsAndAccountsOutput(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/create.php');
+
+        self::assertStringContainsString(
+            'INSERT INTO {$accountsTable}',
+            $source
+        );
+        self::assertStringContainsString(':playername, :name, :superuser, :title, :password, :password_algo, :sex, :login, :laston, :uniqueid, :lastip, :gold, :location, :emailaddress, :emailvalidation, :referer, NOW(), :badguy, :allowednavs',
+            $source
+        );
+        self::assertStringContainsString("'playername' => ParameterType::STRING", $source);
+        self::assertStringContainsString("'superuser' => ParameterType::INTEGER", $source);
+        self::assertStringContainsString("'gold' => ParameterType::INTEGER", $source);
+        self::assertStringContainsString("'referer' => ParameterType::INTEGER", $source);
+        self::assertStringContainsString('INSERT INTO {$accountsOutputTable} VALUES (:acctid, :output)', $source);
+        self::assertStringContainsString("'output' => ParameterType::STRING", $source);
+        self::assertStringNotContainsString(
+            "('$shortname','$title $shortname'",
+            $source
+        );
+    }
 }


### PR DESCRIPTION
### Motivation

- Harden account creation SQL by replacing string-interpolated inserts with parameterized statements to reduce injection and interpolation risks.
- Ensure all dynamic registration values are bound with explicit types rather than concatenated into SQL.
- Preserve existing registration behavior, including hooks, email verification flow, and date semantics (keep `regdate` as `NOW()` and preserve `laston` formatting).

### Description

- Rewrote the successful-registration `accounts` insert in `create.php` to use `$conn = Database::getDoctrineConnection()` and `executeStatement()` with named placeholders and an explicit `ParameterType` map for all dynamic fields (player/login/name/title, `password`/`password_algo`, IP/`uniqueid`/email/`emailvalidation`, `referer`/`superuser`/`gold`, serialized `allowednavs`, location and other default bootstrap columns).
- Replaced the `INSERT INTO accounts_output VALUES ({$row['acctid']}, '')` bootstrap with a parameterized `executeStatement()` call bound on `:acctid` and `:output`.
- Kept `regdate` as `NOW()` and preserved the existing `laston` formatting behavior, and left surrounding logic (duplicate-name checks, hooks, mail sending, and login form flow) intact for backward compatibility.
- Added a focused regression test `tests/Security/SuperuserEndpointHardeningWave2RegressionTest.php` to assert the registration-path inserts are parameterized and the old interpolated `VALUES ('$shortname', ...)` pattern is not present.

### Testing

- Ran `php -l create.php` which reported no syntax errors.
- Ran `php -l tests/Security/SuperuserEndpointHardeningWave2RegressionTest.php` which reported no syntax errors.
- Ran `./vendor/bin/phpunit tests/Security/SuperuserEndpointHardeningWave2RegressionTest.php` which passed (tests succeeded but produced existing suite warnings).
- Ran `composer test` which executed the full suite (tests passed, with existing warnings/deprecations/notices reported).
- Ran `composer static` which completed with no static analysis errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7ae11ffb08329a82d9a2309bdff72)