### PR TITLE
Normalize badword lists and fix PHP 8 substring handling in source scanner

### DIFF
--- a/badword.php
+++ b/badword.php
@@ -80,7 +80,7 @@ $output->rawOutput("<input name='word'><input type='submit' class='button' value
 $sql = "SELECT * FROM " . Database::prefix("nastywords") . " WHERE type='good'";
 $result = Database::query($sql);
 $row = Database::fetchAssoc($result);
-$words = explode(" ", $row['words']);
+$words = badword_words_from_row($row);
 if ($op == "addgood") {
     $newRegexpPost = Http::post('word');
     $newregexp = is_string($newRegexpPost) ? stripslashes($newRegexpPost) : '';
@@ -159,7 +159,7 @@ $sql = "SELECT * FROM " . Database::prefix("nastywords") . " WHERE type='nasty'"
 $result = Database::query($sql);
 $row = Database::fetchAssoc($result);
 
-$words = explode(" ", $row['words']);
+$words = badword_words_from_row($row);
 reset($words);
 
 if ($op == "add") {
@@ -219,8 +219,40 @@ if ($op == "add" || $op == "remove") {
 }
 Footer::pageFooter();
 
-function show_word_list($words)
+/**
+ * Convert a nastywords database row into a normalized word list.
+ *
+ * Legacy installs may be missing either the good-word or nasty-word row, and
+ * the words column is nullable in older schemas. Returning an empty list keeps
+ * the editor usable until the next add/remove operation recreates the row.
+ *
+ * @param array<string, mixed>|false|null $row Database row returned for one word-list type.
+ *
+ * @return array<int, string> Non-empty words from the row.
+ */
+function badword_words_from_row(array|false|null $row): array
 {
+    if (!is_array($row) || !isset($row['words']) || !is_string($row['words'])) {
+        return [];
+    }
+
+    $words = explode(" ", $row['words']);
+
+    return array_values(array_filter(
+        $words,
+        static fn (string $word): bool => trim($word) !== ''
+    ));
+}
+
+/**
+ * Render a grouped list of configured words.
+ *
+ * @param array<int, string> $words Words to display.
+ */
+function show_word_list(array $words): void
+{
+    $output = Output::getInstance();
+
     sort($words);
     $lastletter = "";
     foreach ($words as $key => $val) {

--- a/badword.php
+++ b/badword.php
@@ -236,11 +236,11 @@ function badword_words_from_row(array|false|null $row): array
         return [];
     }
 
-    $words = explode(" ", $row['words']);
+    $words = preg_split('/\s+/', $row['words']);
 
     return array_values(array_filter(
-        $words,
-        static fn (string $word): bool => trim($word) !== ''
+        array_map('trim', $words),
+        static fn (string $word): bool => $word !== ''
     ));
 }
 

--- a/source.php
+++ b/source.php
@@ -107,8 +107,10 @@ if (
             if ($entry[0] == '.') {
                 continue;
             }
-            // skip any php files
-            if (substr($entry, strrpos($entry, '.')) == ".php") {
+            // Skip any php files. strrpos() returns false for names without a dot,
+            // so guard the offset before passing it to substr() on PHP 8+.
+            $extensionOffset = strrpos($entry, '.');
+            if ($extensionOffset !== false && substr($entry, $extensionOffset) == ".php") {
                 continue;
             }
             $ndir = $base . "/" . $entry;

--- a/source.php
+++ b/source.php
@@ -141,7 +141,8 @@ if (
         $d = dir("$key");
         $files = array();
         while (false !== ($entry = $d->read())) {
-            if (substr($entry, strrpos($entry, ".")) == ".php") {
+            $extOffset = strrpos($entry, '.');
+            if ($extOffset !== false && substr($entry, $extOffset) === ".php") {
                 array_push($files, "$entry");
             }
         }

--- a/source.php
+++ b/source.php
@@ -107,10 +107,8 @@ if (
             if ($entry[0] == '.') {
                 continue;
             }
-            // Skip any php files. strrpos() returns false for names without a dot,
-            // so guard the offset before passing it to substr() on PHP 8+.
-            $extensionOffset = strrpos($entry, '.');
-            if ($extensionOffset !== false && substr($entry, $extensionOffset) == ".php") {
+            // Skip any .php files.
+            if (str_ends_with($entry, '.php')) {
                 continue;
             }
             $ndir = $base . "/" . $entry;
@@ -141,8 +139,7 @@ if (
         $d = dir("$key");
         $files = array();
         while (false !== ($entry = $d->read())) {
-            $extOffset = strrpos($entry, '.');
-            if ($extOffset !== false && substr($entry, $extOffset) === ".php") {
+            if (str_ends_with($entry, '.php')) {
                 array_push($files, "$entry");
             }
         }


### PR DESCRIPTION
### Motivation

- Prevent errors and warnings when the `nastywords` DB row is missing or has a nullable `words` column by returning an empty list instead of passing null to `explode`.
- Normalize and filter configured good/nasty word lists to remove empty entries and trim cruft so the word editor remains usable on legacy installs.
- Fix a PHP 8 compatibility issue in the source directory scanner where `substr` was called with a `false` offset returned by `strrpos` causing warnings.

### Description

- Add `badword_words_from_row(array|false|null $row): array` to normalize a DB row into a filtered word list with a docblock and type hints, returning `[]` for missing/invalid rows.
- Replace direct `explode(" ", $row['words'])` calls with `badword_words_from_row($row)` for both `good` and `nasty` lists and use `array_values(array_filter(...))` to remove empty entries.
- Rename/adjust `show_word_list` to accept an `array` of words and obtain the `Output` instance internally, keeping the rendered grouping behavior intact.
- Update `source.php` to check the result of `strrpos($entry, '.')` before calling `substr()` to avoid passing `false` to `substr` on filenames without extensions.

### Testing

- Ran PHP syntax checks with `php -l` on the modified files, which reported no syntax errors.
- Executed the project's automated test suite (`phpunit` / `composer test`) and observed all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fed97488d48329a350d59c3ece2903)