### PR TITLE
fix: parameterize create and paylog read queries

### DIFF
--- a/create.php
+++ b/create.php
@@ -67,10 +67,21 @@ if ($op == "forgotval") {
     $id = Http::get('id');
     $conn = Database::getDoctrineConnection();
     $accountsTable = Database::prefix('accounts');
-    $sql = "SELECT acctid,login,superuser,password,name,replaceemail,emailaddress,emailvalidation FROM " . Database::prefix("accounts") . " WHERE forgottenpassword='" . Database::escape($id) . "' AND forgottenpassword!=''";
-    $result = Database::query($sql);
-    if (Database::numRows($result) > 0) {
-        $row = Database::fetchAssoc($result);
+    $result = $conn->executeQuery(
+        "SELECT acctid,login,superuser,password,name,replaceemail,emailaddress,emailvalidation
+            FROM {$accountsTable}
+            WHERE forgottenpassword = :forgottenpassword AND forgottenpassword != :emptyForgottenPassword",
+        [
+            'forgottenpassword' => (string) $id,
+            'emptyForgottenPassword' => '',
+        ],
+        [
+            'forgottenpassword' => ParameterType::STRING,
+            'emptyForgottenPassword' => ParameterType::STRING,
+        ]
+    );
+    $row = $result->fetchAssociative();
+    if ($row !== false) {
         $conn->executeStatement(
             "UPDATE {$accountsTable} SET forgottenpassword = :forgottenpassword WHERE forgottenpassword = :id",
             [
@@ -122,10 +133,21 @@ if ($op == "forgotval") {
     $id = Http::get('id');
     $conn = Database::getDoctrineConnection();
     $accountsTable = Database::prefix('accounts');
-    $sql = "SELECT acctid,login,superuser,password,name,replaceemail,emailaddress FROM " . Database::prefix("accounts") . " WHERE emailvalidation='" . Database::escape($id) . "' AND emailvalidation!=''";
-    $result = Database::query($sql);
-    if (Database::numRows($result) > 0) {
-        $row = Database::fetchAssoc($result);
+    $result = $conn->executeQuery(
+        "SELECT acctid,login,superuser,password,name,replaceemail,emailaddress
+            FROM {$accountsTable}
+            WHERE emailvalidation = :emailvalidation AND emailvalidation != :emptyEmailValidation",
+        [
+            'emailvalidation' => (string) $id,
+            'emptyEmailValidation' => '',
+        ],
+        [
+            'emailvalidation' => ParameterType::STRING,
+            'emptyEmailValidation' => ParameterType::STRING,
+        ]
+    );
+    $row = $result->fetchAssociative();
+    if ($row !== false) {
         if ($row['replaceemail'] != '') {
             $replace_array = explode("|", $row['replaceemail']);
             $replaceemail = $replace_array[0]; //1==date
@@ -214,10 +236,21 @@ if ($op == "forgotval") {
 if ($op == "forgot") {
     $charname = Http::post('charname');
     if ($charname != "") {
-        $sql = "SELECT acctid,login,emailaddress,forgottenpassword,password FROM " . Database::prefix("accounts") . " WHERE login='" . Database::escape($charname) . "'";
-        $result = Database::query($sql);
-        if (Database::numRows($result) > 0) {
-            $row = Database::fetchAssoc($result);
+        $conn = Database::getDoctrineConnection();
+        $accountsTable = Database::prefix('accounts');
+        $result = $conn->executeQuery(
+            "SELECT acctid,login,emailaddress,forgottenpassword,password
+                FROM {$accountsTable}
+                WHERE login = :login",
+            [
+                'login' => (string) $charname,
+            ],
+            [
+                'login' => ParameterType::STRING,
+            ]
+        );
+        $row = $result->fetchAssociative();
+        if ($row !== false) {
             if (trim($row['emailaddress']) != "") {
                 if ($row['forgottenpassword'] == "") {
                     $row['forgottenpassword'] = substr("x" . md5(date("Y-m-d H:i:s") . $row['password']), 0, 32);
@@ -310,9 +343,18 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
                 $pass2 = '';
             }
             if ((int) $settings->getSetting('blockdupeemail', 0) === 1 && (int) $settings->getSetting('requireemail', 0) === 1) {
-                $sql = "SELECT login FROM " . Database::prefix("accounts") . " WHERE emailaddress='" . Database::escape($email) . "'";
-                $result = Database::query($sql);
-                if (Database::numRows($result) > 0) {
+                $conn = Database::getDoctrineConnection();
+                $accountsTable = Database::prefix('accounts');
+                $result = $conn->executeQuery(
+                    "SELECT login FROM {$accountsTable} WHERE emailaddress = :emailaddress",
+                    [
+                        'emailaddress' => (string) $email,
+                    ],
+                    [
+                        'emailaddress' => ParameterType::STRING,
+                    ]
+                );
+                if ($result->fetchAssociative() !== false) {
                     $blockaccount = true;
                     $msg .= Translator::translate("You may have only one account.`n");
                 }
@@ -351,12 +393,20 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
             }
 
             if (!$blockaccount) {
-                $sql = "SELECT name FROM " . Database::prefix("accounts") . " WHERE login='$shortname'";
-                $result = Database::query($sql);
-                $count = Database::numRows($result);
-                $sql = "SELECT playername FROM " . Database::prefix("accounts") ;
-                $result = Database::query($sql);
-                while ($row = Database::fetchAssoc($result)) {
+                $conn = Database::getDoctrineConnection();
+                $accountsTable = Database::prefix('accounts');
+                $result = $conn->executeQuery(
+                    "SELECT name FROM {$accountsTable} WHERE login = :login",
+                    [
+                        'login' => (string) $shortname,
+                    ],
+                    [
+                        'login' => ParameterType::STRING,
+                    ]
+                );
+                $count = $result->fetchAssociative() === false ? 0 : 1;
+                $result = $conn->executeQuery("SELECT playername FROM {$accountsTable}");
+                while (($row = $result->fetchAssociative()) !== false) {
                     if (Sanitize::sanitize($row['playername']) == $shortname) {
                         $count++;
                         break;
@@ -378,10 +428,17 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
                     }
                     $refer = Http::get('r');
                     if ($refer > "") {
-                        $sql = "SELECT acctid FROM " . Database::prefix("accounts") . " WHERE login='" . Database::escape($refer) . "'";
-                        $result = Database::query($sql);
-                        if (Database::numRows($result) > 0) {
-                            $ref = Database::fetchAssoc($result);
+                        $result = $conn->executeQuery(
+                            "SELECT acctid FROM {$accountsTable} WHERE login = :login",
+                            [
+                                'login' => (string) $refer,
+                            ],
+                            [
+                                'login' => ParameterType::STRING,
+                            ]
+                        );
+                        $ref = $result->fetchAssociative();
+                        if ($ref !== false) {
                             $referer = $ref['acctid'];
                         } else {
                             //expired, deleted...
@@ -471,28 +528,38 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
                     if ($rowsInserted <= 0) {
                         $output->output("`\$Error`^: Your account was not created for an unknown reason, please try again. ");
                     } else {
-                        $sql = "SELECT acctid FROM " . Database::prefix("accounts") . " WHERE login='$shortname'";
-                        $result = Database::query($sql);
-                        $row = Database::fetchAssoc($result);
-                        $args = Http::allPost();
-                        $args['acctid'] = $row['acctid'];
-                        //insert output
-                        // Ensure output bootstrap row uses a bound account id as well.
-                        $accountsOutputTable = Database::prefix('accounts_output');
-                        $conn->executeStatement(
-                            "INSERT INTO {$accountsOutputTable} VALUES (:acctid, :output)",
+                        $result = $conn->executeQuery(
+                            "SELECT acctid FROM {$accountsTable} WHERE login = :login",
                             [
-                                'acctid' => (int) $row['acctid'],
-                                'output' => '',
+                                'login' => (string) $shortname,
                             ],
                             [
-                                'acctid' => ParameterType::INTEGER,
-                                'output' => ParameterType::STRING,
+                                'login' => ParameterType::STRING,
                             ]
                         );
-                        //end
-                        HookHandler::hook("process-create", $args);
-                        if ($emailverification != "") {
+                        $row = $result->fetchAssociative();
+                        if ($row === false) {
+                            $output->output("`\$Error`^: Your account was created, but could not be loaded for post-processing.");
+                        } else {
+                            $args = Http::allPost();
+                            $args['acctid'] = $row['acctid'];
+                            //insert output
+                            // Ensure output bootstrap row uses a bound account id as well.
+                            $accountsOutputTable = Database::prefix('accounts_output');
+                            $conn->executeStatement(
+                                "INSERT INTO {$accountsOutputTable} VALUES (:acctid, :output)",
+                                [
+                                    'acctid' => (int) $row['acctid'],
+                                    'output' => '',
+                                ],
+                                [
+                                    'acctid' => ParameterType::INTEGER,
+                                    'output' => ParameterType::STRING,
+                                ]
+                            );
+                            //end
+                            HookHandler::hook("process-create", $args);
+                            if ($emailverification != "") {
                             $subj = translate_mail($settings_extended->getSetting('verificationmailsubject'), 0);
                             $msg = translate_mail($settings_extended->getSetting('verificationmailtext'), 0);
                             $replace = array(
@@ -510,26 +577,27 @@ if ((int) $settings->getSetting('allowcreation', 1) === 0) {
                             $to_array = array($email => $shortname);
                             $from_array = array($settings->getSetting('gameadminemail', 'postmaster@localhost') => $settings->getSetting('gameadminemail', 'postmaster@localhost'));
                             \Lotgd\Mail::send($to_array, $msg, $subj, $from_array, false, "text/plain");
-                            $output->output("`4An email was sent to `\$%s`4 to validate your address.  Click the link in the email to activate your account.`0`n`n", $email);
-                        } else {
-                            $output->rawOutput("<form action='login.php' method='POST'>");
-                            $output->rawOutput("<input name='name' value=\"$shortname\" type='hidden'>");
-                            $output->rawOutput("<input name='password' value=\"$pass1\" type='hidden'>");
-                            $click = Translator::translate("Click here to log in");
-                            $output->rawOutput("<input type='submit' class='button' value='$click'>");
-                            $output->rawOutput("</form>");
-                            $output->outputNotl("`n");
-                            savesetting("newestplayer", $row['acctid']);
-                        }
-                        $output->output("`\$Your account was created, your login name is `^%s`\$.`n`n", $shortname);
-                        if ($trash > 0) {
-                            $output->output("`^Characters that have never been logged into will be deleted after %s day(s) of no activity.`n`0", $trash);
-                        }
-                        if ($new > 0) {
-                            $output->output("`^Characters that have never reached level 2 will be deleted after %s days of no activity.`n`0", $new);
-                        }
-                        if ($old > 0) {
-                            $output->output("`^Characters that have reached level 2 at least once will be deleted after %s days of no activity.`n`0", $old);
+                                $output->output("`4An email was sent to `\$%s`4 to validate your address.  Click the link in the email to activate your account.`0`n`n", $email);
+                            } else {
+                                $output->rawOutput("<form action='login.php' method='POST'>");
+                                $output->rawOutput("<input name='name' value=\"$shortname\" type='hidden'>");
+                                $output->rawOutput("<input name='password' value=\"$pass1\" type='hidden'>");
+                                $click = Translator::translate("Click here to log in");
+                                $output->rawOutput("<input type='submit' class='button' value='$click'>");
+                                $output->rawOutput("</form>");
+                                $output->outputNotl("`n");
+                                savesetting("newestplayer", $row['acctid']);
+                            }
+                            $output->output("`\$Your account was created, your login name is `^%s`\$.`n`n", $shortname);
+                            if ($trash > 0) {
+                                $output->output("`^Characters that have never been logged into will be deleted after %s day(s) of no activity.`n`0", $trash);
+                            }
+                            if ($new > 0) {
+                                $output->output("`^Characters that have never reached level 2 will be deleted after %s days of no activity.`n`0", $new);
+                            }
+                            if ($old > 0) {
+                                $output->output("`^Characters that have reached level 2 at least once will be deleted after %s days of no activity.`n`0", $old);
+                            }
                         }
                     }
                 }

--- a/paylog.php
+++ b/paylog.php
@@ -164,13 +164,28 @@ if ($op == "") {
         $output->rawOutput("</table><br>");
     }
 
-    $sql = "SELECT " . Database::prefix("paylog") . ".*," . Database::prefix("accounts") . ".name," . Database::prefix("accounts") . ".donation," . Database::prefix("accounts") . ".donationspent FROM " . Database::prefix("paylog") . " LEFT JOIN " . Database::prefix("accounts") . " ON " . Database::prefix("paylog") . ".acctid = " . Database::prefix("accounts") . ".acctid WHERE processdate>='$startdate' AND processdate < '$enddate' ORDER BY payid DESC";
-    $result = Database::query($sql);
+    $accountsTable = Database::prefix('accounts');
+    $result = $conn->executeQuery(
+        "SELECT {$paylogTable}.*, {$accountsTable}.name, {$accountsTable}.donation, {$accountsTable}.donationspent
+            FROM {$paylogTable}
+            LEFT JOIN {$accountsTable} ON {$paylogTable}.acctid = {$accountsTable}.acctid
+            WHERE processdate >= :startdate AND processdate < :enddate
+            ORDER BY payid DESC",
+        [
+            'startdate' => (string) $startdate,
+            'enddate' => (string) $enddate,
+        ],
+        [
+            'startdate' => ParameterType::STRING,
+            'enddate' => ParameterType::STRING,
+        ]
+    );
+    $rows = $result->fetchAllAssociative();
     $output->rawOutput("<table border='0' cellpadding='2' cellspacing='1' bgcolor='#999999'>");
     $output->rawOutput("<tr class='trhead'><td>Date</td><td>$id</td><td>$type</td><td>$gross</td><td>$fee</td><td>$net</td><td>$processed</td><td>$who</td></tr>");
-    $number = Database::numRows($result);
+    $number = count($rows);
     for ($i = 0; $i < $number; $i++) {
-        $row = Database::fetchAssoc($result);
+        $row = $rows[$i];
         $info = Serialization::safeUnserialize($row['info']);
         $normalized = LegacyPayloadNormalizer::normalize($row, $info, $currency);
         if (! $normalized['is_valid']) {

--- a/tests/Security/SuperuserEndpointHardeningWave2RegressionTest.php
+++ b/tests/Security/SuperuserEndpointHardeningWave2RegressionTest.php
@@ -132,7 +132,6 @@ final class SuperuserEndpointHardeningWave2RegressionTest extends TestCase
         self::assertStringContainsString('WHERE processdate >= :startdate AND processdate < :enddate', $source);
         self::assertStringContainsString("'startdate' => ParameterType::STRING", $source);
         self::assertStringContainsString("'enddate' => ParameterType::STRING", $source);
-        self::assertStringContainsString('$rows = $result->fetchAllAssociative();', $source);
         self::assertStringNotContainsString("processdate>='$startdate' AND processdate < '$enddate'", $source);
     }
 }

--- a/tests/Security/SuperuserEndpointHardeningWave2RegressionTest.php
+++ b/tests/Security/SuperuserEndpointHardeningWave2RegressionTest.php
@@ -102,4 +102,37 @@ final class SuperuserEndpointHardeningWave2RegressionTest extends TestCase
             $source
         );
     }
+
+    public function testCreateDuplicateAndReferralLookupsUseExecuteQueryWithStringBindings(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/create.php');
+
+        self::assertStringContainsString(
+            'SELECT login FROM {$accountsTable} WHERE emailaddress = :emailaddress',
+            $source
+        );
+        self::assertStringContainsString(
+            'SELECT name FROM {$accountsTable} WHERE login = :login',
+            $source
+        );
+        self::assertStringContainsString(
+            'SELECT acctid FROM {$accountsTable} WHERE login = :login',
+            $source
+        );
+        self::assertStringContainsString("'emailaddress' => ParameterType::STRING", $source);
+        self::assertStringContainsString("'login' => ParameterType::STRING", $source);
+        self::assertStringNotContainsString("WHERE login='$shortname'", $source);
+        self::assertStringNotContainsString("Database::escape(\$refer)", $source);
+    }
+
+    public function testPaylogMonthWindowQueryUsesBoundDatetimePlaceholders(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/paylog.php');
+
+        self::assertStringContainsString('WHERE processdate >= :startdate AND processdate < :enddate', $source);
+        self::assertStringContainsString("'startdate' => ParameterType::STRING", $source);
+        self::assertStringContainsString("'enddate' => ParameterType::STRING", $source);
+        self::assertStringContainsString('$rows = $result->fetchAllAssociative();', $source);
+        self::assertStringNotContainsString("processdate>='$startdate' AND processdate < '$enddate'", $source);
+    }
 }


### PR DESCRIPTION
### Motivation

- Harden legacy read queries that used string interpolation (account validation, forgotten-password, duplicate-email/name, referral lookups) to eliminate SQL injection risk and remove reliance on `Database::escape()` for these paths.
- Use Doctrine DBAL prepared reads to provide explicit parameter typing and consistent result handling across code paths that consume untrusted input.
- Replace the fragile month-window paylog listing SQL with a parameterized query to ensure date bounds cannot be injected by special characters.

### Description

- Replaced interpolated `SELECT` queries in `create.php` (forgotten-password token lookup, email validation token lookup, forgotten-account lookup, duplicate-email check, duplicate-login/account-name check, referral lookup, and post-insert acctid reload) with `Doctrine DBAL` `executeQuery()` calls bound with `ParameterType::STRING` / `ParameterType::INTEGER` as appropriate.
- Switched read/result handling to DBAL methods such as `fetchAssociative()` and `fetchAllAssociative()` for the migrated queries and updated loops to preserve existing behavior.
- Replaced the month-window paylog listing in `paylog.php` with a bound `executeQuery()` using `:startdate` and `:enddate` and consuming rows via `fetchAllAssociative()`.
- Added focused regression assertions in `tests/Security/SuperuserEndpointHardeningWave2RegressionTest.php` to verify the new `executeQuery()` patterns and that legacy interpolated SQL fragments are absent.

### Testing

- Ran syntax checks with `php -l create.php`, `php -l paylog.php`, and `php -l tests/Security/SuperuserEndpointHardeningWave2RegressionTest.php`, all succeeded.
- Ran the targeted PHPUnit file with `vendor/bin/phpunit tests/Security/SuperuserEndpointHardeningWave2RegressionTest.php` and it passed (test file succeeded, some unrelated warnings reported).
- Ran the full suite via `composer test` which completed successfully while reporting non-fatal warnings/notices in unrelated areas of the test suite.
- Ran static analysis with `composer static` which returned OK (no blocking findings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7bd5d8b3c8329beccb3d87d9c808c)