### PR TITLE
installer: remove DB-side MD5 and add safe post-migration account password upgrade

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -61,6 +61,12 @@ If you are coming directly from **1.3.2** (or earlier 1.x):
 
 ## 5. Run Doctrine Migrations
 
+Copying the new files alone is **not** a complete upgrade. Before permitting
+players to log in, either finish the browser installer or run the Doctrine
+migration command below. Migration `Version20250724000021` widens
+`accounts.password` for bcrypt hashes and adds `accounts.password_algo`; logins
+before those schema changes can truncate new hashes or fail.
+
 Once the legacy upgrade is complete:
 
 1. In your project root, run:
@@ -73,6 +79,17 @@ Once the legacy upgrade is complete:
    locations.
 3. This will apply all new **2.x schema changes**.
 4. Watch for any DB prefix issues — these are now supported and should migrate correctly.
+
+### Password recovery for ancient accounts
+
+The browser installer immediately converts the administrator credential used
+to authorize an ancient upgrade to bcrypt. It preserves all other 32-character
+MD5-shaped values because a single-MD5 hash and a double-MD5 hash cannot be
+distinguished without knowing the plaintext password. It also does not guess
+that arbitrary short database values are plaintext passwords. Players whose
+single-MD5 or plaintext credentials cannot be verified must use the **Forgotten
+Password** flow (or have an administrator set a new password); operators must
+not apply another MD5 pass to stored account values.
 
 ### Advanced admins: CLI-only upgrade
 

--- a/install/data/installer_sqlstatements.php
+++ b/install/data/installer_sqlstatements.php
@@ -786,8 +786,6 @@ $sql_upgrade_statements = array(
 "UPDATE " . Database::prefix("accounts") . " SET race=\"Horrible Gelatinous Blob\" WHERE race='0'",
 "UPDATE " . Database::prefix("accounts") . " SET location=\"The Boar's Head Inn\" WHERE location='1'",
 "UPDATE " . Database::prefix("accounts") . " SET location=\"Degolburg\" WHERE location='0'",
-"UPDATE " . Database::prefix("accounts") . " SET password=md5(password) WHERE length(password) < 32",
-"UPDATE " . Database::prefix("accounts") . " SET password=md5(password)",
 "UPDATE " . Database::prefix("nastywords") . " SET type='nasty'",
 ),
 "0.9.8-prerelease.2" => array(),

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -150,6 +150,7 @@ class Installer
                             'acctid' => (int) ($row['acctid'] ?? 0),
                             'login' => (string) ($row['login'] ?? Http::post('username')),
                             'password' => stripslashes(Http::post('password')),
+                            'verifiedPassword' => (string) ($row['password'] ?? ''),
                             'ancient' => $this->getSetting('installer_version', '-1') === '-1',
                         ];
                         Redirect::redirect("installer.php?stage=1");
@@ -2278,28 +2279,42 @@ class Installer
 
         $connection = Database::getDoctrineConnection();
         $table = Database::prefix('accounts');
-        $accounts = $connection->fetchAllAssociative(
-            "SELECT acctid, password, password_algo FROM {$table}"
-        );
         $metadataUpdates = 0;
+        $lastAcctid = 0;
 
