### PR TITLE
fix: accept zero-based poll choices

### DIFF
--- a/motd.php
+++ b/motd.php
@@ -42,9 +42,9 @@ if ($session['user']['superuser'] & SU_POST_MOTD) {
 }
 
 if ($op == "vote") {
-    // POST is the trust boundary: reject rather than coerce malformed identifiers.
+    // POST is the trust boundary: validate each integer according to its value domain.
     $motditem = Motd::validatePollVoteIdentifier(Http::post('motditem'));
-    $choice = Motd::validatePollVoteIdentifier(Http::post('choice'));
+    $choice = Motd::validatePollVoteChoice(Http::post('choice'));
     $account = (int)($session['user']['acctid'] ?? 0);
     $postedCsrf = Http::post('csrf_token');
     $expectedCsrf = $session['motd_vote_csrf'] ?? null;

--- a/src/Lotgd/Motd.php
+++ b/src/Lotgd/Motd.php
@@ -414,6 +414,29 @@ class Motd
     }
 
     /**
+     * Validate an untrusted zero-based poll choice index without coercion.
+     *
+     * Poll forms submit decimal strings, while internal callers may supply an
+     * integer. Zero is a valid first-choice index. Other scalar types,
+     * non-decimal strings, negative values, and integers outside PHP's
+     * supported range are deliberately rejected at the request boundary.
+     */
+    public static function validatePollVoteChoice(mixed $value): ?int
+    {
+        if (!is_int($value) && !is_string($value)) {
+            return null;
+        }
+
+        if (is_string($value) && preg_match('/^[0-9]+$/D', $value) !== 1) {
+            return null;
+        }
+
+        $choice = filter_var($value, FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+
+        return is_int($choice) ? $choice : null;
+    }
+
+    /**
      * Replace an account's previous response to a poll using typed DBAL parameters.
      */
     public static function recordPollVote(int $motditem, int $choice, int $account): void

--- a/tests/AMotdTest.php
+++ b/tests/AMotdTest.php
@@ -41,6 +41,7 @@ final class AMotdTest extends TestCase
 
         $output = Output::getInstance()->getRawOutput();
         $this->assertStringContainsString("type='radio' name='choice'", $output);
+        $this->assertStringContainsString("type='radio' name='choice' value='0'", $output);
     }
 
     public function testPollItemUnserializesSlashedData(): void

--- a/tests/MotdPollVoteSecurityTest.php
+++ b/tests/MotdPollVoteSecurityTest.php
@@ -46,6 +46,39 @@ final class MotdPollVoteSecurityTest extends TestCase
         self::assertNull(Motd::validatePollVoteIdentifier($value));
     }
 
+    /**
+     * Supply malformed values that must not be accepted as poll choice indexes.
+     *
+     * @return iterable<string, array{mixed}>
+     */
+    public static function invalidChoiceProvider(): iterable
+    {
+        yield 'missing' => [null];
+        yield 'negative integer' => [-1];
+        yield 'signed string' => ['-1'];
+        yield 'positive signed string' => ['+1'];
+        yield 'decimal string' => ['1.5'];
+        yield 'decimal number' => [1.5];
+        yield 'array' => [['0']];
+        yield 'boolean true' => [true];
+        yield 'boolean false' => [false];
+        yield 'quote-bearing injection' => ["0' OR 1=1 --"];
+        yield 'integer overflow' => [PHP_INT_MAX . '0'];
+    }
+
+    public function testChoiceValidatorAcceptsZeroBasedIndexes(): void
+    {
+        self::assertSame(0, Motd::validatePollVoteChoice('0'));
+        self::assertSame(0, Motd::validatePollVoteChoice(0));
+        self::assertSame(4, Motd::validatePollVoteChoice('4'));
+    }
+
+    #[DataProvider('invalidChoiceProvider')]
+    public function testMalformedChoicesAreRejectedWithoutCoercion(mixed $value): void
+    {
+        self::assertNull(Motd::validatePollVoteChoice($value));
+    }
+
     public function testValidVoteDeletesPreviousChoiceThenInsertsTypedReplacement(): void
     {
         self::assertSame(17, Motd::validatePollVoteIdentifier('17'));
@@ -53,7 +86,7 @@ final class MotdPollVoteSecurityTest extends TestCase
 
         $connection = Database::getDoctrineConnection();
 
-        Motd::recordPollVote(17, 3, 42);
+        Motd::recordPollVote(17, 0, 42);
 
         self::assertCount(2, $connection->executeStatements);
         [$delete, $insert] = $connection->executeStatements;
@@ -72,7 +105,7 @@ final class MotdPollVoteSecurityTest extends TestCase
             'INSERT INTO pollresults (choice, account, motditem) VALUES (:choice, :account, :motditem)',
             $insert['sql']
         );
-        self::assertSame(['motditem' => 17, 'choice' => 3, 'account' => 42], $insert['params']);
+        self::assertSame(['motditem' => 17, 'choice' => 0, 'account' => 42], $insert['params']);
         self::assertSame(
             [
                 'motditem' => ParameterType::INTEGER,


### PR DESCRIPTION
### Motivation

- Separate the validation rules for poll identifiers and poll choice indexes so each domain is strictly validated at the request boundary. 
- Preserve the existing request-boundary, avoid coercion of malformed input, and document that form choice values are zero-based.

### Description

- Add `validatePollVoteChoice(mixed): ?int` which accepts decimal integer strings and integers `>= 0` (including `0` and `'0'`) and rejects negatives, signed strings, decimals, non-scalars, booleans, arrays, and injection-shaped input. 
- Keep `validatePollVoteIdentifier(mixed): ?int` strict for poll/MoTD identifiers, accepting only decimal integer strings or integers `>= 1`. 
- Update the `op=vote` handler in `motd.php` to use `validatePollVoteIdentifier()` for `motditem` and `validatePollVoteChoice()` for `choice`, while preserving authentication, CSRF checks, rejection logging, cache invalidation, and typed DBAL prepared statements used by `recordPollVote()`. 
- Security review: the input validation boundary remains the `op=vote` POST handler, CSRF checks and account authentication remain in place, prepared statements are used for DB writes, and rejected requests are logged as before.

### Testing

- Ran `composer install --no-interaction --prefer-dist` successfully. 
- Ran focused tests with `vendor/bin/phpunit tests/MotdPollVoteSecurityTest.php tests/AMotdTest.php` and they passed (`25` tests, `39` assertions). 
- Ran the full test suite with `composer test` and it completed successfully (`739` tests, `4,017` assertions) with existing warnings and notices. 
- Ran static analysis with `composer static` and `php -l` syntax checks on modified files, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9062d5dd08832989135d9f80eb2a1d)