### PR TITLE
docker: fix installer RewriteRule and add container-local readiness probe with CI smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "**" ]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,25 @@ jobs:
           find . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l
       - name: Run tests
         run: composer test
+
+  docker:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Validate Compose and run production smoke test
+        run: tests/Docker/smoke.sh
+      - name: Build supported 64-bit architectures
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          cache-from: type=gha,scope=lotgd-multiarch
+          cache-to: type=gha,mode=max,scope=lotgd-multiarch

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN a2enmod deflate expires headers rewrite \
     && a2dissite 000-default
 COPY docker/apache/lotgd.conf /etc/apache2/sites-available/lotgd.conf
 RUN a2ensite lotgd
+COPY docker/health/ready.php /var/www/lotgd-health/ready.php
 COPY docker/php/production.ini /usr/local/etc/php/conf.d/zz-lotgd.ini
 COPY docker/entrypoint.sh /usr/local/bin/lotgd-entrypoint
 RUN chmod +x /usr/local/bin/lotgd-entrypoint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       APP_ENV: production
       MYSQL_USEDATACACHE: "1"
       MYSQL_DATACACHEPATH: /var/cache/lotgd
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-lotgd}
+      MYSQL_HOST: ${MYSQL_HOST:-db}
+      MYSQL_USER: ${MYSQL_USER:-lotgduser}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD:?MYSQL_PASSWORD must be set}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?MYSQL_ROOT_PASSWORD must be set}
       LOTGD_INSTALL_ENABLED: ${LOTGD_INSTALL_ENABLED:-0}
@@ -19,11 +22,11 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "php", "-r", "exit(file_get_contents('http://127.0.0.1/errors/403.html') === false ? 1 : 0);"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 30s
+      test: ["CMD", "php", "-r", "$c=get_headers('http://127.0.0.1/_health/ready'); exit($c !== false && str_contains($c[0], '204') ? 0 : 1);"]
+      interval: 15s
+      timeout: 3s
+      retries: 4
+      start_period: 60s
     networks:
       - lotgd-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,8 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "php", "-r", "$c=get_headers('http://127.0.0.1/_health/ready'); exit($c !== false && str_contains($c[0], '204') ? 0 : 1);"]
+      # Compose uses $$ to pass a literal $ through to the PHP process.
+      test: ["CMD", "php", "-r", "$$c=get_headers('http://127.0.0.1/_health/ready'); exit($$c !== false && str_contains($$c[0], '204') ? 0 : 1);"]
       interval: 15s
       timeout: 3s
       retries: 4

--- a/docker/apache/lotgd.conf
+++ b/docker/apache/lotgd.conf
@@ -73,15 +73,25 @@
         </FilesMatch>
     </Directory>
 
+    # Readiness is intentionally outside the application document root and is
+    # callable only from inside this container. Reverse proxies and host-port
+    # clients must not be able to use it as a database diagnostic endpoint.
+    Alias /_health/ready /var/www/lotgd-health/ready.php
+    <Directory /var/www/lotgd-health>
+        AllowOverride None
+        Options -Indexes
+        Require local
+    </Directory>
+
     # Installation is an explicit, temporary administrative action. The
     # completion marker still wins because entrypoint removes installer.php.
     RewriteEngine On
     RewriteCond %{ENV:LOTGD_INSTALL_ENABLED} !=1
-    RewriteRule ^(?:installer\.php|install(?:/|$)) - [F,L]
+    RewriteRule ^/(?:installer\.php|install(?:/|$)) - [F,L]
 
     # Keep installer support files unreachable after installer.php is removed,
     # even if an old environment still has the installation flag enabled.
     RewriteCond %{REQUEST_URI} ^/install/ [NC]
     RewriteCond %{DOCUMENT_ROOT}/installer.php !-f
-    RewriteRule ^install/ - [F,L]
+    RewriteRule ^/install/ - [F,L]
 </VirtualHost>

--- a/docker/health/ready.php
+++ b/docker/health/ready.php
@@ -30,12 +30,16 @@ try {
     }
 
     $configurationPath = '/var/www/html/dbconnect.php';
+    clearstatcache(true, $configurationPath);
     if (! is_file($configurationPath) || ! is_readable($configurationPath)) {
         throw new RuntimeException('database configuration unavailable');
     }
 
     // Legacy or hand-edited configuration files may print migration notices.
     // Discard all such output so readiness can never disclose their contents.
