### PR TITLE
fix: cast moderated commentary timestamp to int

### DIFF
--- a/src/Lotgd/Moderate.php
+++ b/src/Lotgd/Moderate.php
@@ -400,7 +400,12 @@ class Moderate
                 if (!isset($session['user']['prefs']['timeformat'])) {
                     $session['user']['prefs']['timeformat'] = '[m/d h:ia]';
                 }
-                $time = strtotime($row['postdate']) + ($session['user']['prefs']['timeoffset'] * 60 * 60);
+                /*
+                 * date() requires an integer Unix timestamp.
+                 * Timezone offsets can include fractions (for example, +5.5 hours),
+                 * so force the calculated value back to an int after applying offset.
+                 */
+                $time = (int) (strtotime($row['postdate']) + ($session['user']['prefs']['timeoffset'] * 60 * 60));
                 $s = date('`7' . $session['user']['prefs']['timeformat'] . '`0 ', $time);
                 $op[$i] = $s . $op[$i];
             } elseif ($session['user']['prefs']['timestamp'] == 2) {


### PR DESCRIPTION
## Summary
- Fix `date()` type mismatch in `src/Lotgd/Moderate.php` when rendering moderated commentary timestamps.
- Cast the computed timestamp to `int` after applying user time offset.
- Add an inline comment explaining why the cast is required (fractional hour offsets produce floats).

## Root Cause
`$session['user']['prefs']['timeoffset']` is rounded to one decimal place and may contain fractional values (for example, `5.5`). Multiplying that by seconds and adding it to `strtotime()` returns a float, but `date()` requires `?int` for its timestamp parameter.

## Validation
- `php -l src/Lotgd/Moderate.php`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbd7861c188329be5d90ef650f4e34)