### PR TITLE
Enable HTTP compression and cache headers for static assets; update Dockerfile and docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # The vhost contains the production security rules, so per-request .htaccess
-# discovery is unnecessary. Only mod_rewrite is needed by those rules.
-RUN a2enmod rewrite \
+# discovery is unnecessary.
+# Compress text responses and let Apache emit explicit freshness metadata for
+# static assets. Dynamic PHP pages remain uncached because game output is tied
+# to the authenticated session.
+RUN a2enmod deflate expires headers rewrite \
     && a2dissite 000-default
 COPY docker/apache/lotgd.conf /etc/apache2/sites-available/lotgd.conf
 RUN a2ensite lotgd

--- a/docker/apache/lotgd.conf
+++ b/docker/apache/lotgd.conf
@@ -27,6 +27,38 @@
         Require all denied
     </FilesMatch>
 
+    # Versioned asset URLs may be reused by browsers and reverse proxies. Keep
+    # the lifetime bounded so extensions and custom themes that use unversioned
+    # URLs are not left stale indefinitely.
+    <IfModule mod_expires.c>
+        ExpiresActive On
+        ExpiresByType text/css "access plus 7 days"
+        ExpiresByType application/javascript "access plus 7 days"
+        ExpiresByType text/javascript "access plus 7 days"
+        ExpiresByType image/avif "access plus 30 days"
+        ExpiresByType image/gif "access plus 30 days"
+        ExpiresByType image/jpeg "access plus 30 days"
+        ExpiresByType image/png "access plus 30 days"
+        ExpiresByType image/svg+xml "access plus 30 days"
+        ExpiresByType image/webp "access plus 30 days"
+        ExpiresByType font/woff2 "access plus 30 days"
+    </IfModule>
+
+    <IfModule mod_headers.c>
+        <FilesMatch "\.(?:avif|css|gif|jpe?g|js|png|svg|webp|woff2)$">
+            Header merge Cache-Control "public"
+        </FilesMatch>
+
+        # Never allow shared caches to retain personalized game responses.
+        <FilesMatch "\.php$">
+            Header always set Cache-Control "no-store, private"
+        </FilesMatch>
+    </IfModule>
+
+    <IfModule mod_deflate.c>
+        AddOutputFilterByType DEFLATE application/javascript application/json image/svg+xml text/css text/html text/javascript text/plain
+    </IfModule>
+
     # Preserve the access boundary formerly supplied by nested .htaccess files.
     # PHP wrappers and modules are loaded by entry points, never invoked directly.
     <Directory /var/www/html/lib>

--- a/docker/apache/lotgd.conf
+++ b/docker/apache/lotgd.conf
@@ -45,7 +45,7 @@
     </IfModule>
 
     <IfModule mod_headers.c>
-        <FilesMatch "\.(?:avif|css|gif|jpe?g|js|png|svg|webp|woff2)$">
+        <FilesMatch "\.(avif|css|gif|jpe?g|js|png|svg|webp|woff2)$">
             Header merge Cache-Control "public"
         </FilesMatch>
 

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -115,6 +115,16 @@ curl -sS -o /dev/null -w 'warm: %{time_total}s\n' http://localhost/
 The first request may populate Twig and Doctrine caches. Subsequent timings are
 most meaningful after several warm-up requests and without concurrent traffic.
 
+Apache also compresses text responses and sends bounded browser-cache metadata
+for CSS, JavaScript, images, and WOFF2 fonts. Personalized PHP responses are
+explicitly marked `no-store, private`; full-page HTTP caching must not be added
+without a session-aware cache design. Inspect both behaviors with:
+
+```bash
+curl --compressed -sSI http://localhost/templates_twig/aurora/assets/style.css
+curl -sSI http://localhost/index.php
+```
+
 ## Operations and troubleshooting
 
 ```bash


### PR DESCRIPTION
### Motivation

- Improve frontend performance by allowing browsers and reverse proxies to cache versioned static assets and reduce payload size with compression while ensuring dynamic, personalized PHP responses are never cached.

### Description

- Enabled Apache modules `deflate`, `expires`, and `headers` in the `Dockerfile` and updated related comments.  
- Added `ExpiresByType` rules for CSS, JS, images, and WOFF2 fonts and a `Cache-Control: public` header for those assets in `docker/apache/lotgd.conf`.  
- Added `Cache-Control: no-store, private` for `.php` responses to prevent shared caches from storing personalized pages.  
- Enabled gzip/deflate for common text response types via `AddOutputFilterByType` and updated `docs/Docker.md` with validation commands that show compression and caching behavior.

### Testing

- Ran `docker compose config` and container validation checks; the compose configuration parsed successfully.  
- Executed the documented runtime checks including `docker compose exec web php -i | grep -E 'opcache.enable =>|opcache.validate_timestamps =>'` and writable cache verification, and they returned the expected results.  
- Verified HTTP responses with `curl --compressed -sSI http://localhost/templates_twig/aurora/assets/style.css` and `curl -sSI http://localhost/index.php`, and observed compressed static assets with `Cache-Control: public` and PHP responses marked `Cache-Control: no-store, private` as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a90647332dc8329b02219bd5a9cf214)