### PR TITLE
fix: allowlist and scalar-guard module pref saves in user_savemodule

### DIFF
--- a/pages/user/user_savemodule.php
+++ b/pages/user/user_savemodule.php
@@ -2,34 +2,64 @@
 
 declare(strict_types=1);
 
+use Doctrine\DBAL\ParameterType;
+use Lotgd\Http;
 use Lotgd\MySQL\Database;
 use Lotgd\Translator;
-use Lotgd\Http;
-use Doctrine\DBAL\ParameterType;
 
-//save module settings.
+// save module settings.
 $userid = (int) Http::get('userid');
 $module = (string) Http::get('module');
+
+/**
+ * Build a strict allowlist of module preference keys so transport metadata
+ * injected by the UI (for example tab state or validation markers) is never
+ * written into module_userprefs.
+ *
+ * @var array<string,bool> $allowedPrefKeys
+ */
+$moduleInfo = get_module_info($module);
+$allowedPrefKeys = [];
+if (isset($moduleInfo['prefs']) && is_array($moduleInfo['prefs'])) {
+    foreach (array_keys($moduleInfo['prefs']) as $prefKey) {
+        if (is_string($prefKey) && $prefKey !== '') {
+            $allowedPrefKeys[$prefKey] = true;
+        }
+    }
+}
+
 $post = Http::allPost();
