### PR TITLE
perf: use prebuilt PHP runtime for Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,10 @@ jobs:
           docker buildx imagetools inspect \
             thecodingmachine/php:8.3-v4-apache@sha256:7bc852ed28adb908d245ef4a71b2c2d19fd9626c1975af61ba5a8f958a035ec7 \
             --format '{{json .Manifest}}' | tee /tmp/runtime-manifest.json
-          grep -q 'linux/amd64' /tmp/runtime-manifest.json
-          grep -q 'linux/arm64' /tmp/runtime-manifest.json
+          # OS and architecture are separate JSON properties; query them as a
+          # pair instead of depending on a nonexistent "linux/amd64" string.
+          jq -e 'any(.manifests[]; .platform.os == "linux" and .platform.architecture == "amd64")' /tmp/runtime-manifest.json
+          jq -e 'any(.manifests[]; .platform.os == "linux" and .platform.architecture == "arm64")' /tmp/runtime-manifest.json
       - name: Build and load AMD64 application image once
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,17 +52,26 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Validate Compose and run production smoke test
-        run: tests/Docker/smoke.sh
-      - name: Build supported 64-bit architectures
+      - name: Reject application-image build toolchains
+        run: tests/Docker/no-build-toolchain.sh
+      - name: Verify runtime image supports AMD64 and ARM64
+        run: |
+          docker buildx imagetools inspect \
+            thecodingmachine/php:8.3-v4-apache@sha256:7bc852ed28adb908d245ef4a71b2c2d19fd9626c1975af61ba5a8f958a035ec7 \
+            --format '{{json .Manifest}}' | tee /tmp/runtime-manifest.json
+          grep -q 'linux/amd64' /tmp/runtime-manifest.json
+          grep -q 'linux/arm64' /tmp/runtime-manifest.json
+      - name: Build and load AMD64 application image once
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          load: true
+          tags: lotgd-ci:${{ github.sha }}
           push: false
-          cache-from: type=gha,scope=lotgd-multiarch
-          cache-to: type=gha,mode=max,scope=lotgd-multiarch
+          cache-from: type=gha,scope=lotgd-amd64
+          cache-to: type=gha,mode=max,scope=lotgd-amd64
+      - name: Validate Compose and run production smoke test
+        run: tests/Docker/smoke.sh lotgd-ci:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,16 +14,17 @@ RUN composer install \
 COPY . ./
 RUN composer dump-autoload --no-dev --classmap-authoritative --no-interaction
 
