### PR TITLE
fix: only summarize processed combat rounds

### DIFF
--- a/battle.php
+++ b/battle.php
@@ -191,8 +191,6 @@ $combatRoundExecuted = false;
 if ($op != "newtarget") {
     // Run through as many rounds as needed.
     do {
-        // Request operations can change during processing, so record the fact that combat actually ran.
-        $combatRoundExecuted = true;
         //we need to restore and calculate here to reflect changes that happen throughout the course of multiple rounds.
         restore_buff_fields();
         calculate_buff_fields();
@@ -256,6 +254,8 @@ if ($op != "newtarget") {
                         $companions = $newcompanions;
 
                         if ($op == "fight" || $op == "run" || $surprised) {
+                            // Record entry into attack processing, not the surrounding state-management loop.
+                            $combatRoundExecuted = true;
                             // Grab an initial roll.
                             $roll = Battle::rollDamage($badguy);
                             if ($op == "fight" && !$surprised) {

--- a/tests/BattleRoundSummaryTest.php
+++ b/tests/BattleRoundSummaryTest.php
@@ -106,6 +106,25 @@ final class BattleRoundSummaryTest extends TestCase
         );
     }
 
+    public function testInitialSearchWithoutSurpriseDoesNotShowRoundSummary(): void
+    {
+        $enemy = $this->enemy('Forest Goblin', 10, 10, true);
+        $operation = 'search';
+        $surprised = false;
+        $combatRoundExecuted = false;
+
+        if ($operation === 'fight' || $operation === 'run' || $surprised) {
+            $combatRoundExecuted = true;
+        }
+
+        Battle::showRoundSummary([$enemy], $combatRoundExecuted);
+
+        self::assertStringNotContainsString(
+            'End of Round',
+            Output::getInstance()->getRawOutput()
+        );
+    }
+
     /**
      * Build the minimum enemy state consumed by Battle::showEnemies().
      *


### PR DESCRIPTION
### Motivation
- Prevent rendering an "End of Round" summary when the controller performed only state-management (e.g. initial `search`) and no attack processing actually occurred.

### Description
- Keep `$combatRoundExecuted` initialized to `false` before the battle-processing loop and remove the unconditional assignment inside the `do` block.  
- Set `$combatRoundExecuted = true` only when entering the attack-processing branch (`if ($op == "fight" || $op == "run" || $surprised)`), and add an inline comment clarifying the flag records entry into attack processing.  
- Add a regression test `testInitialSearchWithoutSurpriseDoesNotShowRoundSummary` to assert an initial `search` with no surprise does not produce an `End of Round` summary, while preserving existing positive summary tests.  
- Files changed: `battle.php` and `tests/BattleRoundSummaryTest.php`.

### Testing
- Ran `php -l battle.php` and `php -l tests/BattleRoundSummaryTest.php` with no syntax errors.  
- Ran `vendor/bin/phpunit --configuration phpunit.xml tests/BattleRoundSummaryTest.php` and the test file passed (`5 tests, 15 assertions`).  
- Ran the full suite via `composer test`; the suite completed successfully (718 tests) with existing warnings/deprecations but no failures.  
- Ran `composer static` (static checks) which completed without introducing new blocking findings.

Security review: not applicable because this change does not touch authentication, session handling, admin/superuser flows, async endpoints, or SQL execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e5092b70c83299c4c21705ba695fe)