-        foreach ($accounts as $account) {
-            $storedPassword = (string) ($account['password'] ?? '');
-            if (! PasswordHelper::isModernHash($storedPassword)
-                || (int) ($account['password_algo'] ?? PasswordHelper::ALGO_LEGACY) === PasswordHelper::ALGO_MODERN
-            ) {
-                continue;
-            }
-
-            $connection->executeStatement(
-                "UPDATE {$table} SET password_algo = :passwordAlgo WHERE acctid = :acctid",
+        do {
+            // Restrict each page to likely bcrypt rows with stale metadata.
+            // PasswordHelper still validates every candidate, so a malformed
+            // value that merely starts with "$2" is never marked modern.
+            $accounts = $connection->fetchAllAssociative(
+                "SELECT acctid, password FROM {$table}"
+                . " WHERE acctid > :lastAcctid AND password_algo <> :modernAlgo"
+                . " AND password LIKE :bcryptPrefix ORDER BY acctid LIMIT 500",
                 [
-                    'passwordAlgo' => PasswordHelper::ALGO_MODERN,
-                    'acctid' => (int) $account['acctid'],
+                    'lastAcctid' => $lastAcctid,
+                    'modernAlgo' => PasswordHelper::ALGO_MODERN,
+                    'bcryptPrefix' => '$2%',
                 ]
             );
-            ++$metadataUpdates;
-        }
+
+            foreach ($accounts as $account) {
+                $lastAcctid = max($lastAcctid, (int) ($account['acctid'] ?? 0));
+                $storedPassword = (string) ($account['password'] ?? '');
+                if (! PasswordHelper::isModernHash($storedPassword)) {
+                    continue;
+                }
+
+                $metadataUpdates += $connection->executeStatement(
+                    "UPDATE {$table} SET password_algo = :passwordAlgo"
+                    . " WHERE acctid = :acctid AND password = :password",
+                    [
+                        'passwordAlgo' => PasswordHelper::ALGO_MODERN,
+                        'acctid' => (int) $account['acctid'],
+                        'password' => $storedPassword,
+                    ]
+                );
+            }
+        } while (count($accounts) === 500);
 
         if ($metadataUpdates > 0) {
             InstallerLogger::log("Aligned password metadata for {$metadataUpdates} modern account(s).");
@@ -2308,19 +2323,28 @@ class Installer
         $credential = $session['installer_admin_credential'] ?? null;
         if (is_array($credential)
             && ($credential['acctid'] ?? 0) > 0
-            && isset($credential['login'], $credential['password'])
+            && isset($credential['login'], $credential['password'], $credential['verifiedPassword'])
         ) {
-            $connection->executeStatement(
+            $adminUpdated = $connection->executeStatement(
                 "UPDATE {$table} SET password = :password, password_algo = :passwordAlgo"
-                . " WHERE acctid = :acctid AND login = :login",
+                . " WHERE acctid = :acctid AND login = :login AND password = :verifiedPassword",
                 [
                     'password' => PasswordHelper::hash((string) $credential['password']),
                     'passwordAlgo' => PasswordHelper::ALGO_MODERN,
                     'acctid' => (int) $credential['acctid'],
                     'login' => (string) $credential['login'],
+                    'verifiedPassword' => (string) $credential['verifiedPassword'],
                 ]
             );
-            InstallerLogger::log('Upgraded the authenticated installer administrator password to bcrypt.');
+            if ($adminUpdated > 0) {
+                InstallerLogger::log('Upgraded the authenticated installer administrator password to bcrypt.');
+            } else {
+                // A concurrent password change must win over the older stage-0
+                // credential; never restore a password that has been replaced.
+                InstallerLogger::log(
+                    'Skipped installer administrator password upgrade because the stored password changed.'
+                );
+            }
         }
 
         if (is_array($credential) && ($credential['ancient'] ?? false)) {

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -143,16 +143,19 @@ class Installer
                     );
 
                     if ($needsauthentication === false) {
-                        // Retain the already-verified credential only until the
-                        // password schema migration can replace this admin's
-                        // ambiguous ancient hash with bcrypt.
-                        $session['installer_admin_credential'] = [
-                            'acctid' => (int) ($row['acctid'] ?? 0),
-                            'login' => (string) ($row['login'] ?? Http::post('username')),
-                            'password' => stripslashes(Http::post('password')),
-                            'verifiedPassword' => (string) ($row['password'] ?? ''),
-                            'ancient' => $this->getSetting('installer_version', '-1') === '-1',
-                        ];
+// Retain the already-verified credential only until the
+// password schema migration can replace this admin's
+// ambiguous ancient hash with bcrypt.
+$installerIsAncient = $this->getSetting('installer_version', '-1') === '-1';
+if ($installerIsAncient) {
+    $session['installer_admin_credential'] = [
+        'acctid' => (int) ($row['acctid'] ?? 0),
+        'login' => (string) ($row['login'] ?? Http::post('username')),
+        'password' => stripslashes(Http::post('password')),
+        'verifiedPassword' => (string) ($row['password'] ?? ''),
+        'ancient' => true,
+    ];
+}
                         Redirect::redirect("installer.php?stage=1");
                     }
                     $this->output->output("`\$That username / password was not found, or is not an account with sufficient privileges to perform the upgrade.`n");

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -143,6 +143,15 @@ class Installer
                     );
 
                     if ($needsauthentication === false) {
+                        // Retain the already-verified credential only until the
+                        // password schema migration can replace this admin's
+                        // ambiguous ancient hash with bcrypt.
+                        $session['installer_admin_credential'] = [
+                            'acctid' => (int) ($row['acctid'] ?? 0),
+                            'login' => (string) ($row['login'] ?? Http::post('username')),
+                            'password' => stripslashes(Http::post('password')),
+                            'ancient' => $this->getSetting('installer_version', '-1') === '-1',
+                        ];
                         Redirect::redirect("installer.php?stage=1");
                     }
                     $this->output->output("`\$That username / password was not found, or is not an account with sufficient privileges to perform the upgrade.`n");
@@ -1559,6 +1568,7 @@ class Installer
         $this->output->output("`2The installer now uses Doctrine migrations to set up the database schema.`n");
         try {
             $this->runMigrations();
+            $this->migrateInstallerAccountPasswords();
             $this->output->output("`@Migrations executed successfully.`n");
         } catch (\Throwable $e) {
             $this->output->output("`\$Migration error:`n" . $e->getMessage());
@@ -2249,6 +2259,82 @@ class Installer
         }
 
         return false;
+    }
+
+    /**
+     * Normalize account password metadata after the bcrypt schema migration.
+     *
+     * This installer-only migration deliberately does not guess whether a
+     * 32-character hexadecimal value is single- or double-MD5. Existing bcrypt
+     * values are preserved and their metadata is corrected. When stage 0 has
+     * authenticated an administrator, that known plaintext credential is used
+     * to replace only that account's password with bcrypt. Other ambiguous MD5
+     * or ancient plaintext accounts remain untouched and must use the Forgotten
+     * Password flow; hashing them speculatively would corrupt valid credentials.
+     */
+    private function migrateInstallerAccountPasswords(): void
+    {
+        global $session;
+
+        $connection = Database::getDoctrineConnection();
+        $table = Database::prefix('accounts');
+        $accounts = $connection->fetchAllAssociative(
+            "SELECT acctid, password, password_algo FROM {$table}"
+        );
+        $metadataUpdates = 0;
+
+        foreach ($accounts as $account) {
+            $storedPassword = (string) ($account['password'] ?? '');
+            if (! PasswordHelper::isModernHash($storedPassword)
+                || (int) ($account['password_algo'] ?? PasswordHelper::ALGO_LEGACY) === PasswordHelper::ALGO_MODERN
+            ) {
+                continue;
+            }
+
+            $connection->executeStatement(
+                "UPDATE {$table} SET password_algo = :passwordAlgo WHERE acctid = :acctid",
+                [
+                    'passwordAlgo' => PasswordHelper::ALGO_MODERN,
+                    'acctid' => (int) $account['acctid'],
+                ]
+            );
+            ++$metadataUpdates;
+        }
+
+        if ($metadataUpdates > 0) {
+            InstallerLogger::log("Aligned password metadata for {$metadataUpdates} modern account(s).");
+        }
+
+        $credential = $session['installer_admin_credential'] ?? null;
+        if (is_array($credential)
+            && ($credential['acctid'] ?? 0) > 0
+            && isset($credential['login'], $credential['password'])
+        ) {
+            $connection->executeStatement(
+                "UPDATE {$table} SET password = :password, password_algo = :passwordAlgo"
+                . " WHERE acctid = :acctid AND login = :login",
+                [
+                    'password' => PasswordHelper::hash((string) $credential['password']),
+                    'passwordAlgo' => PasswordHelper::ALGO_MODERN,
+                    'acctid' => (int) $credential['acctid'],
+                    'login' => (string) $credential['login'],
+                ]
+            );
+            InstallerLogger::log('Upgraded the authenticated installer administrator password to bcrypt.');
+        }
+
+        if (is_array($credential) && ($credential['ancient'] ?? false)) {
+            InstallerLogger::log(
+                'Preserved ambiguous ancient player passwords; affected players must use password recovery.'
+            );
+            $this->output->output(
+                "`^Ancient player passwords were preserved because single- and double-MD5 cannot be distinguished. "
+                . "Players whose old password no longer works must use the Forgotten Password flow; do not hash stored values again.`n"
+            );
+        }
+
+        // Never retain installer plaintext credentials after the one safe use.
+        unset($session['installer_admin_credential']);
     }
 
     /**

--- a/src/Lotgd/PasswordHelper.php
+++ b/src/Lotgd/PasswordHelper.php
@@ -123,4 +123,16 @@ final class PasswordHelper
 
         return ($info['algo'] ?? null) === PASSWORD_BCRYPT;
     }
+
+    /**
+     * Detect the shape shared by historical single- and double-MD5 hashes.
+     *
+     * The two formats cannot be distinguished from the stored value alone.
+     * Callers must preserve a matching value unless they also have the user's
+     * plaintext password and can verify which historical format was used.
+     */
+    public static function isLegacyHash(string $storedHash): bool
+    {
+        return strlen($storedHash) === 32 && ctype_xdigit($storedHash);
+    }
 }

