### PR TITLE
docs(changelog): move Unreleased entries into 2.0.5 (2026-04-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Everything below reflects the path from 1.3.2 → 2.0 RCs.
 
 ## [Unreleased]
 
+_No unreleased changes yet._
+
+## [2.0.5] – 2026-04-10
+
 ### Features
 - Add centralized runtime hardening bootstrap so deployments get safer defaults for HTTPS detection, proxy signaling, and request-surface protections out of the box.
 - Improve installer security defaults and enable stronger admin guidance via the recommendations module during first-run setup.


### PR DESCRIPTION
### Motivation
- Keep the `## [Unreleased]` heading empty for future work while publishing the current pending entries under a formal `2.0.5` release so the changelog matches release practice and existing section styling.

### Description
- Cleared the body of `## [Unreleased]` (left a placeholder) and inserted `## [2.0.5] – 2026-04-10` immediately below, moving all Features/Security/Bug Fixes/Refactor/Dependencies/Docs/Tests bullets from Unreleased into the new `2.0.5` section without changing their wording or category structure in `CHANGELOG.md`.

### Testing
- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95c005bbc8329a46fe5fbdaa889e6)