### PR TITLE
fix: harden Docker installer and database secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,17 @@
+# TEMPLATE ONLY: copy this file to .env and generate unique secrets before use.
 MYSQL_DATABASE=lotgd
 MYSQL_HOST=db
 MYSQL_USER=lotgduser
-MYSQL_PASSWORD=lotgdpass
-MYSQL_ROOT_PASSWORD=rootpass
+# Generate each value separately with: openssl rand -base64 32
+MYSQL_PASSWORD=
+MYSQL_ROOT_PASSWORD=
 # The Docker image and Compose service create and own this persistent path.
 MYSQL_USEDATACACHE=1
 MYSQL_DATACACHEPATH=/var/cache/lotgd
 
-# Host port for plain HTTP. Terminate TLS in a reverse proxy in production.
-LOTGD_HTTP_PORT=80
+# The installer is denied unless an administrator deliberately changes this to 1.
+LOTGD_INSTALL_ENABLED=0
+
+# Loopback-only host port for initial installation. Terminate TLS in a reverse
+# proxy when exposing an installed instance in production.
+LOTGD_HTTP_PORT=8080

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -35,6 +35,16 @@ Before doing anything:
 2. Keep your `config` folder (but update as noted below).  
 3. Run `composer install` to pull required dependencies.
 
+### Docker deployments using legacy example passwords
+
+The hardened Compose configuration rejects the previously documented
+`lotgdpass` and `rootpass` values. Existing `db_data` volumes retain MySQL
+credentials independently of `.env`, so those credentials must be rotated
+before the upgraded web container starts. Follow the complete, backup-aware
+procedure in [Docker deployment: Rotating legacy Docker example
+passwords](docs/Docker.md#rotating-legacy-docker-example-passwords); changing
+only `.env` will leave the application unable to connect.
+
 ---
 
 ## 4. Run Legacy Upgrade (1.x → 2.x bridge)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,15 @@ services:
     build: .
     restart: unless-stopped
     ports:
-      - "${LOTGD_HTTP_PORT:-80}:80"
+      - "127.0.0.1:${LOTGD_HTTP_PORT:-8080}:80"
     env_file: .env
     environment:
       APP_ENV: production
       MYSQL_USEDATACACHE: "1"
       MYSQL_DATACACHEPATH: /var/cache/lotgd
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:?MYSQL_PASSWORD must be set}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?MYSQL_ROOT_PASSWORD must be set}
+      LOTGD_INSTALL_ENABLED: ${LOTGD_INSTALL_ENABLED:-0}
     volumes:
       - lotgd_cache:/var/cache/lotgd
       - lotgd_state:/var/lib/lotgd
@@ -30,8 +33,8 @@ services:
     environment:
       MYSQL_DATABASE: ${MYSQL_DATABASE:-lotgd}
       MYSQL_USER: ${MYSQL_USER:-lotgduser}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-lotgdpass}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-rootpass}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:?MYSQL_PASSWORD must be set}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?MYSQL_ROOT_PASSWORD must be set}
     volumes:
       - db_data:/var/lib/mysql
     healthcheck:

--- a/docker/apache/lotgd.conf
+++ b/docker/apache/lotgd.conf
@@ -73,8 +73,14 @@
         </FilesMatch>
     </Directory>
 
-    # Keep an abandoned installer unreachable after installer.php is removed.
+    # Installation is an explicit, temporary administrative action. The
+    # completion marker still wins because entrypoint removes installer.php.
     RewriteEngine On
+    RewriteCond %{ENV:LOTGD_INSTALL_ENABLED} !=1
+    RewriteRule ^(?:installer\.php|install(?:/|$)) - [F,L]
+
+    # Keep installer support files unreachable after installer.php is removed,
+    # even if an old environment still has the installation flag enabled.
     RewriteCond %{REQUEST_URI} ^/install/ [NC]
     RewriteCond %{DOCUMENT_ROOT}/installer.php !-f
     RewriteRule ^install/ - [F,L]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,8 +8,7 @@ dbconnect_path="/var/www/html/dbconnect.php"
 # match values previously published as usable examples.
 validate_secret() {
     variable_name="$1"
-    eval "secret_value=\${$variable_name:-}"
-
+    secret_value=$(printenv "$variable_name" 2>/dev/null || true)
     case "$secret_value" in
         ""|lotgdpass|rootpass|changeme|password|example)
             echo "$variable_name must be set to a non-example secret; generate one with 'openssl rand -base64 32'" >&2

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,6 +4,23 @@ set -eu
 state_path="${LOTGD_STATE_PATH:-/var/lib/lotgd}"
 dbconnect_path="/var/www/html/dbconnect.php"
 
