### PR TITLE
Zugzug

### DIFF
--- a/badword.php
+++ b/badword.php
@@ -80,7 +80,7 @@ $output->rawOutput("<input name='word'><input type='submit' class='button' value
 $sql = "SELECT * FROM " . Database::prefix("nastywords") . " WHERE type='good'";
 $result = Database::query($sql);
 $row = Database::fetchAssoc($result);
-$words = explode(" ", $row['words']);
+$words = badword_words_from_row($row);
 if ($op == "addgood") {
     $newRegexpPost = Http::post('word');
     $newregexp = is_string($newRegexpPost) ? stripslashes($newRegexpPost) : '';
@@ -159,7 +159,7 @@ $sql = "SELECT * FROM " . Database::prefix("nastywords") . " WHERE type='nasty'"
 $result = Database::query($sql);
 $row = Database::fetchAssoc($result);
 
-$words = explode(" ", $row['words']);
+$words = badword_words_from_row($row);
 reset($words);
 
 if ($op == "add") {
@@ -219,8 +219,40 @@ if ($op == "add" || $op == "remove") {
 }
 Footer::pageFooter();
 
-function show_word_list($words)
+/**
+ * Convert a nastywords database row into a normalized word list.
+ *
+ * Legacy installs may be missing either the good-word or nasty-word row, and
+ * the words column is nullable in older schemas. Returning an empty list keeps
+ * the editor usable until the next add/remove operation recreates the row.
+ *
+ * @param array<string, mixed>|false|null $row Database row returned for one word-list type.
+ *
+ * @return array<int, string> Non-empty words from the row.
+ */
+function badword_words_from_row(array|false|null $row): array
 {
+    if (!is_array($row) || !isset($row['words']) || !is_string($row['words'])) {
+        return [];
+    }
+
+    $words = explode(" ", $row['words']);
+
+    return array_values(array_filter(
+        $words,
+        static fn (string $word): bool => trim($word) !== ''
+    ));
+}
+
+/**
+ * Render a grouped list of configured words.
+ *
+ * @param array<int, string> $words Words to display.
+ */
+function show_word_list(array $words): void
+{
+    $output = Output::getInstance();
+
     sort($words);
     $lastletter = "";
     foreach ($words as $key => $val) {

--- a/badword.php
+++ b/badword.php
@@ -236,11 +236,11 @@ function badword_words_from_row(array|false|null $row): array
         return [];
     }
 
-    $words = explode(" ", $row['words']);
+    $words = preg_split('/\s+/', $row['words']);
 
     return array_values(array_filter(
-        $words,
-        static fn (string $word): bool => trim($word) !== ''
+        array_map('trim', $words),
+        static fn (string $word): bool => $word !== ''
     ));
 }
 

--- a/source.php
+++ b/source.php
@@ -107,8 +107,10 @@ if (
             if ($entry[0] == '.') {
                 continue;
             }
-            // skip any php files
-            if (substr($entry, strrpos($entry, '.')) == ".php") {
+            // Skip any php files. strrpos() returns false for names without a dot,
+            // so guard the offset before passing it to substr() on PHP 8+.
+            $extensionOffset = strrpos($entry, '.');
+            if ($extensionOffset !== false && substr($entry, $extensionOffset) == ".php") {
                 continue;
             }
             $ndir = $base . "/" . $entry;

--- a/source.php
+++ b/source.php
@@ -141,7 +141,8 @@ if (
         $d = dir("$key");
         $files = array();
         while (false !== ($entry = $d->read())) {
-            if (substr($entry, strrpos($entry, ".")) == ".php") {
+            $extOffset = strrpos($entry, '.');
+            if ($extOffset !== false && substr($entry, $extOffset) === ".php") {
                 array_push($files, "$entry");
             }
         }

--- a/source.php
+++ b/source.php
@@ -107,10 +107,8 @@ if (
             if ($entry[0] == '.') {
                 continue;
             }
-            // Skip any php files. strrpos() returns false for names without a dot,
-            // so guard the offset before passing it to substr() on PHP 8+.
-            $extensionOffset = strrpos($entry, '.');
-            if ($extensionOffset !== false && substr($entry, $extensionOffset) == ".php") {
+            // Skip any .php files.
+            if (str_ends_with($entry, '.php')) {
                 continue;
             }
             $ndir = $base . "/" . $entry;
@@ -141,8 +139,7 @@ if (
         $d = dir("$key");
         $files = array();
         while (false !== ($entry = $d->read())) {
-            $extOffset = strrpos($entry, '.');
-            if ($extOffset !== false && substr($entry, $extOffset) === ".php") {
+            if (str_ends_with($entry, '.php')) {
                 array_push($files, "$entry");
             }
         }


### PR DESCRIPTION
This pull request focuses on improving code clarity, maintainability, and robustness in both the `badword.php` and `source.php` files. The most significant changes include refactoring how word lists are extracted from database rows, enhancing compatibility with legacy data, and modernizing file extension checks.

**Bad word list handling improvements:**

* Introduced the `badword_words_from_row` function in `badword.php` to robustly extract and normalize word lists from database rows, handling legacy cases where the row or column may be missing or empty. This prevents errors and ensures the editor remains usable in edge cases.
* Updated two locations in `badword.php` to use `badword_words_from_row` instead of directly exploding the `words` column, improving consistency and reliability. [[1]](diffhunk://#diff-4a101d79c798d160ef7b8b2087543af8e341ca09f19057ea593886177b91f4caL83-R83) [[2]](diffhunk://#diff-4a101d79c798d160ef7b8b2087543af8e341ca09f19057ea593886177b91f4caL162-R162)

**File extension handling modernization:**

* Replaced manual substring checks with the `str_ends_with` function in `source.php` to more clearly and safely identify `.php` files when filtering directory entries. This change was applied in two places. [[1]](diffhunk://#diff-d955715f7565f9d1e20fec66f069372089d0cc72f17201df761d16a1c7222b24L110-R111) [[2]](diffhunk://#diff-d955715f7565f9d1e20fec66f069372089d0cc72f17201df761d16a1c7222b24L142-R142)