### PR TITLE
Zugzug

### DIFF
--- a/battle.php
+++ b/battle.php
@@ -191,8 +191,6 @@ $combatRoundExecuted = false;
 if ($op != "newtarget") {
     // Run through as many rounds as needed.
     do {
-        // Request operations can change during processing, so record the fact that combat actually ran.
-        $combatRoundExecuted = true;
         //we need to restore and calculate here to reflect changes that happen throughout the course of multiple rounds.
         restore_buff_fields();
         calculate_buff_fields();
@@ -256,6 +254,8 @@ if ($op != "newtarget") {
                         $companions = $newcompanions;
 
                         if ($op == "fight" || $op == "run" || $surprised) {
+                            // Record entry into attack processing, not the surrounding state-management loop.
+                            $combatRoundExecuted = true;
                             // Grab an initial roll.
                             $roll = Battle::rollDamage($badguy);
                             if ($op == "fight" && !$surprised) {

--- a/tests/BattleRoundSummaryTest.php
+++ b/tests/BattleRoundSummaryTest.php
@@ -106,6 +106,25 @@ final class BattleRoundSummaryTest extends TestCase
         );
     }
 
+    public function testInitialSearchWithoutSurpriseDoesNotShowRoundSummary(): void
+    {
+        $enemy = $this->enemy('Forest Goblin', 10, 10, true);
+        $operation = 'search';
+        $surprised = false;
+        $combatRoundExecuted = false;
+
+        if ($operation === 'fight' || $operation === 'run' || $surprised) {
+            $combatRoundExecuted = true;
+        }
+
+        Battle::showRoundSummary([$enemy], $combatRoundExecuted);
+
+        self::assertStringNotContainsString(
+            'End of Round',
+            Output::getInstance()->getRawOutput()
+        );
+    }
+
     /**
      * Build the minimum enemy state consumed by Battle::showEnemies().
      *


### PR DESCRIPTION
This pull request refines how combat round execution is tracked in `battle.php` and adds a new test to ensure round summaries are not incorrectly shown. The main goal is to more accurately record when a combat round has actually been executed, and to verify this behavior with a unit test.

**Combat round execution tracking:**

* Moved the assignment of `$combatRoundExecuted = true` from the outer processing loop to the specific point where attack processing begins, ensuring it only records actual combat action (`battle.php`). [[1]](diffhunk://#diff-3297507717af2caba5470de672d35c9ce8c8fc8c9cd6c0a455ed37fac4aeb781L194-L195) [[2]](diffhunk://#diff-3297507717af2caba5470de672d35c9ce8c8fc8c9cd6c0a455ed37fac4aeb781R257-R258)

**Testing improvements:**

* Added `testInitialSearchWithoutSurpriseDoesNotShowRoundSummary` to verify that when a search operation is performed without surprise, the round summary is not displayed (`tests/BattleRoundSummaryTest.php`).