--- a/tests/Installer/PasswordMigrationTest.php
+++ b/tests/Installer/PasswordMigrationTest.php
@@ -52,13 +52,9 @@ final class PasswordMigrationTest extends TestCase
     public function testMigrationPreservesHashesAndUpgradesAuthenticatedAncientAdmin(): void
     {
         $bcrypt = PasswordHelper::hash('existing-player-password');
-        $doubleMd5 = md5(md5('legacy-player-password'));
-        $plaintext = 'ancient-player-password';
         $connection = Database::getDoctrineConnection();
         $connection->fetchAllResults = [[
             ['acctid' => 1, 'password' => $bcrypt, 'password_algo' => PasswordHelper::ALGO_LEGACY],
-            ['acctid' => 2, 'password' => $doubleMd5, 'password_algo' => PasswordHelper::ALGO_LEGACY],
-            ['acctid' => 3, 'password' => $plaintext, 'password_algo' => PasswordHelper::ALGO_LEGACY],
         ]];
 
         global $session;
@@ -67,12 +63,18 @@ final class PasswordMigrationTest extends TestCase
                 'acctid' => 9,
                 'login' => 'AncientAdmin',
                 'password' => 'known-admin-password',
+                'verifiedPassword' => md5('known-admin-password'),
                 'ancient' => true,
             ],
         ];
 
         $method = new \ReflectionMethod(Installer::class, 'migrateInstallerAccountPasswords');
         $method->invoke(new Installer());