+# Fail before modifying persistent state when database credentials are absent or
+# match values previously published as usable examples.
+validate_secret() {
+    variable_name="$1"
+    eval "secret_value=\${$variable_name:-}"
+
+    case "$secret_value" in
+        ""|lotgdpass|rootpass|changeme|password|example)
+            echo "$variable_name must be set to a non-example secret; generate one with 'openssl rand -base64 32'" >&2
+            exit 1
+            ;;
+    esac
+}
+
+validate_secret MYSQL_PASSWORD
+validate_secret MYSQL_ROOT_PASSWORD
+
 mkdir -p "$state_path"
 if [ ! -w "$state_path" ]; then
     echo "LOTGD_STATE_PATH '$state_path' is not writable" >&2

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -8,10 +8,47 @@ dependencies, and MySQL 8.4.
 
 ## Initial configuration
 
-Copy the example environment and replace the sample database passwords:
+`.env.example` is a template, not a deployable configuration. Copy it and
+generate two independent database secrets locally (do not commit `.env`):
 
 ```bash
 cp .env.example .env
+sed -i "s|^MYSQL_PASSWORD=$|MYSQL_PASSWORD=$(openssl rand -base64 32)|" .env
+sed -i "s|^MYSQL_ROOT_PASSWORD=$|MYSQL_ROOT_PASSWORD=$(openssl rand -base64 32)|" .env
+```
+
+Compose refuses to render the deployment when either secret is missing, and
+the web container rejects the documented legacy/example password values during
+startup.
+
+### Deliberately enabling initial installation
+
+The installer is denied by default. Set `LOTGD_INSTALL_ENABLED=1` in `.env`
+only for the installation window, recreate the web container, and start the
+stack. The published port remains restricted to the Docker host's loopback
+interface (`127.0.0.1:8080` by default):
+
+```bash
+docker compose up -d --build
+```
+
+On a remote server, reach it through an SSH tunnel instead of publishing the
+installer publicly. Run this on the administrator's workstation, replacing
+`admin@example.com` with the SSH destination, then browse to
+`http://127.0.0.1:8080/installer.php`:
+
+```bash
+ssh -N -L 8080:127.0.0.1:8080 admin@example.com
+```
+
+Installer stage 11 writes the persistent `installation-complete` marker and
+removes `installer.php`. That marker takes precedence over
+`LOTGD_INSTALL_ENABLED`, so restoring or leaving the flag at `1` cannot restore
+installer access after successful completion. Set `LOTGD_INSTALL_ENABLED=0`
+again and recreate the web container as defense in depth:
+
+```bash
+docker compose up -d --force-recreate web
 ```
 
 `MYSQL_USEDATACACHE=1` and `MYSQL_DATACACHEPATH=/var/cache/lotgd` enable the
@@ -32,8 +69,10 @@ development dependencies and generates an authoritative classmap. PHP hides
 errors from responses, logs them to container stderr, and enables OPcache
 without timestamp validation. Rebuild the image to deploy code changes.
 
-Only container port 80 is exposed. Set `LOTGD_HTTP_PORT` to choose its host
-mapping.
+Only container port 80 is exposed, and its host mapping is loopback-only. Set
+`LOTGD_HTTP_PORT` to choose another loopback host port. To serve an installed
+game remotely, put a TLS reverse proxy on a public interface and proxy to
+`127.0.0.1:${LOTGD_HTTP_PORT}`; do not make the installer port public.
 
 ### SSL/TLS is not included
 
@@ -101,6 +140,13 @@ docker compose ps
 docker compose exec web php -i | grep -E 'opcache.enable =>|opcache.validate_timestamps =>'
 docker compose exec --user www-data web sh -c 'test -w /var/cache/lotgd/twig && test -w /var/cache/lotgd/doctrine'
 docker compose exec web find /var/cache/lotgd -mindepth 1 -maxdepth 2 -type f -print
