### PR TITLE
refactor: migrate core security SQL paths to typed DBAL bindings

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -221,7 +221,14 @@ If you maintain custom overrides of any migrated page, update those overrides to
 
 ### SQL addslashes baseline status
 
-The SQL addslashes QA baseline (`src/Lotgd/QA/SqlAddslashesUsageCheck.php`) is now empty: all previously tracked core call sites have been migrated to Doctrine DBAL parameter binding. Any new SQL-building `addslashes()` usage in `pages/` or `src/` will fail QA and should be migrated to `executeQuery()` / `executeStatement()` with explicit parameter types.
+The SQL addslashes QA baseline (`src/Lotgd/QA/SqlAddslashesUsageCheck.php`) remains empty: all previously tracked core call sites have been migrated to Doctrine DBAL parameter binding. Any new SQL-building `addslashes()` usage in `pages/` or `src/` will fail QA and should be migrated to `executeQuery()` / `executeStatement()` with explicit parameter types.
+
+A companion guard (`src/Lotgd/QA/InterpolatedDatabaseQueryCheck.php`) now flags new dynamic `Database::query(...)` usage under `src/Lotgd` except for explicitly whitelisted legacy-heavy paths (`Modules.php`, `Commentary.php`, `Newday.php`, `Pvp.php`) that are still under staged migration.
+
+Recent hardening pass migration status:
+
+- Fully migrated (DBAL parameter binding): `src/Lotgd/Security/PasskeyCredentialRepository.php`, `src/Lotgd/CheckBan.php`, `src/Lotgd/ForcedNavigation.php`, `src/Lotgd/Async/Handler/Timeout.php`, and `src/Lotgd/PlayerFunctions.php`.
+- Partially migrated (legacy SQL still present in staged areas): `src/Lotgd/Modules.php`, `src/Lotgd/Newday.php`, `src/Lotgd/Commentary.php`, `src/Lotgd/Pvp.php`.
 
 ### Refactoring Legacy SQL to Prepared Statements
 

--- a/src/Lotgd/Async/Handler/Timeout.php
+++ b/src/Lotgd/Async/Handler/Timeout.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lotgd\Async\Handler;
 
+use Doctrine\DBAL\ParameterType;
 use Lotgd\MySQL\Database;
 use Lotgd\Output;
 use Lotgd\Settings;
@@ -119,10 +120,17 @@ class Timeout
 
         if ($this->isNeverTimeoutIfBrowserOpen()) {
             $session['user']['laston'] = date('Y-m-d H:i:s'); // set to now
-            // manual db update
-            $sql = 'UPDATE ' . Database::prefix('accounts') . " set laston='" . $session['user']['laston']
-                . "' WHERE acctid=" . $session['user']['acctid'];
-            Database::query($sql);
+            Database::getDoctrineConnection()->executeStatement(
+                'UPDATE ' . Database::prefix('accounts') . ' SET laston = :laston WHERE acctid = :acctid',
+                [
+                    'laston' => (string) $session['user']['laston'],
+                    'acctid' => (int) ($session['user']['acctid'] ?? 0),
+                ],
+                [
+                    'laston' => ParameterType::STRING,
+                    'acctid' => ParameterType::INTEGER,
+                ]
+            );
         }
 
         $timeout = strtotime($session['user']['laston']) - strtotime(date('Y-m-d H:i:s', strtotime('-' . $settings->getSetting('LOGINTIMEOUT', 900) . ' seconds')));

--- a/src/Lotgd/CheckBan.php
+++ b/src/Lotgd/CheckBan.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use Doctrine\DBAL\ParameterType;
 use Lotgd\MySQL\Database;
 use Lotgd\Cookies;
 use Lotgd\Translator;
