### PR TITLE
fix(news): clamp and validate pagination inputs (page, offset)

### DIFF
--- a/news.php
+++ b/news.php
@@ -53,7 +53,8 @@ $page = filter_var($pageInput, FILTER_VALIDATE_INT);
 if ($page === false || $page < 1) {
     $page = 1;
 }
-$page = min($page, 10000);
+$maxPage = max(1, (int) ceil($totaltoday / $newsperpage));
+$page = min($page, $maxPage, 10000);
 $pageoffset = ($page - 1) * $newsperpage;
 $sql = "SELECT * FROM " . Database::prefix("news") . " WHERE newsdate='" . date("Y-m-d", $timestamp) . "' ORDER BY newsid DESC LIMIT $pageoffset,$newsperpage";
 $result = Database::query($sql);

--- a/news.php
+++ b/news.php
@@ -35,6 +35,9 @@ if ($session['user']['loggedin']) {
     DateTime::checkDay();
 }
 $newsperpage = (int) $settings->getSetting('newsperpage', 50);
+// Upper bound on page number to prevent extreme SQL offsets from being generated
+// by crafted URLs (e.g. page=99999999) before we know the real page count.
+const MAX_PAGE_HARD_LIMIT = 10000;
 
 $offsetInput = Http::get('offset');
 $offset = filter_var($offsetInput, FILTER_VALIDATE_INT);
@@ -54,7 +57,7 @@ if ($page === false || $page < 1) {
     $page = 1;
 }
 $maxPage = max(1, (int) ceil($totaltoday / $newsperpage));
-$page = min($page, $maxPage, 10000);
+$page = min($page, $maxPage, MAX_PAGE_HARD_LIMIT);
 $pageoffset = ($page - 1) * $newsperpage;
 $sql = "SELECT * FROM " . Database::prefix("news") . " WHERE newsdate='" . date("Y-m-d", $timestamp) . "' ORDER BY newsid DESC LIMIT $pageoffset,$newsperpage";
 $result = Database::query($sql);

--- a/news.php
+++ b/news.php
@@ -38,7 +38,8 @@ $newsperpage = (int) $settings->getSetting('newsperpage', 50);
 
 $offsetInput = Http::get('offset');
 $offset = filter_var($offsetInput, FILTER_VALIDATE_INT);
-if ($offset === false) {
+// Clamp offset to a safe non-negative integer for date navigation.
+if ($offset === false || $offset < 0) {
     $offset = 0;
 }
 $timestamp = DateTime::newsTimestampFromOffset($offset);
@@ -46,15 +47,14 @@ $sql = "SELECT count(newsid) AS c FROM " . Database::prefix("news") . " WHERE ne
 $result = Database::query($sql);
 $row = Database::fetchAssoc($result);
 $totaltoday = $row['c'];
-$page = (int)Http::get('page');
-if (!$page) {
+$pageInput = Http::get('page');
+$page = filter_var($pageInput, FILTER_VALIDATE_INT);
+// Clamp page to a bounded integer to prevent invalid and extreme offsets.
+if ($page === false || $page < 1) {
     $page = 1;
 }
-$pageoffset = $page;
-if ($pageoffset > 0) {
-    $pageoffset--;
-}
-$pageoffset *= $newsperpage;
+$page = min($page, 10000);
+$pageoffset = ($page - 1) * $newsperpage;
 $sql = "SELECT * FROM " . Database::prefix("news") . " WHERE newsdate='" . date("Y-m-d", $timestamp) . "' ORDER BY newsid DESC LIMIT $pageoffset,$newsperpage";
 $result = Database::query($sql);
 Header::pageHeader("LoGD News");


### PR DESCRIPTION
### Motivation
- Prevent invalid, negative, or extreme `page`/`offset` inputs from producing incorrect offsets or very expensive queries by validating and clamping the values before use.

### Description
- Parse `offset` and `page` using `filter_var(..., FILTER_VALIDATE_INT)` and fall back to safe defaults for invalid input.
- Enforce `offset >= 0` (default `0`) and `page >= 1` (default `1`) and add a defensive cap of `page <= 10000` to avoid extreme offsets.
- Recompute `$pageoffset` strictly from the clamped page via `($page - 1) * $newsperpage` and use these clamped values in the SQL `LIMIT` clause.
- Left pagination link generation intact and verified that links will continue to render using the (now normalized) `offset` and `page` values.

### Testing
- Ran `php -l news.php` and there were no syntax errors.
- Ran the full test suite with `composer test`, which completed successfully (713 tests ran) with warnings and notices but no failing tests.
- Ran static analysis with `composer static`, which returned `[OK] No errors`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f525a22e208329985d5392436524b9)