### PR TITLE
docs: replace removed translate delete block with historical note

### DIFF
--- a/src/Lotgd/Translator.php
+++ b/src/Lotgd/Translator.php
@@ -152,18 +152,8 @@ class Translator
                 if (isset(self::$translation_table[$namespace][$indata])) {
                         $outdata = self::$translation_table[$namespace][$indata];
                     $foundtranslation = true;
-                    // Remove this from the untranslated texts table if it is
-                    // in there and we are collecting texts
-                    // This delete is horrible on very heavily translated games.
-                    // It has been requested to be removed.
-                    /*
-                    if (Settings::getInstance()->getSetting("collecttexts", false)) {
-        $sql = "DELETE FROM " . Database::prefix("untranslated") .
-            " WHERE intext='" . addslashes($indata) .
-            "' AND language='" . (defined('LANGUAGE') ? constant('LANGUAGE') : '') . "'";
-        Database::query($sql);
-                    }
-                    */
+                    // Historical note: the old delete path was intentionally removed for heavy-translation performance reasons.
+                    // Untranslated text collection now relies on the DBAL insert path below.
                 } elseif ($settings instanceof Settings && $settings->getSetting("collecttexts", false)) {
                     $connection = Database::getDoctrineConnection();
                     $connection->executeStatement(


### PR DESCRIPTION
### Motivation
- Clarify why the legacy `DELETE` path around the untranslated-text collection was removed and avoid leaving a large obsolete commented SQL block in `src/Lotgd/Translator.php`.

### Description
- Replaced the multi-line commented `DELETE ... addslashes(...)` / `Database::query($sql)` block inside `Translator::translate()` with a concise 1–2 line historical note stating the delete path was intentionally removed for heavy-translation performance and that collection now uses the DBAL insert path below, with no runtime behavior changes.

### Testing
- Ran `php -l src/Lotgd/Translator.php` which completed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb856abac48329a8c6f013f377898b)