### PR TITLE
fix(motd): secure MoTD poll vote handling (input validation, CSRF, DBAL writes, tests)

### DIFF
--- a/motd.php
+++ b/motd.php
@@ -42,12 +42,30 @@ if ($session['user']['superuser'] & SU_POST_MOTD) {
 }
 
 if ($op == "vote") {
-    $motditem = Http::post('motditem');
-    $choice = (string)Http::post('choice');
-    $sql = "DELETE FROM " . Database::prefix("pollresults") . " WHERE motditem='$motditem' AND account='{$session['user']['acctid']}'";
-    Database::query($sql);
-    $sql = "INSERT INTO " . Database::prefix("pollresults") . " (choice,account,motditem) VALUES ('$choice','{$session['user']['acctid']}','$motditem')";
-    Database::query($sql);
+    // POST is the trust boundary: reject rather than coerce malformed identifiers.
+    $motditem = Motd::validatePollVoteIdentifier(Http::post('motditem'));
+    $choice = Motd::validatePollVoteIdentifier(Http::post('choice'));
+    $account = (int)($session['user']['acctid'] ?? 0);
+    $postedCsrf = Http::post('csrf_token');
+    $expectedCsrf = $session['motd_vote_csrf'] ?? null;
+
+    if (
+        $motditem === null
+        || $choice === null
+        || $account <= 0
+        || empty($session['user']['loggedin'])
+        || !is_string($postedCsrf)
+        || !is_string($expectedCsrf)
+        || $expectedCsrf === ''
+        || !hash_equals($expectedCsrf, $postedCsrf)
+    ) {
+        debuglog('Rejected invalid or unauthorized MoTD poll vote request.');
+        http_response_code(400);
+        header("Location: motd.php");
+        exit();
+    }
+
+    Motd::recordPollVote($motditem, $choice, $account);
     DataCache::getInstance()->invalidatedatacache("poll-$motditem");
     header("Location: motd.php");
     exit();

--- a/src/Lotgd/Motd.php
+++ b/src/Lotgd/Motd.php
@@ -136,8 +136,18 @@ class Motd
         }
 
         if ($session['user']['loggedin'] && $showpoll) {
+            if (
+                !isset($session['motd_vote_csrf'])
+                || !is_string($session['motd_vote_csrf'])
+                || $session['motd_vote_csrf'] === ''
+            ) {
+                $session['motd_vote_csrf'] = bin2hex(random_bytes(32));
+            }
+
             $output->rawOutput("<form action='motd.php?op=vote' method='POST'>");
             $output->rawOutput("<input type='hidden' name='motditem' value='$id'>");
+            $csrfToken = htmlspecialchars($session['motd_vote_csrf'], ENT_QUOTES, 'UTF-8');
+            $output->rawOutput("<input type='hidden' name='csrf_token' value='$csrfToken'>");
         }
 
         foreach ($bodyData['opt'] as $key => $val) {
@@ -379,5 +389,61 @@ class Motd
             Nav::add('', "motd.php?op=$editop&id=$id");
             Nav::add('', "motd.php?op=del&id=$id");
         }
+    }
+
+    /**
+     * Validate an untrusted poll identifier without coercing malformed values.
+     *
+     * HTML forms submit decimal strings, while internal callers may supply an
+     * integer. Other scalar types, non-decimal strings, and non-positive values
+     * are deliberately rejected at the request boundary.
+     */
+    public static function validatePollVoteIdentifier(mixed $value): ?int
+    {
+        if (!is_int($value) && !is_string($value)) {
+            return null;
+        }
+
+        if (is_string($value) && preg_match('/^[1-9][0-9]*$/D', $value) !== 1) {
+            return null;
+        }
+
+        $identifier = filter_var($value, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+
+        return is_int($identifier) ? $identifier : null;
+    }
+
+    /**
+     * Replace an account's previous response to a poll using typed DBAL parameters.
+     */
+    public static function recordPollVote(int $motditem, int $choice, int $account): void
+    {
+        $connection = Database::getDoctrineConnection();
+        $connection->executeStatement(
+            'DELETE FROM ' . Database::prefix('pollresults')
+            . ' WHERE motditem = :motditem AND account = :account',
+            [
+                'motditem' => $motditem,
+                'account' => $account,
+            ],
+            [
+                'motditem' => ParameterType::INTEGER,
+                'account' => ParameterType::INTEGER,
+            ]
+        );
+        $connection->executeStatement(
+            'INSERT INTO ' . Database::prefix('pollresults')
+            . ' (choice, account, motditem) VALUES (:choice, :account, :motditem)',
+            [
+                'motditem' => $motditem,
+                'choice' => $choice,
+                'account' => $account,
+            ],
+            [
+                'motditem' => ParameterType::INTEGER,
+                'choice' => ParameterType::INTEGER,
+                'account' => ParameterType::INTEGER,
+            ]
+        );
     }
 }

