### PR TITLE
chore: upgrade PHPStan to ^2.2 and phpstan-doctrine to ^2.0; address PHPStan 2 compatibility findings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         "wikimedia/composer-merge-plugin": "^2.1"
     },
     "require-dev": {
-        "phpstan/phpstan-doctrine": "^1.3",
-        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan-doctrine": "^2.0",
+        "phpstan/phpstan": "^2.2",
         "phpunit/phpunit": "^12.0",
         "squizlabs/php_codesniffer": "^4.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6e6a2089723ce7cf36dca4b28ef6747e",
+    "content-hash": "363fc05abb1053557a08c82342d30f4b",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -3694,15 +3694,15 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.34",
+            "version": "2.2.9",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/4dd89ca7aa30fdc6760be21550d583bcc32e8476",
-                "reference": "4dd89ca7aa30fdc6760be21550d583bcc32e8476",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/13d6b4f347bad222da436580c8304fa6f83e6bd0",
+                "reference": "13d6b4f347bad222da436580c8304fa6f83e6bd0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -3720,6 +3720,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -3743,25 +3754,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-28T10:04:39+00:00"
+            "time": "2026-08-22T07:38:16+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",
-            "version": "1.5.7",
+            "version": "2.0.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-doctrine.git",
-                "reference": "231d3f795ed5ef54c98961fd3958868cbe091207"
+                "reference": "b4623954d5ffee6311e4ddbaef65c074ae0f781a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/231d3f795ed5ef54c98961fd3958868cbe091207",
-                "reference": "231d3f795ed5ef54c98961fd3958868cbe091207",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/b4623954d5ffee6311e4ddbaef65c074ae0f781a",
+                "reference": "b4623954d5ffee6311e4ddbaef65c074ae0f781a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.12.12"
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.2.2"
             },
             "conflict": {
                 "doctrine/collections": "<1.0",
@@ -3774,23 +3785,25 @@
                 "cache/array-adapter": "^1.1",
                 "composer/semver": "^3.3.2",
                 "cweagans/composer-patches": "^1.7.3",
-                "doctrine/annotations": "^1.11 || ^2.0",
+                "doctrine/annotations": "^2.0",
                 "doctrine/collections": "^1.6 || ^2.1",
                 "doctrine/common": "^2.7 || ^3.0",
-                "doctrine/dbal": "^2.13.8 || ^3.3.3",
+                "doctrine/dbal": "^3.3.8",
                 "doctrine/lexer": "^2.0 || ^3.0",
-                "doctrine/mongodb-odm": "^1.3 || ^2.4.3",
+                "doctrine/mongodb-odm": "^2.4.3",
                 "doctrine/orm": "^2.16.0",
-                "doctrine/persistence": "^2.2.1 || ^3.2",
+                "doctrine/persistence": "^2.2.1 || ^3.4.3",
                 "gedmo/doctrine-extensions": "^3.8",
                 "nesbot/carbon": "^2.49",
-                "nikic/php-parser": "^4.13.2",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/phpstan-phpunit": "^1.3.13",
-                "phpstan/phpstan-strict-rules": "^1.5.1",
+                "phpstan/phpstan-deprecation-rules": "^2.0.2",
+                "phpstan/phpstan-phpunit": "^2.0.8",
+                "phpstan/phpstan-strict-rules": "^2.0",
                 "phpunit/phpunit": "^9.6.20",
                 "ramsey/uuid": "^4.2",
-                "symfony/cache": "^5.4"
+                "shipmonk/name-collision-detector": "^2.1",
+                "symfony/cache": "^5.4",
+                "symfony/uid": "^5.4 || ^6.4 || ^7.3"
             },
             "type": "phpstan-extension",
             "extra": {
@@ -3811,11 +3824,14 @@
                 "MIT"
             ],
             "description": "Doctrine extensions for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
-                "source": "https://github.com/phpstan/phpstan-doctrine/tree/1.5.7"
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/2.0.28"
             },
