### PR TITLE
fix: harden Docker runtime file permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,10 +59,13 @@ RUN install -d -o www-data -g www-data -m 0775 \
         /var/cache/lotgd/twig \
         /var/cache/lotgd/doctrine \
         /var/lib/lotgd \
-    && chown -R www-data:www-data /var/www/html
+        /var/lib/lotgd/logs \
+    && chown -R root:root /var/www/html \
+    && chmod -R go-w /var/www/html
 
 ENV APP_ENV=production \
     LOTGD_STATE_PATH=/var/lib/lotgd \
+    LOTGD_DATA_DIR=/var/lib/lotgd/logs \
     MYSQL_USEDATACACHE=1 \
     MYSQL_DATACACHEPATH=/var/cache/lotgd
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD:?MYSQL_PASSWORD must be set}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?MYSQL_ROOT_PASSWORD must be set}
       LOTGD_INSTALL_ENABLED: ${LOTGD_INSTALL_ENABLED:-0}
+      LOTGD_DATA_DIR: /var/lib/lotgd/logs
+      LOTGD_STATE_PATH: /var/lib/lotgd
     volumes:
       - lotgd_cache:/var/cache/lotgd
       - lotgd_state:/var/lib/lotgd

--- a/docker/apache/lotgd.conf
+++ b/docker/apache/lotgd.conf
@@ -73,6 +73,12 @@
         </FilesMatch>
     </Directory>
 
+    # Installer diagnostics may contain credentials and internal paths. They
+    # are never web content, even while installation is explicitly enabled.
+    <Directory /var/www/html/install/errors>
+        Require all denied
+    </Directory>
+
     # Readiness is intentionally outside the application document root and is
     # callable only from inside this container. Reverse proxies and host-port
     # clients must not be able to use it as a database diagnostic endpoint.
@@ -86,6 +92,9 @@
     # Installation is an explicit, temporary administrative action. The
     # completion marker still wins because entrypoint removes installer.php.
     RewriteEngine On
+    RewriteCond /var/lib/lotgd/installation-complete -f
+    RewriteRule ^/(?:installer\.php|install(?:/|$)) - [F,L]
+
     RewriteCond %{ENV:LOTGD_INSTALL_ENABLED} !=1
     RewriteRule ^/(?:installer\.php|install(?:/|$)) - [F,L]
 

--- a/docker/apache/lotgd.conf
+++ b/docker/apache/lotgd.conf
@@ -92,7 +92,7 @@
     # Installation is an explicit, temporary administrative action. The
     # completion marker still wins because entrypoint removes installer.php.
     RewriteEngine On
-    RewriteCond /var/lib/lotgd/installation-complete -f
+    RewriteCond %{ENV:LOTGD_STATE_PATH}/installation-complete -f
     RewriteRule ^/(?:installer\.php|install(?:/|$)) - [F,L]
 
     RewriteCond %{ENV:LOTGD_INSTALL_ENABLED} !=1

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,7 +2,16 @@
 set -eu
 
 state_path="${LOTGD_STATE_PATH:-/var/lib/lotgd}"
+log_path="${LOTGD_DATA_DIR:-$state_path/logs}"
 dbconnect_path="/var/www/html/dbconnect.php"
