### PR TITLE
Make Release workflow manual, add artifact retention, and tighten CI cache keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
           key: ${{ runner.os }}-php-${{ env.PHP_VERSION }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-php-${{ env.PHP_VERSION }}-composer-
-            ${{ runner.os }}-php-
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-interaction
       - name: Run static analysis

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,13 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  # Manual only: release archives are prepared by maintainers on demand.
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Tag to package (for example: v2.0.0)"
+        required: true
+        type: string
 
 jobs:
   package:
@@ -13,11 +17,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.release_tag }}
       - name: Extract version
         id: vars
         run: |
           # Remove leading 'v' from the tag name
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${{ github.event.inputs.release_tag }}"
+          VERSION="${VERSION#v}"
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Create archives
         run: |
@@ -32,6 +38,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: lotgd-${{ steps.vars.outputs.VERSION }}
+          # Keep release workflow artifacts briefly to reduce billable storage.
+          retention-days: 14
           path: |
             dist/lotgd-${{ steps.vars.outputs.VERSION }}.tar.gz
             dist/lotgd-${{ steps.vars.outputs.VERSION }}.zip

--- a/README.md
+++ b/README.md
@@ -192,11 +192,27 @@ will guide you through the setup.
 
 ## Release Workflow
 
-Releases are created automatically when pushing a tag that starts with `v`.
-Update the version in `common.php`, commit the change and push a tag like
-`v2.0.0` or `v2.0.0-rc1`. GitHub Actions then builds archives that contain the
-application and its `vendor/` dependencies while omitting development files such
-as the `tests/` directory.
+Releases are prepared manually by maintainers. The `Release` GitHub Actions
+workflow is intentionally configured as **manual-only** (`workflow_dispatch`) so
+it does not auto-run on tags.
+
+When a maintainer wants release archives built by GitHub Actions:
+
+1. Update the version in `common.php` and push changes.
+2. Open **Actions → Release → Run workflow**.
+3. Provide the target tag/ref (for example `v2.0.0` or `v2.0.0-rc1`) and run.
+
+The workflow builds archives that contain the application and its `vendor/`
+dependencies while omitting development files such as the `tests/` directory.
+
+### GitHub Actions Storage Policy
+
+- CI uses a Composer cache key scoped to OS + PHP version + `composer.lock` to
+  avoid uncontrolled cache growth.
+- Release artifacts use a 14-day retention period to reduce billable GitHub
+  Actions storage.
+- Set repository-level artifact/log retention in GitHub settings for additional
+  control of monthly storage usage.
 
 ## Cron Job Setup
 


### PR DESCRIPTION
### Motivation
- Prevent accidental automatic releases and reduce GitHub Actions storage costs by making release packaging manual and limiting artifact retention. 
- Reduce uncontrolled Composer cache growth by tightening the cache key fallback in CI.
- Update documentation to reflect the new manual release process and storage policy.

### Description
- Convert the `Release` workflow from `push`-on-tag to `workflow_dispatch` with a required `release_tag` input and use that input as the checkout ref and version source. 
- Add `retention-days: 14` to release artifact uploads so built archives are kept for two weeks. 
- Remove the broad Composer cache `restore-keys` fallback in the CI workflow so the cache key is scoped to OS + PHP version + `composer.lock`. 
- Update `README.md` to document the manual release procedure, the GitHub Actions storage policy, and the change to CI/Release behavior.

### Testing
- No application unit tests were executed as part of this PR; CI job semantics remain to run `composer static` and `composer test` in the `tests` job after merge. 
- Workflow files were changed only (YAML syntax preserved) and will be validated by GitHub Actions when run. 
- Documentation was updated and reviewed for consistency with the workflow changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a69cce18832999ce7bd4332ade83)