### PR TITLE
fix: reject invalid mount grants without changing player state

### DIFF
--- a/mounts.php
+++ b/mounts.php
@@ -12,6 +12,7 @@ use Lotgd\Page\Footer;
 use Lotgd\Http;
 use Lotgd\Modules\HookHandler;
 use Lotgd\Settings;
+use Lotgd\Mounts;
 // addnews ready
 // mail ready
 // translator ready
@@ -142,28 +143,14 @@ if ($op == "deactivate") {
     Http::set("op", "");
     invalidatedatacache("mountdata-$id");
 } elseif ($op == "give") {
-    if ($id === null) {
-        $op = '';
-    } else {
-        $session['user']['hashorse'] = $id;
-    }
-    // changed to make use of the cached query
-    $sql = "SELECT * FROM " . Database::prefix("mounts") . " WHERE mountid = :mountId";
-    $row = $connection->executeQuery($sql, ['mountId' => $id], ['mountId' => ParameterType::INTEGER])->fetchAssociative();
-    if ($row === false) {
+    $grantResult = Mounts::grantToCurrentUser($id);
+    if ($grantResult === Mounts::GRANT_NOT_FOUND) {
         error_log('Denied mount give action: mount record was not found');
-        $op = '';
-        Http::set('op', '');
-    } else {
-        $buff = unserialize($row['mountbuff']);
+        $output->output('`$That mount could not be found, so it was not granted.`0`n');
+    } elseif ($grantResult === Mounts::GRANT_INVALID_BUFF) {
+        error_log('Denied mount give action: stored mount buff was malformed');
+        $output->output('`$That mount has invalid buff data, so it was not granted.`0`n');
     }
-    if (!isset($buff) || !is_array($buff)) {
-        $buff = [];
-    }
-    if (($buff['schema'] ?? '') == "") {
-        $buff['schema'] = "mounts";
-    }
-    Buffs::applyBuff("mount", $buff);
     $op = "";
     Http::set("op", "");
 } elseif ($op == "save") {

--- a/mounts.php
+++ b/mounts.php
@@ -143,13 +143,15 @@ if ($op == "deactivate") {
     Http::set("op", "");
     invalidatedatacache("mountdata-$id");
 } elseif ($op == "give") {
-    $grantResult = Mounts::grantToCurrentUser($id);
-    if ($grantResult === Mounts::GRANT_NOT_FOUND) {
-        error_log('Denied mount give action: mount record was not found');
-        $output->output('`$That mount could not be found, so it was not granted.`0`n');
-    } elseif ($grantResult === Mounts::GRANT_INVALID_BUFF) {
-        error_log('Denied mount give action: stored mount buff was malformed');
-        $output->output('`$That mount has invalid buff data, so it was not granted.`0`n');
+    if ($id === null) {
+        error_log('Denied mount give action: missing or invalid mount id');
+    } else {
+        $grantResult = Mounts::grantToCurrentUser($id);
+        if ($grantResult === Mounts::GRANT_NOT_FOUND) {
+            $output->output('`$' . Translator::translate('That mount could not be found, so it was not granted.') . '`0`n');
+        } elseif ($grantResult === Mounts::GRANT_INVALID_BUFF) {
+            $output->output('`$' . Translator::translate('That mount has invalid buff data, so it was not granted.') . '`0`n');
+        }
     }
     $op = "";
     Http::set("op", "");

--- a/src/Lotgd/Mounts.php
+++ b/src/Lotgd/Mounts.php
@@ -8,10 +8,15 @@ declare(strict_types=1);
 
 namespace Lotgd;
 
+use Doctrine\DBAL\ParameterType;
 use Lotgd\MySQL\Database;
 
 class Mounts
 {
+    public const GRANT_SUCCESS = 'success';
+    public const GRANT_NOT_FOUND = 'not_found';
+    public const GRANT_INVALID_BUFF = 'invalid_buff';
+
     /**
      * Instance for singleton pattern.
      */
@@ -86,5 +91,43 @@ class Mounts
         $this->playerMount = self::getmount($horse);
 
         return $this->playerMount;
+    }
+
+    /**
+     * Grant a stored mount to the current user after validating its buff.
+     *
+     * The session is deliberately changed only after both the database row and
+     * its serialized buff have been validated.
+     */
+    public static function grantToCurrentUser(int $mountId): string
+    {
+        global $session;
+
+        $connection = Database::getDoctrineConnection();
+        $sql = 'SELECT * FROM ' . Database::prefix('mounts') . ' WHERE mountid = :mountId';
+        $row = $connection->executeQuery(
+            $sql,
+            ['mountId' => $mountId],
+            ['mountId' => ParameterType::INTEGER]
+        )->fetchAssociative();
+
+        if ($row === false) {
+            return self::GRANT_NOT_FOUND;
+        }
+
+        $serializedBuff = $row['mountbuff'] ?? null;
+        $buff = Serialization::safeUnserialize($serializedBuff);
+        if (!is_array($buff)) {
+            return self::GRANT_INVALID_BUFF;
+        }
+
+        if (($buff['schema'] ?? '') === '') {
+            $buff['schema'] = 'mounts';
+        }
+
+        $session['user']['hashorse'] = $mountId;
+        Buffs::applyBuff('mount', $buff);
+
+        return self::GRANT_SUCCESS;
     }
 }

--- a/src/Lotgd/Mounts.php
+++ b/src/Lotgd/Mounts.php
@@ -112,12 +112,14 @@ class Mounts
         )->fetchAssociative();
 
         if ($row === false) {
+            error_log("Denied mount give: mount record not found (mountId={$mountId})");
             return self::GRANT_NOT_FOUND;
         }
 
         $serializedBuff = $row['mountbuff'] ?? null;
         $buff = Serialization::safeUnserialize($serializedBuff);
         if (!is_array($buff)) {
+            error_log("Denied mount give: stored buff is malformed (mountId={$mountId})");
             return self::GRANT_INVALID_BUFF;
         }
 

--- a/tests/MountsTest.php
+++ b/tests/MountsTest.php
@@ -6,6 +6,7 @@ namespace Lotgd\Tests;
 
 use Lotgd\Mounts;
 use Lotgd\Tests\Stubs\Database;
+use Lotgd\Tests\Stubs\DoctrineConnection;
 use PHPUnit\Framework\TestCase;
 
 final class MountsTest extends TestCase
@@ -34,6 +35,8 @@ final class MountsTest extends TestCase
         \Lotgd\MySQL\Database::$lastCacheName = '';
         unset(\Lotgd\MySQL\Database::$queryCacheResults['mountdata-7']);
         Mounts::getInstance()->setPlayerMount([]);
+        Database::resetDoctrineConnection();
+        unset($GLOBALS['session']);
     }
 
     public function testGetmountExecutesQuery(): void
@@ -67,5 +70,62 @@ final class MountsTest extends TestCase
 
         $mounts->loadPlayerMount(7);
         $this->assertSame($this->cachedMountRow, $mounts->getPlayerMount());
+    }
+
+    public function testGrantRejectsMissingMountWithoutChangingCurrentMountOrBuff(): void
+    {
+        $connection = new DoctrineConnection();
+        $connection->fetchAllResults = [[]];
+        Database::setDoctrineConnection($connection);
+        $GLOBALS['session'] = $this->existingMountSession();
+
+        $result = Mounts::grantToCurrentUser(999);
+
+        $this->assertSame(Mounts::GRANT_NOT_FOUND, $result);
+        $this->assertSame(7, $GLOBALS['session']['user']['hashorse']);
+        $this->assertSame(['rounds' => 3], $GLOBALS['session']['bufflist']['mount']);
+    }
+
+    public function testGrantRejectsMalformedBuffWithoutChangingCurrentMountOrBuff(): void
+    {
+        $this->prepareGrantRow(['mountid' => 8, 'mountbuff' => 'not serialized data']);
+        $GLOBALS['session'] = $this->existingMountSession();
+
+        $result = Mounts::grantToCurrentUser(8);
+
+        $this->assertSame(Mounts::GRANT_INVALID_BUFF, $result);
+        $this->assertSame(7, $GLOBALS['session']['user']['hashorse']);
+        $this->assertSame(['rounds' => 3], $GLOBALS['session']['bufflist']['mount']);
+    }
+
+    public function testGrantAppliesValidMountAndBuff(): void
+    {
+        $buff = ['rounds' => 5, 'atkmod' => 1.2];
+        $this->prepareGrantRow(['mountid' => 8, 'mountbuff' => serialize($buff)]);
+        $GLOBALS['session'] = $this->existingMountSession();
+
+        $result = Mounts::grantToCurrentUser(8);
+
+        $this->assertSame(Mounts::GRANT_SUCCESS, $result);
+        $this->assertSame(8, $GLOBALS['session']['user']['hashorse']);
+        $this->assertSame(5, $GLOBALS['session']['bufflist']['mount']['rounds']);
+        $this->assertSame('mounts', $GLOBALS['session']['bufflist']['mount']['schema']);
+    }
+
+    /** @param array<string, mixed> $row */
+    private function prepareGrantRow(array $row): void
+    {
+        $connection = new DoctrineConnection();
+        $connection->fetchAllResults = [[$row]];
+        Database::setDoctrineConnection($connection);
+    }
+
+    /** @return array<string, mixed> */
+    private function existingMountSession(): array
+    {
+        return [
+            'user' => ['hashorse' => 7, 'superuser' => 0],
+            'bufflist' => ['mount' => ['rounds' => 3]],
+        ];
     }
 }


