### PR TITLE
fix(auth): prefix player-search queries and modernize admin password updates

### DIFF
--- a/pages/user/user_save.php
+++ b/pages/user/user_save.php
@@ -7,6 +7,7 @@ use Lotgd\Nav;
 use Lotgd\MySQL\Database;
 use Lotgd\GameLog;
 use Lotgd\Output;
+use Lotgd\PasswordHelper;
 use Lotgd\Settings;
 use Lotgd\Http;
 
@@ -45,12 +46,15 @@ foreach ($post as $key => $val) {
     if (isset($userinfo[$key])) {
         if ($key == "newpassword") {
             if ($val > "") {
-                $fieldUpdates['password'] = md5(md5($val));
+                $passwordHash = PasswordHelper::hash((string) $val);
+                $fieldUpdates['password'] = $passwordHash;
+                $fieldUpdates['password_algo'] = PasswordHelper::ALGO_MODERN;
                 $updates++;
                 $output->output("`\$Password value has been updated.`0`n");
-                debuglog($session['user']['name'] . "`0 changed password to $val", $userid);
+                debuglog($session['user']['name'] . "`0 changed the target account's password", $userid);
                 if ($session['user']['acctid'] == $userid) {
-                    $session['user']['password'] = md5(md5($val));
+                    $session['user']['password'] = $passwordHash;
+                    $session['user']['password_algo'] = PasswordHelper::ALGO_MODERN;
                 }
             }
         } elseif ($key == "superuser") {

--- a/src/Lotgd/PlayerSearch.php
+++ b/src/Lotgd/PlayerSearch.php
@@ -265,8 +265,9 @@ final class PlayerSearch
         );
 
         $sql = sprintf(
-            'SELECT %s FROM accounts a WHERE %s ORDER BY %s LIMIT %d',
+            'SELECT %s FROM %s a WHERE %s ORDER BY %s LIMIT %d',
             implode(', ', $columns),
+            Database::prefix('accounts'),
             implode(' OR ', $wrapped),
             $this->buildOrderByClause($orderPriorities, $alphabetical),
             $limit
@@ -514,8 +515,9 @@ final class PlayerSearch
         );
 
         $sql = sprintf(
-            'SELECT %s FROM accounts a WHERE %s ORDER BY %s LIMIT %d',
+            'SELECT %s FROM %s a WHERE %s ORDER BY %s LIMIT %d',
             implode(', ', $columns),
+            Database::prefix('accounts'),
             implode(' OR ', $wrapped),
             $orderClause,
             $limit

--- a/tests/PlayerSearch/PlayerSearchTest.php
+++ b/tests/PlayerSearch/PlayerSearchTest.php
@@ -31,6 +31,7 @@ final class PlayerSearchTest extends TestCase
         }
 
         \Lotgd\MySQL\Database::$mockResults = [];
+        Database::setPrefix('lotgd_');
 
         $this->search = new PlayerSearch();
         $this->connection = Database::getDoctrineConnection();
@@ -46,6 +47,7 @@ final class PlayerSearchTest extends TestCase
         }
 
         \Lotgd\MySQL\Database::$mockResults = [];
+        Database::setPrefix('');
     }
 
     public function testFindExactLoginReturnsSingleRow(): void
@@ -60,6 +62,7 @@ final class PlayerSearchTest extends TestCase
         $this->assertSame('Alpha', $result[0]['name']);
 
         $sql = end($this->connection->queries);
+        $this->assertStringContainsString('FROM lotgd_accounts a', $sql);
         $this->assertStringContainsString('a.login = :loginExact', $sql);
         $this->assertStringContainsString('LIMIT 1', $sql);
 
@@ -227,6 +230,7 @@ final class PlayerSearchTest extends TestCase
         $this->assertCount(1, $result['rows']);
         $this->assertSame('alpha@example.com', $result['rows'][0]['emailaddress']);
         $this->assertCount(1, $this->connection->queries);
+        $this->assertStringContainsString('FROM lotgd_accounts a', $this->connection->queries[0]);
         $this->assertStringContainsString('legacyExactPattern', $this->connection->queries[0]);
         $this->assertArrayHasKey('legacyExactPattern', $this->connection->executeQueryParams[0]);
     }