--- a/tests/MotdPollVoteSecurityTest.php
+++ b/tests/MotdPollVoteSecurityTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\Motd;
+use Lotgd\MySQL\Database;
+use Lotgd\Tests\Stubs\DoctrineBootstrap;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class MotdPollVoteSecurityTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/Stubs/DoctrineBootstrap.php';
+
+        Database::$doctrineConnection = null;
+        Database::$instance = null;
+        DoctrineBootstrap::$conn = null;
+    }
+
+    /**
+     * Supply values that must never cross the poll vote validation boundary.
+     *
+     * @return iterable<string, array{mixed}>
+     */
+    public static function invalidIdentifierProvider(): iterable
+    {
+        yield 'missing' => [null];
+        yield 'array' => [['1']];
+        yield 'quote-bearing injection' => ["1' OR 1=1 --"];
+        yield 'decimal suffix' => ['1.0'];
+        yield 'zero integer' => [0];
+        yield 'zero string' => ['0'];
+        yield 'negative integer' => [-1];
+        yield 'negative string' => ['-1'];
+        yield 'boolean' => [true];
+    }
+
+    #[DataProvider('invalidIdentifierProvider')]
+    public function testMalformedIdentifiersAreRejectedWithoutCoercion(mixed $value): void
+    {
+        self::assertNull(Motd::validatePollVoteIdentifier($value));
+    }
+
+    public function testValidVoteDeletesPreviousChoiceThenInsertsTypedReplacement(): void
+    {
+        self::assertSame(17, Motd::validatePollVoteIdentifier('17'));
+        self::assertSame(3, Motd::validatePollVoteIdentifier(3));
+
+        $connection = Database::getDoctrineConnection();
+
+        Motd::recordPollVote(17, 3, 42);
+
+        self::assertCount(2, $connection->executeStatements);
+        [$delete, $insert] = $connection->executeStatements;
+
+        self::assertSame(
+            'DELETE FROM pollresults WHERE motditem = :motditem AND account = :account',
+            $delete['sql']
+        );
+        self::assertSame(['motditem' => 17, 'account' => 42], $delete['params']);
+        self::assertSame(
+            ['motditem' => ParameterType::INTEGER, 'account' => ParameterType::INTEGER],
+            $delete['types']
+        );
+
+        self::assertSame(
+            'INSERT INTO pollresults (choice, account, motditem) VALUES (:choice, :account, :motditem)',
+            $insert['sql']
+        );
+        self::assertSame(['motditem' => 17, 'choice' => 3, 'account' => 42], $insert['params']);
+        self::assertSame(
+            [
+                'motditem' => ParameterType::INTEGER,
+                'choice' => ParameterType::INTEGER,
+                'account' => ParameterType::INTEGER,
+            ],
+            $insert['types']
+        );
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent SQL modification via malformed `POST` values and ensure the MoTD poll vote path validates inputs before touching DB or cache.
- Require a session-backed CSRF token for the state-changing vote action and ensure the authenticated account id is typed before use.
- Replace unsafe interpolated SQL with typed Doctrine DBAL statements and add regression tests to prevent regressions.

### Description

- Introduced a strict request boundary by adding `Motd::validatePollVoteIdentifier()` which accepts only positive integer identifiers and rejects missing, array, boolean, quote-bearing, decimal, zero, negative, or otherwise malformed inputs. 
- Cast the authenticated account id to an `int` at the handler and added session-backed CSRF token generation in the poll form and `csrf_token` validation (using `hash_equals`) in the vote handler. 
- Replaced interpolated `Database::query()` calls with typed DBAL prepared statements using `Database::getDoctrineConnection()` and `executeStatement()` with named placeholders and `ParameterType::INTEGER` for `motditem`, `choice`, and `account`, and preserved cache invalidation, redirect, and `exit()` semantics. 
- Added focused regression tests in `tests/MotdPollVoteSecurityTest.php` proving malformed/quote-bearing POST values cannot bypass validation or alter SQL structure and proving a valid integer vote deletes the previous result then inserts a typed replacement; rejected requests are logged via `debuglog()`. 
- Security review: input validation boundary is explicit at `Motd::validatePollVoteIdentifier()` and the vote handler, CSRF protection is added and validated with `hash_equals()`, prepared statements are used for all writes with only `Database::prefix()` concatenated for the trusted table name, authorization requires a logged-in session and positive `acctid`, and invalid/unauthorized vote attempts are recorded with `debuglog()` for auditing. 

### Testing

- Ran `php -l` on `motd.php`, `src/Lotgd/Motd.php`, and `tests/MotdPollVoteSecurityTest.php` with no syntax errors. 
- Ran the focused PHPUnit test: `vendor/bin/phpunit --configuration phpunit.xml tests/MotdPollVoteSecurityTest.php` and it passed. 
- Ran the full test suite using `composer test` which completed successfully (test run in repository: 728 tests, 4,003 assertions) though unrelated warnings/notices were reported by some tests. 
- Ran static checks with `composer static` (legacy HTTP and SQL-addslashes checks passed); `phpcs` reported a pre-existing file-header/docblock warning in `src/Lotgd/Motd.php` and a side-effect/definition warning for `motd.php` which are unrelated to the security fix and left unchanged in this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a905e2b70d8832993359fa9edb7f9fa)