+```
+
+The repository also includes a focused configuration regression test (it
+requires the Docker Compose plugin):
+
+```bash
+tests/Docker/compose-security.sh
 ```
 
 After completing installation and requesting a Twig-backed page, repeat the

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -21,6 +21,55 @@ Compose refuses to render the deployment when either secret is missing, and
 the web container rejects the documented legacy/example password values during
 startup.
 
+### Rotating legacy Docker example passwords
+
+Deployments that already initialized `db_data` with the formerly documented
+`lotgdpass` and `rootpass` values must rotate the persisted MySQL accounts
+**before** starting the hardened web container. Merely editing `.env` does not
+change accounts stored in an existing MySQL volume. Back up both the database
+and `lotgd_state`, stop the web service, and then run the following from the
+checkout while `.env` still contains the old values:
+
+```bash
+docker compose stop web
+docker compose up -d db
+
+new_app_password=$(openssl rand -base64 32)
+new_root_password=$(openssl rand -base64 32)
+
+# Update the application configuration in lotgd_state while the web service is stopped.
+docker compose run --rm --no-deps \
+    --entrypoint php \
+    -e NEW_APP_PASSWORD="$new_app_password" \
+    web -r '
+$path = "/var/lib/lotgd/dbconnect.php";
+$config = require $path;
+$config["DB_PASS"] = getenv("NEW_APP_PASSWORD");
+if (file_put_contents($path, "<?php\n\nreturn " . var_export($config, true) . ";\n") === false) {
+    fwrite(STDERR, "Unable to update dbconnect.php\n");
+    exit(1);
+}'
+
+# Rotate both persisted MySQL accounts in one atomic ALTER USER statement.
+docker compose exec -T -e MYSQL_PWD=rootpass db mysql --user=root <<SQL
+ALTER USER
+    'lotgduser'@'%' IDENTIFIED BY '$new_app_password',
+    'root'@'localhost' IDENTIFIED BY '$new_root_password';
+SQL
+
+sed -i "s|^MYSQL_PASSWORD=lotgdpass$|MYSQL_PASSWORD=$new_app_password|" .env
+sed -i "s|^MYSQL_ROOT_PASSWORD=rootpass$|MYSQL_ROOT_PASSWORD=$new_root_password|" .env
+unset new_app_password new_root_password
+
+docker compose up -d --force-recreate db web
+```
+
+If the deployment used a different `MYSQL_USER` or MySQL account host, adjust
+the account in `ALTER USER` accordingly. Do not destroy `db_data` as a shortcut:
+that deletes the game database. After the recreated services are healthy,
+verify application login and retain the pre-rotation backups until the upgrade
+has been validated.
+
 ### Deliberately enabling initial installation
 
 The installer is denied by default. Set `LOTGD_INSTALL_ENABLED=1` in `.env`
@@ -154,8 +203,8 @@ request to compare cold and warm timings (replace `/` with a known lightweight
 page for the installation):
 
 ```bash
-curl -sS -o /dev/null -w 'cold: %{time_total}s\n' http://localhost/
-curl -sS -o /dev/null -w 'warm: %{time_total}s\n' http://localhost/
+curl -sS -o /dev/null -w 'cold: %{time_total}s\n' "http://127.0.0.1:${LOTGD_HTTP_PORT:-8080}/"
+curl -sS -o /dev/null -w 'warm: %{time_total}s\n' "http://127.0.0.1:${LOTGD_HTTP_PORT:-8080}/"
 ```
 
 The first request may populate Twig and Doctrine caches. Subsequent timings are
@@ -167,8 +216,8 @@ explicitly marked `no-store, private`; full-page HTTP caching must not be added
 without a session-aware cache design. Inspect both behaviors with:
 
 ```bash
