### PR TITLE
fix: normalize resurrectionturns numeric handling in non-percent path

### DIFF
--- a/newday.php
+++ b/newday.php
@@ -249,7 +249,8 @@ if ($dp < $dkills) {
         AddNews::add("`&%s`& has been resurrected by %s`&.", $session['user']['name'], $settings->getSetting('deathoverlord', '`$Ramius'));
         $spirits = -6;
         $resurrectionturns = $settings->getSetting('resurrectionturns', -6);
-        if (strstr($resurrectionturns, '%')) {
+        // Settings may be persisted as ints/floats/strings; guard string-only operations, then normalize for numeric math.
+        if (is_string($resurrectionturns) && strstr($resurrectionturns, '%')) {
             $resurrectionturns = strtok($resurrectionturns, '%');
             $resurrectionturns = (int)$resurrectionturns;
             if ($resurrectionturns < -100) {
@@ -257,7 +258,7 @@ if ($dp < $dkills) {
             }
             $resurrectionturns = round(($turnsperday + $dkff) * ($resurrectionturns / 100), 0);
         } else {
-            // Settings may be persisted as strings; cast first so strict typing and numeric functions receive a number.
+            // Cast first so strict typing and numeric functions/comparisons always receive a numeric value.
             $resurrectionturnsNumeric = (int) $resurrectionturns;
             if ($resurrectionturnsNumeric < -($turnsperday + $dkff)) {
                 $resurrectionturnsNumeric = -($turnsperday + $dkff);

--- a/newday.php
+++ b/newday.php
@@ -257,9 +257,12 @@ if ($dp < $dkills) {
             }
             $resurrectionturns = round(($turnsperday + $dkff) * ($resurrectionturns / 100), 0);
         } else {
-            if ($resurrectionturns < -($turnsperday + $dkff)) {
-                $resurrectionturns = -($turnsperday + $dkff);
+            // Settings may be persisted as strings; cast first so strict typing and numeric functions receive a number.
+            $resurrectionturnsNumeric = (int) $resurrectionturns;
+            if ($resurrectionturnsNumeric < -($turnsperday + $dkff)) {
+                $resurrectionturnsNumeric = -($turnsperday + $dkff);
             }
+            $resurrectionturns = $resurrectionturnsNumeric;
         }
         $session['user']['deathpower'] -= $settings->getSetting('resurrectioncost', 100);
         $session['user']['restorepage'] = "village.php?c=1";


### PR DESCRIPTION
### Motivation
- Ensure the non-`%` resurrection-turns path uses a numeric value for all comparisons and math because settings may be stored as strings and strict typing or numeric functions can behave unexpectedly.
- Preserve existing percent-based behavior (percentage values remain calculated relative to `(turnsperday + dkff)` and bounded as before) while making the fixed-value path type-safe and predictable for values like `-6%`, `-6`, `0`, and positive integers.

### Description
- Added an explicit cast to `int` for the non-`%` `resurrectionturns` path into a temporary variable `$resurrectionturnsNumeric` and used it for clamping. 
- Clamped `resurrectionturnsNumeric` to the lower bound `-($turnsperday + $dkff)` and then assigned it back to `$resurrectionturns` for downstream use. 
- Added an inline comment explaining why casting is required (settings may be persisted as strings; strict typing + numeric functions require int/float). 
- Left the percent-handling branch unchanged so percent strings continue to be processed and rounded as before.

### Testing
- Ran `php -l newday.php` which reported no syntax errors. 
- Ran `composer test` which completed successfully (tests passed) but reported warnings, deprecations, and PHPUnit notices. 
- Ran `composer static` which completed with `[OK] No errors` reported by the static analysis tool.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6e726ad4c832984c00a1090cd11a7)