-FROM php:8.3-apache
+# This multiarch image ships the required extensions as pre-built modules.
+# Keep the manifest-list digest synchronized with docs/Docker.md.
+FROM thecodingmachine/php:8.3-v4-apache@sha256:7bc852ed28adb908d245ef4a71b2c2d19fd9626c1975af61ba5a8f958a035ec7
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        libjpeg-dev \
-        libonig-dev \
-        libpng-dev \
-        libzip-dev \
-    && docker-php-ext-configure gd --with-jpeg \
-    && docker-php-ext-install -j"$(nproc)" gd mbstring mysqli opcache pdo pdo_mysql zip \
-    && rm -rf /var/lib/apt/lists/*
+USER root
+
+# The fat runtime enables all required modules except GD by default. Its
+# entrypoint materializes the corresponding ini file before Apache starts.
+ENV PHP_EXTENSION_GD=1 \
+    APACHE_RUN_USER=www-data \
+    APACHE_RUN_GROUP=www-data
 
 # The vhost contains the production security rules, so per-request .htaccess
 # discovery is unnecessary.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   web:
+    image: ${LOTGD_WEB_IMAGE:-lotgd-web:local}
     build: .
     restart: unless-stopped
     ports:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -56,4 +56,6 @@ if [ -f "$state_path/installation-complete" ]; then
     rm -f /var/www/html/installer.php
 fi
 
-exec "$@"
+# Preserve the runtime image's extension/Apache initialization after applying
+# the application-specific volume and secret checks above.
+exec /usr/local/bin/docker-entrypoint.sh "$@"

--- a/docker/health/ready.php
+++ b/docker/health/ready.php
@@ -14,6 +14,7 @@ const REQUIRED_EXTENSIONS = [
     'gd',
     'mbstring',
     'mysqli',
+    'opcache',
     'pdo',
     'pdo_mysql',
     'zip',

--- a/docker/health/ready.php
+++ b/docker/health/ready.php
@@ -14,7 +14,9 @@ const REQUIRED_EXTENSIONS = [
     'gd',
     'mbstring',
     'mysqli',
-    'opcache',
+    // OPcache is registered under this Zend extension name; the ini directive
+    // and function prefix use lowercase "opcache", but extension_loaded does not.
+    'Zend OPcache',
     'pdo',
     'pdo_mysql',
     'zip',

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -6,6 +6,53 @@ the default Compose file is production-oriented, while
 The image uses PHP 8.3 with Apache, OPcache, optimized production Composer
 dependencies, and MySQL 8.4.
 
+## PHP runtime image
+
+The application stage uses the maintained, multiarch
+`thecodingmachine/php:8.3-v4-apache` fat image. It is pinned to the immutable
+manifest-list digest
+`sha256:7bc852ed28adb908d245ef4a71b2c2d19fd9626c1975af61ba5a8f958a035ec7`,
+not merely to its moving tag. The same manifest contains native `linux/amd64`
+and `linux/arm64` variants. The image retains the official PHP/Apache-compatible
+interfaces used here: `a2enmod`, `a2ensite`, `apache2-foreground`, the
+`/usr/local/etc/php/conf.d` scan directory, and the Apache configuration below
+`/etc/apache2`. The application explicitly runs Apache as `www-data` and chains
+the runtime's entrypoint so its binary-module configuration still runs.
+
+The production runtime contract is derived from `Dockerfile`,
+`docker/health/ready.php`, Composer's platform requirements, and the production
+smoke test:
+
+| Requirement | Reason |
+| --- | --- |
+| `gd` | Game image processing; enabled from the runtime's pre-built module. |
+| `mbstring` | Multibyte-safe game and dependency string handling. |
+| `mysqli` | Legacy database access and the readiness query. |
+| `opcache` | Production bytecode caching and readiness cache invalidation. |
+| `pdo`, `pdo_mysql` | Doctrine and modern MySQL data access. |
+| `zip` | Composer dependencies and archive handling. |
+
+Composer also requires the standard/core modules `ctype`, `dom`, `fileinfo`,
+`filter`, `hash`, `iconv`, `json`, `libxml`, `pcre`, `phar`, `simplexml`,
+`tokenizer`, and `xmlwriter`; the selected fat runtime provides them. The smoke
+test verifies the seven explicit runtime extensions and the runtime build runs
+Composer against the resulting platform.
+
+To update the runtime, review upstream release and security information, inspect
+the tag with `docker buildx imagetools inspect`, verify that its manifest still
+contains both required architectures, and run the commands in
+[Health and performance verification](#health-and-performance-verification).
+Then update the digest in `Dockerfile`, `.github/workflows/ci.yml`, and this
+section in one dedicated maintenance PR. Runtime updates are scheduled
+maintenance or definition/security changes; ordinary application PRs must not
+refresh the base. The static CI guard rejects extension compilers and native
+build toolchains in the application Dockerfile.
+
+The Docker CI job has a target wall-clock budget of **at most five minutes**.
+It therefore builds and loads the AMD64 application image once, passes that
+exact image to the production smoke test, and checks ARM64 availability from
+the already-published runtime manifest without QEMU or emulated compilation.
+
 ## Initial configuration
 
 `.env.example` is a template, not a deployable configuration. Copy it and
@@ -186,14 +233,16 @@ docker compose exec --user root web chmod -R u+rwX,g+rwX /var/cache/lotgd
 ## Health and performance verification
 
 Compose waits for MySQL's health check before starting the web service. The web
-health check requests the static `/errors/403.html` page, avoiding database or
-session mutations.
+health check calls the container-local `/_health/ready` endpoint, which validates
+the runtime extensions, configuration file, and a side-effect-free `SELECT 1`
+without creating a game session.
 
 Validate and inspect the running deployment:
 
 ```bash
 docker compose config
 docker compose ps
+docker run --rm <image> php -m
 docker compose exec web php -i | grep -E 'opcache.enable =>|opcache.validate_timestamps =>'
 docker compose exec --user www-data web sh -c 'test -w /var/cache/lotgd/twig && test -w /var/cache/lotgd/doctrine'
 docker compose exec web find /var/cache/lotgd -mindepth 1 -maxdepth 2 -type f -print
@@ -207,10 +256,14 @@ instead of publishing the probe through a reverse proxy. Installation can
 therefore proceed while the container reports `starting` or `unhealthy`, and a
 completed installation transitions it to `healthy` without a restart.
 
-The repository also includes a focused configuration regression test (it
-requires the Docker Compose plugin):
+The repository also includes a focused production smoke test and configuration
+regression test (both require the Docker Compose plugin). Build an image once
+and pass its tag to the smoke test; the script deliberately refuses to build it
+again:
 
 ```bash
+docker build -t lotgd-smoke:local .
+tests/Docker/smoke.sh lotgd-smoke:local
 tests/Docker/compose-security.sh
 ```
 

--- a/tests/Docker/no-build-toolchain.sh
+++ b/tests/Docker/no-build-toolchain.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# The application image must only assemble pre-built runtime artifacts. Keep
+# compilation in the upstream runtime image and out of ordinary application CI.
+forbidden='docker-php-ext-(install|configure)|(^|[^[:alnum:]_-])phpize([^[:alnum:]_-]|$)|(^|[[:space:]])make([[:space:]]|$)|(^|[[:space:]])(gcc|g[+][+]|clang|build-essential|autoconf)([[:space:]\\]|$)'
+
+if grep -En "$forbidden" Dockerfile; then
+    echo "Dockerfile must not install or invoke a PHP/native build toolchain" >&2
+    exit 1
+fi
+
+echo "Dockerfile contains no native extension build toolchain"

--- a/tests/Docker/smoke.sh
+++ b/tests/Docker/smoke.sh
@@ -11,6 +11,12 @@ export MYSQL_DATABASE=lotgd
 export MYSQL_HOST=db
 export MYSQL_USER=lotgduser
 
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <prebuilt-web-image>" >&2
+    exit 2
+fi
+export LOTGD_WEB_IMAGE="$1"
+
 created_env=false
 
 cleanup() {
@@ -38,8 +44,7 @@ EOF
 fi
 
 docker compose config >/dev/null
-docker compose build web
-docker compose up -d
+docker compose up -d --no-build
 
 # Wait for MySQL before installing the minimal, read-only probe configuration.
 attempt=0
@@ -100,7 +105,7 @@ done
 # Verify the exact runtime prerequisites rather than assuming a successful
 # package installation means PHP loaded every module.
 docker compose exec -T web php -r '
-    foreach (["gd", "mbstring", "mysqli", "pdo", "pdo_mysql", "zip"] as $extension) {
+    foreach (["gd", "mbstring", "mysqli", "opcache", "pdo", "pdo_mysql", "zip"] as $extension) {
         if (! extension_loaded($extension)) {
             fwrite(STDERR, "Missing PHP extension\n");
             exit(1);
@@ -148,7 +153,7 @@ assert_status /modules/cities.php 403
 
 # The log directory stays denied even during the deliberately enabled
 # installation window. Recreate Apache so its environment sees the new flag.
-LOTGD_INSTALL_ENABLED=1 docker compose up -d --force-recreate --no-deps web
+LOTGD_INSTALL_ENABLED=1 docker compose up -d --force-recreate --no-deps --no-build web
 attempt=0
 until curl --silent --output /dev/null "http://127.0.0.1:${LOTGD_HTTP_PORT}/install/errors/install.log"; do
     attempt=$((attempt + 1))

--- a/tests/Docker/smoke.sh
+++ b/tests/Docker/smoke.sh
@@ -105,7 +105,8 @@ done
 # Verify the exact runtime prerequisites rather than assuming a successful
 # package installation means PHP loaded every module.
 docker compose exec -T web php -r '
-    foreach (["gd", "mbstring", "mysqli", "opcache", "pdo", "pdo_mysql", "zip"] as $extension) {
+    // PHP exposes OPcache to extension_loaded() under its registered Zend name.
+    foreach (["gd", "mbstring", "mysqli", "Zend OPcache", "pdo", "pdo_mysql", "zip"] as $extension) {
         if (! extension_loaded($extension)) {
             fwrite(STDERR, "Missing PHP extension\n");
             exit(1);


### PR DESCRIPTION
### Motivation

- Reduce CI/PR build time and remove emulated native PHP extension compilation from the application image by relying on a maintained multiarch runtime that already ships required binary modules.
- Ensure the production image contains the exact PHP extensions the application requires and make ARM64 verification decoupled from emulated builds.
- Prevent accidental reintroduction of toolchains and compilers into the application Dockerfile via a static guard in CI.

### Description

- Replace `FROM php:8.3-apache` with the pinned multiarch runtime `thecodingmachine/php:8.3-v4-apache@sha256:7bc852ed...` in `Dockerfile` and enable `gd` via `ENV PHP_EXTENSION_GD=1`, plus set `APACHE_RUN_USER`/`APACHE_RUN_GROUP` for runtime compatibility.
- Remove `apt` install / `docker-php-ext-configure` / `docker-php-ext-install` steps from the application Dockerfile so only pre-built binary modules remain in the runtime image.
- Chain the runtime image entrypoint from `docker/entrypoint.sh` (`exec /usr/local/bin/docker-entrypoint.sh "$@"`) so the runtime's module/Apache initialization still runs after application-specific checks.
- Add `opcache` to the readiness probe `docker/health/ready.php` and explicitly require these runtime extensions: `gd`, `mbstring`, `mysqli`, `opcache`, `pdo`, `pdo_mysql`, `zip`.
- Make the production smoke script `tests/Docker/smoke.sh` accept a prebuilt image argument, run Compose with `--no-build`, and avoid rebuilding the web service during the smoke run.
- Add `tests/Docker/no-build-toolchain.sh` to fail CI if the application `Dockerfile` contains `docker-php-ext-*`, `phpize`, `make`, or compiler package references.
- Update `docker-compose.yml` to allow an override image via `LOTGD_WEB_IMAGE` while keeping developer local build semantics.
- Modify `.github/workflows/ci.yml` to: remove QEMU step from the PR path, verify the upstream runtime manifest contains `linux/amd64` and `linux/arm64`, build/load the AMD64 application image once (`build-push-action` with `platforms: linux/amd64` and `load: true`), and run the smoke test against the built image tag; add the static guard step.
- Update `docs/Docker.md` describing the runtime origin, digest-pinning, update process, the required extensions inventory, ARM64 handling policy and the CI five-minute job budget.

### Testing

- Ran shell syntax and basic script checks with `sh -n` and executable tests for `docker/entrypoint.sh`, `tests/Docker/smoke.sh`, and `tests/Docker/no-build-toolchain.sh` (passed).
- Linted `docker/health/ready.php` with `php -l` (no syntax errors) and confirmed `opcache` addition; grepped for extension references across changed files (updated to include `opcache`).
- Executed Composer steps and static analysis: `composer install`, `composer static` (PHPStan), and `composer test` (PHPUnit) locally; unit test suite completed: `761` tests, `4102` assertions, with existing warnings/deprecations/notices reported (test run succeeded).
- Validated YAML syntax for `ci.yml` and `docker-compose.yml` using Ruby `YAML.load_file` (passed) and ran `git diff --check` (no issues).
- CI- and Docker-dependent checks documented and wired into the workflow (runtime manifest inspection, AMD64-only build+load, and smoke test using the built image tag), but `docker`/`docker buildx` and `docker run` based checks could not be executed in this environment (no Docker installed); these remain part of CI and are invoked by the updated workflow and smoke scripts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a919067d0348329a03e8e6fff8df6d2)