### PR TITLE
fix: safely decode mount editor buffs

### DIFF
--- a/mounts.php
+++ b/mounts.php
@@ -383,7 +383,13 @@ if ($op == "") {
             Nav::add("", "mounts.php?op=save&subop=module&id=$id&module=$module");
         } else {
             $output->output("Mount Editor:`n");
-            $row['mountbuff'] = unserialize($row['mountbuff']);
+            $preparedBuff = Mounts::prepareBuffForEditor($row['mountbuff'] ?? null, (int) $row['mountid']);
+            $row['mountbuff'] = $preparedBuff['buff'];
+            if (!$preparedBuff['valid']) {
+                $output->output(
+                    '`$' . Translator::translate('The stored buff data for this mount is invalid. An empty buff form is shown instead.') . '`0`n'
+                );
+            }
             mountform($row);
         }
     }

--- a/src/Lotgd/Mounts.php
+++ b/src/Lotgd/Mounts.php
@@ -131,4 +131,24 @@ class Mounts
 
         return self::GRANT_SUCCESS;
     }
+
+    /**
+     * Decode and validate a stored mount buff before populating the editor form.
+     *
+     * Serialization::safeUnserialize() disables class instantiation. Keeping the
+     * array check here gives every mount-edit caller the same form-safe boundary.
+     *
+     * @return array{buff: array<mixed>, valid: bool}
+     */
+    public static function prepareBuffForEditor(mixed $storedBuff, int $mountId): array
+    {
+        $buff = Serialization::safeUnserialize($storedBuff);
+        if (!is_array($buff)) {
+            error_log("Invalid stored mount buff while editing mount (mountId={$mountId})");
+
+            return ['buff' => [], 'valid' => false];
+        }
+
+        return ['buff' => $buff, 'valid' => true];
+    }
 }

--- a/tests/MountsTest.php
+++ b/tests/MountsTest.php
@@ -127,6 +127,33 @@ final class MountsTest extends TestCase
         $this->assertSame(['rounds' => 3], $GLOBALS['session']['bufflist']['mount']);
     }
 
+    public function testPrepareBuffForEditorAcceptsSerializedArray(): void
+    {
+        $buff = ['rounds' => 5, 'atkmod' => 1.2];
+
+        $result = Mounts::prepareBuffForEditor(serialize($buff), 8);
+
+        $this->assertTrue($result['valid']);
+        $this->assertSame($buff, $result['buff']);
+    }
+
+    public function testPrepareBuffForEditorReturnsFormSafeArrayForMalformedData(): void
+    {
+        $result = Mounts::prepareBuffForEditor('not serialized data', 8);
+
+        $this->assertFalse($result['valid']);
+        $this->assertSame([], $result['buff']);
+    }
+
+    public function testPrepareBuffForEditorDoesNotInstantiateSerializedObjects(): void
+    {
+        $result = Mounts::prepareBuffForEditor(serialize(new MountBuffSerializationFixture()), 8);
+
+        $this->assertFalse($result['valid']);
+        $this->assertSame([], $result['buff']);
+        $this->assertFalse(MountBuffSerializationFixture::$wasUnserialized);
+    }
+
     /** @param array<string, mixed> $row */
     private function prepareGrantRow(array $row): void
     {


### PR DESCRIPTION
### Motivation

- Replace an unsafe direct `unserialize()` call in the mount-editor display path with a validated decoding boundary to avoid object instantiation and malformed payloads. 
- Ensure administrators see a friendly warning when stored buff data is invalid and make the editor show a form-safe empty buff instead of corrupt data.

### Description

- Replace `unserialize($row['mountbuff'])` in the `op === 'edit'` branch of `mounts.php` with a call to `Mounts::prepareBuffForEditor(...)` that uses `Lotgd\Serialization::safeUnserialize()` and requires the result to be an array. 
- Add `Mounts::prepareBuffForEditor(mixed $storedBuff, int $mountId): array` in `src/Lotgd/Mounts.php` which returns a form-safe empty array for malformed data, logs the affected mount ID, and relies on `safeUnserialize()`'s `allowed_classes => false` to prevent class instantiation. 
- Show a translated administrator warning via `Translator::translate()` when stored buff data is invalid and ensure the editor receives an empty buff array for rendering. 
- Add regression tests in `tests/MountsTest.php` to cover valid serialized arrays, malformed serialized data, and serialized objects that must not instantiate, and verify unchanged behavior for the grant path. 
- Security review: input validation boundary is `Mounts::prepareBuffForEditor()`, CSRF and authorization for mount editor are unchanged, existing prepared SQL usage remains unchanged, and invalid payloads are logged with the mount ID.

### Testing

- Ran syntax checks with `php -l mounts.php`, `php -l src/Lotgd/Mounts.php`, and `php -l tests/MountsTest.php` and all returned no syntax errors. 
- Ran the unit tests for the changed file with `vendor/bin/phpunit --configuration phpunit.xml tests/MountsTest.php` and they passed (10 tests, 29 assertions). 
- Executed the full suite with `composer test` which completed successfully in this environment (759 tests, 4,099 assertions) while retaining unrelated pre-existing warnings and notices. 
- Ran static checks with `composer static` which passed the repository checks, and ran `phpcs` which reported pre-existing structural warnings only and no new errors in the modified lines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a912ab4f9c48329ba83e1dd710fae81)