+unset($post['showFormTabIndex'], $post['validation_error']);
 $post = modulehook("validateprefs", $post, true, $module);
 if (isset($post['validation_error']) && $post['validation_error']) {
     Translator::getInstance()->setSchema("module-$module");
     $post['validation_error'] =
-        Translator::translateInline($post['validation_error']);
+        Translator::translateInline((string) $post['validation_error']);
     Translator::getInstance()->setSchema();
     $output->output("Unable to change settings: `\$%s`0", $post['validation_error']);
 } else {
     $conn = Database::getDoctrineConnection();
     $output->outputNotl("`n");
     foreach ($post as $key => $val) {
-        $output->output("`\$Setting '`2%s`\$' to '`2%s`\$'`n", $key, htmlspecialchars($val, ENT_QUOTES, 'UTF-8'));
+        if (!is_string($key) || !isset($allowedPrefKeys[$key])) {
+            continue;
+        }
+
+        // Strict typing + htmlspecialchars require scalar/stringable-like input.
+        // Skip arrays/objects from malformed payloads before formatting/output.
+        if (!is_scalar($val)) {
+            continue;
+        }
+
+        $value = (string) $val;
+        $output->output("`\$Setting '`2%s`\$' to '`2%s`\$'`n", $key, htmlspecialchars($value, ENT_QUOTES, 'UTF-8'));
         $conn->executeStatement(
             'REPLACE INTO ' . Database::prefix('module_userprefs') . ' (modulename,userid,setting,value) VALUES (:module,:userid,:setting,:value)',
             [
                 'module' => $module,
                 'userid' => $userid,
                 'setting' => $key,
-                'value' => (string) $val,
+                'value' => $value,
             ],
             [
                 'module' => ParameterType::STRING,

--- a/tests/User/UserLegacyHttpMigrationTest.php
+++ b/tests/User/UserLegacyHttpMigrationTest.php
@@ -57,6 +57,41 @@ PHP);
         $this->assertSame('INTEGER', $statement['types']['userid'] ?? null);
     }
 
+    public function testUserSavemoduleFiltersTransportMetadataAndNonScalarValues(): void
+    {
+        $payload = $this->runIsolatedPageScript(<<<'PHP'
+$_GET['userid'] = '42';
+$_GET['module'] = 'samplemodule';
+$_POST = [
+    'showFormTabIndex' => ['bad'],
+    'display_name' => 'Visible Name',
+    'theme' => 'dark',
+    'unknown_pref' => 'ignored',
+];
+$GLOBALS['__test_module_info'] = [
+    'prefs' => [
+        'display_name' => 'Display Name|string|',
+        'theme' => 'Theme|string|',
+    ],
+];
+
+require LOTGD_TEST_ROOT . '/tests/User/isolated_user_savemodule.php';
+PHP);
+
+        $statements = $payload['statements'] ?? null;
+        $this->assertIsArray($statements);
+        $this->assertCount(2, $statements);
+
+        $settings = array_map(
+            static fn (array $statement): string => (string) ($statement['params']['setting'] ?? ''),
+            $statements
+        );
+        sort($settings);
+
+        $this->assertSame(['display_name', 'theme'], $settings);
+    }
+
+
     /**
      * Execute page-inclusion tests in an isolated PHP process so test-only
      * function/class shims cannot leak into the main PHPUnit process.

--- a/tests/User/isolated_user_savemodule.php
+++ b/tests/User/isolated_user_savemodule.php
@@ -19,6 +19,27 @@ namespace {
         }
     }
 
+    if (!function_exists('get_module_info')) {
+        /**
+         * Test shim returning declared preference keys for allowlist behaviour.
+         *
+         * @return array<string,mixed>
+         */
+        function get_module_info(string $shortname, bool $with_db = true): array
+        {
+            if (isset($GLOBALS['__test_module_info']) && is_array($GLOBALS['__test_module_info'])) {
+                return $GLOBALS['__test_module_info'];
+            }
+
+            return [
+                'prefs' => [
+                    'display_name' => 'Display Name|string|',
+                    'theme' => 'Theme|string|',
+                ],
+            ];
+        }
+    }
+
     if (!function_exists('httpset')) {
         function httpset(string $var, mixed $value, bool $force = false): void
         {
@@ -43,7 +64,8 @@ namespace {
     require LOTGD_TEST_ROOT . '/pages/user/user_savemodule.php';
 
     $conn = Database::getDoctrineConnection();
-    $statement = $conn->executeStatements[0] ?? null;
+    $statements = $conn->executeStatements;
+    $statement = $statements[0] ?? null;
     $normalize = static function (mixed $value) use (&$normalize): mixed {
         if ($value instanceof \UnitEnum) {
             return $value->name;
@@ -58,5 +80,5 @@ namespace {
         return $value;
     };
 
-    echo json_encode(['statement' => $normalize($statement)], JSON_THROW_ON_ERROR);
+    echo json_encode(['statement' => $normalize($statement), 'statements' => $normalize($statements)], JSON_THROW_ON_ERROR);
 }


### PR DESCRIPTION
### Motivation
- Prevent UI transport/control metadata and non-scalar payloads from being persisted when saving module prefs and avoid passing non-string values to `htmlspecialchars` under `strict_types`.
- Harden the save loop so only declared module preference keys are written to `module_userprefs` and malformed POST data cannot cause a fatal.

### Description
- Build an allowlist of valid preference keys from `get_module_info($module)['prefs']` and use it to limit which POST keys are processed. 
- Remove transport/control keys (`showFormTabIndex`, `validation_error`) from POST handling before persistence and cast persisted values to string only after allowlist and scalar checks. 
- Skip non-string keys and non-scalar values to ensure safe use of `htmlspecialchars` and DB writes. 
- Added concise PHPDoc and inline comments explaining why metadata keys are filtered and why scalar guards are required under strict types. 
- Tests: updated `tests/User/isolated_user_savemodule.php` to provide a `get_module_info()` shim and return all executed statements, and added `testUserSavemoduleFiltersTransportMetadataAndNonScalarValues` to `tests/User/UserLegacyHttpMigrationTest.php` to cover the regression case.

### Testing
- Ran syntax checks with `php -l pages/user/user_savemodule.php`, `php -l tests/User/UserLegacyHttpMigrationTest.php`, and `php -l tests/User/isolated_user_savemodule.php` which all reported no syntax errors. 
- Ran the isolated test subset with `./vendor/bin/phpunit --filter UserLegacyHttpMigrationTest` which passed (4 tests, 23 assertions). 
- Ran the full test suite via `composer test`; the run completed successfully (707 tests) but produced a small number of warnings/notices which are unrelated to this change. 
- Ran static analysis with `composer static` which completed with no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8d53071908329ae834664fcf8109b)