### PR TITLE
docs: complete 2.0.5 changelog coverage for recent high-impact updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _No unreleased changes yet._
 ### Features
 - Add centralized runtime hardening bootstrap so deployments get safer defaults for HTTPS detection, proxy signaling, and request-surface protections out of the box.
 - Improve installer security defaults and enable stronger admin guidance via the recommendations module during first-run setup.
+- Extend the charrestore module with a user-prefs-only restore option so admins can overwrite preference data without replacing full character records.
 
 ### Security
 - Harden HTTPS/proxy detection by validating forwarded-proto handling paths, including `HTTP_FORWARDED_PROTO` and related trusted-header guardrails.
@@ -28,6 +29,9 @@ _No unreleased changes yet._
 - Fix payment/IPN edge cases around duplicate callbacks, canonical paylog selection, and retry consistency so credits are applied exactly once.
 - Resolve follow-up regressions in proxy-aware HTTPS detection and runtime hardening bootstrap behavior across mixed hosting/proxy setups.
 - Correct module/object preference cache invalidation and related typing issues discovered during the SQL hardening migration wave.
+- Keep navigation access-key generation stable during holiday mode so keybindings no longer depend on seasonal rendering changes.
+- Fix user-account config save/load handling when optional settings are empty, preventing dropped values and inconsistent persistence.
+- Cast moderated commentary timestamps to integers to avoid type-related moderation issues on timestamp handling.
 
 ### Refactor
 - Migrate additional legacy SQL reads/writes to Doctrine DBAL with explicit typed bindings across superuser and core maintenance/admin flows.
@@ -36,6 +40,7 @@ _No unreleased changes yet._
 ### Dependencies/Tooling
 - Transition CI and release workflows to Node.js 24 in GitHub Actions.
 - Raise static analysis memory defaults and tighten QA tooling heuristics to keep large security migration waves reliable in CI.
+- Add a manual release `workflow_dispatch` path, increase release artifact retention, and tighten CI cache-key strategy for more reliable pipeline runs.
 
 ### Docs
 - Clarify canonical payment idempotency policy and duplicate-IPN test scope for operators and contributors.


### PR DESCRIPTION
### Motivation
- Ensure the `2.0.5` release notes reflect high-impact changes merged after the previous cut so users and operators see accurate feature, bugfix, and tooling information.

### Description
- Add a Features bullet noting `charrestore` supports a user-prefs-only restore mode so admins can overwrite preference data without replacing full character records.
- Add Bug Fixes bullets for stabilizing navigation access-key generation during holiday rendering, fixing user-account config save/load when optional settings are empty, and casting moderated commentary timestamps to integers to avoid type-related issues.
- Add a Dependencies/Tooling bullet describing a manual `workflow_dispatch` release path, increased release artifact retention, and a tightened CI cache-key strategy for more reliable pipelines.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95c89bf6c8329b9669da0be6bd0c7)