-            "time": "2024-12-02T16:47:26+00:00"
+            "time": "2026-07-13T08:43:43+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -5350,13 +5366,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Lotgd/MySQL/Database.php
+++ b/src/Lotgd/MySQL/Database.php
@@ -448,8 +448,9 @@ class Database
     {
         if ($force === null || $force === false) {
             $special_prefixes = [];
-            if (file_exists('prefixes.php')) {
-                require_once 'prefixes.php';
+            $prefixesFile = realpath('prefixes.php');
+            if ($prefixesFile !== false) {
+                require_once $prefixesFile;
             }
             $prefix = self::$prefix;
             if (isset($special_prefixes[$tablename])) {

--- a/src/Lotgd/PageParts.php
+++ b/src/Lotgd/PageParts.php
@@ -658,8 +658,8 @@ class PageParts
             $paypalstr .= '<form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">'
                 . "<input type='hidden' name='cmd' value='_xclick'>"
                 . "<input type='hidden' name='business' value='$paysite'>"
-                . "<input type='hidden' name='item_name' value='" . (isset($settings) ? $settings->getSetting('paypaltext', 'Legend of the Green Dragon Site Donation from') : 'Legend of the Green Dragon Site Donation From') . " " . Sanitize::fullSanitize($session['user']['name']) . "'>"
-                . "<input type='hidden' name='item_number' value='" . htmlentities($session['user']['login'], ENT_COMPAT, isset($settings) ? $settings->getSetting('charset', 'UTF-8') : 'UTF-8') . ":" . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] . "'>"
+                . "<input type='hidden' name='item_name' value='" . $settings->getSetting('paypaltext', 'Legend of the Green Dragon Site Donation from') . " " . Sanitize::fullSanitize($session['user']['name']) . "'>"
+                . "<input type='hidden' name='item_number' value='" . htmlentities($session['user']['login'], ENT_COMPAT, $settings->getSetting('charset', 'UTF-8')) . ":" . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] . "'>"
                 . "<input type='hidden' name='no_shipping' value='1'>";
             if (file_exists('payment.php')) {
                 $paypalstr .= "<input type='hidden' name='notify_url' value='http://" . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . "/payment.php'>";


### PR DESCRIPTION
### Motivation

- Bring static analysis toolchain to PHPStan 2.x and the matching Doctrine extension to benefit from improved checks and updated rule sets. 
- Ensure the repository's `phpstan.neon` includes (`vendor/phpstan/phpstan-doctrine/extension.neon` and `rules.neon`) remain valid under PHPStan 2.x. 
- Fix newly-reported PHPStan-2 compatibility issues that indicate real-code robustness problems rather than suppressible legacy debt. 

### Description

- Bumped dev dependencies in `composer.json` to `phpstan/phpstan: ^2.2` and `phpstan/phpstan-doctrine: ^2.0` and re-resolved `composer.lock` so the lockfile is consistent with the new constraints. 
- Verified that `phpstan.neon` continues to include `vendor/phpstan/phpstan-doctrine/extension.neon` and `vendor/phpstan/phpstan-doctrine/rules.neon` and left rule sets unchanged. 
- Fixed a `requireOnce.fileNotFound` report by resolving `prefixes.php` with `realpath()` before `require_once` in `Database::prefix()` so PHPStan can statically confirm the file load is guarded. 
- Removed two redundant null/`isset` guards reported as `isset.variable` by using the already-validated `$settings` in the `PageParts::buildPaypalDonationMarkup()` paysite branch to satisfy PHPStan 2's stricter checks. 

### Testing

- Ran `composer update phpstan/phpstan phpstan/phpstan-doctrine --with-all-dependencies` to update packages; update completed and lockfile written. 
- Ran `composer static` (PHPStan) and iteratively fixed the reported findings until there were no PHPStan errors (initially 3 reports, reduced to 0 after the targeted fixes). 
- Ran `composer test` and verified the test suite completed (752 tests, 4,078 assertions) with existing warnings/notes but no new test failures. 
- Performed `php -l` on modified files and `composer validate --no-check-publish`, and ran `git diff --check` to ensure no trailing issues were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a908826118883298f086e68013dd770)