+
+        $candidateQuery = $connection->fetchAllLog[0];
+        self::assertStringContainsString('password LIKE :bcryptPrefix', $candidateQuery['sql']);
+        self::assertStringContainsString('LIMIT 500', $candidateQuery['sql']);
+        self::assertSame('$2%', $candidateQuery['params']['bcryptPrefix']);
 
         $accountUpdates = array_values(array_filter(
             $connection->executeStatements,
@@ -84,19 +86,77 @@ final class PasswordMigrationTest extends TestCase
 
         self::assertCount(2, $accountUpdates);
         self::assertSame(
-            ['passwordAlgo' => PasswordHelper::ALGO_MODERN, 'acctid' => 1],
+            [
+                'passwordAlgo' => PasswordHelper::ALGO_MODERN,
+                'acctid' => 1,
+                'password' => $bcrypt,
+            ],
             $accountUpdates[0]['params']
         );
 
         $adminUpdate = $accountUpdates[1];
         self::assertSame(9, $adminUpdate['params']['acctid']);
         self::assertSame('AncientAdmin', $adminUpdate['params']['login']);
+        self::assertSame(md5('known-admin-password'), $adminUpdate['params']['verifiedPassword']);
         self::assertSame(PasswordHelper::ALGO_MODERN, $adminUpdate['params']['passwordAlgo']);
         self::assertTrue(password_verify('known-admin-password', $adminUpdate['params']['password']));
         self::assertArrayNotHasKey('installer_admin_credential', $session);
 
-        // Neither the double-MD5 player nor the unsupported plaintext player
-        // receives an UPDATE; both retain a recovery path instead of corruption.
+        // The SQL candidate filter excludes double-MD5 and plaintext players;
+        // both retain a recovery path instead of risking hash corruption.
         self::assertStringContainsString('Forgotten Password flow', Output::getInstance()->getRawOutput());
+    }
+
+    /**
+     * Ensure a password changed after stage-0 authentication is never restored.
+     */
+    public function testMigrationUsesVerifiedHashAsOptimisticLockForAdminUpdate(): void
+    {
+        $connection = Database::getDoctrineConnection();
+        $connection->fetchAllResults = [[]];
+        $connection->executeStatementResults = [0];
+
+        global $session;
+        $session = [
+            'installer_admin_credential' => [
+                'acctid' => 9,
+                'login' => 'AncientAdmin',
+                'password' => 'obsolete-password',
+                'verifiedPassword' => md5('obsolete-password'),
+                'ancient' => false,
+            ],
+        ];
+
+        $method = new \ReflectionMethod(Installer::class, 'migrateInstallerAccountPasswords');
+        $method->invoke(new Installer());
+
+        $adminUpdate = $connection->executeStatements[0];
+        self::assertStringContainsString('password = :verifiedPassword', $adminUpdate['sql']);
+        self::assertSame(md5('obsolete-password'), $adminUpdate['params']['verifiedPassword']);
+        self::assertArrayNotHasKey('installer_admin_credential', $session);
+    }
+
+    /**
+     * Ensure metadata candidates are processed in bounded keyset pages.
+     */
+    public function testMigrationPaginatesModernHashCandidates(): void
+    {
+        $connection = Database::getDoctrineConnection();
+        $firstPage = [];
+        for ($acctid = 1; $acctid <= 500; ++$acctid) {
+            $firstPage[] = ['acctid' => $acctid, 'password' => '$2malformed'];
+        }
+        $connection->fetchAllResults = [$firstPage, []];
+
+        global $session;
+        $session = [];
+
+        $method = new \ReflectionMethod(Installer::class, 'migrateInstallerAccountPasswords');
+        $method->invoke(new Installer());
+
+        self::assertCount(2, $connection->fetchAllLog);
+        self::assertSame(0, $connection->fetchAllLog[0]['params']['lastAcctid']);
+        self::assertSame(500, $connection->fetchAllLog[1]['params']['lastAcctid']);
+        self::assertSame([], $connection->executeStatements);
     }
 }