@@ -24,6 +25,7 @@ class CheckBan
     public static function check(?string $login = null): void
     {
         global $session;
+        $connection = Database::getDoctrineConnection();
 
         if (isset($session['banoverride']) && $session['banoverride']) {
             return;
@@ -33,22 +35,35 @@ class CheckBan
             $ip = $_SERVER['REMOTE_ADDR'];
             $id = Cookies::getLgi() ?? '';
         } else {
-            $sql = "SELECT lastip,uniqueid,banoverride,superuser FROM " . Database::prefix('accounts') . " WHERE login='$login'";
-            $result = Database::query($sql);
-            $row = Database::fetchAssoc($result);
-            if ($row['banoverride'] || ($row['superuser'] & ~SU_DOESNT_GIVE_GROTTO)) {
-                $session['banoverride'] = true;
-                Database::freeResult($result);
+            $row = $connection->fetchAssociative(
+                'SELECT lastip, uniqueid, banoverride, superuser FROM ' . Database::prefix('accounts') . ' WHERE login = :login',
+                ['login' => $login],
+                ['login' => ParameterType::STRING]
+            );
+            if (!is_array($row) || $row === []) {
                 return;
             }
-            Database::freeResult($result);
+            if ($row['banoverride'] || ($row['superuser'] & ~SU_DOESNT_GIVE_GROTTO)) {
+                $session['banoverride'] = true;
+                return;
+            }
             $ip = $row['lastip'];
             $id = $row['uniqueid'];
         }
 
-        Database::query("DELETE FROM " . Database::prefix('bans') . " WHERE banexpire < '" . date('Y-m-d H:m:s') . "' AND banexpire<'" . DATETIME_DATEMAX . "'");
-        $sql = "SELECT * FROM " . Database::prefix('bans') . " WHERE ((substring('$ip',1,length(ipfilter))=ipfilter AND ipfilter<>'') OR (uniqueid='$id' AND uniqueid<>'')) AND banexpire>='" . date('Y-m-d H:m:s') . "'";
-        $result = Database::query($sql);
+        $now = date('Y-m-d H:i:s');
+        $connection->executeStatement(
+            'DELETE FROM ' . Database::prefix('bans') . ' WHERE banexpire < :now AND banexpire < :datemax',
+            ['now' => $now, 'datemax' => DATETIME_DATEMAX],
+            ['now' => ParameterType::STRING, 'datemax' => ParameterType::STRING]
+        );
+        $result = $connection->executeQuery(
+            'SELECT * FROM ' . Database::prefix('bans') .
+            " WHERE ((substring(:ip, 1, length(ipfilter)) = ipfilter AND ipfilter <> '') OR (uniqueid = :uniqueid AND uniqueid <> ''))" .
+            ' AND banexpire >= :now',
+            ['ip' => (string) $ip, 'uniqueid' => (string) $id, 'now' => $now],
+            ['ip' => ParameterType::STRING, 'uniqueid' => ParameterType::STRING, 'now' => ParameterType::STRING]
+        );
         if (Database::numRows($result) > 0) {
             $session = [];
             Translator::getInstance()->setSchema('ban');
@@ -69,8 +84,19 @@ class CheckBan
                     $session['message'] .= Translator::getInstance()->sprintfTranslate("`^This ban will be removed `\$after`^ %s.`n`0", date('M d, Y', strtotime($row['banexpire'])));
                     $session['message'] .= Translator::getInstance()->sprintfTranslate("`^(This means in %s %s and %s %s)`0", $hours, $tl_hours, $mins, $tl_mins);
                 }
-                $sql = "UPDATE " . Database::prefix('bans') . " SET lasthit='" . date('Y-m-d H:i:s') . "' WHERE ipfilter='{$row['ipfilter']}' AND uniqueid='{$row['uniqueid']}'";
-                Database::query($sql);
+                $connection->executeStatement(
+                    'UPDATE ' . Database::prefix('bans') . ' SET lasthit = :lasthit WHERE ipfilter = :ipfilter AND uniqueid = :uniqueid',
+                    [
+                        'lasthit' => date('Y-m-d H:i:s'),
+                        'ipfilter' => (string) $row['ipfilter'],
+                        'uniqueid' => (string) $row['uniqueid'],
+                    ],
+                    [
+                        'lasthit' => ParameterType::STRING,
+                        'ipfilter' => ParameterType::STRING,
+                        'uniqueid' => ParameterType::STRING,
+                    ]
+                );
                 $session['message'] .= "`n";
                 $session['message'] .= Translator::getInstance()->sprintfTranslate("`n`4The ban was issued by %s`^.`n", $row['banner']);
             }

--- a/src/Lotgd/Commentary.php
+++ b/src/Lotgd/Commentary.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use Doctrine\DBAL\ParameterType;
 use Lotgd\Settings;
 use Lotgd\Nav as Navigation;
 use Lotgd\Output;
@@ -161,6 +162,7 @@ class Commentary
     private static function handleRemoval(string $section, string $returnPath, int $removeId): void
     {
         global $session;
+        $connection = Database::getDoctrineConnection();
 
         $commentary = Database::prefix('commentary');
         $accounts   = Database::prefix('accounts');
@@ -176,30 +178,42 @@ SELECT
 FROM {$commentary} c
 INNER JOIN {$accounts} a ON a.acctid = c.author -- link author data
 LEFT JOIN {$clans} cl ON cl.clanid = a.clanid   -- link clan data
-WHERE commentid = {$removeId}
+WHERE commentid = :commentid
 SQL;
-        $row = Database::fetchAssoc(Database::query($sql));
+        $row = $connection->fetchAssociative(
+            $sql,
+            ['commentid' => $removeId],
+            ['commentid' => ParameterType::INTEGER]
+        );
 
         $moderated = Database::prefix('moderatedcomments');
         $now       = date('Y-m-d H:i:s');
-        $comment   = addslashes(serialize($row));
+        $comment   = serialize($row);
 
         $sql = <<<SQL
 INSERT LOW_PRIORITY INTO {$moderated}
     (moderator, moddate, comment)            -- moderation record columns
 VALUES
-    ('{$session['user']['acctid']}',         -- moderator ID
-     '{$now}',                               -- time of moderation
-     '{$comment}'                            -- serialized comment data
+    (:moderator,                             -- moderator ID
+     :moddate,                               -- time of moderation
+     :comment                                -- serialized comment data
     )
 SQL;
-        Database::query($sql);
+        $connection->executeStatement(
+            $sql,
+            ['moderator' => (int) $session['user']['acctid'], 'moddate' => $now, 'comment' => $comment],
+            ['moderator' => ParameterType::INTEGER, 'moddate' => ParameterType::STRING, 'comment' => ParameterType::STRING]
+        );
 
         $sql = <<<SQL
 DELETE FROM {$commentary}                 -- remove comment entry
-WHERE commentid = {$removeId}             -- by comment identifier
+WHERE commentid = :commentid             -- by comment identifier
 SQL;
-        Database::query($sql);
+        $connection->executeStatement(
+            $sql,
+            ['commentid' => $removeId],
+            ['commentid' => ParameterType::INTEGER]
+        );
 
         DataCache::getInstance()->invalidatedatacache("comments-$section");
         DataCache::getInstance()->invalidatedatacache('comments-or11');
@@ -231,8 +245,11 @@ SQL;
      */
     public static function injectRawComment(string $section, int $author, string $comment): void
     {
-        $sql = 'INSERT INTO ' . Database::prefix('commentary') . " (postdate,section,author,comment) VALUES ('" . date('Y-m-d H:i:s') . "','$section',$author,'" . Database::escape($comment) . "')";
-        Database::query($sql);
+        Database::getDoctrineConnection()->executeStatement(
+            'INSERT INTO ' . Database::prefix('commentary') . ' (postdate,section,author,comment) VALUES (:postdate, :section, :author, :comment)',
+            ['postdate' => date('Y-m-d H:i:s'), 'section' => $section, 'author' => $author, 'comment' => $comment],
+            ['postdate' => ParameterType::STRING, 'section' => ParameterType::STRING, 'author' => ParameterType::INTEGER, 'comment' => ParameterType::STRING]
+        );
         DataCache::getInstance()->invalidatedatacache("comments-{$section}");
         DataCache::getInstance()->invalidatedatacache('comments-or11');
     }
@@ -281,8 +298,12 @@ SQL;
         } else {
             // Check for duplicate posts and persist the comment
             $commentary = $args['commentary'];
-            $commentarySql = self::buildCommentQuery($section);
-            $result = Database::query($commentarySql);
+            $commentarySql = self::buildCommentQuery();
+            $result = Database::getDoctrineConnection()->executeQuery(
+                $commentarySql,
+                ['section' => $section],
+                ['section' => ParameterType::STRING]
+            );
             $authorId = (int) $session['user']['acctid'];
 
             self::setDoublePost((bool) self::persistComment($result, $commentary, $authorId, $section));
@@ -352,11 +373,11 @@ SQL;
      * @param string $section The section to retrieve the latest comment from
      * @return string The SQL query string
      */
-    private static function buildCommentQuery(string $section): string
+    private static function buildCommentQuery(): string
     {
         return 'SELECT comment, author FROM '
             . Database::prefix('commentary')
-            . " WHERE section = '$section'"
+            . ' WHERE section = :section'
             . ' ORDER BY commentid DESC LIMIT 1';
     }
 

--- a/src/Lotgd/ForcedNavigation.php
+++ b/src/Lotgd/ForcedNavigation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use Doctrine\DBAL\ParameterType;
 use Lotgd\Settings;
 use Lotgd\Translator;
 use Lotgd\MySQL\Database;
@@ -25,8 +26,11 @@ class ForcedNavigation
         $requestUri = PhpGenericEnvironment::getRequestUri();
         Output::getInstance()->rawOutput("<!--\nAllowAnonymous: " . ($anonymous ? "True" : "False") . "\nOverride Forced Nav: " . ($overrideforced ? "True" : "False") . "\n-->");
         if (isset($session['loggedin']) && $session['loggedin']) {
-            $sql = "SELECT * FROM " . Database::prefix('accounts') . " WHERE acctid='" . $session['user']['acctid'] . "'";
-            $result = Database::query($sql);
+            $result = Database::getDoctrineConnection()->executeQuery(
+                'SELECT * FROM ' . Database::prefix('accounts') . ' WHERE acctid = :acctid',
+                ['acctid' => (int) ($session['user']['acctid'] ?? 0)],
+                ['acctid' => ParameterType::INTEGER]
+            );
             if (Database::numRows($result) == 1) {
                 $session['user'] = Database::fetchAssoc($result);
                 global $baseaccount;

--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -66,13 +66,13 @@ class Newday
         );
 
         $timestamp = date('Y-m-d H:i:s', strtotime('now'));
-        $movedToArchive = $connection->executeStatement(
-            'INSERT IGNORE INTO ' . Database::prefix('debuglog_archive') .
-            ' SELECT * FROM ' . Database::prefix('debuglog') . ' WHERE date < :timestamp',
-            ['timestamp' => $timestamp],
-            ['timestamp' => ParameterType::STRING]
-        );
-        if ($movedToArchive >= 0) {
+        try {
+            $movedToArchive = $connection->executeStatement(
+                'INSERT IGNORE INTO ' . Database::prefix('debuglog_archive') .
+                ' SELECT * FROM ' . Database::prefix('debuglog') . ' WHERE date < :timestamp',
+                ['timestamp' => $timestamp],
+                ['timestamp' => ParameterType::STRING]
+            );
             $connection->executeStatement(
                 'DELETE FROM ' . Database::prefix('debuglog') . ' WHERE date < :timestamp',
                 ['timestamp' => $timestamp],
@@ -96,9 +96,9 @@ class Newday
                 false,
                 $session['user']['acctid'] ?? 0
             );
-        } else {
+        } catch (\Exception $e) {
             GameLog::log(
-                'ERROR, problems with moving the debuglog to the archive',
+                'ERROR, problems with moving the debuglog to the archive: ' . $e->getMessage(),
                 'maintenance',
                 false,
                 $session['user']['acctid'] ?? 0,

--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use Doctrine\DBAL\ParameterType;
 use Lotgd\Translator;
 use Lotgd\MySQL\Database;
 use Lotgd\GameLog;
@@ -49,32 +50,48 @@ class Newday
     {
         global $session;
         $settings = Settings::getInstance();
+        $connection = Database::getDoctrineConnection();
 
         $timestamp = self::calculateExpirationTimestamp('2 month');
-        Database::query('DELETE FROM ' . Database::prefix('referers') . " WHERE last < '$timestamp'");
+        $affectedRows = $connection->executeStatement(
+            'DELETE FROM ' . Database::prefix('referers') . ' WHERE last < :timestamp',
+            ['timestamp' => $timestamp],
+            ['timestamp' => ParameterType::STRING]
+        );
         GameLog::log(
-            'Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('referers') . " older than $timestamp.",
+            'Deleted ' . $affectedRows . ' records from ' . Database::prefix('referers') . " older than $timestamp.",
             'maintenance',
             false,
             $session['user']['acctid'] ?? 0
         );
 
         $timestamp = date('Y-m-d H:i:s', strtotime('now'));
-        $sql = 'INSERT IGNORE INTO ' . Database::prefix('debuglog_archive') .
-            ' SELECT * FROM ' . Database::prefix('debuglog') . " WHERE date <'$timestamp'";
-        $ok = Database::query($sql);
-        if ($ok) {
-            $sql = 'DELETE FROM ' . Database::prefix('debuglog') . " WHERE date <'$timestamp'";
-            Database::query($sql);
+        $movedToArchive = $connection->executeStatement(
+            'INSERT IGNORE INTO ' . Database::prefix('debuglog_archive') .
+            ' SELECT * FROM ' . Database::prefix('debuglog') . ' WHERE date < :timestamp',
+            ['timestamp' => $timestamp],
+            ['timestamp' => ParameterType::STRING]
+        );
+        if ($movedToArchive >= 0) {
+            $connection->executeStatement(
+                'DELETE FROM ' . Database::prefix('debuglog') . ' WHERE date < :timestamp',
+                ['timestamp' => $timestamp],
+                ['timestamp' => ParameterType::STRING]
+            );
 
             $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expiredebuglog', 18) . ' days');
-            $sql = 'DELETE FROM ' . Database::prefix('debuglog_archive') . " WHERE date <'$timestamp'";
+            $expiredArchiveRows = 0;
             if ($settings->getSetting('expiredebuglog', 18) > 0) {
-                Database::query($sql);
+                $expiredArchiveRows = $connection->executeStatement(
+                    'DELETE FROM ' . Database::prefix('debuglog_archive') . ' WHERE date < :timestamp',
+                    ['timestamp' => $timestamp],
+                    ['timestamp' => ParameterType::STRING]
+                );
             }
 
             GameLog::log(
-                'Moved ' . Database::affectedRows() . ' from ' . Database::prefix('debuglog') . ' to ' . Database::prefix('debuglog_archive') . " older than $timestamp.",
+                'Moved ' . $movedToArchive . ' from ' . Database::prefix('debuglog') . ' to ' . Database::prefix('debuglog_archive')
+                . " older than $timestamp. Purged $expiredArchiveRows archived rows.",
                 'maintenance',
                 false,
                 $session['user']['acctid'] ?? 0
@@ -90,10 +107,13 @@ class Newday
         }
 
         $timestamp = self::calculateExpirationTimestamp($settings->getSetting('oldmail', 14) . ' days');
-        $sql = 'DELETE FROM ' . Database::prefix('mail') . " WHERE sent<'$timestamp'";
-        Database::query($sql);
+        $affectedRows = $connection->executeStatement(
+            'DELETE FROM ' . Database::prefix('mail') . ' WHERE sent < :timestamp',
+            ['timestamp' => $timestamp],
+            ['timestamp' => ParameterType::STRING]
+        );
         GameLog::log(
-            'Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('mail') . " older than $timestamp.",
+            'Deleted ' . $affectedRows . ' records from ' . Database::prefix('mail') . " older than $timestamp.",
             'maintenance',
             false,
             $session['user']['acctid'] ?? 0
@@ -102,58 +122,74 @@ class Newday
 
         if ((int) $settings->getSetting('expirecontent', 180) > 0) {
             $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expirecontent', 180) . ' days');
-            $sql = 'DELETE FROM ' . Database::prefix('news') . " WHERE newsdate<'$timestamp'";
+            $affectedRows = $connection->executeStatement(
+                'DELETE FROM ' . Database::prefix('news') . ' WHERE newsdate < :timestamp',
+                ['timestamp' => $timestamp],
+                ['timestamp' => ParameterType::STRING]
+            );
             GameLog::log(
-                'Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('news') . " older than $timestamp.",
+                'Deleted ' . $affectedRows . ' records from ' . Database::prefix('news') . " older than $timestamp.",
                 'comment expiration',
                 false,
                 $session['user']['acctid'] ?? 0
             );
-            Database::query($sql);
         }
 
         $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expiregamelog', 30) . ' days');
-        $sql = 'DELETE FROM ' . Database::prefix('gamelog') . " WHERE date < '$timestamp' ";
         if ($settings->getSetting('expiregamelog', 30) > 0) {
-            Database::query($sql);
+            $affectedRows = $connection->executeStatement(
+                'DELETE FROM ' . Database::prefix('gamelog') . ' WHERE date < :timestamp',
+                ['timestamp' => $timestamp],
+                ['timestamp' => ParameterType::STRING]
+            );
             GameLog::log(
-                'Cleaned up ' . Database::prefix('gamelog') . ' table removing ' . Database::affectedRows() . " older than $timestamp.",
+                'Cleaned up ' . Database::prefix('gamelog') . ' table removing ' . $affectedRows . " older than $timestamp.",
                 'maintenance',
                 false,
                 $session['user']['acctid'] ?? 0
             );
         }
 
-        $sql = 'DELETE FROM ' . Database::prefix('commentary') . " WHERE postdate<'" . self::calculateExpirationTimestamp($settings->getSetting('expirecontent', 180) . ' days') . "'";
         if ($settings->getSetting('expirecontent', 180) > 0) {
             $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expirecontent', 180) . ' days');
-            Database::query($sql);
+            $affectedRows = $connection->executeStatement(
+                'DELETE FROM ' . Database::prefix('commentary') . ' WHERE postdate < :timestamp',
+                ['timestamp' => $timestamp],
+                ['timestamp' => ParameterType::STRING]
+            );
             GameLog::log(
-                'Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('commentary') . " older than $timestamp.",
+                'Deleted ' . $affectedRows . ' records from ' . Database::prefix('commentary') . " older than $timestamp.",
                 'comment expiration',
                 false,
                 $session['user']['acctid'] ?? 0
             );
         }
 
-        $sql = 'DELETE FROM ' . Database::prefix('moderatedcomments') . " WHERE moddate<'" . self::calculateExpirationTimestamp($settings->getSetting('expirecontent', 180) . ' days') . "'";
         if ($settings->getSetting('expirecontent', 180) > 0) {
             $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expirecontent', 180) . ' days');
-            Database::query($sql);
+            $affectedRows = $connection->executeStatement(
+                'DELETE FROM ' . Database::prefix('moderatedcomments') . ' WHERE moddate < :timestamp',
+                ['timestamp' => $timestamp],
+                ['timestamp' => ParameterType::STRING]
+            );
             GameLog::log(
-                'Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('moderatedcomments') . " older than $timestamp.",
+                'Deleted ' . $affectedRows . ' records from ' . Database::prefix('moderatedcomments') . " older than $timestamp.",
                 'comment expiration',
                 false,
                 $session['user']['acctid'] ?? 0
             );
         }
 
-        $sql = 'DELETE FROM ' . Database::prefix('faillog') . " WHERE date<'" . self::calculateExpirationTimestamp($settings->getSetting('expirefaillog', 1) . ' days') . "'";
         if ($settings->getSetting('expirefaillog', 1) > 0) {
-            Database::query($sql);
+            $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expirefaillog', 1) . ' days');
+            $affectedRows = $connection->executeStatement(
+                'DELETE FROM ' . Database::prefix('faillog') . ' WHERE date < :timestamp',
+                ['timestamp' => $timestamp],
+                ['timestamp' => ParameterType::STRING]
+            );
             $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expirecontent', 180) . ' days');
             GameLog::log(
-                'Deleted ' . Database::affectedRows() . ' records from ' . Database::prefix('faillog') . " older than $timestamp.",
+                'Deleted ' . $affectedRows . ' records from ' . Database::prefix('faillog') . " older than $timestamp.",
                 'maintenance',
                 false,
                 $session['user']['acctid'] ?? 0

--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -65,33 +65,33 @@ class Newday
             $session['user']['acctid'] ?? 0
         );
 
-        $timestamp = date('Y-m-d H:i:s', strtotime('now'));
+        $moveCutoff = date('Y-m-d H:i:s', strtotime('now'));
         try {
             $movedToArchive = $connection->executeStatement(
                 'INSERT IGNORE INTO ' . Database::prefix('debuglog_archive') .
                 ' SELECT * FROM ' . Database::prefix('debuglog') . ' WHERE date < :timestamp',
-                ['timestamp' => $timestamp],
+                ['timestamp' => $moveCutoff],
                 ['timestamp' => ParameterType::STRING]
             );
             $connection->executeStatement(
                 'DELETE FROM ' . Database::prefix('debuglog') . ' WHERE date < :timestamp',
-                ['timestamp' => $timestamp],
+                ['timestamp' => $moveCutoff],
                 ['timestamp' => ParameterType::STRING]
             );
 
-            $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expiredebuglog', 18) . ' days');
+            $purgeCutoff = self::calculateExpirationTimestamp($settings->getSetting('expiredebuglog', 18) . ' days');
             $expiredArchiveRows = 0;
             if ($settings->getSetting('expiredebuglog', 18) > 0) {
                 $expiredArchiveRows = $connection->executeStatement(
                     'DELETE FROM ' . Database::prefix('debuglog_archive') . ' WHERE date < :timestamp',
-                    ['timestamp' => $timestamp],
+                    ['timestamp' => $purgeCutoff],
                     ['timestamp' => ParameterType::STRING]
                 );
             }
 
             GameLog::log(
                 'Moved ' . $movedToArchive . ' from ' . Database::prefix('debuglog') . ' to ' . Database::prefix('debuglog_archive')
-                . " older than $timestamp. Purged $expiredArchiveRows archived rows.",
+                . " older than $moveCutoff. Purged $expiredArchiveRows archived rows older than $purgeCutoff.",
                 'maintenance',
                 false,
                 $session['user']['acctid'] ?? 0
@@ -187,7 +187,6 @@ class Newday
                 ['timestamp' => $timestamp],
                 ['timestamp' => ParameterType::STRING]
             );
-            $timestamp = self::calculateExpirationTimestamp($settings->getSetting('expirecontent', 180) . ' days');
             GameLog::log(
                 'Deleted ' . $affectedRows . ' records from ' . Database::prefix('faillog') . " older than $timestamp.",
                 'maintenance',

--- a/src/Lotgd/PlayerFunctions.php
+++ b/src/Lotgd/PlayerFunctions.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Lotgd;
 
 use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\ParameterType;
 use Lotgd\Settings;
 use Lotgd\MySQL\Database;
 use Lotgd\Modules\HookHandler;
@@ -29,6 +30,7 @@ class PlayerFunctions
     public static function charCleanup(int $id, int $type): bool
     {
         global $session;
+        $connection = Database::getDoctrineConnection();
         // Run module hooks for character deletion
         $args = HookHandler::hook('delete_character', ['acctid' => $id, 'deltype' => $type]);
 
@@ -38,31 +40,51 @@ class PlayerFunctions
         }
 
         // Remove output cache records for this player
-        Database::query('DELETE FROM ' . Database::prefix('accounts_output') . " WHERE acctid=$id;");
+        $connection->executeStatement(
+            'DELETE FROM ' . Database::prefix('accounts_output') . ' WHERE acctid = :acctid',
+            ['acctid' => $id],
+            ['acctid' => ParameterType::INTEGER]
+        );
 
         // Remove comments from this player
-        Database::query('DELETE FROM ' . Database::prefix('commentary') . " WHERE author=$id;");
+        $connection->executeStatement(
+            'DELETE FROM ' . Database::prefix('commentary') . ' WHERE author = :author',
+            ['author' => $id],
+            ['author' => ParameterType::INTEGER]
+        );
 
         // Handle clan cleanup logic
-        $sql = 'SELECT clanrank,clanid FROM ' . Database::prefix('accounts') . " WHERE acctid=$id";
-        $res = Database::query($sql);
+        $res = $connection->executeQuery(
+            'SELECT clanrank, clanid FROM ' . Database::prefix('accounts') . ' WHERE acctid = :acctid',
+            ['acctid' => $id],
+            ['acctid' => ParameterType::INTEGER]
+        );
         $row = Database::fetchAssoc($res);
         if ($row['clanid'] != 0 && ($row['clanrank'] == CLAN_LEADER || $row['clanrank'] == CLAN_FOUNDER)) {
             $cid = $row['clanid'];
-            $sql = 'SELECT count(acctid) as counter FROM ' . Database::prefix('accounts')
-                . " WHERE clanid=$cid AND clanrank >= " . CLAN_LEADER . " AND acctid<>$id ORDER BY clanrank DESC, clanjoindate";
-            $res = Database::query($sql);
+            $res = $connection->executeQuery(
+                'SELECT count(acctid) as counter FROM ' . Database::prefix('accounts')
+                . ' WHERE clanid = :clanid AND clanrank >= :leader_rank AND acctid <> :acctid ORDER BY clanrank DESC, clanjoindate',
+                ['clanid' => $cid, 'leader_rank' => CLAN_LEADER, 'acctid' => $id],
+                ['clanid' => ParameterType::INTEGER, 'leader_rank' => ParameterType::INTEGER, 'acctid' => ParameterType::INTEGER]
+            );
             $row = Database::fetchAssoc($res);
             if ($row['counter'] == 0) {
-                $sql = 'SELECT name,acctid,clanrank FROM ' . Database::prefix('accounts')
-                    . " WHERE clanid=$cid AND clanrank > " . CLAN_APPLICANT . " AND acctid<>$id ORDER BY clanrank DESC, clanjoindate";
-                $res = Database::query($sql);
+                $res = $connection->executeQuery(
+                    'SELECT name, acctid, clanrank FROM ' . Database::prefix('accounts')
+                    . ' WHERE clanid = :clanid AND clanrank > :applicant_rank AND acctid <> :acctid ORDER BY clanrank DESC, clanjoindate',
+                    ['clanid' => $cid, 'applicant_rank' => CLAN_APPLICANT, 'acctid' => $id],
+                    ['clanid' => ParameterType::INTEGER, 'applicant_rank' => ParameterType::INTEGER, 'acctid' => ParameterType::INTEGER]
+                );
                 if (Database::numRows($res)) {
                     $row = Database::fetchAssoc($res);
                     if ($row['clanrank'] != CLAN_LEADER && $row['clanrank'] != CLAN_FOUNDER) {
                         $id1 = $row['acctid'];
-                        $sql = 'UPDATE ' . Database::prefix('accounts') . ' SET clanrank=' . CLAN_LEADER . " WHERE acctid=$id1";
-                        Database::query($sql);
+                        $connection->executeStatement(
+                            'UPDATE ' . Database::prefix('accounts') . ' SET clanrank = :leader_rank WHERE acctid = :acctid',
+                            ['leader_rank' => CLAN_LEADER, 'acctid' => $id1],
+                            ['leader_rank' => ParameterType::INTEGER, 'acctid' => ParameterType::INTEGER]
+                        );
                     }
                     GameLog::log(
                         'Clan ' . $cid . ' has a new leader ' . $row['name'] . ' as there were no others left',
@@ -71,16 +93,22 @@ class PlayerFunctions
                         $session['user']['acctid'] ?? 0
                     );
                 } else {
-                    $sql = 'DELETE FROM ' . Database::prefix('clans') . " WHERE clanid=$cid";
-                    Database::query($sql);
+                    $connection->executeStatement(
+                        'DELETE FROM ' . Database::prefix('clans') . ' WHERE clanid = :clanid',
+                        ['clanid' => $cid],
+                        ['clanid' => ParameterType::INTEGER]
+                    );
                     GameLog::log(
                         'Clan ' . $cid . ' has been disbanded as the last member left',
                         'clan',
                         false,
                         $session['user']['acctid'] ?? 0
                     );
-                    $sql = 'UPDATE ' . Database::prefix('accounts') . " SET clanid=0,clanrank=0,clanjoindate='" . DATETIME_DATEMIN . "' WHERE clanid=$cid";
-                    Database::query($sql);
+                    $connection->executeStatement(
+                        'UPDATE ' . Database::prefix('accounts') . ' SET clanid = :empty_clanid, clanrank = :empty_clanrank, clanjoindate = :clanjoindate WHERE clanid = :clanid',
+                        ['empty_clanid' => 0, 'empty_clanrank' => 0, 'clanjoindate' => DATETIME_DATEMIN, 'clanid' => $cid],
+                        ['empty_clanid' => ParameterType::INTEGER, 'empty_clanrank' => ParameterType::INTEGER, 'clanjoindate' => ParameterType::STRING, 'clanid' => ParameterType::INTEGER]
+                    );
                 }
             }
         }
@@ -98,8 +126,11 @@ class PlayerFunctions
     {
         global $session;
         if ($player !== false) {
-            $sql = 'SELECT strength,wisdom,intelligence,attack FROM ' . Database::prefix('accounts') . ' WHERE acctid=' . ((int)$player) . ';';
-            $result = Database::query($sql);
+            $result = Database::getDoctrineConnection()->executeQuery(
+                'SELECT strength,wisdom,intelligence,attack FROM ' . Database::prefix('accounts') . ' WHERE acctid = :acctid',
+                ['acctid' => (int) $player],
+                ['acctid' => ParameterType::INTEGER]
+            );
             $row = Database::fetchAssoc($result);
             if (!$row) {
                 return 0;
@@ -121,8 +152,11 @@ class PlayerFunctions
     {
         global $session;
         if ($player !== false) {
-            $sql = 'SELECT strength,wisdom,intelligence,attack FROM ' . Database::prefix('accounts') . ' WHERE acctid=' . ((int)$player) . ';';
-            $result = Database::query($sql);
+            $result = Database::getDoctrineConnection()->executeQuery(
+                'SELECT strength,wisdom,intelligence,attack FROM ' . Database::prefix('accounts') . ' WHERE acctid = :acctid',
+                ['acctid' => (int) $player],
+                ['acctid' => ParameterType::INTEGER]
+            );
             $row = Database::fetchAssoc($result);
             if (!$row) {
                 return 0;
@@ -148,8 +182,11 @@ class PlayerFunctions
     {
         global $session;
         if ($player !== false) {
-            $sql = 'SELECT constitution,wisdom,defense FROM ' . Database::prefix('accounts') . ' WHERE acctid=' . ((int)$player) . ';';
-            $result = Database::query($sql);
+            $result = Database::getDoctrineConnection()->executeQuery(
+                'SELECT constitution,wisdom,defense FROM ' . Database::prefix('accounts') . ' WHERE acctid = :acctid',
+                ['acctid' => (int) $player],
+                ['acctid' => ParameterType::INTEGER]
+            );
             $row = Database::fetchAssoc($result);
             if (!$row) {
                 return 0;
@@ -170,8 +207,11 @@ class PlayerFunctions
     {
         global $session;
         if ($player !== false) {
-            $sql = 'SELECT constitution,wisdom,defense FROM ' . Database::prefix('accounts') . ' WHERE acctid=' . ((int)$player) . ';';
-            $result = Database::query($sql);
+            $result = Database::getDoctrineConnection()->executeQuery(
+                'SELECT constitution,wisdom,defense FROM ' . Database::prefix('accounts') . ' WHERE acctid = :acctid',
+                ['acctid' => (int) $player],
+                ['acctid' => ParameterType::INTEGER]
+            );
             $row = Database::fetchAssoc($result);
             if (!$row) {
                 return 0;
@@ -196,8 +236,11 @@ class PlayerFunctions
     {
         global $session;
         if ($player !== false) {
-            $sql = 'SELECT dexterity,intelligence FROM ' . Database::prefix('accounts') . ' WHERE acctid=' . ((int)$player) . ';';
-            $result = Database::query($sql);
+            $result = Database::getDoctrineConnection()->executeQuery(
+                'SELECT dexterity,intelligence FROM ' . Database::prefix('accounts') . ' WHERE acctid = :acctid',
+                ['acctid' => (int) $player],
+                ['acctid' => ParameterType::INTEGER]
+            );
             $row = Database::fetchAssoc($result);
             if (!$row) {
                 return 0;
@@ -214,8 +257,11 @@ class PlayerFunctions
     {
         global $session;
         if ($player !== false) {
-            $sql = 'SELECT constitution,wisdom,defense FROM ' . Database::prefix('accounts') . ' WHERE acctid=' . ((int)$player) . ';';
-            $result = Database::query($sql);
+            $result = Database::getDoctrineConnection()->executeQuery(
+                'SELECT constitution,wisdom,defense FROM ' . Database::prefix('accounts') . ' WHERE acctid = :acctid',
+                ['acctid' => (int) $player],
+                ['acctid' => ParameterType::INTEGER]
+            );
             $row = Database::fetchAssoc($result);
             if (!$row) {
                 return 0;
@@ -238,8 +284,11 @@ class PlayerFunctions
         } elseif (isset($checked_users[$player])) {
             $user =& $checked_users[$player];
         } else {
-            $sql = 'SELECT acctid,laston,loggedin FROM ' . Database::prefix('accounts') . ' WHERE acctid=' . ((int)$player) . ';';
-            $result = Database::query($sql);
+            $result = Database::getDoctrineConnection()->executeQuery(
+                'SELECT acctid,laston,loggedin FROM ' . Database::prefix('accounts') . ' WHERE acctid = :acctid',
+                ['acctid' => (int) $player],
+                ['acctid' => ParameterType::INTEGER]
+            );
             $row = Database::fetchAssoc($result);
             $row = HookHandler::hook('is-player-online', $row);
             if (!$row) {
@@ -453,8 +502,11 @@ class PlayerFunctions
 
     public static function validDkTitle(string $title, int $dks, int $gender): bool
     {
-        $sql = 'SELECT dk,male,female FROM ' . Database::prefix('titles') . " WHERE dk <= $dks ORDER by dk DESC";
-        $res = Database::query($sql);
+        $res = Database::getDoctrineConnection()->executeQuery(
+            'SELECT dk,male,female FROM ' . Database::prefix('titles') . ' WHERE dk <= :dk ORDER by dk DESC',
+            ['dk' => $dks],
+            ['dk' => ParameterType::INTEGER]
+        );
         $d = -1;
         while ($row = Database::fetchAssoc($res)) {
             if ($d == -1) {
@@ -476,24 +528,39 @@ class PlayerFunctions
     public static function getDkTitle(int $dks, int $gender, string|false $ref = false): string
     {
         $refdk = -1;
+        $connection = Database::getDoctrineConnection();
         if ($ref !== false) {
-            $sql = 'SELECT max(dk) as dk FROM ' . Database::prefix('titles') . " WHERE dk<='$dks' and ref='$ref'";
-            $res = Database::query($sql);
+            $res = $connection->executeQuery(
+                'SELECT max(dk) as dk FROM ' . Database::prefix('titles') . ' WHERE dk <= :dk and ref = :ref',
+                ['dk' => $dks, 'ref' => $ref],
+                ['dk' => ParameterType::INTEGER, 'ref' => ParameterType::STRING]
+            );
             $row = Database::fetchAssoc($res);
             $refdk = $row['dk'];
         }
-        $sql = 'SELECT max(dk) as dk FROM ' . Database::prefix('titles') . " WHERE dk<='$dks'";
-        $res = Database::query($sql);
+        $res = $connection->executeQuery(
+            'SELECT max(dk) as dk FROM ' . Database::prefix('titles') . ' WHERE dk <= :dk',
+            ['dk' => $dks],
+            ['dk' => ParameterType::INTEGER]
+        );
         $row = Database::fetchAssoc($res);
         $anydk = $row['dk'];
-        $useref = '';
-        $targetdk = $anydk;
+        $targetdk = (int) $anydk;
+        $params = ['target_dk' => $targetdk];
+        $types = ['target_dk' => ParameterType::INTEGER];
+        $refFilterSql = '';
         if ($refdk >= $anydk) {
-            $useref = "AND ref='$ref'";
-            $targetdk = $refdk;
+            $targetdk = (int) $refdk;
+            $params['target_dk'] = $targetdk;
+            $params['ref'] = (string) $ref;
+            $types['ref'] = ParameterType::STRING;
+            $refFilterSql = ' AND ref = :ref';
         }
-        $sql = 'SELECT male,female FROM ' . Database::prefix('titles') . " WHERE dk='$targetdk' $useref ORDER BY RAND(" . Random::eRand() . ") LIMIT 1";
-        $res = Database::query($sql);
+        $res = $connection->executeQuery(
+            'SELECT male,female FROM ' . Database::prefix('titles') . ' WHERE dk = :target_dk' . $refFilterSql . ' ORDER BY RAND(' . Random::eRand() . ') LIMIT 1',
+            $params,
+            $types
+        );
         $row = ['male' => 'God', 'female' => 'Goddess'];
         if (Database::numRows($res) != 0) {
             $row = Database::fetchAssoc($res);

--- a/src/Lotgd/Pvp.php
+++ b/src/Lotgd/Pvp.php
@@ -63,20 +63,25 @@ class Pvp
 
         $settings = Settings::getInstance();
         $output = Output::getInstance();
+        $connection = Database::getDoctrineConnection();
         $pvptime = $settings->getSetting('pvptimeout', 600);
         $pvptimeout = date('Y-m-d H:i:s', strtotime("-$pvptime seconds"));
 
         // Legacy support for numeric id or login name
         if (is_numeric($name)) {
-            $where = "acctid=$name";
+            $where = 'acctid = :acctid';
+            $params = ['acctid' => (int) $name];
+            $types = ['acctid' => ParameterType::INTEGER];
         } else {
-            $where = "login='$name'";
+            $where = 'login = :login';
+            $params = ['login' => (string) $name];
+            $types = ['login' => ParameterType::STRING];
         }
         $sql = "SELECT name AS creaturename, level AS creaturelevel, weapon AS creatureweapon, dragonkills AS dragonkills," .
             "gold AS creaturegold, experience AS creatureexp, maxhitpoints AS creaturehealth, attack AS creatureattack, " .
             "defense AS creaturedefense, loggedin, location, laston, alive, acctid, pvpflag, boughtroomtoday, race FROM " .
             Database::prefix('accounts') . " WHERE $where";
-        $result = Database::query($sql);
+        $result = $connection->executeQuery($sql, $params, $types);
         if (Database::numRows($result) > 0) {
             $row = Database::fetchAssoc($result);
             if ($session['user']['dragonkills'] < $row['dragonkills']) {
@@ -92,8 +97,11 @@ class Pvp
                 $output->output("`\$Error:`4 That user is now online, and cannot be attacked until they log off again.");
                 return false;
             } elseif ($session['user']['playerfights'] > 0) {
-                $sql = "UPDATE " . Database::prefix('accounts') . " SET pvpflag='" . date('Y-m-d H:i:s') . "' WHERE acctid={$row['acctid']}";
-                Database::query($sql);
+                $connection->executeStatement(
+                    'UPDATE ' . Database::prefix('accounts') . ' SET pvpflag = :pvpflag WHERE acctid = :acctid',
+                    ['pvpflag' => date('Y-m-d H:i:s'), 'acctid' => (int) $row['acctid']],
+                    ['pvpflag' => ParameterType::STRING, 'acctid' => ParameterType::INTEGER]
+                );
                 $row['creatureexp'] = round($row['creatureexp'], 0);
                 $row['playerstarthp'] = $session['user']['hitpoints'];
                 $row['fightstartdate'] = strtotime('now');
@@ -117,9 +125,13 @@ class Pvp
 
         $settings = Settings::getInstance();
         $output = Output::getInstance();
+        $connection = Database::getDoctrineConnection();
 
-        $sql = "SELECT gold FROM " . Database::prefix('accounts') . " WHERE acctid='" . (int) $badguy['acctid'] . "'";
-        $result = Database::query($sql);
+        $result = $connection->executeQuery(
+            'SELECT gold FROM ' . Database::prefix('accounts') . ' WHERE acctid = :acctid',
+            ['acctid' => (int) $badguy['acctid']],
+            ['acctid' => ParameterType::INTEGER]
+        );
         $row = Database::fetchAssoc($result);
         if (!isset($row['gold'])) {
             $row['gold'] = 0;
@@ -190,9 +202,34 @@ class Pvp
             Translator::sprintfTranslate(...$mailmessage)
         );
 
-        $sql = "UPDATE " . Database::prefix('accounts') . " SET alive=0, goldinbank=(goldinbank+IF(gold<{$badguy['creaturegold']},gold-{$badguy['creaturegold']},0)),gold=IF(gold<{$badguy['creaturegold']},0,gold-{$badguy['creaturegold']}), experience=IF(experience>=$lostexp,experience-$lostexp,0) WHERE acctid=" . (int) $badguy['acctid'];
+        $sql = 'UPDATE ' . Database::prefix('accounts')
+            . ' SET alive = 0, '
+            . 'goldinbank = (goldinbank + IF(gold < :creaturegold_for_bank, gold - :creaturegold_for_delta, 0)), '
+            . 'gold = IF(gold < :creaturegold_for_gold, 0, gold - :creaturegold_for_subtract), '
+            . 'experience = IF(experience >= :lostexp_for_check, experience - :lostexp_for_subtract, 0) '
+            . 'WHERE acctid = :acctid';
         DebugLog::add($sql, (int) $badguy['acctid'], $session['user']['acctid']);
-        Database::query($sql);
+        $connection->executeStatement(
+            $sql,
+            [
+                'creaturegold_for_bank' => (int) $badguy['creaturegold'],
+                'creaturegold_for_delta' => (int) $badguy['creaturegold'],
+                'creaturegold_for_gold' => (int) $badguy['creaturegold'],
+                'creaturegold_for_subtract' => (int) $badguy['creaturegold'],
+                'lostexp_for_check' => (int) $lostexp,
+                'lostexp_for_subtract' => (int) $lostexp,
+                'acctid' => (int) $badguy['acctid'],
+            ],
+            [
+                'creaturegold_for_bank' => ParameterType::INTEGER,
+                'creaturegold_for_delta' => ParameterType::INTEGER,
+                'creaturegold_for_gold' => ParameterType::INTEGER,
+                'creaturegold_for_subtract' => ParameterType::INTEGER,
+                'lostexp_for_check' => ParameterType::INTEGER,
+                'lostexp_for_subtract' => ParameterType::INTEGER,
+                'acctid' => ParameterType::INTEGER,
+            ]
+        );
         return $args['handled'];
     }
 
@@ -205,6 +242,7 @@ class Pvp
 
         $settings = Settings::getInstance();
         $output = Output::getInstance();
+        $connection = Database::getDoctrineConnection();
 
         Navigation::add('Daily news', 'news.php');
         $killedin = $badguy['location'];
@@ -216,8 +254,11 @@ class Pvp
             $wonamount = 0;
         }
 
-        $sql = "SELECT level FROM " . Database::prefix('accounts') . " WHERE acctid={$badguy['acctid']}";
-        $result = Database::query($sql);
+        $result = $connection->executeQuery(
+            'SELECT level FROM ' . Database::prefix('accounts') . ' WHERE acctid = :acctid',
+            ['acctid' => (int) $badguy['acctid']],
+            ['acctid' => ParameterType::INTEGER]
+        );
         $row = Database::fetchAssoc($result);
 
         $wonexp = round($session['user']['experience'] * $settings->getSetting('pvpdefgain', 10) / 100, 0);
@@ -253,9 +294,13 @@ class Pvp
         );
 
         if ($row['level'] >= $badguy['creaturelevel']) {
-            $sql = "UPDATE " . Database::prefix('accounts') . " SET gold=gold+" . $winamount . ", experience=experience+" . $wonexp . " WHERE acctid=" . (int) $badguy['acctid'];
+            $sql = 'UPDATE ' . Database::prefix('accounts') . ' SET gold = gold + :winamount, experience = experience + :wonexp WHERE acctid = :acctid';
             DebugLog::add($sql);
-            Database::query($sql);
+            $connection->executeStatement(
+                $sql,
+                ['winamount' => (int) $winamount, 'wonexp' => (int) $wonexp, 'acctid' => (int) $badguy['acctid']],
+                ['winamount' => ParameterType::INTEGER, 'wonexp' => ParameterType::INTEGER, 'acctid' => ParameterType::INTEGER]
+            );
         }
 
         $session['user']['alive'] = 0;
@@ -417,15 +462,40 @@ class Pvp
             $output->rawOutput('</tr>');
         }
 
-        $sql = "SELECT count(location) as counter, location FROM " . Database::prefix('accounts') .
-            " WHERE (locked=0) " .
-            "AND (slaydragon=0) AND " .
-            "(age>$days OR dragonkills>0 OR pk>0 OR experience>$exp) " .
-            ($levdiff == -1 ? '' : "AND (level>=$lev1 AND level<=$lev2)") .
-            " AND (alive=1) " .
-            "AND (laston<'$last' OR loggedin=0) AND (acctid<>$id) " .
-            "AND location!='$loc' GROUP BY location ORDER BY location; ";
-        $result = Database::query($sql);
+        $summaryParams = [
+            'days' => (int) $days,
+            'exp' => (int) $exp,
+            'last' => $last,
+            'acctid' => (int) $id,
+            'current_location' => (string) $location,
+        ];
+        $summaryTypes = [
+            'days' => ParameterType::INTEGER,
+            'exp' => ParameterType::INTEGER,
+            'last' => ParameterType::STRING,
+            'acctid' => ParameterType::INTEGER,
+            'current_location' => ParameterType::STRING,
+        ];
+        $levelSummaryFilterSql = '';
+        if ($levdiff != -1) {
+            $levelSummaryFilterSql = 'AND (level >= :lev1 AND level <= :lev2) ';
+            $summaryParams['lev1'] = (int) $lev1;
+            $summaryParams['lev2'] = (int) $lev2;
+            $summaryTypes['lev1'] = ParameterType::INTEGER;
+            $summaryTypes['lev2'] = ParameterType::INTEGER;
+        }
+        $result = Database::getDoctrineConnection()->executeQuery(
+            'SELECT count(location) as counter, location FROM ' . Database::prefix('accounts')
+            . ' WHERE (locked=0) '
+            . 'AND (slaydragon=0) AND '
+            . '(age > :days OR dragonkills > 0 OR pk > 0 OR experience > :exp) '
+            . $levelSummaryFilterSql
+            . 'AND (alive = 1) '
+            . 'AND (laston < :last OR loggedin = 0) AND (acctid <> :acctid) '
+            . 'AND location <> :current_location GROUP BY location ORDER BY location',
+            $summaryParams,
+            $summaryTypes
+        );
 
         if ($j == 0) {
             $noone = Translator::translateInline('`iThere are no available targets.`i');

--- a/src/Lotgd/QA/InterpolatedDatabaseQueryCheck.php
+++ b/src/Lotgd/QA/InterpolatedDatabaseQueryCheck.php
@@ -126,8 +126,7 @@ final class InterpolatedDatabaseQueryCheck
                 continue;
             }
 
-            $argumentToken = $this->firstArgumentToken($tokens, $index);
-            if ($argumentToken === null || $this->isAllowedArgumentToken($argumentToken)) {
+            if ($this->isFirstArgumentSafe($tokens, $index)) {
                 continue;
             }
 
@@ -156,29 +155,45 @@ final class InterpolatedDatabaseQueryCheck
     }
 
     /**
+     * Check whether the entire first argument to Database::query() is safe
+     * (composed only of constant string literals, optionally concatenated).
+     *
      * @param list<array<int,int|string>|string> $tokens
      */
-    private function firstArgumentToken(array $tokens, int $index): array|string|null
+    private function isFirstArgumentSafe(array $tokens, int $index): bool
     {
         $tokenCount = count($tokens);
+
         for ($i = $index + 4; $i < $tokenCount; $i++) {
             $token = $tokens[$i];
+
+            // Skip whitespace and comments.
             if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
                 continue;
             }
 
-            return $token;
+            // Closing paren or comma at the top level ends the first argument.
+            if ($token === ')' || $token === ',') {
+                return true;
+            }
+
+            // Constant (single-quoted) string literals are safe.
+            if (is_array($token) && $token[0] === T_CONSTANT_ENCAPSED_STRING) {
+                continue;
+            }
+
+            // Dot (concatenation) of constant strings is safe.
+            if ($token === '.') {
+                continue;
+            }
+
+            // Everything else (variables, interpolated strings, heredocs,
+            // function calls, etc.) is considered dynamic / unsafe.
+            return false;
         }
 
-        return null;
-    }
-
-    private function isAllowedArgumentToken(array|string $token): bool
-    {
-        if (is_string($token)) {
-            return $token === ')' || $token === '"' || $token === '\'';
-        }
-
-        return in_array($token[0], [T_CONSTANT_ENCAPSED_STRING, T_START_HEREDOC], true);
+        // Reached end of token stream without a closing paren – treat as safe
+        // (malformed code; not our concern).
+        return true;
     }
 }

--- a/src/Lotgd/QA/InterpolatedDatabaseQueryCheck.php
+++ b/src/Lotgd/QA/InterpolatedDatabaseQueryCheck.php
@@ -122,11 +122,12 @@ final class InterpolatedDatabaseQueryCheck
                 continue;
             }
 
-            if (!$this->isStaticQueryCall($tokens, $index)) {
+            $openParenIndex = 0;
+            if (!$this->isStaticQueryCall($tokens, $index, $openParenIndex)) {
                 continue;
             }
 
-            if ($this->isFirstArgumentSafe($tokens, $index)) {
+            if ($this->isFirstArgumentSafe($tokens, $openParenIndex)) {
                 continue;
             }
 
@@ -141,17 +142,59 @@ final class InterpolatedDatabaseQueryCheck
     /**
      * @param list<array<int,int|string>|string> $tokens
      */
-    private function isStaticQueryCall(array $tokens, int $index): bool
+    private function isStaticQueryCall(array $tokens, int $index, int &$openParenIndex = 0): bool
     {
-        $doubleColonToken = $tokens[$index + 1] ?? null;
+        $tokenCount = count($tokens);
+
+        $i = $this->skipWhitespaceAndComments($tokens, $index + 1, $tokenCount);
+        if ($i >= $tokenCount) {
+            return false;
+        }
+
+        $doubleColonToken = $tokens[$i];
         $isDoubleColon = $doubleColonToken === '::'
             || (is_array($doubleColonToken) && ($doubleColonToken[0] ?? null) === T_DOUBLE_COLON);
+        if (!$isDoubleColon) {
+            return false;
+        }
 
-        return $isDoubleColon
-            && is_array($tokens[$index + 2] ?? null)
-            && ($tokens[$index + 2][0] ?? null) === T_STRING
-            && strtolower((string) ($tokens[$index + 2][1] ?? '')) === 'query'
-            && ($tokens[$index + 3] ?? null) === '(';
+        $i = $this->skipWhitespaceAndComments($tokens, $i + 1, $tokenCount);
+        if (
+            $i >= $tokenCount
+            || !is_array($tokens[$i])
+            || ($tokens[$i][0] ?? null) !== T_STRING
+            || strtolower((string) ($tokens[$i][1] ?? '')) !== 'query'
+        ) {
+            return false;
+        }
+
+        $i = $this->skipWhitespaceAndComments($tokens, $i + 1, $tokenCount);
+        if ($i >= $tokenCount || $tokens[$i] !== '(') {
+            return false;
+        }
+
+        $openParenIndex = $i;
+
+        return true;
+    }
+
+    /**
+     * Advance past whitespace and comment tokens.
+     *
+     * @param list<array<int,int|string>|string> $tokens
+     */
+    private function skipWhitespaceAndComments(array $tokens, int $start, int $tokenCount): int
+    {
+        while ($start < $tokenCount) {
+            $token = $tokens[$start];
+            if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                $start++;
+                continue;
+            }
+            break;
+        }
+
+        return $start;
     }
 
     /**
@@ -159,12 +202,13 @@ final class InterpolatedDatabaseQueryCheck
      * (composed only of constant string literals, optionally concatenated).
      *
      * @param list<array<int,int|string>|string> $tokens
+     * @param int $openParenIndex Index of the '(' token that opens the argument list.
      */
-    private function isFirstArgumentSafe(array $tokens, int $index): bool
+    private function isFirstArgumentSafe(array $tokens, int $openParenIndex): bool
     {
         $tokenCount = count($tokens);
 
-        for ($i = $index + 4; $i < $tokenCount; $i++) {
+        for ($i = $openParenIndex + 1; $i < $tokenCount; $i++) {
             $token = $tokens[$i];
 
             // Skip whitespace and comments.
@@ -177,7 +221,10 @@ final class InterpolatedDatabaseQueryCheck
                 return true;
             }
 
-            // Constant (single-quoted) string literals are safe.
+            // Constant string literals (single- or double-quoted without
+            // interpolation) are safe.  Interpolated strings (tokenised as
+            // '"', T_ENCAPSED_AND_WHITESPACE, etc.) and heredocs
+            // (T_START_HEREDOC) will fall through to the unsafe return below.
             if (is_array($token) && $token[0] === T_CONSTANT_ENCAPSED_STRING) {
                 continue;
             }

--- a/src/Lotgd/QA/InterpolatedDatabaseQueryCheck.php
+++ b/src/Lotgd/QA/InterpolatedDatabaseQueryCheck.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\QA;
+
+/**
+ * Detect dynamic Database::query(...) calls in core Lotgd namespaces.
+ *
+ * Policy:
+ *  - Prefer Doctrine DBAL prepared statements in core paths.
+ *  - Database::query() remains allowed in explicitly whitelisted legacy files.
+ *  - New usage in non-whitelisted core paths should be migrated to
+ *    executeQuery()/executeStatement() with typed parameters.
+ */
+final class InterpolatedDatabaseQueryCheck
+{
+    /**
+     * @var list<string>
+     */
+    private const SCAN_ROOTS = [
+        'src/Lotgd',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const ALLOWED_PATHS = [
+        // Self-exclusion so examples in this checker are not flagged.
+        'src/Lotgd/QA/InterpolatedDatabaseQueryCheck.php',
+
+        // Legacy-heavy core paths still in migration.
+        'src/Lotgd/Modules.php',
+        'src/Lotgd/Commentary.php',
+        'src/Lotgd/Newday.php',
+        'src/Lotgd/Pvp.php',
+    ];
+
+    /**
+     * @return list<string>
+     */
+    public function collectViolations(string $repositoryRoot): array
+    {
+        $violations = [];
+
+        foreach (self::SCAN_ROOTS as $relativeRoot) {
+            $absoluteRoot = rtrim($repositoryRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relativeRoot;
+            if (!is_dir($absoluteRoot)) {
+                continue;
+            }
+
+            $directoryIterator = new \RecursiveDirectoryIterator($absoluteRoot, \FilesystemIterator::SKIP_DOTS);
+            $iterator = new \RecursiveIteratorIterator($directoryIterator);
+
+            foreach ($iterator as $file) {
+                if (!($file instanceof \SplFileInfo) || $file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $relativePath = str_replace('\\', '/', substr($file->getPathname(), strlen(rtrim($repositoryRoot, DIRECTORY_SEPARATOR)) + 1));
+                if ($this->isWhitelistedPath($relativePath)) {
+                    continue;
+                }
+
+                foreach ($this->collectFileViolations($file->getPathname(), $relativePath) as $violation) {
+                    $violations[] = $violation;
+                }
+            }
+        }
+
+        sort($violations);
+
+        return $violations;
+    }
+
+    public function run(string $repositoryRoot): int
+    {
+        $violations = $this->collectViolations($repositoryRoot);
+        if ($violations === []) {
+            echo "Interpolated Database::query() usage check passed.\n";
+            return 0;
+        }
+
+        fwrite(STDERR, "Detected dynamic Database::query() usage in src/Lotgd core paths.\n");
+        fwrite(STDERR, "Use Doctrine executeQuery()/executeStatement() with bound parameters and types.\n");
+        foreach ($violations as $violation) {
+            fwrite(STDERR, " - {$violation}\n");
+        }
+
+        return 1;
+    }
+
+    private function isWhitelistedPath(string $relativePath): bool
+    {
+        foreach (self::ALLOWED_PATHS as $allowedPath) {
+            if ($relativePath === $allowedPath) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectFileViolations(string $absolutePath, string $relativePath): array
+    {
+        $contents = file_get_contents($absolutePath);
+        if ($contents === false) {
+            return [];
+        }
+
+        $tokens = token_get_all($contents);
+        $lines = preg_split("/\r\n|\n|\r/", $contents) ?: [];
+        $violations = [];
+
+        $tokenCount = count($tokens);
+        for ($index = 0; $index < $tokenCount; $index++) {
+            $token = $tokens[$index];
+            if (!is_array($token) || $token[0] !== T_STRING || $token[1] !== 'Database') {
+                continue;
+            }
+
+            if (!$this->isStaticQueryCall($tokens, $index)) {
+                continue;
+            }
+
+            $argumentToken = $this->firstArgumentToken($tokens, $index);
+            if ($argumentToken === null || $this->isAllowedArgumentToken($argumentToken)) {
+                continue;
+            }
+
+            $lineNumber = (int) $token[2];
+            $lineText = trim($lines[$lineNumber - 1] ?? '');
+            $violations[] = sprintf('%s:%d:%s', $relativePath, $lineNumber, $lineText);
+        }
+
+        return $violations;
+    }
+
+    /**
+     * @param list<array<int,int|string>|string> $tokens
+     */
+    private function isStaticQueryCall(array $tokens, int $index): bool
+    {
+        $doubleColonToken = $tokens[$index + 1] ?? null;
+        $isDoubleColon = $doubleColonToken === '::'
+            || (is_array($doubleColonToken) && ($doubleColonToken[0] ?? null) === T_DOUBLE_COLON);
+
+        return $isDoubleColon
+            && is_array($tokens[$index + 2] ?? null)
+            && ($tokens[$index + 2][0] ?? null) === T_STRING
+            && strtolower((string) ($tokens[$index + 2][1] ?? '')) === 'query'
+            && ($tokens[$index + 3] ?? null) === '(';
+    }
+
+    /**
+     * @param list<array<int,int|string>|string> $tokens
+     */
+    private function firstArgumentToken(array $tokens, int $index): array|string|null
+    {
+        $tokenCount = count($tokens);
+        for ($i = $index + 4; $i < $tokenCount; $i++) {
+            $token = $tokens[$i];
+            if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            return $token;
+        }
+
+        return null;
+    }
+
+    private function isAllowedArgumentToken(array|string $token): bool
+    {
+        if (is_string($token)) {
+            return $token === ')' || $token === '"' || $token === '\'';
+        }
+
+        return in_array($token[0], [T_CONSTANT_ENCAPSED_STRING, T_START_HEREDOC], true);
+    }
+}

--- a/src/Lotgd/QA/SqlAddslashesUsageCheck.php
+++ b/src/Lotgd/QA/SqlAddslashesUsageCheck.php
@@ -65,7 +65,11 @@ final class SqlAddslashesUsageCheck
      *     target_removal_version: string
      * }>
      */
-    private const LEGACY_SQL_ADDSLASHES_BASELINE = [];
+    private const LEGACY_SQL_ADDSLASHES_BASELINE = [
+        // Baseline intentionally empty after staged Doctrine migrations.
+        // Keep array entry format documented above when temporary exceptions
+        // are unavoidable for legacy-only compatibility paths.
+    ];
 
     /**
      * @return list<string> Human-readable violations in "file:line:text" format.

--- a/src/Lotgd/Security/PasskeyCredentialRepository.php
+++ b/src/Lotgd/Security/PasskeyCredentialRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lotgd\Security;
 
+use Doctrine\DBAL\ParameterType;
 use Lotgd\MySQL\Database;
 
 /**
@@ -39,7 +40,11 @@ class PasskeyCredentialRepository
         // which prevents false negatives from legacy-wrapper-specific checks.
         $acctId = max(0, $acctId);
         $table = Database::prefix(self::TABLE_NAME);
-        $result = Database::query("SELECT acctid, credential_id, credential_id_hash, public_key, sign_count, label, transports, created_at, last_used_at FROM {$table} WHERE acctid = {$acctId} ORDER BY created_at ASC");
+        $result = Database::getDoctrineConnection()->executeQuery(
+            "SELECT acctid, credential_id, credential_id_hash, public_key, sign_count, label, transports, created_at, last_used_at FROM {$table} WHERE acctid = :acctid ORDER BY created_at ASC",
+            ['acctid' => $acctId],
+            ['acctid' => ParameterType::INTEGER]
+        );
 
         $items = [];
         while ($row = Database::fetchAssoc($result)) {
@@ -65,10 +70,19 @@ class PasskeyCredentialRepository
     public function findByCredentialId(string $credentialId): ?array
     {
         $credentialId = trim($credentialId);
-        $credentialIdEscaped = Database::escape($credentialId);
-        $credentialIdHashEscaped = Database::escape($this->credentialIdHash($credentialId));
+        $credentialIdHash = $this->credentialIdHash($credentialId);
         $table = Database::prefix(self::TABLE_NAME);
-        $result = Database::query("SELECT acctid, credential_id, credential_id_hash, public_key, sign_count, label, transports, created_at, last_used_at FROM {$table} WHERE credential_id_hash = '{$credentialIdHashEscaped}' AND credential_id = '{$credentialIdEscaped}' LIMIT 1");
+        $result = Database::getDoctrineConnection()->executeQuery(
+            "SELECT acctid, credential_id, credential_id_hash, public_key, sign_count, label, transports, created_at, last_used_at FROM {$table} WHERE credential_id_hash = :credential_id_hash AND credential_id = :credential_id LIMIT 1",
+            [
+                'credential_id_hash' => $credentialIdHash,
+                'credential_id' => $credentialId,
+            ],
+            [
+                'credential_id_hash' => ParameterType::STRING,
+                'credential_id' => ParameterType::STRING,
+            ]
+        );
         $row = Database::fetchAssoc($result);
 
         if (!is_array($row)) {
@@ -100,19 +114,39 @@ class PasskeyCredentialRepository
         int $createdAt
     ): void {
         $table = Database::prefix(self::TABLE_NAME);
+        $connection = Database::getDoctrineConnection();
         $acctId = max(0, $acctId);
         $credentialId = trim($credentialId);
-        $credentialIdEscaped = Database::escape($credentialId);
-        $credentialIdHashEscaped = Database::escape($this->credentialIdHash($credentialId));
-        $publicKeyPem = Database::escape($publicKeyPem);
+        $credentialIdHash = $this->credentialIdHash($credentialId);
         $signCount = max(0, $signCount);
-        $label = Database::escape(trim($label));
-        $transports = Database::escape($transports);
+        $label = trim($label);
         $createdAt = max(0, $createdAt);
 
-        Database::query(
+        $connection->executeStatement(
             "INSERT INTO {$table} (acctid, credential_id, credential_id_hash, public_key, sign_count, label, transports, created_at, last_used_at)"
-            . " VALUES ({$acctId}, '{$credentialIdEscaped}', '{$credentialIdHashEscaped}', '{$publicKeyPem}', {$signCount}, '{$label}', '{$transports}', {$createdAt}, 0)"
+            . ' VALUES (:acctid, :credential_id, :credential_id_hash, :public_key, :sign_count, :label, :transports, :created_at, :last_used_at)',
+            [
+                'acctid' => $acctId,
+                'credential_id' => $credentialId,
+                'credential_id_hash' => $credentialIdHash,
+                'public_key' => $publicKeyPem,
+                'sign_count' => $signCount,
+                'label' => $label,
+                'transports' => $transports,
+                'created_at' => $createdAt,
+                'last_used_at' => 0,
+            ],
+            [
+                'acctid' => ParameterType::INTEGER,
+                'credential_id' => ParameterType::STRING,
+                'credential_id_hash' => ParameterType::STRING,
+                'public_key' => ParameterType::STRING,
+                'sign_count' => ParameterType::INTEGER,
+                'label' => ParameterType::STRING,
+                'transports' => ParameterType::STRING,
+                'created_at' => ParameterType::INTEGER,
+                'last_used_at' => ParameterType::INTEGER,
+            ]
         );
     }
 
@@ -123,12 +157,25 @@ class PasskeyCredentialRepository
     {
         $table = Database::prefix(self::TABLE_NAME);
         $credentialId = trim($credentialId);
-        $credentialIdEscaped = Database::escape($credentialId);
-        $credentialIdHashEscaped = Database::escape($this->credentialIdHash($credentialId));
+        $credentialIdHash = $this->credentialIdHash($credentialId);
         $signCount = max(0, $signCount);
         $lastUsedAt = max(0, $lastUsedAt);
 
-        Database::query("UPDATE {$table} SET sign_count = {$signCount}, last_used_at = {$lastUsedAt} WHERE credential_id_hash = '{$credentialIdHashEscaped}' AND credential_id = '{$credentialIdEscaped}'");
+        Database::getDoctrineConnection()->executeStatement(
+            "UPDATE {$table} SET sign_count = :sign_count, last_used_at = :last_used_at WHERE credential_id_hash = :credential_id_hash AND credential_id = :credential_id",
+            [
+                'sign_count' => $signCount,
+                'last_used_at' => $lastUsedAt,
+                'credential_id_hash' => $credentialIdHash,
+                'credential_id' => $credentialId,
+            ],
+            [
+                'sign_count' => ParameterType::INTEGER,
+                'last_used_at' => ParameterType::INTEGER,
+                'credential_id_hash' => ParameterType::STRING,
+                'credential_id' => ParameterType::STRING,
+            ]
+        );
     }
 
     /**
@@ -137,13 +184,25 @@ class PasskeyCredentialRepository
     public function deleteForAccount(int $acctId, string $credentialId): bool
     {
         $table = Database::prefix(self::TABLE_NAME);
+        $connection = Database::getDoctrineConnection();
         $acctId = max(0, $acctId);
         $credentialId = trim($credentialId);
-        $credentialIdEscaped = Database::escape($credentialId);
-        $credentialIdHashEscaped = Database::escape($this->credentialIdHash($credentialId));
-        Database::query("DELETE FROM {$table} WHERE acctid = {$acctId} AND credential_id_hash = '{$credentialIdHashEscaped}' AND credential_id = '{$credentialIdEscaped}'");
+        $credentialIdHash = $this->credentialIdHash($credentialId);
+        $affectedRows = $connection->executeStatement(
+            "DELETE FROM {$table} WHERE acctid = :acctid AND credential_id_hash = :credential_id_hash AND credential_id = :credential_id",
+            [
+                'acctid' => $acctId,
+                'credential_id_hash' => $credentialIdHash,
+                'credential_id' => $credentialId,
+            ],
+            [
+                'acctid' => ParameterType::INTEGER,
+                'credential_id_hash' => ParameterType::STRING,
+                'credential_id' => ParameterType::STRING,
+            ]
+        );
 
-        return Database::affectedRows() > 0;
+        return $affectedRows > 0;
     }
 
     /**

--- a/tests/CheckBanParameterBindingTest.php
+++ b/tests/CheckBanParameterBindingTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\CheckBan;
+use Lotgd\MySQL\Database;
+use Lotgd\Tests\Stubs\DoctrineBootstrap;
+use PHPUnit\Framework\TestCase;
+
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+final class CheckBanParameterBindingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/Stubs/DoctrineBootstrap.php';
+
+        Database::$doctrineConnection = null;
+        Database::$instance = null;
+        DoctrineBootstrap::$conn = null;
+        Database::$mockResults = [];
+
+        if (!defined('SU_DOESNT_GIVE_GROTTO')) {
+            define('SU_DOESNT_GIVE_GROTTO', 0);
+        }
+        if (!defined('DATETIME_DATEMAX')) {
+            define('DATETIME_DATEMAX', '2159-01-01 00:00:00');
+        }
+
+        global $session;
+        $session = [];
+    }
+
+    public function testCheckUsesBoundParametersForLoginAndBans(): void
+    {
+        $conn = Database::getDoctrineConnection();
+        $conn->fetchAssociativeResults = [[
+            'lastip' => '1.2.3.4',
+            'uniqueid' => 'device-1',
+            'banoverride' => 0,
+            'superuser' => 0,
+        ]];
+        $conn->fetchAllResults = [[]];
+
+        CheckBan::check("bad'login");
+
+        $this->assertSame("bad'login", $conn->lastFetchAssociativeParams['login'] ?? null);
+        $this->assertSame(ParameterType::STRING, $conn->lastFetchAssociativeTypes['login'] ?? null);
+
+        $deleteStatement = $conn->executeStatements[0] ?? null;
+        $this->assertNotNull($deleteStatement);
+        $this->assertStringContainsString('DELETE FROM', $deleteStatement['sql']);
+        $this->assertArrayHasKey('now', $deleteStatement['params']);
+
+        $queryParams = end($conn->executeQueryParams);
+        $queryTypes = end($conn->executeQueryTypes);
+        $this->assertSame('1.2.3.4', $queryParams['ip'] ?? null);
+        $this->assertSame(ParameterType::STRING, $queryTypes['ip'] ?? null);
+    }
+}

--- a/tests/PlayerFunctionsCharCleanupTest.php
+++ b/tests/PlayerFunctionsCharCleanupTest.php
@@ -55,6 +55,6 @@ final class PlayerFunctionsCharCleanupTest extends TestCase
         $result = PlayerFunctions::charCleanup(1, 0);
         $this->assertTrue($result);
         $this->assertSame([1], \Lotgd\Modules\HookHandler::$deleted);
-        $this->assertCount(3, Database::$queries);
+        $this->assertCount(0, Database::$queries);
     }
 }

--- a/tests/QA/InterpolatedDatabaseQueryCheckTest.php
+++ b/tests/QA/InterpolatedDatabaseQueryCheckTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\QA;
+
+use Lotgd\QA\InterpolatedDatabaseQueryCheck;
+use PHPUnit\Framework\TestCase;
+
+final class InterpolatedDatabaseQueryCheckTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private array $fixtureRoots = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->fixtureRoots as $root) {
+            $this->removeDirectoryRecursively($root);
+        }
+        $this->fixtureRoots = [];
+    }
+
+    public function testCheckerFlagsDynamicDatabaseQueryUsage(): void
+    {
+        $root = $this->createFixtureRoot();
+        file_put_contents(
+            $root . '/src/Lotgd/Security/example.php',
+            "<?php\nuse Lotgd\\MySQL\\Database;\nDatabase::query(\$sql);\n"
+        );
+
+        $checker = new InterpolatedDatabaseQueryCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('src/Lotgd/Security/example.php:3:', $violations[0]);
+    }
+
+    public function testCheckerIgnoresWhitelistedLegacyPath(): void
+    {
+        $root = $this->createFixtureRoot();
+        file_put_contents(
+            $root . '/src/Lotgd/Modules.php',
+            "<?php\nDatabase::query(\$sql);\n"
+        );
+
+        $checker = new InterpolatedDatabaseQueryCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertSame([], $violations);
+    }
+
+    public function testCheckerAllowsLiteralDatabaseQuery(): void
+    {
+        $root = $this->createFixtureRoot();
+        file_put_contents(
+            $root . '/src/Lotgd/Security/literal.php',
+            "<?php\nDatabase::query('SELECT 1');\n"
+        );
+
+        $checker = new InterpolatedDatabaseQueryCheck();
+        $violations = $checker->collectViolations($root);
+
+        $this->assertSame([], $violations);
+    }
+
+    private function createFixtureRoot(): string
+    {
+        $root = sys_get_temp_dir() . '/lotgd-interpolated-query-check-' . uniqid('', true);
+        mkdir($root . '/src/Lotgd/Security', 0777, true);
+        $this->fixtureRoots[] = $root;
+
+        return $root;
+    }
+
+    private function removeDirectoryRecursively(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $items = scandir($path);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $current = $path . DIRECTORY_SEPARATOR . $item;
+            if (is_dir($current)) {
+                $this->removeDirectoryRecursively($current);
+                continue;
+            }
+
+            @unlink($current);
+        }
+
+        @rmdir($path);
+    }
+}

--- a/tests/Security/PasskeyCredentialRepositoryDoctrineBindingTest.php
+++ b/tests/Security/PasskeyCredentialRepositoryDoctrineBindingTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Security;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\MySQL\Database;
+use Lotgd\Security\PasskeyCredentialRepository;
+use Lotgd\Tests\Stubs\DoctrineBootstrap;
+use PHPUnit\Framework\TestCase;
+
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+final class PasskeyCredentialRepositoryDoctrineBindingTest extends TestCase
+{
+    private PasskeyCredentialRepository $repository;
+
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
+
+        Database::$doctrineConnection = null;
+        Database::$instance = null;
+        DoctrineBootstrap::$conn = null;
+        Database::$mockResults = [];
+
+        $this->repository = new PasskeyCredentialRepository();
+    }
+
+    public function testInsertUsesExecuteStatementWithTypedParameters(): void
+    {
+        $conn = Database::getDoctrineConnection();
+        $conn->executeStatements = [];
+
+        $this->repository->insert(42, "cred'Ω", 'pem-data', 7, 'Primary Key', 'usb,nfc', 1700000000);
+
+        $statement = $conn->executeStatements[0] ?? null;
+        $this->assertNotNull($statement);
+        $this->assertStringContainsString(':credential_id', $statement['sql']);
+        $this->assertSame("cred'Ω", $statement['params']['credential_id']);
+        $this->assertSame(ParameterType::STRING, $statement['types']['credential_id']);
+    }
+
+    public function testDeleteReturnsTrueWhenExecuteStatementAffectsRows(): void
+    {
+        $conn = Database::getDoctrineConnection();
+        $deleted = $this->repository->deleteForAccount(99, 'cred-1');
+
+        $statement = end($conn->executeStatements);
+        $this->assertTrue($deleted);
+        $this->assertStringContainsString('DELETE FROM', $statement['sql']);
+        $this->assertSame(99, $statement['params']['acctid']);
+        $this->assertSame(ParameterType::INTEGER, $statement['types']['acctid']);
+    }
+}

--- a/tests/Security/SessionHardeningDoctrineBindingTest.php
+++ b/tests/Security/SessionHardeningDoctrineBindingTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Security;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\Async\Handler\Timeout;
+use Lotgd\ForcedNavigation;
+use Lotgd\MySQL\Database;
+use Lotgd\Settings;
+use Lotgd\Tests\Stubs\DoctrineBootstrap;
+use Lotgd\Tests\Stubs\DummySettings;
+use PHPUnit\Framework\TestCase;
+
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+final class SessionHardeningDoctrineBindingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
+
+        Database::$doctrineConnection = null;
+        Database::$instance = null;
+        DoctrineBootstrap::$conn = null;
+        Database::$mockResults = [];
+        Database::$settings_table = [
+            'charset' => 'UTF-8',
+            'LOGINTIMEOUT' => 900,
+            'enabletranslation' => true,
+            'collecttexts' => '',
+        ];
+
+        Settings::setInstance(new DummySettings(Database::$settings_table));
+
+        $_SERVER['REQUEST_URI'] = '/village.php';
+        $_SERVER['HTTP_HOST'] = 'localhost';
+        $_SERVER['SERVER_PORT'] = '80';
+        $_SERVER['PHP_SELF'] = '/index.php';
+
+        global $session;
+        $session = [
+            'loggedin' => true,
+            'user' => [
+                'acctid' => 22,
+                'laston' => date('Y-m-d H:i:s'),
+                'loggedin' => 1,
+                'allowednavs' => serialize(['/village.php' => true]),
+                'bufflist' => serialize([]),
+                'dragonpoints' => serialize([]),
+                'prefs' => serialize([]),
+            ],
+            'allowednavs' => ['/village.php' => true],
+        ];
+    }
+
+    public function testForcedNavigationLoadsAccountWithBoundAcctId(): void
+    {
+        $conn = Database::getDoctrineConnection();
+        $conn->fetchAllResults = [[[
+            'acctid' => 22,
+            'laston' => date('Y-m-d H:i:s'),
+            'loggedin' => 1,
+            'allowednavs' => serialize(['/village.php' => true]),
+            'bufflist' => serialize([]),
+            'dragonpoints' => serialize([]),
+            'prefs' => serialize([]),
+        ]]];
+
+        ForcedNavigation::doForcedNav(false, true);
+
+        $params = $conn->executeQueryParams[0] ?? [];
+        $types = $conn->executeQueryTypes[0] ?? [];
+        $this->assertSame(22, $params['acctid'] ?? null);
+        $this->assertSame(ParameterType::INTEGER, $types['acctid'] ?? null);
+    }
+
+    public function testTimeoutStatusUsesBoundParamsWhenKeepingSessionAlive(): void
+    {
+        global $session;
+
+        $conn = Database::getDoctrineConnection();
+        Timeout::getInstance()->setNeverTimeoutIfBrowserOpen(true);
+        $response = Timeout::getInstance()->timeoutStatus(true);
+
+        $this->assertNotNull($response);
+        $statement = end($conn->executeStatements);
+        $this->assertStringContainsString('UPDATE', $statement['sql']);
+        $this->assertSame(22, $statement['params']['acctid'] ?? null);
+        $this->assertSame(ParameterType::INTEGER, $statement['types']['acctid'] ?? null);
+
+        $session['loggedin'] = false;
+        Timeout::getInstance()->setNeverTimeoutIfBrowserOpen(false);
+    }
+}


### PR DESCRIPTION
### Motivation

- Eliminate interpolated SQL in security-sensitive and auth-adjacent core paths and replace manual escaping with Doctrine DBAL parameter binding to remove SQL-injection risks and harden session/auth flows. 
- Begin a staged migration of high-density legacy query files in `src/Lotgd` to typed `executeQuery()` / `executeStatement()` calls while preserving legacy module compatibility and existing SQL semantics. 

### Description

- Replaced string-interpolated `Database::query()` / `Database::escape()` usages with Doctrine DBAL prepared calls (`Database::getDoctrineConnection()->executeQuery()` / `executeStatement()`) and explicit `ParameterType` maps in the following security/auth-adjacent files: `src/Lotgd/Security/PasskeyCredentialRepository.php`, `src/Lotgd/CheckBan.php`, `src/Lotgd/ForcedNavigation.php`, and `src/Lotgd/Async/Handler/Timeout.php`. 
- Performed a larger pass converting many high-density legacy queries to typed DBAL usage in `src/Lotgd/PlayerFunctions.php`, `src/Lotgd/Newday.php`, `src/Lotgd/Commentary.php`, and `src/Lotgd/Pvp.php` while keeping behavior-compatible SQL semantics (filters, ordering, limits). 
- Added a QA guard `src/Lotgd/QA/InterpolatedDatabaseQueryCheck.php` that flags dynamic `Database::query(...)` uses under `src/Lotgd` (with explicit legacy-whitelist for staged files) and tightened the `SqlAddslashesUsageCheck` baseline; updated `UPGRADING.md` to document what is fully migrated vs. staged. 
- Added regression tests covering the migrated security flows and QA checker: `tests/Security/PasskeyCredentialRepositoryDoctrineBindingTest.php`, `tests/CheckBanParameterBindingTest.php`, `tests/Security/SessionHardeningDoctrineBindingTest.php`, and `tests/QA/InterpolatedDatabaseQueryCheckTest.php`, plus a small adjustment to `tests/PlayerFunctionsCharCleanupTest.php` to reflect the DBAL path. 
- Security review: untrusted inputs (acctid/login/ip/uniqueid/credential IDs) are now bound at the DBAL boundary with explicit types; prepared statements are used for reads and writes; CSRF/authz controls and security-relevant logging were preserved and not weakened by these changes. 

### Testing

- Ran `php -l` on changed PHP files (all returned “No syntax errors detected”).
- Executed targeted PHPUnit suites for new/affected tests (`tests/Security/PasskeyCredentialRepositoryDoctrineBindingTest.php`, `tests/CheckBanParameterBindingTest.php`, `tests/Security/SessionHardeningDoctrineBindingTest.php`, `tests/QA/InterpolatedDatabaseQueryCheckTest.php`, `tests/QA/SqlAddslashesUsageCheckTest.php`) and they passed. 
- Ran `composer static` (static analysis/QA checks) and the added QA checks passed with no new blocking findings. 
- Ran full test suite with `composer test`; the suite completed successfully in this branch with existing baseline warnings/notices but no new failures introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7d2db60348329a0d0f8b40327e3d2)