--- a/tests/User/UserSaveParameterizedUpdateTest.php
+++ b/tests/User/UserSaveParameterizedUpdateTest.php
@@ -35,6 +35,7 @@ namespace {
     if (!function_exists('debuglog')) {
         function debuglog(string $message, mixed $userid = null): void
         {
+            $GLOBALS['__test_debuglog'][] = ['message' => $message, 'userid' => $userid];
         }
     }
     if (!function_exists('debug')) {
@@ -71,12 +72,79 @@ namespace {
 
 namespace Lotgd\Tests\User {
     use Lotgd\Names;
+    use Lotgd\PasswordHelper;
     use Lotgd\Settings;
     use Lotgd\MySQL\Database;
+    use PHPUnit\Framework\Attributes\RunInSeparateProcess;
     use PHPUnit\Framework\TestCase;
 
     final class UserSaveParameterizedUpdateTest extends TestCase
     {
+        #[RunInSeparateProcess]
+        public function testNewPasswordUsesModernHashAndDoesNotLeakPlaintextToLog(): void
+        {
+            Database::resetDoctrineConnection();
+            $connection = Database::getDoctrineConnection();
+            $connection->executeStatements = [];
+
+            $plaintext = 'Never-Log-This-Password!';
+            $targetUserid = 42;
+            $oldvalues = [
+                'newpassword' => '',
+                'playername' => 'Admin',
+                'title' => '',
+                'ctitle' => '',
+            ];
+            $serialized = htmlentities(serialize($oldvalues), ENT_COMPAT, 'UTF-8');
+
+            $include = function () use ($plaintext, $serialized, $oldvalues, $targetUserid): void {
+                global $_POST, $_GET, $session, $userid, $userinfo, $__test_debuglog;
+
+                $_POST = ['newpassword' => $plaintext, 'oldvalues' => $serialized];
+                $_GET = [];
+                $__test_debuglog = [];
+                $session = [
+                    'user' => [
+                        'acctid' => $targetUserid,
+                        'superuser' => SU_MEGAUSER,
+                        'name' => 'Admin',
+                        'password' => 'old hash',
+                        'password_algo' => PasswordHelper::ALGO_LEGACY,
+                    ],
+                ];
+                $userid = $targetUserid;
+                $userinfo = $oldvalues;
+
+                require __DIR__ . '/../../pages/user/user_save.php';
+            };
+
+            \Closure::bind($include, null, null)();
+
+            $statement = null;
+            foreach (array_reverse($connection->executeStatements) as $entry) {
+                if (str_contains($entry['sql'], 'UPDATE ' . Database::prefix('accounts'))) {
+                    $statement = $entry;
+                    break;
+                }
+            }
+
+            $this->assertNotNull($statement, 'No UPDATE statement executed for accounts table');
+            $params = $statement['params'];
+            $this->assertTrue(PasswordHelper::verify(
+                $plaintext,
+                $params['password'],
+                $params['password_algo']
+            ));
+            $this->assertSame(PasswordHelper::ALGO_MODERN, $params['password_algo']);
+            $this->assertSame($params['password'], $GLOBALS['session']['user']['password']);
+            $this->assertSame(PasswordHelper::ALGO_MODERN, $GLOBALS['session']['user']['password_algo']);
+
+            $logOutput = implode("\n", array_column($GLOBALS['__test_debuglog'], 'message'));
+            $this->assertStringNotContainsString($plaintext, $logOutput);
+            $this->assertStringNotContainsString($params['password'], $logOutput);
+            $this->assertStringContainsString("changed the target account's password", $logOutput);
+        }
+
         public function testUpdateBindsParametersForQuotedAndMultibyteNames(): void
         {
             Database::resetDoctrineConnection();
@@ -221,4 +289,3 @@ namespace Lotgd\Tests\User {
         }
     }
 }
-


### PR DESCRIPTION
### Motivation

- Ensure player-search queries respect a configured database prefix instead of hardcoding the `accounts` table to support installations with table prefixes. 
- Replace legacy double-MD5 admin-reset password behaviour with the modern password helper and algorithm marker to improve security and future-proof verification. 
- Avoid leaking plaintext passwords or password hashes into audit/debug logs while keeping admin auditability. 

### Description

- Updated `src/Lotgd/PlayerSearch.php` to use `Database::prefix('accounts')` for both the standard search and legacy lookup SQL while retaining the `a` alias and all bound parameters. 
- Replaced double-MD5 hashing in `pages/user/user_save.php` with `PasswordHelper::hash()` and included `password_algo = PasswordHelper::ALGO_MODERN` in the same parameterized update, and synchronized `session` fields when an admin edits their own account. 
- Changed the relevant `debuglog()` call to record that a password change occurred without including the plaintext password or its hash. 
- Added focused tests: updated `tests/PlayerSearch/PlayerSearchTest.php` to configure a non-empty prefix and assert queries use the prefixed table, and added `tests/User/UserSaveParameterizedUpdateTest.php` to validate the admin password-update flow, hash verification, algorithm marker, session sync, and absence of plaintext in logs. 

### Testing

- Syntax checks: `php -l src/Lotgd/PlayerSearch.php`, `php -l pages/user/user_save.php`, and `php -l tests/User/UserSaveParameterizedUpdateTest.php` completed with no syntax errors. 
- Unit tests: `vendor/bin/phpunit --configuration phpunit.xml tests/PlayerSearch/PlayerSearchTest.php tests/User/UserSaveParameterizedUpdateTest.php` passed (focused suite showed all tests green; recorded assertions in transcript). 
- Full suite and static checks: `composer test` ran and completed (suite passed with existing warnings/deprecations as noted), and `composer static` checks for legacy HTTP wrappers and SQL addslashes passed. 
- Security review: untrusted input enters through `Http::allPost()` / `Http::post()` and `newpassword` is normalized to a string before hashing; CSRF protections for the existing admin form remain unchanged; updates are executed via the existing parameterized Doctrine `executeStatement` avoiding `addslashes` patterns; authorization and superuser checks are unchanged and remain in place; audit logging now records the password-change event without including plaintext or hashes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a95972040088329bfe4de6d3d12bce9)