+
+case "$log_path/" in
+    "$state_path"/*) ;;
+    *)
+        echo "LOTGD_DATA_DIR '$log_path' must be inside LOTGD_STATE_PATH '$state_path'" >&2
+        exit 1
+        ;;
+esac
 
 # Fail before modifying persistent state when database credentials are absent or
 # match values previously published as usable examples.
@@ -20,9 +29,14 @@ validate_secret() {
 validate_secret MYSQL_PASSWORD
 validate_secret MYSQL_ROOT_PASSWORD
 
-mkdir -p "$state_path"
-if [ ! -w "$state_path" ]; then
-    echo "LOTGD_STATE_PATH '$state_path' is not writable" >&2
+# Runtime directories live outside the document root. Re-apply ownership and
+# restrictive modes on every start because named volumes retain old metadata.
+install -d -o www-data -g www-data -m 0750 "$state_path" "$log_path"
+install -d -o www-data -g www-data -m 0770 \
+    /var/cache/lotgd /var/cache/lotgd/twig /var/cache/lotgd/doctrine
+
+if ! su -s /bin/sh www-data -c "test -w '$state_path' && test -w '$log_path'"; then
+    echo "LOTGD_STATE_PATH '$state_path' or installer log directory '$log_path' is not writable by www-data" >&2
     exit 1
 fi
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,6 +5,9 @@ state_path="${LOTGD_STATE_PATH:-/var/lib/lotgd}"
 log_path="${LOTGD_DATA_DIR:-$state_path/logs}"
 dbconnect_path="/var/www/html/dbconnect.php"
 
+state_path="$(realpath -m "$state_path")"
+log_path="$(realpath -m "$log_path")"
+
 case "$log_path/" in
     "$state_path"/*) ;;
     *)

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -90,8 +90,11 @@ installer publicly. Run this on the administrator's workstation, replacing
 ssh -N -L 8080:127.0.0.1:8080 admin@example.com
 ```
 
-Installer stage 11 writes the persistent `installation-complete` marker and
-removes `installer.php`. That marker takes precedence over
+Installer stage 11 lets `www-data` write only the persistent
+`installation-complete` marker. Apache denies the installer immediately when
+that marker appears; because application files are root-owned, the root-run
+entrypoint removes `installer.php` on the next container start. The marker takes
+precedence over
 `LOTGD_INSTALL_ENABLED`, so restoring or leaving the flag at `1` cannot restore
 installer access after successful completion. Set `LOTGD_INSTALL_ENABLED=0`
 again and recreate the web container as defense in depth:
@@ -113,7 +116,9 @@ Build and launch the immutable application image:
 docker compose up -d --build
 ```
 
-The default web service has no source-code bind mount. Composer installs without
+The default web service has no source-code bind mount. Application code is
+root-owned and read-only to `www-data`; only the cache and persistent state
+volumes are writable by the web process. Composer installs without
 development dependencies and generates an authoritative classmap. PHP hides
 errors from responses, logs them to container stderr, and enables OPcache
 without timestamp validation. Rebuild the image to deploy code changes.
@@ -155,14 +160,17 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build --f
 ## Persistent volumes and permissions
 
 `db_data` holds MySQL data, `lotgd_cache` holds the shared runtime cache, and
-`lotgd_state` preserves `dbconnect.php` plus the installer's completion marker.
+`lotgd_state` preserves `dbconnect.php`, installer logs under `logs/install.log`,
+and the installer's completion marker.
 The state volume prevents an image replacement from losing database settings or
 restoring an installer that an administrator already removed. Back up
 `lotgd_state` together with the database; do not delete it during a routine
 deployment.
 
-The image creates `/var/cache/lotgd/{twig,doctrine}` as `www-data`; Docker copies
-those initial directories into a newly created named volume. Removing only the
+The image and entrypoint create `/var/cache/lotgd/{twig,doctrine}` and
+`/var/lib/lotgd/logs` as `www-data` with restrictive permissions; Docker copies
+the initial directories into newly created named volumes, and startup repairs
+volume metadata without making the document root writable. Removing only the
 cache volume discards generated cache data but not game, configuration, or
 database data.
 
@@ -170,7 +178,7 @@ Inspect ownership and repair an existing volume created with incorrect
 permissions as root:
 
 ```bash
-docker compose exec web stat -c '%U:%G %a %n' /var/cache/lotgd /var/cache/lotgd/{twig,doctrine}
+docker compose exec web stat -c '%U:%G %a %n' /var/cache/lotgd /var/cache/lotgd/{twig,doctrine} /var/lib/lotgd /var/lib/lotgd/logs /var/www/html
 docker compose exec --user root web chown -R www-data:www-data /var/cache/lotgd
 docker compose exec --user root web chmod -R u+rwX,g+rwX /var/cache/lotgd
 ```
@@ -243,6 +251,8 @@ changes do not appear in production, rebuild the immutable image. In
 development, confirm both Compose files were supplied and verify that
 `APP_ENV=development` is present with `docker compose exec web env`.
 
-Installer failures are logged to `install/errors/install.log`. Production PHP
+Installer failures are logged outside the document root at
+`/var/lib/lotgd/logs/install.log`. Apache denies `/install/errors/` regardless
+of whether installation is enabled. Production PHP
 errors are available through `docker compose logs web` and are never displayed
 to clients.

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -347,12 +347,20 @@ class Installer
         if (array_key_exists('delete_installer', $_POST) && $_POST['delete_installer'] == '1') {
             if (file_exists($file)) {
                 try {
-                    if ($this->recordContainerInstallationCompletion() && unlink($file)) {
-                        $this->output->output("`\$Installer file installer.php removed.`n");
+                    $statePath = getenv('LOTGD_STATE_PATH');
+                    $containerCompletion = $statePath !== false && trim($statePath) !== '';
+                    if ($this->recordContainerInstallationCompletion()
+                        && ($containerCompletion || unlink($file))
+                    ) {
+                        if ($containerCompletion) {
+                            $this->output->output("`\$Installation completion recorded. The installer is now disabled and will be removed at the next container start.`n");
+                        } else {
+                            $this->output->output("`\$Installer file installer.php removed.`n");
+                        }
                     } else {
                         $this->output->output("`\$Unable to record installation completion or delete installer.php. Please verify LOTGD_STATE_PATH is writable and remove it manually.`n");
                     }
-                } catch (Throwable $e) {
+                } catch (\Throwable $e) {
                     $this->output->output("`\$Error deleting installer.php: " . $e->getMessage() . "`n");
                 }
             }
@@ -871,7 +879,7 @@ class Installer
     public function stage6(): void
     {
         global $session, $logd_version, $recommended_modules, $noinstallnavs, $stage, $DB_USEDATACACHE;
-        $dbconnectPath = dirname(__DIR__, 2) . '/dbconnect.php';
+        $dbconnectPath = $this->getDbconnectWritePath();
         $success = false;
 
         if (file_exists($dbconnectPath)) {
@@ -2145,14 +2153,28 @@ class Installer
      */
     private function verifyInstallDirectoryWritable(): bool
     {
-        $dir = dirname(__DIR__, 2);
-        if (! is_writable($dir)) {
-            $this->output->output("`\$Installation directory not writable:`2 %s", $dir);
-            $this->output->output("`2Please adjust permissions, e.g., run `#chmod 775 %s`2. See <a href='https://www.php.net/manual/en/function.chmod.php' target='_blank'>permission docs</a>.", $dir, true);
+        $target = $this->getDbconnectWritePath();
+        $writable = file_exists($target) ? is_writable($target) : is_writable(dirname($target));
+        if (! $writable) {
+            $this->output->output("`\$Database configuration target not writable:`2 %s", $target);
+            $this->output->output("`2Please grant the web-server user write access to this file or its parent directory. See <a href='https://www.php.net/manual/en/function.chmod.php' target='_blank'>permission docs</a>.", true);
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * Return the real configuration target used by immutable containers.
+     */
+    private function getDbconnectWritePath(): string
+    {
+        $statePath = getenv('LOTGD_STATE_PATH');
+        if ($statePath !== false && trim($statePath) !== '') {
+            return rtrim($statePath, '/\\') . '/dbconnect.php';
+        }
+
+        return dirname(__DIR__, 2) . '/dbconnect.php';
     }
 
     private function getSetting(string $name, $default = '')

--- a/install/lib/InstallerLogger.php
+++ b/install/lib/InstallerLogger.php
@@ -11,16 +11,14 @@ class InstallerLogger
      */
     public static function getLogFilePath(): string
     {
-        // Containers define a persistent state path. Never let a data-directory
-        // override redirect their installer diagnostics back into the webroot.
-        $stateDir = getenv('LOTGD_STATE_PATH');
-        if ($stateDir !== false && trim($stateDir) !== '') {
-            return rtrim($stateDir, '/\\') . '/logs/install.log';
-        }
-
         $customDir = getenv('LOTGD_DATA_DIR');
         if ($customDir) {
             return rtrim($customDir, '/') . '/install.log';
+        }
+
+        $stateDir = getenv('LOTGD_STATE_PATH');
+        if ($stateDir !== false && trim($stateDir) !== '') {
+            return rtrim($stateDir, '/\\') . '/logs/install.log';
         }
 
         $defaultDir = __DIR__ . '/../errors';

--- a/install/lib/InstallerLogger.php
+++ b/install/lib/InstallerLogger.php
@@ -11,6 +11,13 @@ class InstallerLogger
      */
     public static function getLogFilePath(): string
     {
+        // Containers define a persistent state path. Never let a data-directory
+        // override redirect their installer diagnostics back into the webroot.
+        $stateDir = getenv('LOTGD_STATE_PATH');
+        if ($stateDir !== false && trim($stateDir) !== '') {
+            return rtrim($stateDir, '/\\') . '/logs/install.log';
+        }
+
         $customDir = getenv('LOTGD_DATA_DIR');
         if ($customDir) {
             return rtrim($customDir, '/') . '/install.log';
@@ -45,12 +52,14 @@ class InstallerLogger
                 return false;
             }
 
-            if (!@mkdir($logDir, 0755, true) && !is_dir($logDir)) {
+            if (!mkdir($logDir, 0750, true) && !is_dir($logDir)) {
+                error_log(sprintf('Unable to create installer log directory: %s', $logDir));
                 return false;
             }
         }
 
         if (!is_writable($logDir)) {
+            error_log(sprintf('Installer log directory is not writable: %s', $logDir));
             return false;
         }
 
@@ -58,12 +67,14 @@ class InstallerLogger
         $entry = sprintf("[%s] %s\n", $date, $message);
 
         try {
-            $written = @file_put_contents($logFile, $entry, FILE_APPEND | LOCK_EX);
+            $written = file_put_contents($logFile, $entry, FILE_APPEND | LOCK_EX);
         } catch (\Throwable $th) {
+            error_log(sprintf('Unable to write installer log %s: %s', $logFile, $th->getMessage()));
             return false;
         }
 
         if ($written === false) {
+            error_log(sprintf('Unable to write installer log: %s', $logFile));
             return false;
         }
 

--- a/tests/Docker/smoke.sh
+++ b/tests/Docker/smoke.sh
@@ -111,7 +111,12 @@ docker compose exec -T --user www-data web sh -c '
     test -w /var/cache/lotgd &&
     test -w /var/cache/lotgd/twig &&
     test -w /var/cache/lotgd/doctrine &&
-    test -w /var/lib/lotgd
+    test -w /var/lib/lotgd &&
+    test -w /var/lib/lotgd/logs &&
+    test ! -w /var/www/html &&
+    php_file=$(find /var/www/html -type f -name "*.php" -print -quit) &&
+    test -n "$php_file" &&
+    test ! -w "$php_file"
 '
 
 # The container-local probe must succeed without returning diagnostic content.
@@ -135,9 +140,25 @@ assert_status() {
 # slash semantics of RewriteRule in VirtualHost context.
 assert_status /installer.php 403
 assert_status /install/ 403
+assert_status /install/errors/install.log 403
 assert_status /_health/ready 403
 assert_status /.env 403
 assert_status /lib/dbwrapper.php 403
 assert_status /modules/cities.php 403
+
+# The log directory stays denied even during the deliberately enabled
+# installation window. Recreate Apache so its environment sees the new flag.
+LOTGD_INSTALL_ENABLED=1 docker compose up -d --force-recreate --no-deps web
+attempt=0
+until curl --silent --output /dev/null "http://127.0.0.1:${LOTGD_HTTP_PORT}/install/errors/install.log"; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 30 ]; then
+        echo "Web container did not restart after enabling the installer" >&2
+        docker compose logs web
+        exit 1
+    fi
+    sleep 1
+done
+assert_status /install/errors/install.log 403
 
 echo "Docker production smoke test passed"

--- a/tests/Installer/Stage11Test.php
+++ b/tests/Installer/Stage11Test.php
@@ -130,7 +130,7 @@ final class Stage11Test extends TestCase
         $this->assertStringContainsString('installer.php file still exists', $output);
     }
 
-    public function testStage11DeletesInstallerFileWhenRequested(): void
+    public function testStage11RecordsCompletionWithoutDeletingImmutableInstaller(): void
     {
         global $session;
         $session['user'] = ['loggedin' => false, 'restorepage' => 'village.php'];
@@ -142,11 +142,11 @@ final class Stage11Test extends TestCase
         $installer = new Installer();
         $installer->stage11();
 
-        $this->assertFileDoesNotExist($this->installerPath);
+        $this->assertFileExists($this->installerPath);
         $this->assertFileExists($this->statePath . '/installation-complete');
 
         $output = Output::getInstance()->getRawOutput();
-        $this->assertStringContainsString('Installer file installer.php removed', $output);
+        $this->assertStringContainsString('installer is now disabled', $output);
     }
 
     /**

--- a/tests/Installer/Stage6Test.php
+++ b/tests/Installer/Stage6Test.php
@@ -85,6 +85,7 @@ final class Stage6Test extends TestCase
 
     protected function tearDown(): void
     {
+        putenv('LOTGD_STATE_PATH');
         chdir($this->originalCwd);
 
         if (is_dir($this->dbconnectPath)) {
@@ -132,6 +133,34 @@ final class Stage6Test extends TestCase
 
         $output = Output::getInstance()->getRawOutput();
         $this->assertStringContainsString('I was able to write your dbconnect.php file', $output);
+    }
+
+    public function testStage6WritesDbconnectIntoContainerStateDirectory(): void
+    {
+        global $session;
+        $statePath = sys_get_temp_dir() . '/lotgd-stage6-' . uniqid('', true);
+        mkdir($statePath, 0700, true);
+        putenv('LOTGD_STATE_PATH=' . $statePath);
+        $session['dbinfo'] = [
+            'DB_HOST' => 'database',
+            'DB_USER' => 'installer',
+            'DB_PASS' => 'password',
+            'DB_NAME' => 'lotgd',
+            'DB_PREFIX' => '',
+        ];
+
+        try {
+            (new Installer())->stage6();
+
+            $this->assertFileExists($statePath . '/dbconnect.php');
+            $this->assertFileDoesNotExist($this->dbconnectPath);
+        } finally {
+            putenv('LOTGD_STATE_PATH');
+            if (file_exists($statePath . '/dbconnect.php')) {
+                unlink($statePath . '/dbconnect.php');
+            }
+            rmdir($statePath);
+        }
     }
 
     public function testStage6GuidesManualCreationWhenFileCannotBeWritten(): void

--- a/tests/InstallerLoggerTest.php
+++ b/tests/InstallerLoggerTest.php
@@ -22,14 +22,14 @@ namespace Lotgd\Tests {
     #[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
     final class InstallerLoggerTest extends TestCase
     {
-        public function testContainerLogPathCannotBeRedirectedOutsideStateDirectory(): void
+        public function testContainerLogPathUsesConfiguredDataDirectory(): void
         {
             putenv('LOTGD_STATE_PATH=/var/lib/lotgd');
-            putenv('LOTGD_DATA_DIR=/var/www/html/install/errors');
+            putenv('LOTGD_DATA_DIR=/var/lib/lotgd/custom-logs');
 
             try {
                 $this->assertSame(
-                    '/var/lib/lotgd/logs/install.log',
+                    '/var/lib/lotgd/custom-logs/install.log',
                     InstallerLogger::getLogFilePath()
                 );
             } finally {

--- a/tests/InstallerLoggerTest.php
+++ b/tests/InstallerLoggerTest.php
@@ -22,6 +22,22 @@ namespace Lotgd\Tests {
     #[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
     final class InstallerLoggerTest extends TestCase
     {
+        public function testContainerLogPathCannotBeRedirectedOutsideStateDirectory(): void
+        {
+            putenv('LOTGD_STATE_PATH=/var/lib/lotgd');
+            putenv('LOTGD_DATA_DIR=/var/www/html/install/errors');
+
+            try {
+                $this->assertSame(
+                    '/var/lib/lotgd/logs/install.log',
+                    InstallerLogger::getLogFilePath()
+                );
+            } finally {
+                putenv('LOTGD_STATE_PATH');
+                putenv('LOTGD_DATA_DIR');
+            }
+        }
+
         public function testLogReturnsFalseWithoutWarningsWhenDirectoryIsNotWritable(): void
         {
             $warnings = [];


### PR DESCRIPTION
### Motivation

- Ensure the production container image is immutable for application code (owned by `root:root`) while limiting `www-data` write access to explicit runtime locations and preventing installer/log fallbacks into the webroot.
- Make installer logging and configuration persistence use the container state volume and fail loudly if the state/log paths are misconfigured or not writable by the web user.
- Prevent any HTTP exposure of installer error logs and ensure the installer cannot be silently restored by image replacements.

### Description

- Dockerfile: make `/var/www/html` `root:root` and remove group/other write; create `/var/lib/lotgd/logs` and add `LOTGD_DATA_DIR` default. (`Dockerfile`).
- Compose & entrypoint: expose `LOTGD_DATA_DIR` / `LOTGD_STATE_PATH` to the container, require `LOTGD_DATA_DIR` to be inside `LOTGD_STATE_PATH`, create and repair runtime dirs at startup with restrictive modes, verify `www-data` write access, and keep `dbconnect.php` in the state volume via symlink (`docker-compose.yml`, `docker/entrypoint.sh`).
- Installer logger: make `InstallerLogger::getLogFilePath()` prefer `LOTGD_STATE_PATH/logs/install.log` when running in a container, remove silent fallbacks into the webroot or tmp without using the state path, and add explicit `error_log()` diagnostics for directory/file creation failures (`install/lib/InstallerLogger.php`).
- Installer changes: adjust Stage 6 to write/read `dbconnect.php` at the state target when `LOTGD_STATE_PATH` is set, update `verifyInstallDirectoryWritable()` to check the real target (file or parent directory), and change Stage 11 behavior so `www-data` only writes the `installation-complete` marker while the root entrypoint removes `installer.php` on next start if necessary (`install/lib/Installer.php`).
- Apache vhost: deny HTTP access to `/install/errors/` unconditionally and block installer access if the persistent completion marker exists (`docker/apache/lotgd.conf`).
- Tests & docs: extend `tests/Docker/smoke.sh` to validate `www-data` can write cache/state/logs while the document root and PHP files are not writable, assert `/install/errors/install.log` is not reachable by HTTP with installer both disabled and enabled, add unit tests for logger path and Stage 6 container state behavior, and update `docs/Docker.md` to document immutable image ownership, state/log paths, and installer removal semantics (`tests/*`, `docs/Docker.md`).

### Testing

- ✅ `vendor/bin/phpunit tests/InstallerLoggerTest.php tests/Installer/Stage6Test.php tests/Installer/Stage11Test.php` — unit tests passed (10 tests, 41 assertions).
- ✅ `composer test` — full PHPUnit suite executed successfully in CI run environment.
- ✅ `php -l install/lib/Installer.php` and `php -l install/lib/InstallerLogger.php` — no syntax errors.
- ✅ `sh -n docker/entrypoint.sh tests/Docker/smoke.sh` — shell lint checks passed.
- ✅ `composer static` — static analysis executed; only an upstream PHPStan version advisory was reported.
- ✅ `git diff --check` — no whitespace or conflict markers.
- ⚠️ `tests/Docker/smoke.sh` (full Docker integration) could not be run in this environment because `docker` is unavailable; CI should run this host-level smoke test to validate runtime behavior and HTTP denial of `/install/errors/install.log`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a91828af464832996ec14864799c631)