### PR TITLE
Make `{paypal_below}` a first-class slot, normalize `paypal-below` hook output, and avoid embedding tokens

### DIFF
--- a/src/Lotgd/Page/Footer.php
+++ b/src/Lotgd/Page/Footer.php
@@ -29,6 +29,9 @@ class Footer
         $template  = Template::getInstance()->getTemplate();
 
         $scriptName = PhpGenericEnvironment::getScriptName();
+        // paypal_below is a first-class template variable; initialize an empty default
+        // at footer start so both legacy and Twig rendering paths always see the token.
+        PageParts::$twigVars['paypal_below'] = '';
 
         $navInstance = Nav::getInstance();
         $header = $navInstance->getHeader();
@@ -126,6 +129,13 @@ class Footer
         $script .= "});\n";
         $script .= "</script>\n";
 
+        // Resolve this once and keep it first-class in replacements.
+        // If a template does not expose {paypal_below}, we append this finalized
+        // markup to the paypal replacement instead of requiring template edits.
+        $paypalBelow = PageParts::resolvePaypalBelowSlot('');
+        $templateProvidesPaypalBelowSlot = strpos($header, '{paypal_below}') !== false
+            || strpos($footer, '{paypal_below}') !== false;
+
         $palreplace = (strpos($footer, '{paypal}') || strpos($header, '{paypal}')) ? '{paypal}' : '{stats}';
 
         if (defined('DB_CHOSEN')) {
@@ -134,7 +144,9 @@ class Footer
                 $header,
                 $footer,
                 $settings,
-                $page->getLogdVersion()
+                $page->getLogdVersion(),
+                $paypalBelow,
+                !$templateProvidesPaypalBelowSlot
             );
         }
 
@@ -171,8 +183,9 @@ class Footer
             'version' => 'Version: ' . $page->getLogdVersion(),
             'pagegen' => PageParts::computePageGenerationStats(PhpGenericEnvironment::getPageStartTime()),
             'copyright' => $page->{$page->getV()}(),
-            // Dedicated slot below PayPal donation markup (intentionally not tied to ad tokens).
-            'paypal_below' => PageParts::resolvePaypalBelowSlot(),
+            // Dedicated slot below PayPal donation markup. Keep this separate from
+            // {paypal} so one-pass token replacement and Twig rendering stay aligned.
+            'paypal_below' => $paypalBelow,
         ];
         if (TwigTemplate::isActive()) {
             PageParts::$twigVars = array_merge(PageParts::$twigVars, $replacements);

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -574,13 +574,19 @@ class PageParts
      * @param string      $footer       Footer template fragment
      * @param Settings|null $settings   Settings handler or null
      * @param string      $logd_version Current game version string
+     * @param string      $paypal_below_markup Optional finalized below-PayPal markup
+     * @param bool        $append_paypal_below_to_paypal Whether below markup should be appended to
+     *                                                    the paypal token when templates do not expose
+     *                                                    a dedicated {paypal_below} slot.
      */
     public static function buildPaypalDonationMarkup(
         string $palreplace,
         string $header,
         string $footer,
         ?Settings $settings,
-        string $logd_version
+        string $logd_version,
+        string $paypal_below_markup = '',
+        bool $append_paypal_below_to_paypal = false
     ): array {
         global $session;
 
@@ -668,13 +674,15 @@ class PageParts
                 . '</form>';
         }
         $paypalstr .= '</td></tr></table>';
-        // Keep this compartmentalized below-PayPal slot independent from ad placeholders
-        // such as {verticalad}; modules should target the dedicated paypal-below hook instead.
-        // The placeholder intentionally represents the full optional markup so unused hooks
-        // do not render an empty table row or extra whitespace below the PayPal buttons.
-        $paypalstr .= '{paypal_below}';
+        $paypalReplacement = $paypalstr;
+        if ($append_paypal_below_to_paypal && $paypal_below_markup !== '') {
+            // Keep paypal_below as a first-class variable while still supporting
+            // templates that only render {paypal}. In that case, append the
+            // finalized below-slot markup at replacement time (not as a token).
+            $paypalReplacement .= $paypal_below_markup;
+        }
 
-        $replacement = (strpos($palreplace, 'paypal') ? '' : '{stats}') . $paypalstr;
+        $replacement = (strpos($palreplace, 'paypal') ? '' : '{stats}') . $paypalReplacement;
         $token = trim($palreplace, '{}');
 
         return self::replaceHeaderFooterTokens(
@@ -682,7 +690,7 @@ class PageParts
             $footer,
             [
                 $token   => $replacement,
-                'paypal' => $paypalstr,
+                'paypal' => $paypalReplacement,
             ]
         );
     }
