### PR TITLE
fix(docker): pin images, enforce least-privilege Compose runtime, and expand Docker QA/smoke tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,14 @@
 version: 2
 updates:
+  # Docker digest updates retain the human-readable tags in Dockerfile and
+  # docker-compose.yml while proposing reviewable, immutable replacements.
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies
+      - security
   - package-ecosystem: composer
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,15 +56,20 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Reject application-image build toolchains
         run: tests/Docker/no-build-toolchain.sh
-      - name: Verify runtime image supports AMD64 and ARM64
+      - name: Verify pinned base images support AMD64 and ARM64
         run: |
-          docker buildx imagetools inspect \
-            thecodingmachine/php:8.3-v4-apache@sha256:7bc852ed28adb908d245ef4a71b2c2d19fd9626c1975af61ba5a8f958a035ec7 \
-            --format '{{json .Manifest}}' | tee /tmp/runtime-manifest.json
-          # OS and architecture are separate JSON properties; query them as a
-          # pair instead of depending on a nonexistent "linux/amd64" string.
-          jq -e 'any(.manifests[]; .platform.os == "linux" and .platform.architecture == "amd64")' /tmp/runtime-manifest.json
-          jq -e 'any(.manifests[]; .platform.os == "linux" and .platform.architecture == "arm64")' /tmp/runtime-manifest.json
+          for image in \
+            'composer:2@sha256:4d71c3c2109c61d5415544264b59ad4087e4c5b7244481723664138fd36d5040' \
+            'thecodingmachine/php:8.3-v4-apache@sha256:7bc852ed28adb908d245ef4a71b2c2d19fd9626c1975af61ba5a8f958a035ec7' \
+            'mysql:8.4@sha256:b3b90af2a6552ae30c266fdb7d5dd55f3afb72404bb78d37fe8a23eb857fd3fb'
+          do
+            docker buildx imagetools inspect "$image" \
+              --format '{{json .Manifest}}' > /tmp/image-manifest.json
+            # OS and architecture are separate JSON properties; query them as
+            # a pair instead of looking for a synthetic platform string.
+            jq -e 'any(.manifests[]; .platform.os == "linux" and .platform.architecture == "amd64")' /tmp/image-manifest.json
+            jq -e 'any(.manifests[]; .platform.os == "linux" and .platform.architecture == "arm64")' /tmp/image-manifest.json
+          done
       - name: Build and load AMD64 application image once
         uses: docker/build-push-action@v6
         with:
@@ -75,5 +80,7 @@ jobs:
           push: false
           cache-from: type=gha,scope=lotgd-amd64
           cache-to: type=gha,mode=max,scope=lotgd-amd64
-      - name: Validate Compose and run production smoke test
+      - name: Validate hardened Compose model
+        run: tests/Docker/compose-security.sh
+      - name: Run production smoke test
         run: tests/Docker/smoke.sh lotgd-ci:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 
 # Install dependency archives before copying the application so ordinary source
 # changes retain the expensive Composer download layer.
-FROM composer:2 AS composer
+# Keep the readable release line while pinning the reviewed multi-architecture
+# index; Dependabot proposes digest refreshes without silently changing builds.
+FROM composer:2@sha256:4d71c3c2109c61d5415544264b59ad4087e4c5b7244481723664138fd36d5040 AS composer
 WORKDIR /app
 COPY composer.json composer.lock ./
 RUN composer install \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,21 @@ services:
     image: ${LOTGD_WEB_IMAGE:-lotgd-web:local}
     build: .
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      # The root entrypoint repairs ownership on persistent volumes.
+      - CHOWN
+      # Persistent directories may already be owned by www-data and need mode
+      # repair before Apache starts.
+      - FOWNER
+      # Apache listens on the image's privileged container port 80.
+      - NET_BIND_SERVICE
+      # Apache starts as root, then switches workers to www-data.
+      - SETGID
+      - SETUID
     ports:
       - "127.0.0.1:${LOTGD_HTTP_PORT:-8080}:80"
     env_file: .env
@@ -21,6 +36,13 @@ services:
     volumes:
       - lotgd_cache:/var/cache/lotgd
       - lotgd_state:/var/lib/lotgd
+    tmpfs:
+      # Keep transient PHP/session data out of the image layer and disallow
+      # executable or privileged files in the shared temporary directory.
+      - /tmp:rw,nosuid,nodev,noexec,mode=1777
+      # Apache needs only volatile PID/lock state in these paths.
+      - /run/apache2:rw,nosuid,nodev,noexec,mode=0755
+      - /var/lock/apache2:rw,nosuid,nodev,noexec,mode=0755
     depends_on:
       db:
         condition: service_healthy