--- a/tests/Installer/PasswordMigrationTest.php
+++ b/tests/Installer/PasswordMigrationTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Installer;
+
+use Lotgd\Installer\Installer;
+use Lotgd\Output;
+use Lotgd\PasswordHelper;
+use Lotgd\Tests\Stubs\Database;
+use Lotgd\Tests\Stubs\DoctrineConnection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression coverage for the installer-only account password migration.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+final class PasswordMigrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        require_once dirname(__DIR__, 2) . '/install/lib/Installer.php';
+        require_once __DIR__ . '/../Stubs/DoctrineBootstrap.php';
+        class_exists(Database::class);
+
+        Database::$tablePrefix = 'lotgd_';
+        Database::$doctrineConnection = new DoctrineConnection();
+        Output::getInstance();
+    }
+
+    protected function tearDown(): void
+    {
+        Database::$tablePrefix = '';
+        Database::$doctrineConnection = null;
+        parent::tearDown();
+    }
+
+    public function testLegacySqlBundleDoesNotHashPasswordsInDatabase(): void
+    {
+        $source = file_get_contents(dirname(__DIR__, 2) . '/install/data/installer_sqlstatements.php');
+
+        self::assertIsString($source);
+        self::assertDoesNotMatchRegularExpression('/\bMD5\s*\(/i', $source);
+    }
+
+    public function testMigrationPreservesHashesAndUpgradesAuthenticatedAncientAdmin(): void
+    {
+        $bcrypt = PasswordHelper::hash('existing-player-password');
+        $doubleMd5 = md5(md5('legacy-player-password'));
+        $plaintext = 'ancient-player-password';
+        $connection = Database::getDoctrineConnection();
+        $connection->fetchAllResults = [[
+            ['acctid' => 1, 'password' => $bcrypt, 'password_algo' => PasswordHelper::ALGO_LEGACY],
+            ['acctid' => 2, 'password' => $doubleMd5, 'password_algo' => PasswordHelper::ALGO_LEGACY],
+            ['acctid' => 3, 'password' => $plaintext, 'password_algo' => PasswordHelper::ALGO_LEGACY],
+        ]];
+
+        global $session;
+        $session = [
+            'installer_admin_credential' => [
+                'acctid' => 9,
+                'login' => 'AncientAdmin',
+                'password' => 'known-admin-password',
+                'ancient' => true,
+            ],
+        ];
+
+        $method = new \ReflectionMethod(Installer::class, 'migrateInstallerAccountPasswords');
+        $method->invoke(new Installer());
+
+        $accountUpdates = array_values(array_filter(
+            $connection->executeStatements,
+            static fn (array $statement): bool => str_starts_with(
+                $statement['sql'],
+                'UPDATE lotgd_accounts SET'
+            )
+        ));
+
+        self::assertCount(2, $accountUpdates);
+        self::assertSame(
+            ['passwordAlgo' => PasswordHelper::ALGO_MODERN, 'acctid' => 1],
+            $accountUpdates[0]['params']
+        );
+
+        $adminUpdate = $accountUpdates[1];
+        self::assertSame(9, $adminUpdate['params']['acctid']);
+        self::assertSame('AncientAdmin', $adminUpdate['params']['login']);
+        self::assertSame(PasswordHelper::ALGO_MODERN, $adminUpdate['params']['passwordAlgo']);
+        self::assertTrue(password_verify('known-admin-password', $adminUpdate['params']['password']));
+        self::assertArrayNotHasKey('installer_admin_credential', $session);
+
+        // Neither the double-MD5 player nor the unsupported plaintext player
+        // receives an UPDATE; both retain a recovery path instead of corruption.
+        self::assertStringContainsString('Forgotten Password flow', Output::getInstance()->getRawOutput());
+    }
+}

