### PR TITLE
fix: decouple nav access key derivation from holiday rendering

### DIFF
--- a/src/Lotgd/Nav.php
+++ b/src/Lotgd/Nav.php
@@ -663,7 +663,6 @@ class Nav
             }
         }
         $extra = '';
-        $ignoreuntil = '';
         Output::getInstance()->closeOpenFont();
         if ($link === false) {
             $text = HolidayText::holidayize($text, 'nav');
@@ -687,99 +686,41 @@ class Nav
                     }
                     $extra .= '-' . date('His');
                 }
+                /** @var string $preHolidayText Access-key source text before seasonal substitutions. */
+                $preHolidayText = $text;
+                $renderText = $preHolidayText;
                 $key = '';
-                if ($text[1] == '?') {
-                    $hchar = strtolower($text[0]);
+                $keyrep = '';
+                $explicitKeyMissingFromPreHolidayText = false;
+                if (isset($preHolidayText[1]) && $preHolidayText[1] === '?') {
+                    $hchar = strtolower($preHolidayText[0]);
                     if ($hchar == ' ' || array_key_exists($hchar, self::$accesskeys) && self::$accesskeys[$hchar] == 1) {
-                        $text = substr($text, 2);
-                        $text = HolidayText::holidayize($text, 'nav');
+                        $preHolidayText = substr($preHolidayText, 2);
                         if ($hchar == ' ') {
                             $key = ' ';
                         }
                     } else {
-                        $key = $text[0];
-                        $text = substr($text, 2);
-                        $text = HolidayText::holidayize($text, 'nav');
-                        $found = false;
-                        $text_len = strlen($text);
-                        for ($i = 0; $i < $text_len; ++$i) {
-                            $char = $text[$i];
-                            if ($ignoreuntil == $char) {
-                                $ignoreuntil = '';
-                            } else {
-                                if ($ignoreuntil <> '') {
-                                    if ($char == '<') {
-                                        $ignoreuntil = '>';
-                                    }
-                                    if ($char == '&') {
-                                        $ignoreuntil = ';';
-                                    }
-                                    if ($char == '`') {
-                                        $ignoreuntil = $text[$i + 1];
-                                    }
-                                } else {
-                                    if ($char == $key) {
-                                        $found = true;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                        if ($found == false) {
-                            if (strpos($text, '__') !== false) {
-                                $text = str_replace('__', '(' . $key . ') ', $text);
-                            } else {
-                                $text = '(' . strtoupper($key) . ') ' . $text;
-                            }
-                            $i = strpos($text, $key);
-                        }
-                    }
-                } else {
-                    $text = HolidayText::holidayize($text, 'nav');
-                }
-                if ($key == '') {
-                    for ($i = 0; $i < strlen($text); $i++) {
-                        $char = substr($text, $i, 1);
-                        if ($ignoreuntil == $char) {
-                            $ignoreuntil = '';
-                        } else {
-                            if ((isset(self::$accesskeys[strtolower($char)]) && self::$accesskeys[strtolower($char)] == 1) || (strpos('abcdefghijklmnopqrstuvwxyz0123456789', strtolower($char)) === false) || $ignoreuntil <> '') {
-                                if ($char == '<') {
-                                    $ignoreuntil = '>';
-                                }
-                                if ($char == '&') {
-                                    $ignoreuntil = ';';
-                                }
-                                if ($char == '`') {
-                                    $ignoreuntil = substr($text, $i + 1, 1);
-                                }
-                            } else {
-                                break;
-                            }
-                        }
+                        $key = $preHolidayText[0];
+                        $preHolidayText = substr($preHolidayText, 2);
+                        $explicitKeyMissingFromPreHolidayText = !self::containsAccessKeyChar($preHolidayText, $key);
                     }
                 }
-                if (!isset($i)) {
-                    $i = 0;
+
+                $renderText = HolidayText::holidayize($preHolidayText, 'nav');
+                if ($key === '') {
+                    $candidateKey = self::findAvailableAccessKey($preHolidayText);
+                    if ($candidateKey !== null) {
+                        $key = $candidateKey;
+                    }
                 }
-                if ($i < strlen($text) && $key != ' ') {
-                    $key = substr($text, $i, 1);
-                    self::$accesskeys[strtolower($key)] = 1;
+
+                /**
+                 * Invariant: Access-key identity is derived from pre-holiday source text;
+                 * holiday text affects presentation only.
+                 */
+                if ($key !== '' && $key !== ' ') {
+                    self::$accesskeys[strtolower($key)] = true;
                     $keyrep = " accesskey=\"$key\" ";
-                } else {
-                    $key = '';
-                    $keyrep = '';
-                }
-                if ($key == '' || $key == ' ') {
-                } else {
-                    $pattern1 = "/^" . preg_quote($key, "/") . "/";
-                    $pattern2 = "/([^`])" . preg_quote($key, "/") . "/";
-                    $rep1 = "`H$key`H";
-                    $rep2 = "\$1`H$key`H";
-                    $text = preg_replace($pattern1, $rep1, $text, 1);
-                    if (strpos($text, '`H') === false) {
-                        $text = preg_replace($pattern2, $rep2, $text, 1);
-                    }
                     if ($pop) {
                         if ($popsize == '') {
                             self::$quickkeys[$key] = "window.open('$link')";
@@ -789,12 +730,24 @@ class Nav
                     } else {
                         self::$quickkeys[$key] = "window.location='$link$extra'";
                     }
+
+                    if ($explicitKeyMissingFromPreHolidayText) {
+                        if (strpos($renderText, '__') !== false) {
+                            $renderText = str_replace('__', '(' . $key . ') ', $renderText);
+                        } else {
+                            $renderText = '(' . strtoupper($key) . ') ' . $renderText;
+                        }
+                    }
+
+                    // Best effort only: if key cannot be located in holiday text, keep keyboard behavior without highlight markup.
+                    $renderText = self::highlightAccessKey($renderText, $key);
                 }
-                if (is_string($text)) {
-                    $text = preg_replace('/^`0+/', '', $text);
+
+                if (is_string($renderText)) {
+                    $renderText = preg_replace('/^`0+/', '', $renderText);
                 }
                 $n = Template::templateReplace('navitem', [
-                    'text' => $output->appoencode($text, $priv),
+                    'text' => $output->appoencode($renderText, $priv),
                     'link' => $link . ($pop != true ? $extra : ''),
                     'accesskey' => $keyrep,
                     'popup' => ($pop == true ? "target='_blank'" . ($popsize > '' ? " onClick=\"" . PageParts::popup($link, $popsize) . "; return false;\"" : '') : ''),
@@ -817,6 +770,99 @@ class Nav
         }
         $instance->appendNav($thisnav);
         return $thisnav;
+    }
+
+    /**
+     * Locate an explicit access-key character in text while ignoring inline formatting markers.
+     */
+    private static function containsAccessKeyChar(string $text, string $key): bool
+    {
+        $textLen = strlen($text);
+        $ignoreUntil = '';
+        for ($i = 0; $i < $textLen; ++$i) {
+            $char = $text[$i];
+            if ($ignoreUntil === $char) {
+                $ignoreUntil = '';
+                continue;
+            }
+            if ($ignoreUntil !== '') {
+                if ($char === '<') {
+                    $ignoreUntil = '>';
+                }
+                if ($char === '&') {
+                    $ignoreUntil = ';';
+                }
+                if ($char === '`' && isset($text[$i + 1])) {
+                    $ignoreUntil = $text[$i + 1];
+                }
+                continue;
+            }
+            if ($char === $key) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Find the first available access-key candidate from pre-holiday text.
+     */
+    private static function findAvailableAccessKey(string $preHolidayText): ?string
+    {
+        $textLen = strlen($preHolidayText);
+        $ignoreUntil = '';
+        for ($i = 0; $i < $textLen; ++$i) {
+            $char = $preHolidayText[$i];
+            if ($ignoreUntil === $char) {
+                $ignoreUntil = '';
+                continue;
+            }
+
+            if (
+                (isset(self::$accesskeys[strtolower($char)]) && self::$accesskeys[strtolower($char)] == 1)
+                || (strpos('abcdefghijklmnopqrstuvwxyz0123456789', strtolower($char)) === false)
+            ) {
+                if ($char == '<') {
+                    $ignoreUntil = '>';
+                }
+                if ($char == '&') {
+                    $ignoreUntil = ';';
+                }
+                if ($char == '`' && isset($preHolidayText[$i + 1])) {
+                    $ignoreUntil = $preHolidayText[$i + 1];
+                }
+                continue;
+            }
+
+            return $char;
+        }
+
+        return null;
+    }
+
+    /**
+     * Highlight the access key in rendered text when possible.
+     */
+    private static function highlightAccessKey(string $renderText, string $key): string
+    {
+        $pattern1 = "/^" . preg_quote($key, "/") . "/";
+        $pattern2 = "/([^`])" . preg_quote($key, "/") . "/";
+        $rep1 = "`H$key`H";
+        $rep2 = "\$1`H$key`H";
+        $highlighted = preg_replace($pattern1, $rep1, $renderText, 1);
+        if (!is_string($highlighted)) {
+            return $renderText;
+        }
+        if (strpos($highlighted, '`H') !== false) {
+            return $highlighted;
+        }
+        $highlighted = preg_replace($pattern2, $rep2, $highlighted, 1);
+        if (!is_string($highlighted)) {
+            return $renderText;
+        }
+
+        return $highlighted;
     }
 
     private static function privateAddSubHeader($text, bool $priv = false): string

--- a/tests/NavAccessKeyHolidayRegressionTest.php
+++ b/tests/NavAccessKeyHolidayRegressionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Nav;
+use Lotgd\Output;
+use Lotgd\Template;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+final class NavAccessKeyHolidayRegressionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $session, $nav, $output;
+        $session = ['user' => ['prefs' => []], 'allowednavs' => [], 'loggedin' => false];
+        $nav = '';
+        $output = new Output();
+        Nav::clearNav();
+        Template::getInstance()->setTemplate([
+            'navitem' => '<a href="{link}"{accesskey}{popup}>{text}</a>',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        global $session, $nav, $output;
+        unset($session, $nav, $output);
+        Template::getInstance()->setTemplate([]);
+    }
+
+    public function testExplicitKeyIsPreservedWhenHighlightIsImpossible(): void
+    {
+        $html = (string) Nav::privateAddNav('z?###', 'foo.php');
+
+        self::assertStringContainsString('href="foo.php"', $html);
+        self::assertStringContainsString('accesskey="z"', $html);
+        self::assertArrayHasKey('z', Nav::getQuickKeys());
+        self::assertStringNotContainsString('`Hz`H', $html);
+    }
+
+    public function testPreHolidayKeyCanExistEvenWhenRenderedTextCannotHighlightIt(): void
+    {
+        $containsMethod = new ReflectionMethod(Nav::class, 'containsAccessKeyChar');
+        $containsMethod->setAccessible(true);
+        $highlightMethod = new ReflectionMethod(Nav::class, 'highlightAccessKey');
+        $highlightMethod->setAccessible(true);
+
+        self::assertTrue($containsMethod->invoke(null, 'Alpha', 'A'));
+        self::assertSame('lpha', $highlightMethod->invoke(null, 'lpha', 'A'));
+    }
+
+    public function testNoCrashWhenHighlightInsertionCannotBeApplied(): void
+    {
+        $html = (string) Nav::privateAddNav('q?---', 'bar.php');
+
+        self::assertNotSame('', $html);
+        self::assertArrayHasKey('q', Nav::getQuickKeys());
+    }
+}


### PR DESCRIPTION
### Motivation

- Holiday substitutions changed the visual text of nav labels which caused access-key derivation to sometimes fail or require searching the post-holiday string; key identity must be stable and driven from the original source text.

### Description

- Split label handling in `Nav::privateAddNav` into `preHolidayText` (source used for explicit `X?` parsing and automatic key selection) and `renderText` (holidayized string used for output). 
- Resolve and register access-key identity only from `preHolidayText`, and register `self::$accesskeys` and quickkey mappings immediately once a key is chosen, independent of whether the rendered text contains the same character.
- Made highlight insertion best-effort by trying to insert highlight markup into `renderText` but not failing if the key cannot be located; the `accesskey` attribute and quickkey behavior are always retained.
- Added private helpers `containsAccessKeyChar`, `findAvailableAccessKey`, and `highlightAccessKey` with PHPDoc comments and an inline invariant: "Access-key identity is derived from pre-holiday source text; holiday text affects presentation only." 
- Added regression tests in `tests/NavAccessKeyHolidayRegressionTest.php` to cover explicit-key preservation when highlighting is impossible, the pre-holiday vs post-render mismatch case, and no-crash behavior when highlight insertion cannot be applied.

### Testing

- Ran `php -l src/Lotgd/Nav.php` and `php -l tests/NavAccessKeyHolidayRegressionTest.php`; both reported no syntax errors. 
- Ran `vendor/bin/phpunit tests/NavAccessKeyHolidayRegressionTest.php`; the new regression tests passed (3 tests, assertions OK with minor deprecations noted). 
- Ran the full suite with `composer test`; the run completed successfully (711 tests) although the baseline output contains warnings/notices/deprecations unrelated to this change. 
- Ran static checks with `composer static`; static analysis passed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccc4fcf83c8329852328d8ed36037e)