@@ -32,11 +54,27 @@ services:
       retries: 4
       start_period: 60s
     networks:
-      - lotgd-network
+      # Reverse proxies join only this frontend boundary.
+      - web-proxy
+      # Database traffic is isolated from proxy-facing containers.
+      - database
 
   db:
-    image: mysql:8.4
+    image: mysql:8.4@sha256:b3b90af2a6552ae30c266fdb7d5dd55f3afb72404bb78d37fe8a23eb857fd3fb
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      # The official entrypoint initializes and repairs the data-volume owner.
+      - CHOWN
+      # Initialization must traverse and repair mysql-owned volume contents.
+      - DAC_OVERRIDE
+      - FOWNER
+      # MySQL's root entrypoint drops to the dedicated mysql account.
+      - SETGID
+      - SETUID
     environment:
       MYSQL_DATABASE: ${MYSQL_DATABASE:-lotgd}
       MYSQL_USER: ${MYSQL_USER:-lotgduser}
@@ -51,7 +89,8 @@ services:
       retries: 10
       start_period: 30s
     networks:
-      - lotgd-network
+      # The database has no route onto the proxy-facing network.
+      - database
 
 volumes:
   db_data:
@@ -59,4 +98,8 @@ volumes:
   lotgd_state:
 
 networks:
-  lotgd-network:
+  web-proxy:
+  database:
+    # Prevent direct external routing even when another container publishes a
+    # port; only services explicitly attached here can reach MySQL.
+    internal: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,10 @@ services:
       # The root entrypoint repairs ownership on persistent volumes.
       - CHOWN
       # Persistent directories may already be owned by www-data and need mode
-      # repair before Apache starts.
+      # repair before Apache starts. DAC_OVERRIDE is also required because the
+      # root entrypoint must traverse their deliberately restrictive 0750/0770
+      # modes after Docker restores the www-data-owned named volumes.
+      - DAC_OVERRIDE
       - FOWNER
       # Apache listens on the image's privileged container port 80.
       - NET_BIND_SERVICE

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -6,6 +6,24 @@ the default Compose file is production-oriented, while
 The image uses PHP 8.3 with Apache, OPcache, optimized production Composer
 dependencies, and MySQL 8.4.
 
+## Pinned multi-architecture images
+
+All external images retain a readable tag and are pinned to a reviewed,
+immutable multi-architecture manifest digest:
+
+| Purpose | Pinned image | Authoritative locations |
+| --- | --- | --- |
+| Composer build stage | `composer:2@sha256:4d71c3c2109c61d5415544264b59ad4087e4c5b7244481723664138fd36d5040` | `Dockerfile`, `.github/workflows/ci.yml` |
+| PHP/Apache runtime | `thecodingmachine/php:8.3-v4-apache@sha256:7bc852ed28adb908d245ef4a71b2c2d19fd9626c1975af61ba5a8f958a035ec7` | `Dockerfile`, `.github/workflows/ci.yml` |
+| MySQL database | `mysql:8.4@sha256:b3b90af2a6552ae30c266fdb7d5dd55f3afb72404bb78d37fe8a23eb857fd3fb` | `docker-compose.yml`, `.github/workflows/ci.yml` |
+
+Dependabot's Docker ecosystem entry proposes monthly digest updates while
+preserving these tags. Review the upstream release and security information,
+confirm that the proposed digest is a manifest index, and merge only after the
+Docker CI job verifies native `linux/amd64` and `linux/arm64` entries. If an
+update is made manually, change every location in the relevant table row and
+the displayed digest in this section in the same maintenance PR.
+
 ## PHP runtime image
 
 The application stage uses the maintained, multiarch
@@ -38,12 +56,10 @@ Composer also requires the standard/core modules `ctype`, `dom`, `fileinfo`,
 test verifies the seven explicit runtime extensions and the runtime build runs
 Composer against the resulting platform.
 