-curl --compressed -sSI http://localhost/templates_twig/aurora/assets/style.css
-curl -sSI http://localhost/index.php
+curl --compressed -sSI "http://127.0.0.1:${LOTGD_HTTP_PORT:-8080}/templates_twig/aurora/assets/style.css"
+curl -sSI "http://127.0.0.1:${LOTGD_HTTP_PORT:-8080}/index.php"
 ```
 
 ## Operations and troubleshooting

--- a/tests/Docker/compose-security.sh
+++ b/tests/Docker/compose-security.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -eu
+
+# Exercise the rendered Compose model rather than relying on textual checks.
+command -v docker >/dev/null 2>&1 || {
+    echo "docker is required to run this test" >&2
+    exit 1
+}
+
+project_dir=$(mktemp -d)
+trap 'rm -rf "$project_dir"' EXIT
+cp docker-compose.yml "$project_dir/docker-compose.yml"
+
+for missing_secret in MYSQL_PASSWORD MYSQL_ROOT_PASSWORD; do
+    cat > "$project_dir/.env" <<'EOF'
+MYSQL_PASSWORD=compose-test-application-secret
+MYSQL_ROOT_PASSWORD=compose-test-root-secret
+EOF
+    sed -i "s/^${missing_secret}=.*$/${missing_secret}=/" "$project_dir/.env"
+    if docker compose --project-directory "$project_dir" config >/dev/null 2>&1; then
+        echo "Compose accepted missing secret '$missing_secret'" >&2
+        exit 1
+    fi
+done
+
+cat > "$project_dir/.env" <<'EOF'
+MYSQL_PASSWORD=compose-test-application-secret
+MYSQL_ROOT_PASSWORD=compose-test-root-secret
+EOF
+rendered=$(docker compose --project-directory "$project_dir" config)
+printf '%s\n' "$rendered" | grep -F 'host_ip: 127.0.0.1' >/dev/null || {
+    echo "Default web port is not bound to loopback:8080" >&2
+    exit 1
+}
+printf '%s\n' "$rendered" | grep -E "published: ['\"]?8080['\"]?$" >/dev/null || {
+    echo "Default host port is not 8080" >&2
+    exit 1
+}
+
+for example_secret in lotgdpass rootpass changeme password example; do
+    if MYSQL_PASSWORD="$example_secret" MYSQL_ROOT_PASSWORD=valid-test-secret \
+        LOTGD_STATE_PATH="$project_dir/state" docker/entrypoint.sh true 2>/dev/null; then
+        echo "Entrypoint accepted documented example secret '$example_secret'" >&2
+        exit 1
+    fi
+done
+
+echo "Docker Compose security configuration passed"


### PR DESCRIPTION
### Motivation

- Reduce attack surface of the Docker deployment by removing usable secret fallbacks and ensuring the installer is only reachable after an explicit admin action.
- Prevent accidental use of documented/example passwords and require operators to generate strong secrets before the stack can start.

### Description

- Require explicit MySQL secrets in `docker-compose.yml` by using Compose variable validation (`${MYSQL_PASSWORD:?MYSQL_PASSWORD must be set}` and `${MYSQL_ROOT_PASSWORD:?MYSQL_ROOT_PASSWORD must be set}`) and bind the web host port to loopback by default (`127.0.0.1:${LOTGD_HTTP_PORT:-8080}:80`).
- Mark `.env.example` clearly as a template, leave secret fields empty, add `LOTGD_INSTALL_ENABLED=0` and document generating secrets (e.g. `openssl rand -base64 32`).
- Add early startup checks to `docker/entrypoint.sh` that reject empty or known example passwords (e.g. `lotgdpass`, `rootpass`, `changeme`, `password`, `example`) with a clear stderr message and non-zero exit.
- Gate the installer at the webserver level in `docker/apache/lotgd.conf` so installer routes and `installer.php` are only reachable when `LOTGD_INSTALL_ENABLED=1`, while the persistent `installation-complete` marker still permanently removes the installer after successful install.
- Document the new workflow and SSH-tunnel recommendation in `docs/Docker.md` and add an executable focused regression test `tests/Docker/compose-security.sh` that asserts missing secrets are rejected, example secrets are refused by the entrypoint, and the default host binding is loopback-only.

### Testing

- Ran `composer install --no-interaction --prefer-dist` successfully to install dependencies.
- Ran `composer test` which executed the full PHPUnit suite: 759 tests, 4099 assertions; the suite completed OK but reports existing warnings/deprecations and PHPUnit notices unrelated to this change.
- Ran `composer static` (PHPStan) successfully.
- Verified `sh -n docker/entrypoint.sh tests/Docker/compose-security.sh` (syntax checks) and exercised the entrypoint: invoking the entrypoint with a documented example secret returns non-zero as expected.
- Performed `git diff --check` and committed the changes (`fix: harden Docker installer configuration`), and the working tree is clean.
- The included `tests/Docker/compose-security.sh` requires the Docker CLI to fully run; it fails fast in CI-local runs if `docker` is unavailable (this environment lacked the Docker CLI), but the script itself performs the intended configuration checks when executed where Docker Compose is present.

Security review (short): input validation boundary is at Compose/entrypoint (environment vars are required and validated early); no new HTTP state-changing endpoints were added and installer access is gated by `LOTGD_INSTALL_ENABLED` plus loopback binding and by the persistent install-complete marker; no SQL changes were introduced and existing DB usage is unchanged; invalid startup credentials are reported to stderr for operator visibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a913a0c90448329803ad7514fd4ba02)