### PR TITLE
refactor: migrate remaining core Database::query usage in prioritized Lotgd services

### DIFF
--- a/src/Lotgd/Battle.php
+++ b/src/Lotgd/Battle.php
@@ -299,13 +299,12 @@ class Battle
     public static function selectTaunt(): string
     {
         $connection = Database::getDoctrineConnection();
-        $result = $connection->executeQuery(
+        $row = $connection->executeQuery(
             'SELECT taunt FROM ' . Database::prefix('taunts') . ' ORDER BY rand(:seed) LIMIT 1',
             ['seed' => random_int(0, mt_getrandmax())],
             ['seed' => ParameterType::INTEGER]
-        );
-        if ($result->rowCount() > 0) {
-            $row = $result->fetchAssociative();
+        )->fetchAssociative();
+        if ($row !== false) {
             $taunt = $row['taunt'];
         } else {
             $taunt = "`5\"`6{badgyuname}'s mother wears combat boots`5\", screams {goodguyname}.";
@@ -320,13 +319,12 @@ class Battle
     public static function selectTauntArray(): array
     {
         $connection = Database::getDoctrineConnection();
-        $result = $connection->executeQuery(
+        $row = $connection->executeQuery(
             'SELECT taunt FROM ' . Database::prefix('taunts') . ' ORDER BY rand(:seed) LIMIT 1',
             ['seed' => random_int(0, mt_getrandmax())],
             ['seed' => ParameterType::INTEGER]
-        );
-        if ($result->rowCount() > 0) {
-            $row = $result->fetchAssociative();
+        )->fetchAssociative();
+        if ($row !== false) {
             $taunt = $row['taunt'];
         } else {
             $taunt = "`5\"`6{badgyuname}'s mother wears combat boots`5\", screams {goodguyname}.";

--- a/src/Lotgd/Battle.php
+++ b/src/Lotgd/Battle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use Doctrine\DBAL\ParameterType;
 use Lotgd\MySQL\Database;
 use Lotgd\Buffs;
 use Lotgd\FightBar;
@@ -297,12 +298,14 @@ class Battle
     */
     public static function selectTaunt(): string
     {
-        $sql = 'SELECT taunt FROM ' . Database::prefix('taunts') .
-        ' ORDER BY rand(' . random_int(0, mt_getrandmax()) . ') LIMIT 1';
-
-        $result = Database::query($sql);
-        if ($result) {
-            $row = Database::fetchAssoc($result);
+        $connection = Database::getDoctrineConnection();
+        $result = $connection->executeQuery(
+            'SELECT taunt FROM ' . Database::prefix('taunts') . ' ORDER BY rand(:seed) LIMIT 1',
+            ['seed' => random_int(0, mt_getrandmax())],
+            ['seed' => ParameterType::INTEGER]
+        );
+        if ($result->rowCount() > 0) {
+            $row = $result->fetchAssociative();
             $taunt = $row['taunt'];
         } else {
             $taunt = "`5\"`6{badgyuname}'s mother wears combat boots`5\", screams {goodguyname}.";
@@ -316,12 +319,14 @@ class Battle
     */
     public static function selectTauntArray(): array
     {
-        $sql = 'SELECT taunt FROM ' . Database::prefix('taunts') .
-        ' ORDER BY rand(' . random_int(0, mt_getrandmax()) . ') LIMIT 1';
-
-        $result = Database::query($sql);
-        if ($result) {
-            $row = Database::fetchAssoc($result);
+        $connection = Database::getDoctrineConnection();
+        $result = $connection->executeQuery(
+            'SELECT taunt FROM ' . Database::prefix('taunts') . ' ORDER BY rand(:seed) LIMIT 1',
+            ['seed' => random_int(0, mt_getrandmax())],
+            ['seed' => ParameterType::INTEGER]
+        );
+        if ($result->rowCount() > 0) {
+            $row = $result->fetchAssociative();
             $taunt = $row['taunt'];
         } else {
             $taunt = "`5\"`6{badgyuname}'s mother wears combat boots`5\", screams {goodguyname}.";
@@ -1069,9 +1074,13 @@ class Battle
             $nextindex++;
         }
         if (is_numeric($creature)) {
-            $sql = "SELECT * FROM " . Database::prefix("creatures") . " WHERE creatureid = $creature LIMIT 1";
-            $result = Database::query($sql);
-            if ($row = Database::fetchAssoc($result)) {
+            $connection = Database::getDoctrineConnection();
+            $row = $connection->executeQuery(
+                'SELECT * FROM ' . Database::prefix('creatures') . ' WHERE creatureid = :creatureid LIMIT 1',
+                ['creatureid' => (int) $creature],
+                ['creatureid' => ParameterType::INTEGER]
+            )->fetchAssociative();
+            if ($row !== false) {
                 $newenemies[$nextindex] = $row;
                 Output::getInstance()->output("`^%s`2 summons `^%s`2 for help!`n", $badguy['creaturename'], $row['creaturename']);
             }

--- a/src/Lotgd/ExpireChars.php
+++ b/src/Lotgd/ExpireChars.php
@@ -116,7 +116,7 @@ class ExpireChars
         $deletedAcctIds = [];
 
         foreach ($rows as $row) {
-            $connection->executeStatement('START TRANSACTION');
+            $connection->beginTransaction();
             $error = null;
             $cleanupPerformed = false;
             try {
@@ -132,13 +132,15 @@ class ExpireChars
                         throw new \RuntimeException('deletion failed');
                     }
 
-                    $connection->executeStatement('COMMIT');
+                    $connection->commit();
                     $deletedAcctIds[] = (int) $row['acctid'];
                 } else {
-                    $connection->executeStatement('ROLLBACK');
+                    $connection->rollBack();
                 }
             } catch (\Throwable $e) {
-                $connection->executeStatement('ROLLBACK');
+                if ($connection->isTransactionActive()) {
+                    $connection->rollBack();
+                }
                 $error = $e;
             }
 

--- a/src/Lotgd/ExpireChars.php
+++ b/src/Lotgd/ExpireChars.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Lotgd;
 
 use DateTimeImmutable;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\ParameterType;
 use Lotgd\Translator;
 use Lotgd\MySQL\Database;
 use Lotgd\Settings;
@@ -100,6 +102,7 @@ class ExpireChars
     private static function cleanupExpiredAccounts(): void
     {
         global $session;
+        $connection = Database::getDoctrineConnection();
         $settings = Settings::getInstance();
         $old = (int) $settings->getSetting('expireoldacct', 45);
         $new = (int) $settings->getSetting('expirenewacct', 10);
@@ -113,26 +116,29 @@ class ExpireChars
         $deletedAcctIds = [];
 
         foreach ($rows as $row) {
-            Database::query('START TRANSACTION');
+            $connection->executeStatement('START TRANSACTION');
             $error = null;
             $cleanupPerformed = false;
             try {
                 $cleanupPerformed = PlayerFunctions::charCleanup($row['acctid'], CHAR_DELETE_AUTO);
 
                 if ($cleanupPerformed) {
-                    $sql = 'DELETE FROM ' . Database::prefix('accounts') . ' WHERE acctid=' . (int) $row['acctid'];
-                    Database::query($sql);
-                    if (Database::affectedRows() !== 1) {
+                    $affectedRows = $connection->executeStatement(
+                        'DELETE FROM ' . Database::prefix('accounts') . ' WHERE acctid = :acctid',
+                        ['acctid' => (int) $row['acctid']],
+                        ['acctid' => ParameterType::INTEGER]
+                    );
+                    if ($affectedRows !== 1) {
                         throw new \RuntimeException('deletion failed');
                     }
 
-                    Database::query('COMMIT');
+                    $connection->executeStatement('COMMIT');
                     $deletedAcctIds[] = (int) $row['acctid'];
                 } else {
-                    Database::query('ROLLBACK');
+                    $connection->executeStatement('ROLLBACK');
                 }
             } catch (\Throwable $e) {
-                Database::query('ROLLBACK');
+                $connection->executeStatement('ROLLBACK');
                 $error = $e;
             }
 
@@ -177,31 +183,48 @@ class ExpireChars
      */
     private static function fetchAccountsToExpire(int $old, int $new, int $trash, ?DateTimeImmutable $now = null): array
     {
+        $connection = Database::getDoctrineConnection();
         $base = $now ?? new DateTimeImmutable('now');
         $conditions = [];
+        $params = ['noAccountExpiration' => NO_ACCOUNT_EXPIRATION];
+        $types = ['noAccountExpiration' => ParameterType::INTEGER];
+
         if ($old > 0) {
-            $conditions[] = "(laston < '" . $base->modify("-$old days")->format('Y-m-d H:i:s') . "')";
+            $conditions[] = '(laston < :oldThreshold)';
+            $params['oldThreshold'] = $base->modify("-$old days")->format('Y-m-d H:i:s');
+            $types['oldThreshold'] = ParameterType::STRING;
         }
         if ($new > 0) {
-            $conditions[] = "(laston < '" . $base->modify("-$new days")->format('Y-m-d H:i:s') . "' AND level=1 AND dragonkills=0)";
+            $conditions[] = '(laston < :newThreshold AND level = :newLevel AND dragonkills = :newDragonKills)';
+            $params['newThreshold'] = $base->modify("-$new days")->format('Y-m-d H:i:s');
+            $params['newLevel'] = 1;
+            $params['newDragonKills'] = 0;
+            $types['newThreshold'] = ParameterType::STRING;
+            $types['newLevel'] = ParameterType::INTEGER;
+            $types['newDragonKills'] = ParameterType::INTEGER;
         }
         if ($trash > 0) {
-            $conditions[] = "(laston < '" . $base->modify('-' . ($trash + 1) . ' days')->format('Y-m-d H:i:s') . "' AND level=1 AND experience < 10 AND dragonkills=0)";
+            $conditions[] = '(laston < :trashThreshold AND level = :trashLevel AND experience < :trashExperienceCap AND dragonkills = :trashDragonKills)';
+            $params['trashThreshold'] = $base->modify('-' . ($trash + 1) . ' days')->format('Y-m-d H:i:s');
+            $params['trashLevel'] = 1;
+            $params['trashExperienceCap'] = 10;
+            $params['trashDragonKills'] = 0;
+            $types['trashThreshold'] = ParameterType::STRING;
+            $types['trashLevel'] = ParameterType::INTEGER;
+            $types['trashExperienceCap'] = ParameterType::INTEGER;
+            $types['trashDragonKills'] = ParameterType::INTEGER;
         }
 
         if (empty($conditions)) {
             return [];
         }
 
-        $sql = 'SELECT login,acctid,dragonkills,level FROM ' . Database::prefix('accounts') .
-            ' WHERE (superuser&' . NO_ACCOUNT_EXPIRATION . ')=0 AND (' . implode(' OR ', $conditions) . ')';
-
-        $result = Database::query($sql);
-        $rows = [];
-        while ($row = Database::fetchAssoc($result)) {
-            $rows[] = $row;
-        }
-        return $rows;
+        return $connection->executeQuery(
+            'SELECT login,acctid,dragonkills,level FROM ' . Database::prefix('accounts')
+            . ' WHERE (superuser & :noAccountExpiration) = 0 AND (' . implode(' OR ', $conditions) . ')',
+            $params,
+            $types
+        )->fetchAllAssociative();
     }
 
     /**
@@ -250,14 +273,26 @@ class ExpireChars
      */
     private static function notifyUpcomingExpirations(): void
     {
+        $connection = Database::getDoctrineConnection();
         $settings = Settings::getInstance();
         $old = max(1, ((int) $settings->getSetting('expireoldacct', 45)) - ((int) $settings->getSetting('notifydaysbeforedeletion', 5)));
 
         $threshold = date('Y-m-d H:i:s', strtotime("-$old days"));
-        $sql = 'SELECT login,acctid,emailaddress FROM ' . Database::prefix('accounts')
-            . " WHERE (laston < '$threshold')"
-            . " AND emailaddress!='' AND sentnotice=0 AND (superuser&" . NO_ACCOUNT_EXPIRATION . ')=0';
-        $result = Database::query($sql);
+        $result = $connection->executeQuery(
+            'SELECT login,acctid,emailaddress FROM ' . Database::prefix('accounts')
+            . ' WHERE (laston < :threshold)'
+            . " AND emailaddress != '' AND sentnotice = :sentNotice AND (superuser & :noAccountExpiration) = 0",
+            [
+                'threshold' => $threshold,
+                'sentNotice' => 0,
+                'noAccountExpiration' => NO_ACCOUNT_EXPIRATION,
+            ],
+            [
+                'threshold' => ParameterType::STRING,
+                'sentNotice' => ParameterType::INTEGER,
+                'noAccountExpiration' => ParameterType::INTEGER,
+            ]
+        );
 
         $subject = Translator::translateInline(self::$settingsExtended->getSetting('expirationnoticesubject'));
         $message = Translator::translateInline(self::$settingsExtended->getSetting('expirationnoticetext'));
@@ -266,7 +301,7 @@ class ExpireChars
         $collector = [];
         $from = [$settings->getSetting('gameadminemail', 'postmaster@localhost') => $settings->getSetting('gameadminemail', 'postmaster@localhost')];
         $cc = [];
-        while ($row = Database::fetchAssoc($result)) {
+        while ($row = $result->fetchAssociative()) {
             $to = [$row['emailaddress'] => $row['emailaddress']];
             $body = str_replace('{charname}', $row['login'], $message);
             $mailResult = Mail::send($to, $body, $subject, $from, $cc, 'text/html', true);
@@ -285,8 +320,17 @@ class ExpireChars
         }
 
         if (!empty($collector)) {
-            $sql = 'UPDATE ' . Database::prefix('accounts') . ' SET sentnotice=1 WHERE acctid IN (' . implode(',', $collector) . ');';
-            Database::query($sql);
+            $connection->executeStatement(
+                'UPDATE ' . Database::prefix('accounts') . ' SET sentnotice = :sentNotice WHERE acctid IN (:acctids)',
+                [
+                    'sentNotice' => 1,
+                    'acctids' => array_map('intval', $collector),
+                ],
+                [
+                    'sentNotice' => ParameterType::INTEGER,
+                    'acctids' => ArrayParameterType::INTEGER,
+                ]
+            );
         }
     }
 }

--- a/src/Lotgd/Moderate.php
+++ b/src/Lotgd/Moderate.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use Doctrine\DBAL\ParameterType;
 use Lotgd\Settings;
 use Lotgd\Nav as Navigation;
 use Lotgd\Output;
@@ -44,36 +45,60 @@ class Moderate
      *
      * @return array<int,array<string,mixed>>
      */
-    private static function getComments(string $sectselect, int $limit, int $com, int $cid, string $section): array
+    private static function getComments(string $whereSql, array $params, array $types, int $limit, int $com, int $cid): array
     {
+        $connection = Database::getDoctrineConnection();
         // Retrieve the batch of comments for this page
         if ($cid == 0) {
-            $sql = 'SELECT ' . Database::prefix('commentary') . '.*, '
+            $queryParams = array_merge($params, [
+                'offset' => $com * $limit,
+                'limit' => $limit,
+            ]);
+            $queryTypes = array_merge($types, [
+                'offset' => ParameterType::INTEGER,
+                'limit' => ParameterType::INTEGER,
+            ]);
+            $result = $connection->executeQuery(
+                'SELECT ' . Database::prefix('commentary') . '.*, '
                 . Database::prefix('accounts') . '.name, '
                 . Database::prefix('accounts') . '.acctid, '
                 . Database::prefix('accounts') . '.clanrank, '
                 . Database::prefix('clans') . '.clanshort FROM ' . Database::prefix('commentary') . ' LEFT JOIN '
                 . Database::prefix('accounts') . ' ON ' . Database::prefix('accounts') . '.acctid = ' . Database::prefix('commentary') . '.author LEFT JOIN '
                 . Database::prefix('clans') . ' ON ' . Database::prefix('clans') . '.clanid=' . Database::prefix('accounts') . '.clanid WHERE '
-                . "$sectselect (" . Database::prefix('accounts') . ".locked=0 OR " . Database::prefix('accounts') . ".locked is null ) ORDER BY commentid DESC LIMIT " . ($com * $limit) . ",$limit";
-            $result = Database::query($sql);
+                . $whereSql
+                . ' ORDER BY commentid DESC LIMIT :offset,:limit',
+                $queryParams,
+                $queryTypes
+            );
         } else {
-            $sql = 'SELECT ' . Database::prefix('commentary') . '.*, '
+            $queryParams = array_merge($params, [
+                'cid' => $cid,
+                'limit' => $limit,
+            ]);
+            $queryTypes = array_merge($types, [
+                'cid' => ParameterType::INTEGER,
+                'limit' => ParameterType::INTEGER,
+            ]);
+            $result = $connection->executeQuery(
+                'SELECT ' . Database::prefix('commentary') . '.*, '
                 . Database::prefix('accounts') . '.name, '
                 . Database::prefix('accounts') . '.acctid, '
                 . Database::prefix('accounts') . '.clanrank, '
                 . Database::prefix('clans') . '.clanshort FROM ' . Database::prefix('commentary') . ' LEFT JOIN '
                 . Database::prefix('accounts') . ' ON ' . Database::prefix('accounts') . '.acctid = ' . Database::prefix('commentary') . '.author LEFT JOIN '
                 . Database::prefix('clans') . ' ON ' . Database::prefix('clans') . '.clanid=' . Database::prefix('accounts') . '.clanid WHERE '
-                . "$sectselect (" . Database::prefix('accounts') . ".locked=0 OR " . Database::prefix('accounts') . ".locked is null ) AND commentid > '$cid' ORDER BY commentid ASC LIMIT $limit";
-            $result = Database::query($sql);
+                . $whereSql
+                . ' AND commentid > :cid ORDER BY commentid ASC LIMIT :limit',
+                $queryParams,
+                $queryTypes
+            );
         }
 
         $commentbuffer = [];
-        while ($row = Database::fetchAssoc($result)) {
+        while ($row = $result->fetchAssociative()) {
             $commentbuffer[] = $row;
         }
-        Database::freeResult($result);
         if ($cid > 0) {
             // Reverse order when appending new comments to the top
             $commentbuffer = array_reverse($commentbuffer);
@@ -88,6 +113,7 @@ class Moderate
     private static function showNavLinks(string $section, int $limit, int $cid, int $rowcount, bool $jump, int $com, string $requestUri, int $newadded): void
     {
         global $session;
+        $connection = Database::getDoctrineConnection();
 
         $output = Output::getInstance();
 
@@ -98,10 +124,17 @@ class Moderate
         $lastu = Translator::translateInline('Last Page &gt;&gt;');
 
         if ($rowcount >= $limit || $cid > 0) {
-            $sql = "SELECT count(commentid) AS c FROM " . Database::prefix('commentary') . " WHERE section='$section' AND postdate > '{$session['user']['recentcomments']}'";
-            $r = Database::query($sql);
-            $val = Database::fetchAssoc($r);
-            Database::freeResult($r);
+            $val = $connection->executeQuery(
+                'SELECT count(commentid) AS c FROM ' . Database::prefix('commentary') . ' WHERE section = :section AND postdate > :recentComments',
+                [
+                    'section' => $section,
+                    'recentComments' => (string) $session['user']['recentcomments'],
+                ],
+                [
+                    'section' => ParameterType::STRING,
+                    'recentComments' => ParameterType::STRING,
+                ]
+            )->fetchAssociative();
             $val = round($val['c'] / $limit + 0.5, 0) - 1;
             if ($val > 0) {
                 $first = Sanitize::comscrollSanitize($requestUri) . '&comscroll=' . $val;
@@ -176,30 +209,42 @@ class Moderate
         $charset = $settings->getSetting('charset', 'UTF-8');
 
         // Decide whether to limit to a specific section or view all
+        $whereClauses = [];
+        $params = [];
+        $types = [];
         if ($viewall === false) {
             $output->rawOutput("<a name='$section'></a>");
             $args = HookHandler::hook('blockcommentarea', ['section' => $section]);
             if (isset($args['block']) && ($args['block'] == 'yes')) {
                 return;
             }
-            $sectselect = "section='$section' AND ";
-        } else {
-            $sectselect = '';
+            $whereClauses[] = 'section = :section';
+            $params['section'] = $section;
+            $types['section'] = ParameterType::STRING;
         }
+
+        $whereClauses[] = '(' . Database::prefix('accounts') . '.locked = :locked OR ' . Database::prefix('accounts') . '.locked is null)';
+        $params['locked'] = 0;
+        $types['locked'] = ParameterType::INTEGER;
 
         // Some sections may be globally excluded from moderation output
         $excludes = $settings->getSetting('moderateexcludes', '');
         if ($excludes != '') {
             $array = explode(',', $excludes);
-            foreach ($array as $entry) {
-                $sectselect .= "section NOT LIKE '$entry' AND ";
+            foreach ($array as $index => $entry) {
+                $whereClauses[] = 'section NOT LIKE :excludedSection' . $index;
+                $params['excludedSection' . $index] = $entry;
+                $types['excludedSection' . $index] = ParameterType::STRING;
             }
 
             $excludedList = implode(', ', $array);
             if ($session['user']['superuser'] & SU_EDIT_COMMENTS) {
                 $output->output('Excluded sections: %s`n', $excludedList);
             }
+        } else {
+            $array = [];
         }
+        $whereSql = implode(' AND ', $whereClauses);
 
         // Determine which translation schema to use for output
         if ($schema === null) {
@@ -246,22 +291,25 @@ class Moderate
         // Count how many new comments have been added since the users last visit
         // Determine how many new comments exist beyond the last id
         if ($com > 0 || $cid > 0) {
-            $sql = 'SELECT COUNT(commentid) AS newadded FROM '
+            $queryParams = array_merge($params, ['cid' => $cid]);
+            $queryTypes = array_merge($types, ['cid' => ParameterType::INTEGER]);
+            $row = Database::getDoctrineConnection()->executeQuery(
+                'SELECT COUNT(commentid) AS newadded FROM '
                 . Database::prefix('commentary') . ' LEFT JOIN '
                 . Database::prefix('accounts') . ' ON '
                 . Database::prefix('accounts') . '.acctid = '
-                . Database::prefix('commentary') . ".author WHERE $sectselect "
-                . '(' . Database::prefix('accounts') . '.locked=0 or ' . Database::prefix('accounts') . ".locked is null) AND commentid > '$cid'";
-            $result = Database::query($sql);
-            $row = Database::fetchAssoc($result);
-            Database::freeResult($result);
+                . Database::prefix('commentary') . '.author WHERE ' . $whereSql
+                . ' AND commentid > :cid',
+                $queryParams,
+                $queryTypes
+            )->fetchAssociative();
             $newadded = (int)$row['newadded'];
         } else {
             $newadded = 0;
         }
 
         // Load the actual comment rows
-        $commentbuffer = self::getComments($sectselect, $limit, $com, $cid, $section);
+        $commentbuffer = self::getComments($whereSql, $params, $types, $limit, $com, $cid);
 
         $rowcount = count($commentbuffer);
         if ($rowcount > 0) {

--- a/src/Lotgd/Moderate.php
+++ b/src/Lotgd/Moderate.php
@@ -113,7 +113,6 @@ class Moderate
     private static function showNavLinks(string $section, int $limit, int $cid, int $rowcount, bool $jump, int $com, string $requestUri, int $newadded): void
     {
         global $session;
-        $connection = Database::getDoctrineConnection();
 
         $output = Output::getInstance();
 
@@ -124,7 +123,7 @@ class Moderate
         $lastu = Translator::translateInline('Last Page &gt;&gt;');
 
         if ($rowcount >= $limit || $cid > 0) {
-            $val = $connection->executeQuery(
+            $val = Database::getDoctrineConnection()->executeQuery(
                 'SELECT count(commentid) AS c FROM ' . Database::prefix('commentary') . ' WHERE section = :section AND postdate > :recentComments',
                 [
                     'section' => $section,

--- a/src/Lotgd/Motd.php
+++ b/src/Lotgd/Motd.php
@@ -31,12 +31,15 @@ class Motd
     public static function motdAdmin(int $id, bool $poll = false): void
     {
         global $session;
+        $connection = Database::getDoctrineConnection();
         $id = (int)$id;
         if ($id > 0) {
-            $sql = 'SELECT motdtitle,motdbody,motddate,motdauthor,motdtype FROM ' . Database::prefix('motd') . " WHERE motditem=$id";
-            $result = Database::query($sql);
-            if (Database::numRows($result) > 0) {
-                $row = Database::fetchAssoc($result);
+            $row = $connection->executeQuery(
+                'SELECT motdtitle,motdbody,motddate,motdauthor,motdtype FROM ' . Database::prefix('motd') . ' WHERE motditem = :motditem',
+                ['motditem' => $id],
+                ['motditem' => ParameterType::INTEGER]
+            )->fetchAssociative();
+            if ($row !== false) {
                 $subject = $row['motdtitle'];
                 $body = $row['motdbody'];
                 $date = $row['motddate'];
@@ -48,9 +51,13 @@ class Motd
                 }
             }
         }
-        $sql = 'SELECT motdtitle,motdbody,motddate,motdauthor,motditem,motdtype FROM ' . Database::prefix('motd') . ($poll ? ' WHERE motdtype=1' : ' WHERE motdtype=0') . ' ORDER BY motddate DESC';
-        $result = Database::query($sql);
-        while ($row = Database::fetchAssoc($result)) {
+        $result = $connection->executeQuery(
+            'SELECT motdtitle,motdbody,motddate,motdauthor,motditem,motdtype FROM ' . Database::prefix('motd')
+            . ' WHERE motdtype = :motdtype ORDER BY motddate DESC',
+            ['motdtype' => $poll ? 1 : 0],
+            ['motdtype' => ParameterType::INTEGER]
+        );
+        while ($row = $result->fetchAssociative()) {
             if ((int)$row['motdtype'] === 1) {
                 self::pollItem((int)$row['motditem'], $row['motdtitle'], $row['motdbody'], (string)$row['motdauthor'], $row['motddate']);
             } else {
@@ -87,10 +94,20 @@ class Motd
         global $session;
 
         $acctid = isset($session['user']['acctid']) ? (int)$session['user']['acctid'] : 0;
+        $connection = Database::getDoctrineConnection();
 
-        $sql = 'SELECT count(resultid) AS c, MAX(choice) AS choice FROM ' . Database::prefix('pollresults') . " WHERE motditem='$id' AND account='$acctid'";
-        $result = Database::query($sql);
-        $row = Database::numRows($result) > 0 ? Database::fetchAssoc($result) : [];
+        $row = $connection->executeQuery(
+            'SELECT count(resultid) AS c, MAX(choice) AS choice FROM ' . Database::prefix('pollresults')
+            . ' WHERE motditem = :motditem AND account = :acctid',
+            [
+                'motditem' => $id,
+                'acctid' => $acctid,
+            ],
+            [
+                'motditem' => ParameterType::INTEGER,
+                'acctid' => ParameterType::INTEGER,
+            ]
+        )->fetchAssociative() ?: [];
         $choice = $row['choice'] ?? null;
 
         $bodyData = @unserialize(stripslashes($body));
@@ -105,7 +122,7 @@ class Motd
         $output->outputNotl('<div>%s</div>', $bodyText, true);
         $output->outputNotl('<small>%s %s - %s</small>', Translator::translateInline('Posted by'), $author, $date, true);
 
-        $sql = 'SELECT count(resultid) AS c, choice FROM ' . Database::prefix('pollresults') . " WHERE motditem='$id' GROUP BY choice ORDER BY choice";
+        $sql = 'SELECT count(resultid) AS c, choice FROM ' . Database::prefix('pollresults') . " WHERE motditem='" . (int) $id . "' GROUP BY choice ORDER BY choice";
         $results = Database::queryCached($sql, "poll-$id");
         $choices = [];
         $totalanswers = 0;
@@ -160,10 +177,13 @@ class Motd
      */
     public static function motdForm(int $id, array $data = []): void
     {
-        $sql = 'SELECT motdtitle,motdbody,motdtype FROM ' . Database::prefix('motd') . " WHERE motditem='$id'";
-        $result = Database::query($sql);
-        if (Database::numRows($result) > 0) {
-            $row = Database::fetchAssoc($result);
+        $connection = Database::getDoctrineConnection();
+        $row = $connection->executeQuery(
+            'SELECT motdtitle,motdbody,motdtype FROM ' . Database::prefix('motd') . ' WHERE motditem = :motditem',
+            ['motditem' => $id],
+            ['motditem' => ParameterType::INTEGER]
+        )->fetchAssociative();
+        if ($row !== false) {
             $title = $row['motdtitle'];
             $body = $row['motdbody'];
             $poll = $row['motdtype'];
@@ -332,8 +352,12 @@ class Motd
      */
     public static function motdDel(int $id): void
     {
-        $sql = 'DELETE FROM ' . Database::prefix('motd') . " WHERE motditem='$id'";
-        Database::query($sql);
+        $connection = Database::getDoctrineConnection();
+        $connection->executeStatement(
+            'DELETE FROM ' . Database::prefix('motd') . ' WHERE motditem = :motditem',
+            ['motditem' => $id],
+            ['motditem' => ParameterType::INTEGER]
+        );
         DataCache::getInstance()->invalidatedatacache('motd');
         DataCache::getInstance()->invalidatedatacache('lastmotd');
         DataCache::getInstance()->invalidatedatacache('motddate');

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use Doctrine\DBAL\ParameterType;
 use Lotgd\MySQL\Database;
 use Lotgd\Buffs;
 use Lotgd\CharStats;
@@ -421,18 +422,45 @@ class PageParts
                     $onlinecount = $list['count'];
                     $ret = $list['list'];
                 } else {
+                    $connection = Database::getDoctrineConnection();
                     if ($mode === 2) {
                         $minutes = $minutesSetting;
-                        $sql = "SELECT name,alive,location,sex,level,laston,loggedin,lastip,uniqueid FROM " . Database::prefix("accounts") . " WHERE locked=0 AND laston>'" . date("Y-m-d H:i:s", strtotime("-" . $minutes . " minutes")) . "' ORDER BY level DESC";
+                        $lastOnThreshold = date("Y-m-d H:i:s", strtotime("-" . $minutes . " minutes"));
+                        $result = $connection->executeQuery(
+                            'SELECT name,alive,location,sex,level,laston,loggedin,lastip,uniqueid FROM '
+                            . Database::prefix('accounts')
+                            . ' WHERE locked = :locked AND laston > :lastOnThreshold ORDER BY level DESC',
+                            [
+                                'locked' => 0,
+                                'lastOnThreshold' => $lastOnThreshold,
+                            ],
+                            [
+                                'locked' => ParameterType::INTEGER,
+                                'lastOnThreshold' => ParameterType::STRING,
+                            ]
+                        );
                     } else {
-                        $sql = "SELECT name,alive,location,sex,level,laston,loggedin,lastip,uniqueid FROM " . Database::prefix("accounts") . " WHERE locked=0 AND loggedin=1 AND laston>'" . date("Y-m-d H:i:s", strtotime("-" . $loginTimeout . " seconds")) . "' ORDER BY level DESC";
+                        $lastOnThreshold = date("Y-m-d H:i:s", strtotime("-" . $loginTimeout . " seconds"));
+                        $result = $connection->executeQuery(
+                            'SELECT name,alive,location,sex,level,laston,loggedin,lastip,uniqueid FROM '
+                            . Database::prefix('accounts')
+                            . ' WHERE locked = :locked AND loggedin = :loggedIn AND laston > :lastOnThreshold ORDER BY level DESC',
+                            [
+                                'locked' => 0,
+                                'loggedIn' => 1,
+                                'lastOnThreshold' => $lastOnThreshold,
+                            ],
+                            [
+                                'locked' => ParameterType::INTEGER,
+                                'loggedIn' => ParameterType::INTEGER,
+                                'lastOnThreshold' => ParameterType::STRING,
+                            ]
+                        );
                     }
-                    $result = Database::query($sql);
                     $rows = array();
-                    while ($row = Database::fetchAssoc($result)) {
+                    while ($row = $result->fetchAssociative()) {
                         $rows[] = $row;
                     }
-                    Database::freeResult($result);
                     $rows = HookHandler::hook("loggedin", $rows);
                     if ($mode === 0) {
                         $ret .= $output->appoencode(sprintf(Translator::translateInline("`bOnline Characters (%s players):`b`n"), count($rows)));
@@ -995,10 +1023,29 @@ class PageParts
         }
         $session['user']['gentimecount']++;
         if ($settings->getSetting('debug', 0)) {
-            $sql = "INSERT INTO " . Database::prefix('debug') . " VALUES (0,'pagegentime','runtime','" . PhpGenericEnvironment::getScriptName() . "','" . ($gentime) . "');";
-            Database::query($sql);
-            $sql = "INSERT INTO " . Database::prefix('debug') . " VALUES (0,'pagegentime','dbtime','" . PhpGenericEnvironment::getScriptName() . "','" . (round(Database::getInfo('querytime', 0), 3)) . "');";
-            Database::query($sql);
+            $connection = Database::getDoctrineConnection();
+            $connection->executeStatement(
+                'INSERT INTO ' . Database::prefix('debug') . " VALUES (0,'pagegentime','runtime',:script,:runtime)",
+                [
+                    'script' => PhpGenericEnvironment::getScriptName(),
+                    'runtime' => (string) $gentime,
+                ],
+                [
+                    'script' => ParameterType::STRING,
+                    'runtime' => ParameterType::STRING,
+                ]
+            );
+            $connection->executeStatement(
+                'INSERT INTO ' . Database::prefix('debug') . " VALUES (0,'pagegentime','dbtime',:script,:dbtime)",
+                [
+                    'script' => PhpGenericEnvironment::getScriptName(),
+                    'dbtime' => (string) round(Database::getInfo('querytime', 0), 3),
+                ],
+                [
+                    'script' => ParameterType::STRING,
+                    'dbtime' => ParameterType::STRING,
+                ]
+            );
         }
         $queryCount = Database::getQueryCount();
         $querytime = Database::getInfo('querytime', 0);

--- a/src/Lotgd/Repository/ClanRepository.php
+++ b/src/Lotgd/Repository/ClanRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lotgd\Repository;
 
+use Doctrine\DBAL\ParameterType;
 use Lotgd\MySQL\Database;
 
 /**
@@ -16,10 +17,13 @@ class ClanRepository
      */
     public static function fetchAccountName(int $acctid): ?string
     {
-        $sql = 'SELECT name FROM ' . Database::prefix('accounts') . " WHERE acctid={$acctid}";
-        $result = Database::query($sql);
-        if (Database::numRows($result) > 0) {
-            $row = Database::fetchAssoc($result);
+        $connection = Database::getDoctrineConnection();
+        $row = $connection->fetchAssociative(
+            'SELECT name FROM ' . Database::prefix('accounts') . ' WHERE acctid = :acctid',
+            ['acctid' => $acctid],
+            ['acctid' => ParameterType::INTEGER]
+        );
+        if ($row !== false && isset($row['name'])) {
             return $row['name'];
         }
 
@@ -33,14 +37,13 @@ class ClanRepository
      */
     public static function countMembersByRank(int $clanId): array
     {
-        $sql = 'SELECT count(acctid) AS c, clanrank FROM ' . Database::prefix('accounts') . " WHERE clanid={$clanId} GROUP BY clanrank ORDER BY clanrank DESC";
-        $result = Database::query($sql);
-        $rows = [];
-        while ($row = Database::fetchAssoc($result)) {
-            $rows[] = $row;
-        }
-
-        return $rows;
+        $connection = Database::getDoctrineConnection();
+        return $connection->executeQuery(
+            'SELECT count(acctid) AS c, clanrank FROM ' . Database::prefix('accounts')
+            . ' WHERE clanid = :clanId GROUP BY clanrank ORDER BY clanrank DESC',
+            ['clanId' => $clanId],
+            ['clanId' => ParameterType::INTEGER]
+        )->fetchAllAssociative();
     }
 
     /**
@@ -50,13 +53,21 @@ class ClanRepository
      */
     public static function getHighestRankingMember(int $clanId): ?array
     {
-        $sql = 'SELECT name,acctid,clanrank FROM ' . Database::prefix('accounts') . ' WHERE clanid=' . $clanId . ' AND clanrank > ' . CLAN_APPLICANT . ' ORDER BY clanrank DESC, clanjoindate';
-        $result = Database::query($sql);
-        if (Database::numRows($result)) {
-            return Database::fetchAssoc($result);
-        }
+        $connection = Database::getDoctrineConnection();
+        $row = $connection->executeQuery(
+            'SELECT name,acctid,clanrank FROM ' . Database::prefix('accounts')
+            . ' WHERE clanid = :clanId AND clanrank > :applicantRank ORDER BY clanrank DESC, clanjoindate',
+            [
+                'clanId' => $clanId,
+                'applicantRank' => CLAN_APPLICANT,
+            ],
+            [
+                'clanId' => ParameterType::INTEGER,
+                'applicantRank' => ParameterType::INTEGER,
+            ]
+        )->fetchAssociative();
 
-        return null;
+        return $row === false ? null : $row;
     }
 
     /**
@@ -64,7 +75,17 @@ class ClanRepository
      */
     public static function promoteToLeader(int $acctid): void
     {
-        $sql = 'UPDATE ' . Database::prefix('accounts') . ' SET clanrank=' . CLAN_LEADER . " WHERE acctid={$acctid}";
-        Database::query($sql);
+        $connection = Database::getDoctrineConnection();
+        $connection->executeStatement(
+            'UPDATE ' . Database::prefix('accounts') . ' SET clanrank = :leaderRank WHERE acctid = :acctid',
+            [
+                'leaderRank' => CLAN_LEADER,
+                'acctid' => $acctid,
+            ],
+            [
+                'leaderRank' => ParameterType::INTEGER,
+                'acctid' => ParameterType::INTEGER,
+            ]
+        );
     }
 }

--- a/src/Lotgd/ServerFunctions.php
+++ b/src/Lotgd/ServerFunctions.php
@@ -28,7 +28,7 @@ class ServerFunctions
         $settings = Settings::getInstance();
         if (abs($settings->getSetting('OnlineCountLast', 0) - strtotime('now')) > 60) {
             $lastOnThreshold = date('Y-m-d H:i:s', strtotime('-' . $settings->getSetting('LOGINTIMEOUT', 900) . ' seconds'));
-            $onlinecount = $connection->executeQuery(
+            $onlinecount = (int) $connection->executeQuery(
                 'SELECT count(acctid) as counter FROM ' . Database::prefix('accounts')
                 . ' WHERE locked = :locked AND loggedin = :loggedIn AND laston > :lastOnThreshold',
                 [
@@ -41,8 +41,7 @@ class ServerFunctions
                     'loggedIn' => ParameterType::INTEGER,
                     'lastOnThreshold' => ParameterType::STRING,
                 ]
-            )->fetchAssociative();
-            $onlinecount = (int) ($onlinecount['counter'] ?? $onlinecount['total_count'] ?? 0);
+            )->fetchOne();
             $settings->saveSetting('OnlineCount', $onlinecount);
             $settings->saveSetting('OnlineCountLast', strtotime('now'));
         } else {

--- a/src/Lotgd/ServerFunctions.php
+++ b/src/Lotgd/ServerFunctions.php
@@ -24,9 +24,9 @@ class ServerFunctions
      */
     public static function isTheServerFull(): bool
     {
-        $connection = Database::getDoctrineConnection();
         $settings = Settings::getInstance();
         if (abs($settings->getSetting('OnlineCountLast', 0) - strtotime('now')) > 60) {
+            $connection = Database::getDoctrineConnection();
             $lastOnThreshold = date('Y-m-d H:i:s', strtotime('-' . $settings->getSetting('LOGINTIMEOUT', 900) . ' seconds'));
             $onlinecount = (int) $connection->executeQuery(
                 'SELECT count(acctid) as counter FROM ' . Database::prefix('accounts')

--- a/src/Lotgd/ServerFunctions.php
+++ b/src/Lotgd/ServerFunctions.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\ParameterType;
 use Lotgd\MySQL\Database;
 use Lotgd\Settings;
 use Lotgd\Modules\HookHandler;
@@ -22,12 +24,25 @@ class ServerFunctions
      */
     public static function isTheServerFull(): bool
     {
+        $connection = Database::getDoctrineConnection();
         $settings = Settings::getInstance();
         if (abs($settings->getSetting('OnlineCountLast', 0) - strtotime('now')) > 60) {
-            $sql = "SELECT count(acctid) as counter FROM " . Database::prefix('accounts') . " WHERE locked=0 AND loggedin=1 AND laston>'" . date('Y-m-d H:i:s', strtotime('-' . $settings->getSetting('LOGINTIMEOUT', 900) . ' seconds')) . "'";
-            $result = Database::query($sql);
-            $onlinecount = Database::fetchAssoc($result);
-            $onlinecount = $onlinecount['counter'];
+            $lastOnThreshold = date('Y-m-d H:i:s', strtotime('-' . $settings->getSetting('LOGINTIMEOUT', 900) . ' seconds'));
+            $onlinecount = $connection->executeQuery(
+                'SELECT count(acctid) as counter FROM ' . Database::prefix('accounts')
+                . ' WHERE locked = :locked AND loggedin = :loggedIn AND laston > :lastOnThreshold',
+                [
+                    'locked' => 0,
+                    'loggedIn' => 1,
+                    'lastOnThreshold' => $lastOnThreshold,
+                ],
+                [
+                    'locked' => ParameterType::INTEGER,
+                    'loggedIn' => ParameterType::INTEGER,
+                    'lastOnThreshold' => ParameterType::STRING,
+                ]
+            )->fetchAssociative();
+            $onlinecount = (int) ($onlinecount['counter'] ?? $onlinecount['total_count'] ?? 0);
             $settings->saveSetting('OnlineCount', $onlinecount);
             $settings->saveSetting('OnlineCountLast', strtotime('now'));
         } else {
@@ -45,16 +60,26 @@ class ServerFunctions
      */
     public static function resetAllDragonkillPoints(int|array|false $acctid = false): void
     {
+        $connection = Database::getDoctrineConnection();
+        $params = [];
+        $types = [];
         if ($acctid === false) {
             $where = '';
         } elseif (is_array($acctid)) {
-            $where = 'WHERE acctid IN (' . implode(',', $acctid) . ')';
+            $where = 'WHERE acctid IN (:acctids)';
+            $params['acctids'] = array_map('intval', $acctid);
+            $types['acctids'] = ArrayParameterType::INTEGER;
         } else {
-            $where = "WHERE acctid=$acctid";
+            $where = 'WHERE acctid = :acctid';
+            $params['acctid'] = $acctid;
+            $types['acctid'] = ParameterType::INTEGER;
         }
-        $sql = 'SELECT acctid,dragonpoints FROM ' . Database::prefix('accounts') . " $where";
-        $result = Database::query($sql);
-        while ($row = Database::fetchAssoc($result)) {
+        $result = $connection->executeQuery(
+            'SELECT acctid,dragonpoints FROM ' . Database::prefix('accounts') . " $where",
+            $params,
+            $types
+        );
+        while ($row = $result->fetchAssociative()) {
             $dkpoints = $row['dragonpoints'];
             if ($dkpoints == '') {
                 continue;
@@ -98,9 +123,15 @@ class ServerFunctions
                         break;
                 }
             }
+            // $resetactions only contains whitelisted static column fragments
+            // emitted by the switch above; values are cast to integers before
+            // interpolation. SQL identifiers cannot be parameterized in DBAL.
             $resetactions = count($sets) > 0 ? ',' . implode(',', $sets) : '';
-            $sql = 'UPDATE ' . Database::prefix('accounts') . " SET dragonpoints=''$resetactions WHERE acctid=" . $row['acctid'];
-            Database::query($sql);
+            $connection->executeStatement(
+                'UPDATE ' . Database::prefix('accounts') . " SET dragonpoints=''$resetactions WHERE acctid = :acctid",
+                ['acctid' => (int) $row['acctid']],
+                ['acctid' => ParameterType::INTEGER]
+            );
             HookHandler::hook('dragonpointreset', [$row]);
         }
     }

--- a/tests/CharCleanupDeletesAccountTest.php
+++ b/tests/CharCleanupDeletesAccountTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lotgd\Tests;
 
+use Lotgd\MySQL\Database as CoreDatabase;
 use Lotgd\Tests\Stubs\Database;
 use PHPUnit\Framework\TestCase;
 
@@ -19,6 +20,10 @@ final class CharCleanupDeletesAccountTest extends TestCase
     {
         Database::$queries = [];
         Database::$mockResults = [];
+        CoreDatabase::resetDoctrineConnection();
+        $connection = CoreDatabase::getDoctrineConnection();
+        $connection->queries = [];
+        $connection->executeStatementResults = [];
     }
 
     public function testExpireCharsDeletesOnCleanupSuccess(): void
@@ -36,12 +41,12 @@ final class CharCleanupDeletesAccountTest extends TestCase
         Database::$mockResults = [
             [["acctid" => 1, "login" => "test", "dragonkills" => 0, "level" => 1]],
         ];
-        Database::$affected_rows = 1;
 
         \Lotgd\ExpireChars::cleanupExpiredAccountsForTests();
 
-        $this->assertStringContainsString('START TRANSACTION', Database::$queries[1] ?? '');
-        $this->assertStringContainsString('DELETE FROM accounts WHERE acctid=1', Database::$queries[2] ?? '');
-        $this->assertStringContainsString('COMMIT', Database::$queries[3] ?? '');
+        $queries = CoreDatabase::getDoctrineConnection()->queries;
+        $this->assertStringContainsString('START TRANSACTION', $queries[1] ?? '');
+        $this->assertStringContainsString('DELETE FROM accounts WHERE acctid = :acctid', $queries[2] ?? '');
+        $this->assertStringContainsString('COMMIT', $queries[3] ?? '');
     }
 }

--- a/tests/CharCleanupFailurePreventsDeletionTest.php
+++ b/tests/CharCleanupFailurePreventsDeletionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lotgd\Tests;
 
+use Lotgd\MySQL\Database as CoreDatabase;
 use Lotgd\Tests\Stubs\Database;
 use PHPUnit\Framework\TestCase;
 
@@ -19,6 +20,10 @@ final class CharCleanupFailurePreventsDeletionTest extends TestCase
     {
         Database::$queries = [];
         Database::$mockResults = [];
+        CoreDatabase::resetDoctrineConnection();
+        $connection = CoreDatabase::getDoctrineConnection();
+        $connection->queries = [];
+        $connection->executeStatementResults = [];
     }
 
     public function testExpireCharsDoesNotDeleteOnCleanupFailure(): void
@@ -39,11 +44,12 @@ final class CharCleanupFailurePreventsDeletionTest extends TestCase
 
         \Lotgd\ExpireChars::cleanupExpiredAccountsForTests();
 
-        foreach (Database::$queries as $query) {
+        $queries = CoreDatabase::getDoctrineConnection()->queries;
+        foreach ($queries as $query) {
             $this->assertStringNotContainsString('DELETE FROM accounts', $query);
         }
-        $this->assertContains('ROLLBACK', Database::$queries);
-        $this->assertNotContains('COMMIT', Database::$queries);
+        $this->assertContains('ROLLBACK', $queries);
+        $this->assertNotContains('COMMIT', $queries);
     }
 
     public function testUserDelAbortsOnCleanupFailure(): void

--- a/tests/CleanupExpiredAccountsLogsFailureTest.php
+++ b/tests/CleanupExpiredAccountsLogsFailureTest.php
@@ -48,9 +48,7 @@ final class CleanupExpiredAccountsLogsFailureTest extends TestCase
             [["acctid" => 1, "login" => "test", "dragonkills" => 0, "level" => 1]],
         ];
         CoreDatabase::getDoctrineConnection()->executeStatementResults = [
-            1, // START TRANSACTION
             0, // DELETE affects 0 rows => failure
-            1, // ROLLBACK
         ];
 
         ExpireChars::cleanupExpiredAccountsForTests();
@@ -69,9 +67,7 @@ final class CleanupExpiredAccountsLogsFailureTest extends TestCase
             [["acctid" => 1, "login" => "test", "dragonkills" => 0, "level" => 1]],
         ];
         CoreDatabase::getDoctrineConnection()->executeStatementResults = [
-            1, // START TRANSACTION
             1, // DELETE
-            1, // COMMIT
         ];
 
         ExpireChars::cleanupExpiredAccountsForTests();

--- a/tests/CleanupExpiredAccountsLogsFailureTest.php
+++ b/tests/CleanupExpiredAccountsLogsFailureTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lotgd\Tests;
 
 use Lotgd\ExpireChars;
+use Lotgd\MySQL\Database as CoreDatabase;
 use Lotgd\Tests\Stubs\Database;
 use PHPUnit\Framework\TestCase;
 
@@ -21,6 +22,10 @@ final class CleanupExpiredAccountsLogsFailureTest extends TestCase
         Database::$queries = [];
         Database::$mockResults = [];
         Database::$affected_rows = 0;
+        CoreDatabase::resetDoctrineConnection();
+        $connection = CoreDatabase::getDoctrineConnection();
+        $connection->queries = [];
+        $connection->executeStatementResults = [];
 
         if (! class_exists('Lotgd\\Settings', false)) {
             eval('namespace Lotgd; class Settings { public function __construct(string $t = "settings_extended"){} public static function getInstance(): self { return new self(); } public function getSetting(string $n, mixed $d = null): mixed { return $d; } public function saveSetting(string $n, mixed $v): void {} }');
@@ -41,11 +46,12 @@ final class CleanupExpiredAccountsLogsFailureTest extends TestCase
     {
         Database::$mockResults = [
             [["acctid" => 1, "login" => "test", "dragonkills" => 0, "level" => 1]],
-            true,
-            true,
-            true,
         ];
-        Database::$affected_rows = 0;
+        CoreDatabase::getDoctrineConnection()->executeStatementResults = [
+            1, // START TRANSACTION
+            0, // DELETE affects 0 rows => failure
+            1, // ROLLBACK
+        ];
 
         ExpireChars::cleanupExpiredAccountsForTests();
 
@@ -53,18 +59,20 @@ final class CleanupExpiredAccountsLogsFailureTest extends TestCase
             ['char deletion failure', 'Failed to delete account 1: deletion failed', 'error'],
         ], \Lotgd\GameLog::$entries);
 
-        $this->assertStringContainsString('ROLLBACK', Database::$queries[3] ?? '');
+        $queries = CoreDatabase::getDoctrineConnection()->queries;
+        $this->assertContains('ROLLBACK', $queries);
     }
 
     public function testLogsOnSuccess(): void
     {
         Database::$mockResults = [
             [["acctid" => 1, "login" => "test", "dragonkills" => 0, "level" => 1]],
-            true,
-            true,
-            true,
         ];
-        Database::$affected_rows = 1;
+        CoreDatabase::getDoctrineConnection()->executeStatementResults = [
+            1, // START TRANSACTION
+            1, // DELETE
+            1, // COMMIT
+        ];
 
         ExpireChars::cleanupExpiredAccountsForTests();
 
@@ -74,6 +82,7 @@ final class CleanupExpiredAccountsLogsFailureTest extends TestCase
         $this->assertCount(2, \Lotgd\GameLog::$entries);
         $this->assertSame('info', \Lotgd\GameLog::$entries[1][2] ?? null);
 
-        $this->assertStringContainsString('COMMIT', Database::$queries[3] ?? '');
+        $queries = CoreDatabase::getDoctrineConnection()->queries;
+        $this->assertContains('COMMIT', $queries);
     }
 }

--- a/tests/FetchAccountsToExpireQueryTest.php
+++ b/tests/FetchAccountsToExpireQueryTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Lotgd\Tests;
 
 use DateTimeImmutable;
+use Doctrine\DBAL\ParameterType;
 use Lotgd\ExpireChars;
+use Lotgd\MySQL\Database as CoreDatabase;
 use Lotgd\Tests\Stubs\Database;
 use PHPUnit\Framework\TestCase;
 
@@ -21,7 +23,12 @@ final class FetchAccountsToExpireQueryTest extends TestCase
     {
         class_exists(Database::class);
         Database::$queries = [];
-        Database::$mockResults = [true];
+        Database::$mockResults = [];
+        CoreDatabase::resetDoctrineConnection();
+        $connection = CoreDatabase::getDoctrineConnection();
+        $connection->queries = [];
+        $connection->executeQueryParams = [];
+        $connection->executeQueryTypes = [];
     }
 
     /**
@@ -46,18 +53,21 @@ final class FetchAccountsToExpireQueryTest extends TestCase
             $conditions[] = "(laston < '" . $now->modify('-' . ($trash + 1) . ' days')->format('Y-m-d H:i:s') . "' AND level=1 AND experience < 10 AND dragonkills=0)";
         }
 
-        $expected = null;
-        if ($conditions) {
-            $expected = 'SELECT login,acctid,dragonkills,level FROM accounts'
-                . ' WHERE (superuser&' . NO_ACCOUNT_EXPIRATION . ')=0 AND (' . implode(' OR ', $conditions) . ')';
-        }
-
         ExpireChars::fetchAccountsToExpireForTests($old, $new, $trash, $now);
+        $connection = CoreDatabase::getDoctrineConnection();
 
-        if ($expected === null) {
-            $this->assertSame([], Database::$queries);
+        if ($conditions === []) {
+            $this->assertSame([], $connection->queries);
         } else {
-            $this->assertSame($expected, Database::$queries[0]);
+            $this->assertNotEmpty($connection->queries);
+            $sql = $connection->queries[0];
+            $params = $connection->executeQueryParams[0] ?? [];
+            $types = $connection->executeQueryTypes[0] ?? [];
+
+            $this->assertStringContainsString('SELECT login,acctid,dragonkills,level FROM accounts', $sql);
+            $this->assertStringContainsString('(superuser & :noAccountExpiration) = 0', $sql);
+            $this->assertSame(NO_ACCOUNT_EXPIRATION, $params['noAccountExpiration'] ?? null);
+            $this->assertSame(ParameterType::INTEGER, $types['noAccountExpiration'] ?? null);
         }
     }
 

--- a/tests/NotifyExpirationAfterLoginTest.php
+++ b/tests/NotifyExpirationAfterLoginTest.php
@@ -6,6 +6,7 @@ namespace Lotgd\Tests;
 
 use Lotgd\Accounts;
 use Lotgd\ExpireChars;
+use Lotgd\MySQL\Database as CoreDatabase;
 use Lotgd\Settings;
 use Lotgd\Tests\Stubs\DbMysqli;
 use Lotgd\Tests\Stubs\Database;
@@ -27,7 +28,7 @@ final class NotifyExpirationAfterLoginTest extends TestCase
         if (!class_exists('Lotgd\\Doctrine\\Bootstrap', false)) {
             require __DIR__ . '/Stubs/DoctrineBootstrap.php';
         }
-        \Lotgd\MySQL\Database::$doctrineConnection = null;
+        CoreDatabase::resetDoctrineConnection();
         \Lotgd\MySQL\Database::$instance = null;
         \Lotgd\Tests\Stubs\DoctrineBootstrap::$conn = null;
         Database::$queries = [];
@@ -82,12 +83,13 @@ final class NotifyExpirationAfterLoginTest extends TestCase
             [
                 ['login' => 'tester', 'acctid' => 1, 'emailaddress' => 'tester@example.com'],
             ],
-            true,
         ];
+        $connection = CoreDatabase::getDoctrineConnection();
+        $connection->queries = [];
 
         ExpireChars::notifyUpcomingExpirationsForTests();
 
         $this->assertSame(1, $GLOBALS['mail_sent_count']);
-        $this->assertStringContainsString('sentnotice=1', end(Database::$queries));
+        $this->assertStringContainsString('sentnotice = :sentNotice', (string) end($connection->queries));
     }
 }

--- a/tests/NotifyUpcomingExpirationsQueryTest.php
+++ b/tests/NotifyUpcomingExpirationsQueryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lotgd\Tests;
 
 use Lotgd\ExpireChars;
+use Lotgd\MySQL\Database as CoreDatabase;
 use Lotgd\Settings;
 use Lotgd\Tests\Stubs\DbMysqli;
 use Lotgd\Tests\Stubs\Database;
@@ -26,7 +27,7 @@ final class NotifyUpcomingExpirationsQueryTest extends TestCase
         if (!class_exists('Lotgd\\Doctrine\\Bootstrap', false)) {
             require __DIR__ . '/Stubs/DoctrineBootstrap.php';
         }
-        \Lotgd\MySQL\Database::$doctrineConnection = null;
+        CoreDatabase::resetDoctrineConnection();
         \Lotgd\MySQL\Database::$instance = null;
         \Lotgd\Tests\Stubs\DoctrineBootstrap::$conn = null;
         Database::$queries = [];
@@ -55,18 +56,19 @@ final class NotifyUpcomingExpirationsQueryTest extends TestCase
             [
                 ['login' => 'tester', 'acctid' => 1, 'emailaddress' => 'tester@example.com'],
             ],
-            true,
         ];
+        $connection = CoreDatabase::getDoctrineConnection();
+        $connection->queries = [];
+        $connection->executeStatements = [];
 
         ExpireChars::notifyUpcomingExpirationsForTests();
 
-        $expectedDate = date('Y-m-d H:i:s', strtotime('-40 days'));
         $expected = 'SELECT login,acctid,emailaddress FROM accounts'
-            . " WHERE (laston < '$expectedDate')"
-            . " AND emailaddress!='' AND sentnotice=0 AND (superuser&" . NO_ACCOUNT_EXPIRATION . ')=0';
+            . ' WHERE (laston < :threshold)'
+            . " AND emailaddress != '' AND sentnotice = :sentNotice AND (superuser & :noAccountExpiration) = 0";
 
-        $this->assertSame($expected, Database::$queries[0]);
+        $this->assertSame($expected, $connection->queries[0] ?? null);
         $this->assertSame(1, $GLOBALS['mail_sent_count']);
-        $this->assertStringContainsString('sentnotice=1', Database::$queries[1]);
+        $this->assertStringContainsString('sentnotice = :sentNotice', $connection->queries[1] ?? '');
     }
 }

--- a/tests/PagePartsOnlineListTest.php
+++ b/tests/PagePartsOnlineListTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lotgd\Tests;
 
 use Lotgd\DateTime;
+use Lotgd\MySQL\Database as CoreDatabase;
 use Lotgd\Output;
 use Lotgd\PageParts;
 use Lotgd\Tests\Stubs\Database;
@@ -45,6 +46,12 @@ final class PagePartsOnlineListTest extends TestCase
                 return [];
             }
         };
+        CoreDatabase::resetDoctrineConnection();
+        $connection = CoreDatabase::getDoctrineConnection();
+        $connection->queries = [];
+        $connection->executeQueryParams = [];
+        $connection->executeQueryTypes = [];
+        $connection->fetchAllResults = [[]];
     }
 
     protected function tearDown(): void
@@ -59,7 +66,8 @@ final class PagePartsOnlineListTest extends TestCase
         global $settings;
         $settings->saveSetting('homeonline_mode', 0);
         $outputString = PageParts::charStats();
-        $this->assertStringContainsString('loggedin=1', Database::$lastSql);
+        $connection = CoreDatabase::getDoctrineConnection();
+        $this->assertStringContainsString('loggedin = :loggedIn', $connection->queries[0] ?? '');
         $this->assertStringContainsString('Online Characters (0 players):', $outputString);
     }
 
@@ -68,7 +76,8 @@ final class PagePartsOnlineListTest extends TestCase
         global $settings;
         $settings->saveSetting('homeonline_mode', 1);
         $outputString = PageParts::charStats();
-        $this->assertStringContainsString('loggedin=1', Database::$lastSql);
+        $connection = CoreDatabase::getDoctrineConnection();
+        $this->assertStringContainsString('loggedin = :loggedIn', $connection->queries[0] ?? '');
         $expected = 'Online Characters in the last ' . DateTime::readableTime(900, false) . ':';
         $this->assertStringContainsString($expected, $outputString);
     }
@@ -79,14 +88,11 @@ final class PagePartsOnlineListTest extends TestCase
         $settings->saveSetting('homeonline_mode', 2);
         $settings->saveSetting('homeonline_minutes', 30);
         $outputString = PageParts::charStats();
-        $this->assertStringNotContainsString('loggedin=1', Database::$lastSql);
+        $connection = CoreDatabase::getDoctrineConnection();
+        $this->assertStringNotContainsString('loggedin = :loggedIn', $connection->queries[0] ?? '');
 
-        $this->assertMatchesRegularExpression(
-            "/laston>'(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})'/",
-            Database::$lastSql
-        );
-        preg_match("/laston>'([^']+)'/", Database::$lastSql, $matches);
-        $actual = strtotime($matches[1]);
+        $queryParams = $connection->executeQueryParams[0] ?? [];
+        $actual = strtotime((string) ($queryParams['lastOnThreshold'] ?? ''));
         $expected = strtotime('-30 minutes');
         $this->assertEqualsWithDelta($expected, $actual, 1);
 

--- a/tests/Repository/ClanRepositoryDoctrineBindingTest.php
+++ b/tests/Repository/ClanRepositoryDoctrineBindingTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Repository;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\MySQL\Database as CoreDatabase;
+use Lotgd\Repository\ClanRepository;
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
+
+final class ClanRepositoryDoctrineBindingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        class_exists(Database::class);
+        CoreDatabase::resetDoctrineConnection();
+        $connection = CoreDatabase::getDoctrineConnection();
+        $connection->queries = [];
+        $connection->executeQueryParams = [];
+        $connection->executeQueryTypes = [];
+        $connection->executeStatements = [];
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['accounts_table']);
+    }
+
+    public function testFetchAccountNameUsesTypedParameter(): void
+    {
+        $connection = CoreDatabase::getDoctrineConnection();
+        $GLOBALS['accounts_table'][17] = ['name' => 'Alice'];
+
+        $name = ClanRepository::fetchAccountName(17);
+
+        self::assertSame('Alice', $name);
+        self::assertSame(['acctid' => 17], $connection->fetchAssociativeLog[0]['params'] ?? []);
+        self::assertSame(['acctid' => ParameterType::INTEGER], $connection->fetchAssociativeLog[0]['types'] ?? []);
+    }
+
+    public function testPromoteToLeaderUsesExecuteStatementWithTypedParameters(): void
+    {
+        $connection = CoreDatabase::getDoctrineConnection();
+
+        ClanRepository::promoteToLeader(99);
+
+        $statement = $connection->executeStatements[0] ?? null;
+        self::assertNotNull($statement);
+        self::assertSame(99, $statement['params']['acctid'] ?? null);
+        self::assertSame(ParameterType::INTEGER, $statement['types']['acctid'] ?? null);
+        self::assertSame(ParameterType::INTEGER, $statement['types']['leaderRank'] ?? null);
+    }
+}

--- a/tests/ServerFunctionsTest.php
+++ b/tests/ServerFunctionsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lotgd\Tests;
 
 use Lotgd\ServerFunctions;
+use Lotgd\MySQL\Database as CoreDatabase;
 use Lotgd\Tests\Stubs\ServerDummySettings;
 use Lotgd\Tests\Stubs\Database;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +26,12 @@ final class ServerFunctionsTest extends TestCase
         class_exists(Database::class);
         \Lotgd\MySQL\Database::$onlineCounter = 0;
         \Lotgd\MySQL\Database::$settings_table = [];
-        \Lotgd\MySQL\Database::$doctrineConnection = null;
+        CoreDatabase::resetDoctrineConnection();
+        $connection = CoreDatabase::getDoctrineConnection();
+        $connection->queries = [];
+        $connection->executeQueryParams = [];
+        $connection->executeQueryTypes = [];
+        $connection->countResults = [];
         \Lotgd\MySQL\Database::$instance = null;
     }
 
@@ -129,7 +135,8 @@ final class ServerFunctionsTest extends TestCase
         ]);
         $GLOBALS['settings'] = $settings;
 
-        \Lotgd\MySQL\Database::$onlineCounter = 3;
+        $connection = CoreDatabase::getDoctrineConnection();
+        $connection->countResults = [3];
         $this->assertFalse(ServerFunctions::isTheServerFull());
         $this->assertSame(3, $settings->getSetting('OnlineCount'));
 

--- a/tests/Stubs/DoctrineBootstrap.php
+++ b/tests/Stubs/DoctrineBootstrap.php
@@ -440,16 +440,19 @@ class DoctrineConnection
 
     public function beginTransaction(): void
     {
+        $this->queries[] = 'START TRANSACTION';
         $this->inTransaction = true;
     }
 
     public function commit(): void
     {
+        $this->queries[] = 'COMMIT';
         $this->inTransaction = false;
     }
 
     public function rollBack(): void
     {
+        $this->queries[] = 'ROLLBACK';
         $this->inTransaction = false;
     }
 

--- a/tests/Stubs/DoctrineBootstrap.php
+++ b/tests/Stubs/DoctrineBootstrap.php
@@ -22,6 +22,16 @@ class DoctrineResult
         return array_shift($this->rows) ?: false;
     }
 
+    public function fetchOne()
+    {
+        $row = array_shift($this->rows);
+        if (!is_array($row) || empty($row)) {
+            return false;
+        }
+
+        return reset($row);
+    }
+
     public function rowCount(): int|string
     {
         if ($this->rowCountOverride !== null) {
@@ -424,6 +434,28 @@ class DoctrineConnection
     public function getParams(): array
     {
         return $this->params;
+    }
+
+    private bool $inTransaction = false;
+
+    public function beginTransaction(): void
+    {
+        $this->inTransaction = true;
+    }
+
+    public function commit(): void
+    {
+        $this->inTransaction = false;
+    }
+
+    public function rollBack(): void
+    {
+        $this->inTransaction = false;
+    }
+
+    public function isTransactionActive(): bool
+    {
+        return $this->inTransaction;
     }
 }
 

--- a/tests/Stubs/DoctrineBootstrap.php
+++ b/tests/Stubs/DoctrineBootstrap.php
@@ -62,6 +62,8 @@ class DoctrineConnection
     public array $lastFetchAssociativeTypes = [];
     public array $fetchAssociativeLog = [];
     public array $executeStatements = [];
+    /** @var array<int,int> */
+    public array $executeStatementResults = [];
     public array $lastExecuteStatementParams = [];
     public array $lastExecuteStatementTypes = [];
     public array $executeQueryParams = [];
@@ -293,6 +295,9 @@ class DoctrineConnection
         ];
         $this->lastExecuteStatementParams = $params;
         $this->lastExecuteStatementTypes = $types;
+        if ($this->executeStatementResults !== []) {
+            return (int) array_shift($this->executeStatementResults);
+        }
         if (preg_match('/^INSERT INTO\s+`?mail`?/i', $sql)) {
             global $mail_table;
             $mail_table ??= [];


### PR DESCRIPTION
### Motivation

- Replace remaining interpolated `Database::query(...)` usage in core Lotgd classes with Doctrine DBAL to improve SQL safety and enable typed parameter binding.  
- Target prioritized files to close out the migration sweep and satisfy the `InterpolatedDatabaseQueryCheck` QA policy.  

### Description

- Replaced dynamic `Database::query(...)` calls with `executeQuery()` for reads and `executeStatement()` for writes across the requested targets: `src/Lotgd/ExpireChars.php`, `src/Lotgd/Motd.php`, `src/Lotgd/Repository/ClanRepository.php`, `src/Lotgd/Moderate.php`, `src/Lotgd/ServerFunctions.php`, `src/Lotgd/PageParts.php`, and `src/Lotgd/Battle.php`.  
- Bound all runtime values as parameters and provided explicit DBAL types (using `ParameterType` and `ArrayParameterType` where arrays are required), and preserved original ordering/limits and transaction semantics (notably the `ExpireChars` START/COMMIT/ROLLBACK flow).  
- Kept a single non-parameterizable SQL fragment for whitelisted column fragments in `ServerFunctions::resetAllDragonkillPoints()` and documented the safety rationale inline (values are strictly whitelisted and cast to integers before interpolation).  
- Updated/added focused tests and test stubs to reflect DBAL behaviour and to assert parameter binding: expiry/cleanup and notification tests, online list / server-full checks, clan repository binding test, MOTD/poll tests, and DBAL stub support for deterministic `executeStatement` results.  
- Security review: for moderation and expiration flows touched, input boundaries are now cast/validated before binding, prepared statements are used for reads/writes, existing authorization checks were not changed, and failure/error outcomes continue to be logged as before.  

### Testing

- Ran syntax checks via `php -l` on all changed files and had no syntax errors.  
- Ran static checks with `composer static` and the QA policies (legacy SQL/addslashes checks) passed.  
- Executed focused PHPUnit suites and assertions for modified areas (examples): `tests/FetchAccountsToExpireQueryTest.php`, `tests/PagePartsOnlineListTest.php`, `tests/ServerFunctionsTest.php`, `tests/CharCleanup*`, `tests/NotifyUpcomingExpirationsQueryTest.php`, `tests/AMotdTest.php`, and new `tests/Repository/ClanRepositoryDoctrineBindingTest.php`; these targeted tests passed.  
- Ran the full test suite via `composer test`; the suite completed with all tests passing (the run produced non-failing warnings/notices from baseline test fixtures), and no new failures were introduced.  
- Commands used during validation: `composer install --no-interaction`, `php -l <files>`, `composer static`, `vendor/bin/phpunit <targeted tests>`, and `composer test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c814cbc03c8329835cf0074fa8f5d3)