--- a/tests/Installer/Stage9Test.php
+++ b/tests/Installer/Stage9Test.php
@@ -489,10 +489,15 @@ namespace Lotgd\Tests\Installer {
                 }
             }
 
-            $this->assertContains(
-                'SELECT acctid, password, password_algo FROM accounts',
-                DoctrineBootstrap::$conn->queries,
-                'The post-schema account password migration should still run.'
+            $this->assertNotEmpty(
+                array_filter(
+                    DoctrineBootstrap::$conn->queries,
+                    static fn (string $sql): bool => str_contains(
+                        $sql,
+                        'SELECT acctid, password FROM accounts WHERE acctid > :lastAcctid'
+                    )
+                ),
+                'The paginated post-schema account password migration should still run.'
             );
 
             foreach (DoctrineBootstrap::$conn->queries as $sql) {

--- a/tests/Installer/Stage9Test.php
+++ b/tests/Installer/Stage9Test.php
@@ -489,7 +489,11 @@ namespace Lotgd\Tests\Installer {
                 }
             }
 
-            $this->assertCount(0, DoctrineBootstrap::$conn->queries, 'Doctrine metadata should bypass legacy installer SQL.');
+            $this->assertContains(
+                'SELECT acctid, password, password_algo FROM accounts',
+                DoctrineBootstrap::$conn->queries,
+                'The post-schema account password migration should still run.'
+            );
 
             foreach (DoctrineBootstrap::$conn->queries as $sql) {
                 $this->assertArrayNotHasKey(

--- a/tests/PasswordHelperTest.php
+++ b/tests/PasswordHelperTest.php
@@ -52,6 +52,17 @@ final class PasswordHelperTest extends TestCase
         $this->assertTrue(PasswordHelper::verifyLegacyUpgradeCredential('swordfish', 'swordfish'));
     }
 
+    /**
+     * Single- and double-MD5 values share one conservative classification.
+     */
+    public function testLegacyHashClassificationDoesNotGuessMd5Generation(): void
+    {
+        $this->assertTrue(PasswordHelper::isLegacyHash(md5('swordfish')));
+        $this->assertTrue(PasswordHelper::isLegacyHash(md5(md5('swordfish'))));
+        $this->assertFalse(PasswordHelper::isLegacyHash('short plaintext'));
+        $this->assertFalse(PasswordHelper::isLegacyHash(PasswordHelper::hash('swordfish')));
+    }
+
 
     /**
      * Ensure malformed values with "$2" prefix are not treated as bcrypt hashes.


### PR DESCRIPTION
### Motivation

- Remove destructive database-side `MD5()` rewrites that could corrupt legacy passwords during the legacy SQL execution path.  
- Ensure the installer upgrades accounts to modern bcrypt safely after the schema migration widens `accounts.password` and adds `password_algo`.  
- Avoid guessing whether 32-character legacy values are single-MD5 or double-MD5 and document recovery behavior for ambiguous ancient accounts.

### Description

- Removed the two `MD5()` update statements from the `0.9.8-prerelease.1` block in `install/data/installer_sqlstatements.php` so the legacy SQL bundle no longer rewrites passwords on the DB side.  
- Added `PasswordHelper::isLegacyHash()` to conservatively classify 32-character hexadecimal legacy values without attempting to distinguish single- vs double-MD5.  
- Implemented an installer-only post-migration routine `migrateInstallerAccountPasswords()` in `install/lib/Installer.php` that runs after `runMigrations()` (including migration `Version20250724000021`), obtains the accounts table via `Database::prefix()`, and uses the Doctrine DBAL connection with bound parameters for all updates.  
- Behavior of the migration: it aligns already-modern bcrypt values with `PasswordHelper::ALGO_MODERN`, upgrades the single authenticated installer administrator (using the already-verified plaintext credential captured during stage 0) to bcrypt, leaves ambiguous 32-character MD5-shaped player values and unsupported plaintext untouched, and logs outcomes while directing affected players to the documented Forgotten Password recovery flow.  
- Updated `UPGRADING.md` to warn that copying files alone is insufficient and operators must run the installer or `php bin/doctrine migrations:migrate` so `accounts.password` is widened and `password_algo` is added before allowing logins.  
- Added regression tests: `tests/Installer/PasswordMigrationTest.php` and extended `tests/PasswordHelperTest.php` and `tests/Installer/Stage9Test.php` to cover absence of DB-side `MD5()`, correct treatment of bcrypt and legacy hashes, the authenticated-admin upgrade, and the documented recovery behavior.

### Testing

- Syntax checks: `php -l` on `install/lib/Installer.php`, `src/Lotgd/PasswordHelper.php`, and new/modified tests all returned no syntax errors.  
- Unit tests: targeted runs including `tests/Installer/PasswordMigrationTest.php`, `tests/PasswordHelperTest.php`, and `tests/Installer/Stage9Test.php` passed in the test harness.  
- Full suite: `composer test` completed (765 tests, ~4,125 assertions) reporting OK while preserving existing suite warnings/deprecations; `composer static` (legacy wrapper and SQL addslashes checks plus PHPStan) also passed.  
- All database updates in the migration use Doctrine DBAL `executeStatement()` with named/bound parameters and the `Database::prefix()` lookup for the `accounts` table.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a95af1b415c8329a67f157ede5fce95)