### PR DESCRIPTION
### Motivation

- Prevent the editor from mutating the recipient session before the mount row and its stored buff are validated.  The change ensures missing or malformed stored buffs are rejected rather than turned into empty/incorrect buffs and applied.

### Description

- Stop assigning `$session['user']['hashorse']` before the database lookup and perform a prepared `mountid = :mountId` query first by introducing `Mounts::grantToCurrentUser(int $mountId)`. (files: `mounts.php`, `src/Lotgd/Mounts.php`).
- Use `Serialization::safeUnserialize(... )` (which calls `unserialize(..., ['allowed_classes' => false])`) and require the result to be an array before applying the buff; treat malformed serialized data as a rejected operation and log it. (file: `src/Lotgd/Mounts.php`).
- Update the `give` branch in `mounts.php` to call the guarded grant helper, log denied grants, show translated user-facing messages, and leave the user’s existing `hashorse` and buff state untouched on rejection. (file: `mounts.php`).
- Add behavioral regression tests covering: nonexistent mount id (no changes to `hashorse`/buff), malformed serialized buff (no changes), and a successful grant that sets `hashorse` and applies the buff. (file: `tests/MountsTest.php`).

### Testing

- Ran syntax checks with `php -l mounts.php`, `php -l src/Lotgd/Mounts.php`, and `php -l tests/MountsTest.php` — all reported no syntax errors.
- Ran the focused tests with `vendor/bin/phpunit --display-warnings tests/MountsTest.php` and received `OK (6 tests, 18 assertions)`.
- Ran static analysis with `composer static` and the project checks passed.
- Ran the full test suite with `composer test` which completed (existing suite warnings/deprecations are unrelated to this change) and returned success for the run (755 tests, 4,088 assertions in the environment used).
- Security review: input validation is bounded (mount id normalized by `mountEditorPositiveInteger` before use), CSRF protections remain in-place for state-changing editor actions, the mount lookup uses a prepared `:mountId` parameter with explicit integer typing, authorization (`SU_EDIT_MOUNTS`) is unchanged, and denied outcomes (missing/malformed buff) are logged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a908d6776248329bbc7bccd647319bc)