-To update the runtime, review upstream release and security information, inspect
-the tag with `docker buildx imagetools inspect`, verify that its manifest still
-contains both required architectures, and run the commands in
+To update the runtime, inspect the tag with `docker buildx imagetools inspect`,
+verify that its manifest still contains both required architectures, and run the commands in
 [Health and performance verification](#health-and-performance-verification).
-Then update the digest in `Dockerfile`, `.github/workflows/ci.yml`, and this
-section in one dedicated maintenance PR. Runtime updates are scheduled
+Runtime updates are scheduled
 maintenance or definition/security changes; ordinary application PRs must not
 refresh the base. The static CI guard rejects extension compilers and native
 build toolchains in the application Dockerfile.
@@ -174,6 +190,35 @@ Only container port 80 is exposed, and its host mapping is loopback-only. Set
 `LOTGD_HTTP_PORT` to choose another loopback host port. To serve an installed
 game remotely, put a TLS reverse proxy on a public interface and proxy to
 `127.0.0.1:${LOTGD_HTTP_PORT}`; do not make the installer port public.
+
+### Container privilege and network boundary
+
+Both services set `no-new-privileges`, drop Docker's entire default capability
+set, and add back only the startup capabilities exercised by their official
+entrypoints. The web entrypoint needs `CHOWN` and `FOWNER` to repair persistent
+volume metadata, `NET_BIND_SERVICE` for container port 80, and
+`SETUID`/`SETGID` to start Apache workers as `www-data`.
+MySQL additionally needs `DAC_OVERRIDE` to traverse an existing mysql-owned
+data volume while initializing it. Neither service retains networking,
+mounting, tracing, raw-socket, or module-loading capabilities.
+
+The `web-proxy` network is the frontend boundary and contains only `web` by
+default. The separate `database` network is marked `internal: true`; `web` joins
+it for SQL traffic, while `db` joins only that network. A reverse proxy should
+join `web-proxy`, never `database`.
+
+The web service uses `tmpfs` for `/tmp`, Apache PID state, and Apache locks with
+`nosuid`, `nodev`, and `noexec`; cache and state remain in their named volumes.
+A fully read-only root filesystem was evaluated but is not enabled for this
+runtime image: its inherited `/usr/local/bin/docker-entrypoint.sh` materializes
+PHP extension configuration under `/usr/local/etc/php/conf.d` at container
+startup (including the requested GD module). That write happens before Apache
+starts and cannot be redirected to the Apache/PHP transient paths without
+masking the image's production INI files. The document root therefore remains
+root-owned with group/other writes removed, `www-data` cannot modify code, and
+the reduced capability/no-new-privileges boundary limits the remaining root
+startup process. Re-evaluate `read_only: true` when adopting a runtime whose
+extension configuration is completely fixed at image-build time.
 
 ### SSL/TLS is not included
 

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -195,8 +195,9 @@ game remotely, put a TLS reverse proxy on a public interface and proxy to
 
 Both services set `no-new-privileges`, drop Docker's entire default capability
 set, and add back only the startup capabilities exercised by their official
-entrypoints. The web entrypoint needs `CHOWN` and `FOWNER` to repair persistent
-volume metadata, `NET_BIND_SERVICE` for container port 80, and
+entrypoints. The web entrypoint needs `CHOWN`, `FOWNER`, and `DAC_OVERRIDE` to
+traverse and repair restrictive, `www-data`-owned persistent volume metadata,
+`NET_BIND_SERVICE` for container port 80, and
 `SETUID`/`SETGID` to start Apache workers as `www-data`.
 MySQL additionally needs `DAC_OVERRIDE` to traverse an existing mysql-owned
 data volume while initializing it. Neither service retains networking,

--- a/docs/RaspberryPiDocker.md
+++ b/docs/RaspberryPiDocker.md
@@ -1,76 +1,87 @@
 # Legend of the Green Dragon on Raspberry Pi 4 (Docker-first)
 
-This guide targets **Raspberry Pi 4 + Raspberry Pi OS 64-bit** for a smooth Docker experience.
+This guide targets **Raspberry Pi 4 with Raspberry Pi OS Lite 64-bit**. The
+production images are checked for native ARM64 support in CI, so emulation is
+not required.
 
-## Why Docker?
-Docker is the easiest path on Raspberry Pi because it bundles PHP, Apache, and database dependencies in a reproducible container setup. This avoids manual package hunting, keeps the host clean, and makes upgrades/rollbacks predictable.
+## 1. Install Docker and Compose
 
-## Recommended base image
-Use **Raspberry Pi OS Lite (64-bit)** as the host OS. It is the most stable, officially supported image for Raspberry Pi 4 and keeps the host lightweight while Docker contains the app stack.
+Install Raspberry Pi OS Lite (64-bit), then follow Docker's maintained Debian
+instructions (which include 64-bit Raspberry Pi OS):
 
-Official Raspberry Pi OS downloads:
-- https://www.raspberrypi.com/software/operating-systems/
+- [Docker Engine on Debian](https://docs.docker.com/engine/install/debian/)
+- [Docker Compose plugin](https://docs.docker.com/compose/install/)
+- [Optional Linux post-install steps](https://docs.docker.com/engine/install/linux-postinstall/)
 
-## Recommended Docker tutorials (Raspberry Pi)
-These are authoritative, maintained sources that match the Pi 4 + Debian-based OS stack:
+Verify the installation:
 
-- Docker Engine (Debian/Raspberry Pi OS):
-  - https://docs.docker.com/engine/install/debian/
-- Docker Compose plugin install:
-  - https://docs.docker.com/compose/install/
-- Optional: Post-install steps (docker group, permissions):
-  - https://docs.docker.com/engine/install/linux-postinstall/
-
-## Install LOTGD via Docker (easiest path)
-
-### 1) Install Raspberry Pi OS Lite (64-bit)
-Flash the OS to your SD card (Raspberry Pi Imager), boot the Pi, and complete the standard first-time setup.
-
-### 2) Install Docker Engine + Compose on the Pi
-Follow the official Docker docs above. The Debian instructions explicitly cover **Raspberry Pi OS (64-bit)** under supported platforms/architectures, so they are the correct reference for Pi 4 ARM64. When done, confirm:
-
-```
+```bash
 docker --version
 docker compose version
 ```
 
-### 3) Clone the LOTGD repository
-```
+## 2. Clone and create private configuration
+
+```bash
 git clone https://github.com/lotgd/lotgd.git
 cd lotgd
+cp .env.example .env
+chmod 600 .env
+sed -i "s|^MYSQL_PASSWORD=$|MYSQL_PASSWORD=$(openssl rand -base64 32)|" .env
+sed -i "s|^MYSQL_ROOT_PASSWORD=$|MYSQL_ROOT_PASSWORD=$(openssl rand -base64 32)|" .env
+sed -i 's/^LOTGD_INSTALL_ENABLED=.*/LOTGD_INSTALL_ENABLED=1/' .env
 ```
 
-### 4) Start the Docker environment (already provided in this repo)
-This repository already includes a `Dockerfile` and `docker-compose.yml` suitable for local development/testing. Use the built-in docs:
+Use two independently generated secrets; do not reuse either password or
+commit `.env`. Keep the installer flag at `1` only for initial setup.
 
-- [docs/Docker.md](docs/Docker.md) (repo guide)
+## 3. Start the private installer
 
-Then run:
-
-```
+```bash
 docker compose up -d --build
 ```
 
-CI builds the production Dockerfile for both `linux/amd64` and `linux/arm64`.
-The latter is the 64-bit architecture used by the recommended Raspberry Pi OS
-image, so changes to the documented Pi deployment are checked continuously.
+Compose publishes the selected `${LOTGD_HTTP_PORT}` (8080 by default) on
+`127.0.0.1` **of the Pi only**. It is intentionally not reachable directly at
+`http://raspberrypi.local/` or the Pi's LAN address. From an administrator
+workstation, create an SSH tunnel:
 
-### 5) Finish in the browser
-Open your Pi’s IP address in a browser (e.g., `http://raspberrypi.local/` or `http://<pi-ip>/`) and complete the in-app setup.
+```bash
+ssh -N -L 8080:127.0.0.1:8080 pi@raspberrypi.local
+```
 
-## Notes and troubleshooting
-- If you make changes to the Dockerfile or PHP settings, rebuild with:
-  ```
-  docker compose up -d --build
-  ```
-- For logs:
-  ```
-  docker compose logs -f
-  ```
-- For an interactive shell:
-  ```
-  docker compose exec web bash
-  ```
+Then open `http://127.0.0.1:8080/installer.php` on that workstation and finish
+installation. If `LOTGD_HTTP_PORT` is changed, use that Pi-side port after the
+second colon; the workstation-side port may be any unused local port.
 
-## Alternative (non-Docker) path
-Docker is strongly recommended. If you must install directly on the host, follow the dependencies in `composer.json` and use Apache/PHP + MariaDB on Raspberry Pi OS. This is more fragile, harder to upgrade, and not the easiest path.
+After installation, set `LOTGD_INSTALL_ENABLED=0` in `.env` and recreate web as
+defense in depth. The persistent completion marker already keeps the installer
+locked even if the flag is accidentally left enabled:
+
+```bash
+sed -i 's/^LOTGD_INSTALL_ENABLED=.*/LOTGD_INSTALL_ENABLED=0/' .env
+docker compose up -d --force-recreate web
+```
+
+## 4. Public operation requires a TLS reverse proxy
+
+For a permanently public game, run a TLS-terminating reverse proxy such as
+Caddy, Nginx, or Traefik on the Pi's public/LAN interface and proxy it to
+`127.0.0.1:${LOTGD_HTTP_PORT}`. Do not change the Compose port to `0.0.0.0` and
+do not expose the temporary installer directly. Certificate issuance, trusted
+proxy configuration, Docker network boundaries, backups, and verification are
+covered in [Docker deployment](Docker.md).
+
+## Operations and troubleshooting
+
+```bash
+docker compose logs -f web db
+docker compose up -d --build       # rebuild after image/PHP changes
+docker compose exec web sh         # diagnostic shell
+```
+
+Back up the `db_data` and `lotgd_state` volumes together. The latter contains
+`dbconnect.php`, installer logs, and the completion marker; deleting it can
+lose configuration and installer-lock state. For the non-Docker alternative,
+install the requirements from `composer.json` with Apache/PHP and a compatible
+database, but this path is more fragile and is not recommended.

--- a/tests/Docker/compose-security.sh
+++ b/tests/Docker/compose-security.sh
@@ -55,7 +55,7 @@ for name, pattern in pins.items():
 
 services = model["services"]
 expected_caps = {
-    "web": {"CHOWN", "FOWNER", "NET_BIND_SERVICE", "SETGID", "SETUID"},
+    "web": {"CHOWN", "DAC_OVERRIDE", "FOWNER", "NET_BIND_SERVICE", "SETGID", "SETUID"},
     "db": {"CHOWN", "DAC_OVERRIDE", "FOWNER", "SETGID", "SETUID"},
 }
 for name, capabilities in expected_caps.items():

--- a/tests/Docker/compose-security.sh
+++ b/tests/Docker/compose-security.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -eu
 
-# Exercise the rendered Compose model rather than relying on textual checks.
+# Exercise Compose's normalized JSON model so aliases and short YAML syntax
+# cannot accidentally make a textual security check pass.
 command -v docker >/dev/null 2>&1 || {
     echo "docker is required to run this test" >&2
     exit 1
@@ -27,15 +28,64 @@ cat > "$project_dir/.env" <<'EOF'
 MYSQL_PASSWORD=compose-test-application-secret
 MYSQL_ROOT_PASSWORD=compose-test-root-secret
 EOF
-rendered=$(docker compose --project-directory "$project_dir" config)
-printf '%s\n' "$rendered" | grep -F 'host_ip: 127.0.0.1' >/dev/null || {
-    echo "Default web port is not bound to loopback:8080" >&2
-    exit 1
+docker compose --project-directory "$project_dir" config --format json > "$project_dir/rendered.json"
+
+# Validate both the immutable supply-chain inputs and the runtime boundaries in
+# the fully interpolated model. The application image is intentionally supplied
+# by CI/deployment, while every external image is digest pinned here.
+python3 - "$project_dir/rendered.json" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+model = json.loads(pathlib.Path(sys.argv[1]).read_text())
+compose = pathlib.Path("docker-compose.yml").read_text()
+dockerfile = pathlib.Path("Dockerfile").read_text()
+
+pins = {
+    "composer": r"FROM composer:2@sha256:[0-9a-f]{64} AS composer",
+    "runtime": r"FROM thecodingmachine/php:8\.3-v4-apache@sha256:[0-9a-f]{64}",
+    "database": r"image: mysql:8\.4@sha256:[0-9a-f]{64}",
 }
-printf '%s\n' "$rendered" | grep -E "published: ['\"]?8080['\"]?$" >/dev/null || {
-    echo "Default host port is not 8080" >&2
-    exit 1
+for name, pattern in pins.items():
+    source = compose if name == "database" else dockerfile
+    if not re.search(pattern, source):
+        raise SystemExit(f"{name} image is not pinned by readable tag and digest")
+
+services = model["services"]
+expected_caps = {
+    "web": {"CHOWN", "FOWNER", "NET_BIND_SERVICE", "SETGID", "SETUID"},
+    "db": {"CHOWN", "DAC_OVERRIDE", "FOWNER", "SETGID", "SETUID"},
 }
+for name, capabilities in expected_caps.items():
+    service = services[name]
+    if "no-new-privileges:true" not in service.get("security_opt", []):
+        raise SystemExit(f"{name} does not enable no-new-privileges")
+    if set(service.get("cap_drop", [])) != {"ALL"}:
+        raise SystemExit(f"{name} must drop every default capability")
+    if set(service.get("cap_add", [])) != capabilities:
+        raise SystemExit(f"{name} capability allowlist changed without review")
+
+web_networks = set(services["web"]["networks"])
+db_networks = set(services["db"]["networks"])
+if web_networks != {"web-proxy", "database"} or db_networks != {"database"}:
+    raise SystemExit("web/proxy and database network boundaries are not isolated")
+if not model["networks"]["database"].get("internal", False):
+    raise SystemExit("database network is not internal")
+
+published = services["web"]["ports"][0]
+if published.get("host_ip") != "127.0.0.1" or int(published.get("published")) != 8080:
+    raise SystemExit("default web port is not bound to loopback:8080")
+
+# A fully read-only root is currently blocked by the runtime entrypoint (see
+# docs/Docker.md), but known transient paths must still use restrictive tmpfs.
+tmpfs = services["web"].get("tmpfs", [])
+for path in ("/tmp", "/run/apache2", "/var/lock/apache2"):
+    entry = next((item for item in tmpfs if item.split(":", 1)[0] == path), None)
+    if entry is None or "nosuid" not in entry or "nodev" not in entry or "noexec" not in entry:
+        raise SystemExit(f"{path} is not a restrictive tmpfs mount")
+PY
 
 for example_secret in lotgdpass rootpass changeme password example; do
     if MYSQL_PASSWORD="$example_secret" MYSQL_ROOT_PASSWORD=valid-test-secret \

--- a/tests/Docker/smoke.sh
+++ b/tests/Docker/smoke.sh
@@ -116,6 +116,11 @@ docker compose exec -T web php -r '
     }
 '
 
+# The readiness fixture is intentionally a configured installation. Record its
+# exact content so the later fresh-installer window can temporarily hide the
+# file without weakening the persistence assertion.
+dbconnect_checksum=$(docker compose exec -T web sha256sum /var/lib/lotgd/dbconnect.php | awk '{print $1}')
+
 # Wait for web container to become healthy after configuration is written.
 # The health check probe will attempt a MySQL connection, so increase retry
 # limit to account for any remaining database initialization time.
@@ -189,6 +194,9 @@ wait_for_status() {
         attempt=$((attempt + 1))
         if [ "$attempt" -ge 30 ]; then
             echo "$description (expected $expected, got $actual)" >&2
+            echo "--- Unexpected HTTP response ---" >&2
+            curl --silent --show-error --include \
+                "http://127.0.0.1:${LOTGD_HTTP_PORT}${path}" >&2 || true
             docker compose logs web
             exit 1
         fi
@@ -211,11 +219,23 @@ assert_status /modules/cities.php 403
 docker compose exec -T web sh -c \
     'printf "%s\n" persistent-installer-log > /var/lib/lotgd/logs/install.log'
 
+# A real fresh installer has no dbconnect.php yet. The earlier readiness probe
+# needs one, so retain it under a temporary name in the same state volume while
+# testing installer access; leaving it active would make stage 0 treat the empty
+# CI database as an upgrade and query tables which have not been installed.
+docker compose exec -T web \
+    mv /var/lib/lotgd/dbconnect.php /var/lib/lotgd/dbconnect.php.smoke-backup
+
 # Recreate Apache so its environment sees the temporary installer flag. A 200
 # response is required: curl returning zero for a 403 would be a false positive.
 LOTGD_INSTALL_ENABLED=1 docker compose up -d --force-recreate --no-deps --no-build web
 wait_for_status /installer.php 200 "Installer did not become explicitly accessible"
 assert_status /install/errors/install.log 403
+
+# Restore the exact readiness configuration before modelling completion. The
+# final recreation below must preserve this file alongside logs and the marker.
+docker compose exec -T web \
+    mv /var/lib/lotgd/dbconnect.php.smoke-backup /var/lib/lotgd/dbconnect.php
 
 # Model installer stage 11 by placing its durable completion marker in the
 # state volume. Recreating with the flag deliberately left at 1 proves the
@@ -233,5 +253,10 @@ docker compose exec -T web sh -c '
     grep -F persistent-installer-log /var/lib/lotgd/logs/install.log >/dev/null &&
     grep -F completed /var/lib/lotgd/installation-complete >/dev/null
 '
+restored_checksum=$(docker compose exec -T web sha256sum /var/lib/lotgd/dbconnect.php | awk '{print $1}')
+if [ "$restored_checksum" != "$dbconnect_checksum" ]; then
+    echo "dbconnect.php changed while exercising installer persistence" >&2
+    exit 1
+fi
 
 echo "Docker production smoke test passed"

--- a/tests/Docker/smoke.sh
+++ b/tests/Docker/smoke.sh
@@ -73,6 +73,21 @@ until [ "$(docker inspect --format '{{.State.Health.Status}}' "${COMPOSE_PROJECT
     sleep 2
 done
 
+# A restart loop previously surfaced only as an opaque `docker compose exec`
+# daemon error. Require a stable, executable web process first and print its
+# startup logs immediately if the least-privilege entrypoint cannot initialize.
+attempt=0
+until docker compose exec -T web true >/dev/null 2>&1; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 30 ]; then
+        echo "Web container did not reach a runnable state" >&2
+        docker compose ps web
+        docker compose logs web
+        exit 1
+    fi
+    sleep 1
+done
+
 docker compose exec -T web php -r '
     $configuration = [
         "DB_HOST" => getenv("MYSQL_HOST"),

--- a/tests/Docker/smoke.sh
+++ b/tests/Docker/smoke.sh
@@ -46,6 +46,22 @@ fi
 docker compose config >/dev/null
 docker compose up -d --no-build
 
+# Confirm Docker applied, rather than merely parsed, the privilege boundary.
+# Inspect is used deliberately: a Compose YAML assertion alone cannot prove the
+# daemon created the containers with the requested HostConfig.
+for service in web db; do
+    container="${COMPOSE_PROJECT_NAME}-${service}-1"
+    docker inspect --format '{{json .HostConfig.SecurityOpt}}' "$container" \
+        | grep -F 'no-new-privileges:true' >/dev/null || {
+            echo "no-new-privileges is not effective for $service" >&2
+            exit 1
+        }
+    [ "$(docker inspect --format '{{json .HostConfig.CapDrop}}' "$container")" = '["ALL"]' ] || {
+        echo "default capabilities were not dropped for $service" >&2
+        exit 1
+    }
+done
+
 # Wait for MySQL before installing the minimal, read-only probe configuration.
 attempt=0
 until [ "$(docker inspect --format '{{.State.Health.Status}}' "${COMPOSE_PROJECT_NAME}-db-1")" = healthy ]; do
@@ -142,6 +158,29 @@ assert_status() {
     fi
 }
 
+wait_for_status() {
+    path="$1"
+    expected="$2"
+    description="$3"
+    attempt=0
+    while :; do
+        # curl exits successfully for HTTP 403, so readiness is determined only
+        # from its explicit status output, never from curl's process status.
+        actual=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+            "http://127.0.0.1:${LOTGD_HTTP_PORT}${path}" || true)
+        if [ "$actual" = "$expected" ]; then
+            return
+        fi
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge 30 ]; then
+            echo "$description (expected $expected, got $actual)" >&2
+            docker compose logs web
+            exit 1
+        fi
+        sleep 1
+    done
+}
+
 # These host requests exercise the production vhost, including the leading
 # slash semantics of RewriteRule in VirtualHost context.
 assert_status /installer.php 403
@@ -152,19 +191,32 @@ assert_status /.env 403
 assert_status /lib/dbwrapper.php 403
 assert_status /modules/cities.php 403
 
-# The log directory stays denied even during the deliberately enabled
-# installation window. Recreate Apache so its environment sees the new flag.
+# Seed a log sentinel before recreation. Together with dbconnect.php this proves
+# the state volume retains both installer output and database configuration.
+docker compose exec -T web sh -c \
+    'printf "%s\n" persistent-installer-log > /var/lib/lotgd/logs/install.log'
+
+# Recreate Apache so its environment sees the temporary installer flag. A 200
+# response is required: curl returning zero for a 403 would be a false positive.
 LOTGD_INSTALL_ENABLED=1 docker compose up -d --force-recreate --no-deps --no-build web
-attempt=0
-until curl --silent --output /dev/null "http://127.0.0.1:${LOTGD_HTTP_PORT}/install/errors/install.log"; do
-    attempt=$((attempt + 1))
-    if [ "$attempt" -ge 30 ]; then
-        echo "Web container did not restart after enabling the installer" >&2
-        docker compose logs web
-        exit 1
-    fi
-    sleep 1
-done
+wait_for_status /installer.php 200 "Installer did not become explicitly accessible"
 assert_status /install/errors/install.log 403
+
+# Model installer stage 11 by placing its durable completion marker in the
+# state volume. Recreating with the flag deliberately left at 1 proves the
+# marker takes precedence and cannot be bypassed by stale configuration.
+docker compose exec -T web sh -c \
+    'printf "%s\n" completed > /var/lib/lotgd/installation-complete'
+LOTGD_INSTALL_ENABLED=1 docker compose up -d --force-recreate --no-deps --no-build web
+wait_for_status /installer.php 403 "Completion marker did not lock installer.php"
+assert_status /install/ 403
+
+# All durable installer state must survive both forced recreations.
+docker compose exec -T web sh -c '
+    test -L /var/www/html/dbconnect.php &&
+    test -s /var/lib/lotgd/dbconnect.php &&
+    grep -F persistent-installer-log /var/lib/lotgd/logs/install.log >/dev/null &&
+    grep -F completed /var/lib/lotgd/installation-complete >/dev/null
+'
 
 echo "Docker production smoke test passed"


### PR DESCRIPTION
### Motivation

- Reduce supply-chain and runtime attack surface by pinning external images to reviewed multi-architecture manifest digests and making digest updates reviewable.
- Enforce least-privilege for the `web` and `db` services (drop default caps, `no-new-privileges`, explicit allowlists) and isolate SQL traffic on an `internal` DB network to limit lateral movement.
- Make the installer lifecycle and transient writable paths explicitly testable and durable so an administrator cannot accidentally re-enable the installer or lose persisted configuration.  This is sensitive to installation/auth flows, so the Compose/entrypoint changes additionally preserve the existing secret validation and installer completion marker semantics. 
- Add automated, rendered-model checks and a stricter smoke test to CI so the daemon-level HostConfig (capabilities, security options, networks, tmpfs) and the installer enable/complete/recreate lifecycle are validated in CI.

### Description

- Pin images to immutable digests while keeping readable tags: `composer:2@sha256:4d71...5040` in `Dockerfile`, keep `thecodingmachine/php:8.3-v4-apache@sha256:7bc8...35ec7`, and `mysql:8.4@sha256:b3b9...fd3fb` in `docker-compose.yml`, and add Dependabot `docker` updates. (`Dockerfile`, `docker-compose.yml`, `.github/dependabot.yml`)
- Hardened Compose service definitions: added `security_opt: ["no-new-privileges:true"]`, `cap_drop: [ALL]` and narrowly-scoped `cap_add` entries with inline comments explaining each capability, and added restrictive `tmpfs` mounts for `/tmp`, `/run/apache2`, `/var/lock/apache2` for `web`. Also split networks into `web-proxy` and an `internal: true` `database` network and attached `web` to both while `db` is only on `database`. (`docker-compose.yml`)
- CI and QA improvements: added a monthly Dependabot `docker` ecosystem entry, made the CI job verify AMD64/ARM64 presence in pinned manifests, and run `tests/Docker/compose-security.sh` before the production smoke test. (`.github/workflows/ci.yml`, `.github/dependabot.yml`)
- Static and runtime Compose validations: replaced lightweight text checks with `tests/Docker/compose-security.sh` that renders the normalized Compose model (`docker compose config --format json`) and asserts pinned images, `no-new-privileges`, exact capability allowlists, network isolation (`web-proxy` vs `database` internal), loopback host binding, and restrictive `tmpfs` flags. (`tests/Docker/compose-security.sh`)
- Expanded production smoke test: `tests/Docker/smoke.sh` now inspects runtime `HostConfig` via `docker inspect` to verify `no-new-privileges` and capability drops, treats HTTP codes explicitly when testing the installer, models the installer enable -> accessible -> completion-marker -> recreate -> locked lifecycle, and verifies that `dbconnect.php`, installer logs, and the completion marker persist in the state volume. (`tests/Docker/smoke.sh`)
- Documentation: updated `docs/Docker.md` to list every location that must be updated when refreshing a digest, to document the capability/network/tmpfs decisions and to explain why a fully read-only rootfs is not currently enabled for this runtime image; rewrote `docs/RaspberryPiDocker.md` to explain `.env` creation, independent secrets, `LOTGD_INSTALL_ENABLED=1` usage, SSH tunnelling to loopback-only host binding, and recommending a TLS reverse proxy for permanent public operation. (`docs/Docker.md`, `docs/RaspberryPiDocker.md`)

### Testing

- Ran `composer install` and `composer test`; the test suite completed (761 tests, 4,102 assertions) with the repository's existing warnings/deprecations preserved. (`composer install`, `composer test`)
- Ran static analysis and syntax checks: `composer static`, `sh -n` on modified shell tests, and `git diff --check`; these passed in the local environment. (`composer static`, `sh -n tests/Docker/compose-security.sh tests/Docker/smoke.sh docker/entrypoint.sh`)
- Verified pinned manifest contents remotely with registry HEAD/manifest queries (Python): confirmed `library/composer:2@sha256:4d71...5040` and `library/mysql:8.4@sha256:b3b9...fd3fb` contain native `linux/amd64` and `linux/arm64` entries. (manifest inspection)
- Exercised the new shell checks locally in syntax and logic; `tests/Docker/compose-security.sh` contains the JSON-model assertions and `tests/Docker/smoke.sh` contains the installer lifecycle assertions and explicit HTTP-status evaluation. (static execution / `sh -n` and local syntax checks)
- Note: full daemon-level runtime checks that require a Docker daemon (actual `docker compose up`, `docker inspect` assertions inside the smoke test) cannot be executed in the current local environment because the Docker CLI/daemon was not available here; those runtime checks are run in CI because the workflow now invokes `tests/Docker/compose-security.sh` followed by `tests/Docker/smoke.sh` to validate the effective HostConfig, capability settings, networks, and the installer lifecycle.

If you want, I can split the work into two follow-up tasks: (A) further tighten capability lists after a runtime audit on your target hosts, or (B) attempt `read_only: true` again after adopting a runtime image whose extension/INI materialization is fixed at build-time.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a919dbe9ec88329af816b8e561cb658)