@@ -690,24 +698,32 @@ class PageParts
     /**
      * Resolve the dedicated below-PayPal extension slot via the paypal-below hook.
      *
+     * IMPORTANT: keep {paypal} and {paypal_below} as separate tokens.
+     * Embedding one token inside the other breaks one-pass placeholder replacement
+     * and causes inconsistent behavior between legacy template substitution and Twig.
+     *
      * Hook contract:
      *  - hook name: paypal-below
      *  - input array: ['paypal_below' => string]
      *  - modules should set/append only the paypal_below key and return the array
+     *  - this method always seeds an empty default and normalizes non-string outputs
      *  - modules are responsible for sanitizing any untrusted input before returning HTML
      *
+     * @param string $default Default value to seed before hooks run.
      * @return string Normalized raw HTML replacement content for {paypal_below}.
      */
-    public static function resolvePaypalBelowSlot(): string
+    public static function resolvePaypalBelowSlot(string $default = ''): string
     {
-        $payload = HookHandler::hook('paypal-below', ['paypal_below' => '']);
-        $value = '';
+        $payload = HookHandler::hook('paypal-below', ['paypal_below' => $default]);
+        $value = $default;
         if (is_array($payload)) {
-            $value = $payload['paypal_below'] ?? '';
+            $value = $payload['paypal_below'] ?? $default;
         }
 
-        if (!is_scalar($value)) {
-            return '';
+        if (is_array($value)) {
+            $value = implode('', array_map(static fn ($part): string => is_scalar($part) ? (string) $part : '', $value));
+        } elseif (!is_scalar($value)) {
+            return $default;
         }
 
         return trim((string) $value);

--- a/tests/PagePartsPaypalBelowSlotTest.php
+++ b/tests/PagePartsPaypalBelowSlotTest.php
@@ -39,8 +39,8 @@ final class PagePartsPaypalBelowSlotTest extends TestCase
         $modulehook_returns['paypal-below'] = ['paypal_below' => "  <strong>Donate</strong>  \n"];
         $this->assertSame('<strong>Donate</strong>', PageParts::resolvePaypalBelowSlot());
 
-        $modulehook_returns['paypal-below'] = ['paypal_below' => ['invalid']];
-        $this->assertSame('', PageParts::resolvePaypalBelowSlot());
+        $modulehook_returns['paypal-below'] = ['paypal_below' => ['<span>', 'Below', '</span>']];
+        $this->assertSame('<span>Below</span>', PageParts::resolvePaypalBelowSlot());
 
         $modulehook_returns['paypal-below'] = 'invalid';
         $this->assertSame('', PageParts::resolvePaypalBelowSlot());
@@ -49,7 +49,7 @@ final class PagePartsPaypalBelowSlotTest extends TestCase
         $this->assertSame("<em><script>alert('x')</script></em>", PageParts::resolvePaypalBelowSlot());
     }
 
-    public function testBuildPaypalDonationMarkupAppendsPlaceholderWithoutEmptyRow(): void
+    public function testBuildPaypalDonationMarkupLeavesPaypalTokenAsPureMarkup(): void
     {
         global $session;
         $_SERVER['HTTP_HOST'] = 'example.test';
@@ -74,7 +74,8 @@ final class PagePartsPaypalBelowSlotTest extends TestCase
             '2.0.0'
         );
 
-        $this->assertStringContainsString('</table>{paypal_below}', $header);
+        $this->assertStringContainsString('</table>', $header);
+        $this->assertStringNotContainsString('{paypal_below}', $header);
         $this->assertStringNotContainsString('margin-top: 0.8em', $header);
         $this->assertStringNotContainsString('colspan="2"', $header);
     }


### PR DESCRIPTION
### Motivation

- Make the below-PayPal extension a first-class, deterministic replacement so both legacy and Twig templates see the token consistently. 
- Normalize and safely handle module hook outputs for the `paypal-below` hook to avoid unexpected types and broken markup. 
- Prevent embedding `{paypal_below}` inside `{paypal}` to avoid one-pass replacement bugs and keep behavior consistent across rendering engines.

### Description

- Initialize `PageParts::$twigVars['paypal_below']` early in `Footer::pageFooter` so the token is always present for Twig and legacy paths. 
- Resolve the finalized below-PayPal markup once in `Footer::pageFooter` via `PageParts::resolvePaypalBelowSlot('')` and detect whether the template exposes `{paypal_below}` to decide whether to append the markup to the `{paypal}` replacement. 
- Extend `PageParts::buildPaypalDonationMarkup` signature to accept `$paypal_below_markup` and `$append_paypal_below_to_paypal` and use these to either keep `{paypal_below}` separate or append the finalized markup to the `{paypal}` value when needed. 
- Change `PageParts::resolvePaypalBelowSlot` to accept a default seed, normalize array outputs into a concatenated string of scalar parts, and return the default for unsupported types, trimming the result. 
- Ensure `{paypal}` replacement contains the finalized markup (or appended below-markup) but avoid embedding token placeholders inside each other to preserve one-pass replacement semantics.

### Testing

- Updated and ran the unit tests in `tests/PagePartsPaypalBelowSlotTest.php` which validate normalization of hook values and the produced PayPal markup; the tests passed. 
- Ran the modified test case with `phpunit tests/PagePartsPaypalBelowSlotTest.php` and observed success for the updated assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ac256148832981abde45f2e272a8)