### PR TITLE
fix: render combat round summaries consistently

### DIFF
--- a/battle.php
+++ b/battle.php
@@ -187,9 +187,12 @@ if ($op != "run" && $op != "fight" && $op != "newtarget") {
     }
 }
 $needtostopfighting = false;
+$combatRoundExecuted = false;
 if ($op != "newtarget") {
     // Run through as many rounds as needed.
     do {
+        // Request operations can change during processing, so record the fact that combat actually ran.
+        $combatRoundExecuted = true;
         //we need to restore and calculate here to reflect changes that happen throughout the course of multiple rounds.
         restore_buff_fields();
         calculate_buff_fields();
@@ -534,10 +537,7 @@ if ($op != "newtarget") {
 
 $newenemies = Battle::autoSetTarget($newenemies);
 
-if ($session['user']['hitpoints'] > 0 && count($newenemies) > 0 && ($op == "fight" || $op == "run")) {
-    $output->output("`2`bEnd of Round:`b`n");
-        Battle::showEnemies($newenemies);
-}
+Battle::showRoundSummary($newenemies, $combatRoundExecuted);
 
 if ($session['user']['hitpoints'] <= 0) {
     $session['user']['hitpoints'] = 0;

--- a/src/Lotgd/Battle.php
+++ b/src/Lotgd/Battle.php
@@ -569,7 +569,7 @@ class Battle
     }
 
     /**
-     * Render the post-combat state when a round ran and combat can continue.
+     * Render the post-combat state when a combat round ran and the player is still alive.
      *
      * Summary rendering follows actual combat execution rather than the request
      * operation because target-selection requests can change the operation

--- a/src/Lotgd/Battle.php
+++ b/src/Lotgd/Battle.php
@@ -568,6 +568,28 @@ class Battle
         }
     }
 
+    /**
+     * Render the post-combat state when a round ran and combat can continue.
+     *
+     * Summary rendering follows actual combat execution rather than the request
+     * operation because target-selection requests can change the operation
+     * without processing a round, while combat processing can also mutate it.
+     *
+     * @param array<int|string, array<string, mixed>> $enemies Current enemies
+     * @param bool                                    $roundExecuted Whether combat processing ran
+     */
+    public static function showRoundSummary(array $enemies, bool $roundExecuted): void
+    {
+        global $session;
+
+        if (! $roundExecuted || $session['user']['hitpoints'] <= 0 || count($enemies) === 0) {
+            return;
+        }
+
+        Output::getInstance()->output("`2`bEnd of Round:`b`n");
+        self::showEnemies($enemies);
+    }
+
 /**
  * This function prepares the fight, sets up options and gives hook a hook to change options on a per-player basis.
  *

--- a/tests/BattleRoundSummaryTest.php
+++ b/tests/BattleRoundSummaryTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Battle;
+use Lotgd\Output;
+use Lotgd\Settings;
+use Lotgd\Tests\Stubs\DummySettings;
+use PHPUnit\Framework\TestCase;
+
+final class BattleRoundSummaryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $enemycounter, $session;
+
+        $settings = new DummySettings([
+            'forestcreaturebar' => 2,
+        ]);
+        Settings::setInstance($settings);
+        $GLOBALS['settings'] = $settings;
+
+        $session = [
+            'user' => [
+                'alive' => true,
+                'name' => 'Tester',
+                'level' => 5,
+                'dragonkills' => 0,
+                'hitpoints' => 40,
+                'maxhitpoints' => 50,
+                'prefs' => [
+                    'forestcreaturebar' => 2,
+                ],
+            ],
+        ];
+        $enemycounter = 1;
+        Output::getInstance()->resetOutput();
+    }
+
+    public function testNormalSingleEnemyRoundShowsSummary(): void
+    {
+        Battle::showRoundSummary([$this->enemy('Goblin', 7, 10, true)], true);
+
+        $output = Output::getInstance()->getRawOutput();
+
+        self::assertStringContainsString('End of Round', $output);
+        self::assertStringContainsString('Goblin', $output);
+        self::assertStringContainsString('(7/10)', $output);
+    }
+
+    public function testMultiEnemyRoundShowsEverySurvivorHpAndHealthBars(): void
+    {
+        global $enemycounter;
+
+        $enemycounter = 2;
+        Battle::showRoundSummary([
+            $this->enemy('Goblin Scout', 7, 10, true),
+            $this->enemy('Orc Guard', 12, 15),
+        ], true);
+
+        $output = Output::getInstance()->getRawOutput();
+
+        self::assertStringContainsString('End of Round', $output);
+        self::assertStringContainsString('Goblin Scout', $output);
+        self::assertStringContainsString('(7/10)', $output);
+        self::assertStringContainsString('Orc Guard', $output);
+        self::assertStringContainsString('(12/15)', $output);
+        self::assertGreaterThanOrEqual(
+            3,
+            substr_count($output, "<div style='display: block;background-color:")
+        );
+    }
+
+    public function testSummaryShowsRemainingEnemyAfterAnotherEnemyDies(): void
+    {
+        global $enemycounter;
+
+        $enemycounter = 2;
+        Battle::showRoundSummary([
+            $this->enemy('Fallen Goblin', 0, 10),
+            $this->enemy('Orc Survivor', 9, 15, true),
+        ], true);
+
+        $output = Output::getInstance()->getRawOutput();
+
+        self::assertStringContainsString('End of Round', $output);
+        self::assertStringContainsString('Orc Survivor', $output);
+        self::assertStringContainsString('(9/15)', $output);
+    }
+
+    public function testTargetSelectionWithoutCombatDoesNotShowRoundSummary(): void
+    {
+        global $enemycounter;
+
+        $enemycounter = 2;
+        Battle::showRoundSummary([
+            $this->enemy('Goblin Scout', 10, 10),
+            $this->enemy('Selected Orc', 15, 15, true),
+        ], false);
+
+        self::assertStringNotContainsString(
+            'End of Round',
+            Output::getInstance()->getRawOutput()
+        );
+    }
+
+    /**
+     * Build the minimum enemy state consumed by Battle::showEnemies().
+     *
+     * @return array<string, int|string|bool>
+     */
+    private function enemy(
+        string $name,
+        int $health,
+        int $maxHealth,
+        bool $isTarget = false
+    ): array {
+        return [
+            'creaturename' => $name,
+            'creaturehealth' => $health,
+            'creaturemaxhealth' => $maxHealth,
+            'creaturelevel' => 3,
+            'istarget' => $isTarget,
+            'dead' => $health <= 0,
+        ];
+    }
+}


### PR DESCRIPTION
### Motivation

- Avoid inferring that a combat round executed from the final request operation (`$op`) because operations can change during processing (for example `newtarget` vs `fight`).
- Ensure the post-round enemy summary is always rendered via the same code that produces health bars, translations, and hide-hitpoint behaviour so the UI remains consistent.

### Description

- Add an explicit local boolean `$combatRoundExecuted` in `battle.php` that is set when the round-processing loop is entered to record that combat actually ran. (`battle.php`) 
- Replace the previous ad-hoc end-of-round output with `Battle::showRoundSummary($newenemies, $combatRoundExecuted)`, which decides whether to render the summary. (`battle.php`) 
- Add `Battle::showRoundSummary(array $enemies, bool $roundExecuted)` in `src/Lotgd/Battle.php` with PHPDoc explaining why the summary is based on actual combat execution, and delegate enemy rendering to `Battle::showEnemies()` to preserve health bars, hidden-HP behaviour, translations, and player HP output. (`src/Lotgd/Battle.php`) 
- Add PHPUnit coverage in `tests/BattleRoundSummaryTest.php` that covers: a normal single-enemy round, a multi-enemy round with multiple survivors, a round where one enemy dies and another remains, and a target-selection request that does not execute combat and therefore should not show an "End of Round" heading. (`tests/BattleRoundSummaryTest.php`)

### Testing

- Syntax checks: `php -l battle.php`, `php -l src/Lotgd/Battle.php`, and `php -l tests/BattleRoundSummaryTest.php` all succeeded. 
- Targeted PHPUnit: `vendor/bin/phpunit --configuration phpunit.xml tests/BattleRoundSummaryTest.php` ran the 4 new tests (4 tests, 14 assertions) and passed. 
- Full test suite: `composer test` executed the full suite (717 tests) and completed successfully (with the repository's prior warnings/notices that were unrelated to these changes). 
- Static checks: `composer static` completed successfully. 
- Coding style: `vendor/bin/phpcs` showed the new class and tests pass, while `battle.php` still reports pre-existing file-header/mixed side-effect and trailing-whitespace findings that were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d8692dd3c8329b9a86176b3660069)