+    if (function_exists('opcache_invalidate')) {
+        opcache_invalidate($configurationPath, true);
+    }
     ob_start();
     try {
         $configuration = require $configurationPath;

--- a/docker/health/ready.php
+++ b/docker/health/ready.php
@@ -34,7 +34,14 @@ try {
         throw new RuntimeException('database configuration unavailable');
     }
 
-    $configuration = require $configurationPath;
+    // Legacy or hand-edited configuration files may print migration notices.
+    // Discard all such output so readiness can never disclose their contents.
+    ob_start();
+    try {
+        $configuration = require $configurationPath;
+    } finally {
+        ob_end_clean();
+    }
     if (! is_array($configuration)) {
         // Keep the probe compatible with pre-array 2.x configuration files.
         $configuration = [
@@ -59,7 +66,9 @@ try {
         $configuration['DB_NAME'],
     );
     $result = $database->query('SELECT 1');
-    $ready = $result instanceof mysqli_result && $result->fetch_row() === ['1'];
+    $row = $result instanceof mysqli_result ? $result->fetch_row() : null;
+    // mysqlnd may return native integers while other drivers return strings.
+    $ready = is_array($row) && isset($row[0]) && (string) $row[0] === '1';
     if ($result instanceof mysqli_result) {
         $result->free();
     }

--- a/docker/health/ready.php
+++ b/docker/health/ready.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Container-local readiness probe.
+ *
+ * The endpoint deliberately avoids the game bootstrap so it cannot create a
+ * session or trigger gameplay. Every failure has the same empty response;
+ * operational details remain available only through container logs.
+ */
+
+const REQUIRED_EXTENSIONS = [
+    'gd',
+    'mbstring',
+    'mysqli',
+    'pdo',
+    'pdo_mysql',
+    'zip',
+];
+
+header('Cache-Control: no-store');
+http_response_code(503);
+
+try {
+    foreach (REQUIRED_EXTENSIONS as $extension) {
+        if (! extension_loaded($extension)) {
+            throw new RuntimeException('required extension unavailable');
+        }
+    }
+
+    $configurationPath = '/var/www/html/dbconnect.php';
+    if (! is_file($configurationPath) || ! is_readable($configurationPath)) {
+        throw new RuntimeException('database configuration unavailable');
+    }
+
+    $configuration = require $configurationPath;
+    if (! is_array($configuration)) {
+        // Keep the probe compatible with pre-array 2.x configuration files.
+        $configuration = [
+            'DB_HOST' => $DB_HOST ?? null,
+            'DB_USER' => $DB_USER ?? null,
+            'DB_PASS' => $DB_PASS ?? null,
+            'DB_NAME' => $DB_NAME ?? null,
+        ];
+    }
+
+    foreach (['DB_HOST', 'DB_USER', 'DB_PASS', 'DB_NAME'] as $key) {
+        if (! isset($configuration[$key]) || ! is_string($configuration[$key])) {
+            throw new RuntimeException('database configuration incomplete');
+        }
+    }
+
+    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+    $database = new mysqli(
+        $configuration['DB_HOST'],
+        $configuration['DB_USER'],
+        $configuration['DB_PASS'],
+        $configuration['DB_NAME'],
+    );
+    $result = $database->query('SELECT 1');
+    $ready = $result instanceof mysqli_result && $result->fetch_row() === ['1'];
+    if ($result instanceof mysqli_result) {
+        $result->free();
+    }
+    $database->close();
+
+    if (! $ready) {
+        throw new RuntimeException('database readiness query failed');
+    }
+
+    http_response_code(204);
+} catch (Throwable) {
+    // Never expose credentials, driver errors, filesystem paths, or traces.
+    error_log('LOTGD readiness check failed');
+}

--- a/docker/health/ready.php
+++ b/docker/health/ready.php
@@ -35,14 +35,25 @@ try {
         throw new RuntimeException('database configuration unavailable');
     }
 
+    // Resolve the canonical path so that opcache_invalidate and require use
+    // the real filesystem path rather than the symlink.  With
+    // opcache.validate_timestamps=0 OPcache keeps its own realpath cache that
+    // clearstatcache() cannot clear; passing the resolved path directly
+    // bypasses any stale symlink entry that OPcache may have cached while the
+    // target file did not yet exist.
+    $resolvedPath = realpath($configurationPath);
+    if ($resolvedPath === false) {
+        throw new RuntimeException('database configuration unavailable');
+    }
+
     // Legacy or hand-edited configuration files may print migration notices.
     // Discard all such output so readiness can never disclose their contents.
     if (function_exists('opcache_invalidate')) {
-        opcache_invalidate($configurationPath, true);
+        opcache_invalidate($resolvedPath, true);
     }
     ob_start();
     try {
-        $configuration = require $configurationPath;
+        $configuration = require $resolvedPath;
     } finally {
         ob_end_clean();
     }

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -191,6 +191,14 @@ docker compose exec --user www-data web sh -c 'test -w /var/cache/lotgd/twig && 
 docker compose exec web find /var/cache/lotgd -mindepth 1 -maxdepth 2 -type f -print
 ```
 
+The web service becomes healthy only after PHP can read `dbconnect.php`, all
+required PHP extensions are loaded, and a side-effect-free `SELECT 1` reaches
+the configured database. The readiness URL is restricted to requests from
+inside the web container; use `docker compose ps` or Docker's health status
+instead of publishing the probe through a reverse proxy. Installation can
+therefore proceed while the container reports `starting` or `unhealthy`, and a
+completed installation transitions it to `healthy` without a restart.
+
 The repository also includes a focused configuration regression test (it
 requires the Docker Compose plugin):
 

--- a/docs/RaspberryPiDocker.md
+++ b/docs/RaspberryPiDocker.md
@@ -51,6 +51,10 @@ Then run:
 docker compose up -d --build
 ```
 
+CI builds the production Dockerfile for both `linux/amd64` and `linux/arm64`.
+The latter is the 64-bit architecture used by the recommended Raspberry Pi OS
+image, so changes to the documented Pi deployment are checked continuously.
+
 ### 5) Finish in the browser
 Open your Pi’s IP address in a browser (e.g., `http://raspberrypi.local/` or `http://<pi-ip>/`) and complete the in-app setup.
 

--- a/tests/Docker/smoke.sh
+++ b/tests/Docker/smoke.sh
@@ -57,7 +57,12 @@ docker compose exec -T web php -r '
         "DB_PASS" => getenv("MYSQL_PASSWORD"),
         "DB_NAME" => getenv("MYSQL_DATABASE"),
     ];
-    if (file_put_contents("/var/lib/lotgd/dbconnect.php", "<?php\nreturn " . var_export($configuration, true) . ";\n") === false) {
+    // Deliberate output proves the readiness endpoint safely discards content
+    // emitted by legacy or hand-edited database configuration files.
+    $contents = "<?php\necho \"discarded configuration output\";\nreturn "
+        . var_export($configuration, true)
+        . ";\n";
+    if (file_put_contents("/var/lib/lotgd/dbconnect.php", $contents) === false) {
         exit(1);
     }
 '

--- a/tests/Docker/smoke.sh
+++ b/tests/Docker/smoke.sh
@@ -72,7 +72,7 @@ docker compose exec -T web php -r '
 attempt=0
 until [ "$(docker inspect --format '{{.State.Health.Status}}' "${COMPOSE_PROJECT_NAME}-web-1")" = healthy ]; do
     attempt=$((attempt + 1))
-    if [ "$attempt" -ge 40 ]; then
+    if [ "$attempt" -ge 75 ]; then
         docker compose logs web
         exit 1
     fi
@@ -108,7 +108,7 @@ assert_status() {
     expected="$2"
     actual=$(curl --silent --output /dev/null --write-out '%{http_code}' "http://127.0.0.1:${LOTGD_HTTP_PORT}${path}")
     if [ "$actual" != "$expected" ]; then
-        echo "Unexpected HTTP status for protected path (expected $expected, got $actual)" >&2
+        echo "Unexpected HTTP status for ${path} (expected $expected, got $actual)" >&2
         exit 1
     fi
 }

--- a/tests/Docker/smoke.sh
+++ b/tests/Docker/smoke.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+set -eu
+
+# End-to-end verification of the production image and its HTTP security
+# boundary. Credentials exist only for this disposable Compose project.
+export COMPOSE_PROJECT_NAME="lotgd-ci-${GITHUB_RUN_ID:-local}-$$"
+export LOTGD_HTTP_PORT="${LOTGD_HTTP_PORT:-18080}"
+export MYSQL_PASSWORD="ci-application-secret-$(date +%s)-$$"
+export MYSQL_ROOT_PASSWORD="ci-root-secret-$(date +%s)-$$"
+export MYSQL_DATABASE=lotgd
+export MYSQL_USER=lotgduser
+
+cleanup() {
+    docker compose down --volumes --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+docker compose config >/dev/null
+docker compose build web
+docker compose up -d
+
+# Wait for MySQL before installing the minimal, read-only probe configuration.
+attempt=0
+until [ "$(docker inspect --format '{{.State.Health.Status}}' "${COMPOSE_PROJECT_NAME}-db-1")" = healthy ]; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 60 ]; then
+        docker compose logs db
+        exit 1
+    fi
+    sleep 2
+done
+
+docker compose exec -T web php -r '
+    $configuration = [
+        "DB_HOST" => getenv("MYSQL_HOST"),
+        "DB_USER" => getenv("MYSQL_USER"),
+        "DB_PASS" => getenv("MYSQL_PASSWORD"),
+        "DB_NAME" => getenv("MYSQL_DATABASE"),
+    ];
+    if (file_put_contents("/var/lib/lotgd/dbconnect.php", "<?php\nreturn " . var_export($configuration, true) . ";\n") === false) {
+        exit(1);
+    }
+'
+
+attempt=0
+until [ "$(docker inspect --format '{{.State.Health.Status}}' "${COMPOSE_PROJECT_NAME}-web-1")" = healthy ]; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 40 ]; then
+        docker compose logs web
+        exit 1
+    fi
+    sleep 2
+done
+
+# Verify the exact runtime prerequisites rather than assuming a successful
+# package installation means PHP loaded every module.
+docker compose exec -T web php -r '
+    foreach (["gd", "mbstring", "mysqli", "pdo", "pdo_mysql", "zip"] as $extension) {
+        if (! extension_loaded($extension)) {
+            fwrite(STDERR, "Missing PHP extension\n");
+            exit(1);
+        }
+    }
+'
+docker compose exec -T --user www-data web sh -c '
+    test -w /var/cache/lotgd &&
+    test -w /var/cache/lotgd/twig &&
+    test -w /var/cache/lotgd/doctrine &&
+    test -w /var/lib/lotgd
+'
+
+# The container-local probe must succeed without returning diagnostic content.
+docker compose exec -T web php -r '
+    $body = file_get_contents("http://127.0.0.1/_health/ready");
+    $status = $http_response_header[0] ?? "";
+    exit($body === "" && str_contains($status, "204") ? 0 : 1);
+'
+
+assert_status() {
+    path="$1"
+    expected="$2"
+    actual=$(curl --silent --output /dev/null --write-out '%{http_code}' "http://127.0.0.1:${LOTGD_HTTP_PORT}${path}")
+    if [ "$actual" != "$expected" ]; then
+        echo "Unexpected HTTP status for protected path (expected $expected, got $actual)" >&2
+        exit 1
+    fi
+}
+
+# These host requests exercise the production vhost, including the leading
+# slash semantics of RewriteRule in VirtualHost context.
+assert_status /installer.php 403
+assert_status /install/ 403
+assert_status /_health/ready 403
+assert_status /.env 403
+assert_status /lib/dbwrapper.php 403
+assert_status /modules/cities.php 403
+
+echo "Docker production smoke test passed"

--- a/tests/Docker/smoke.sh
+++ b/tests/Docker/smoke.sh
@@ -8,6 +8,7 @@ export LOTGD_HTTP_PORT="${LOTGD_HTTP_PORT:-18080}"
 export MYSQL_PASSWORD="ci-application-secret-$(date +%s)-$$"
 export MYSQL_ROOT_PASSWORD="ci-root-secret-$(date +%s)-$$"
 export MYSQL_DATABASE=lotgd
+export MYSQL_HOST=db
 export MYSQL_USER=lotgduser
 
 created_env=false
@@ -27,6 +28,7 @@ if [ ! -e .env ]; then
     umask 077
     cat > .env <<EOF
 MYSQL_DATABASE=$MYSQL_DATABASE
+MYSQL_HOST=$MYSQL_HOST
 MYSQL_USER=$MYSQL_USER
 MYSQL_PASSWORD=$MYSQL_PASSWORD
 MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD

--- a/tests/Docker/smoke.sh
+++ b/tests/Docker/smoke.sh
@@ -62,7 +62,7 @@ docker compose exec -T web php -r '
     $contents = "<?php\necho \"discarded configuration output\";\nreturn "
         . var_export($configuration, true)
         . ";\n";
-    if (file_put_contents("/var/lib/lotgd/dbconnect.php", $contents) === false) {
+    if (file_put_contents("/var/www/html/dbconnect.php", $contents) === false) {
         exit(1);
     }
 '

--- a/tests/Docker/smoke.sh
+++ b/tests/Docker/smoke.sh
@@ -10,10 +10,30 @@ export MYSQL_ROOT_PASSWORD="ci-root-secret-$(date +%s)-$$"
 export MYSQL_DATABASE=lotgd
 export MYSQL_USER=lotgduser
 
+created_env=false
+
 cleanup() {
     docker compose down --volumes --remove-orphans >/dev/null 2>&1 || true
+    if [ "$created_env" = true ]; then
+        rm -f .env
+    fi
 }
 trap cleanup EXIT INT TERM
+
+# The production Compose model intentionally requires .env. A clean CI
+# checkout does not contain one, so create a private disposable file without
+# overwriting a developer's existing local configuration.
+if [ ! -e .env ]; then
+    umask 077
+    cat > .env <<EOF
+MYSQL_DATABASE=$MYSQL_DATABASE
+MYSQL_USER=$MYSQL_USER
+MYSQL_PASSWORD=$MYSQL_PASSWORD
+MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD
+LOTGD_HTTP_PORT=$LOTGD_HTTP_PORT
+EOF
+    created_env=true
+fi
 
 docker compose config >/dev/null
 docker compose build web


### PR DESCRIPTION
### Motivation

- Fix an Apache RewriteRule that did not match the leading `/` in a `<VirtualHost>` context, allowing the installer to remain reachable when it should be denied. 
- Provide a secure, stateless container-local readiness check that verifies PHP extensions, `dbconnect.php` readability, and a harmless `SELECT 1` without exposing secrets. 
- Add an automated smoke test and CI job to exercise the vhost rules, readiness probe and produce multi-arch builds so regressions are caught in CI.

### Description

- Adjusted the production vhost rewrite rules so they match the leading slash in `<VirtualHost>` context (`RewriteRule ^/(?:installer\.php|install(?:/|$))` and `RewriteRule ^/install/ - [F,L]`).
- Added a container-local readiness endpoint at `/_health/ready` implemented in `docker/health/ready.php`, which checks required PHP extensions, that `dbconnect.php` is readable (compatibly handling older formats), and that `SELECT 1` succeeds, and that returns only generic HTTP statuses (204 on success, 503 on failure) while logging a generic failure message.
- Restricted the probe to local access via Apache `Alias` + `<Directory /var/www/lotgd-health>` with `Require local`, copied the probe into the image in `Dockerfile`, and updated the web service healthcheck in `docker-compose.yml` to use the new endpoint with conservative `start_period`, `timeout` and `retries` values.
- Added `tests/Docker/smoke.sh` to build/run a disposable Compose project, validate runtime file permissions, required PHP extensions, the empty 204 readiness response, and host-facing route protections (`/installer.php`, `/install/`, `/._health/ready`, `.env`, `lib/*`, `modules/*`), and added a `docker` job in `.github/workflows/ci.yml` that runs the smoke script and builds images for `linux/amd64` and `linux/arm64`.
- Documentation updates in `docs/Docker.md` and `docs/RaspberryPiDocker.md` describing the readiness semantics and the CI multi-arch coverage.
- Security review: the readiness probe defines the input boundary (reads `dbconnect.php` only), performs no state changes, does not return DB errors/paths/credentials, uses a harmless `SELECT 1` (no untrusted SQL), is restricted to container-local requests (`Require local`), and logs only a generic failure message so no sensitive data is exposed.

### Testing

- `php -l docker/health/ready.php` succeeded with no syntax errors. 
- `sh -n tests/Docker/smoke.sh` succeeded (script syntax validated). 
- `composer static` (PHPStan checks) completed successfully in this environment. 
- `composer test` ran the full PHPUnit suite and completed successfully (759 tests, 4099 assertions) with existing warnings/deprecations/notices reported by the suite. 
- Docker-based smoke runs could not be executed locally in this environment because Docker is unavailable here, but a CI job was added that executes `tests/Docker/smoke.sh` and builds multi-arch images so the full end-to-end verification will run in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9158a97c808329aa2bca5da63afb1a)