### PR TITLE
fix: drain OPTIMIZE TABLE results in Newday::dbCleanup

### DIFF
--- a/src/Lotgd/Newday.php
+++ b/src/Lotgd/Newday.php
@@ -33,7 +33,12 @@ class Newday
         $start = microtime(true);
         foreach ($rows as $row) {
             foreach ($row as $val) {
-                $conn->executeStatement('OPTIMIZE TABLE ' . $conn->quoteIdentifier((string) $val));
+                // OPTIMIZE TABLE returns a result set in MySQL. We explicitly
+                // consume and free that result before issuing any further SQL
+                // to avoid SQLSTATE[HY000]: 2014 from unbuffered cursor carryover.
+                $result = $conn->executeQuery('OPTIMIZE TABLE ' . $conn->quoteIdentifier((string) $val));
+                $result->fetchAllAssociative();
+                $result->free();
                 $tables[] = $val;
             }
         }


### PR DESCRIPTION
### Motivation
- Prevent PDO MySQL unbuffered-result carryover (`SQLSTATE[HY000]: 2014`) by ensuring each `OPTIMIZE TABLE` result set is consumed and freed before issuing the next query.

### Description
- Replace `executeStatement('OPTIMIZE TABLE ...')` with a result-returning `executeQuery(...)` and explicitly call `fetchAllAssociative()` followed by `free()` for each table in `Lotgd\Newday::dbCleanup()`, while preserving the existing table collection and `GameLog::log(...)` behavior.
- Add an inline comment explaining why draining/freeing the result is required to avoid MySQL unbuffered cursor carryover; no other logic or SQL input boundaries were changed.

### Testing
- Ran `php -l src/Lotgd/Newday.php` which returned no syntax errors.
- Ran `php cron.php 2 1` to exercise the DB cleanup path but the process failed in this environment due to a missing `dbconnect.php` during bootstrap, so end-to-end DB execution could not be validated here (see `logs/bootstrap.log`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8dcd9f6f48329bec2933ff784ff6d)