### PR TITLE
docs: document async settings test isolation in Unreleased Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Everything below reflects the path from 1.3.2 → 2.0 RCs.
 ### Removed
 - Delete the unused `async/js/ajax_polling.js`. The polling client has been emitted inline by `async/setup.php` for some time and the file was no longer loaded by anything; keeping it around risked a second, duplicate polling loop in custom templates that still referenced it.
 
+### Tests
+- Load async settings test fixtures from temporary files via `LOTGD_ASYNC_SETTINGS_FILE`, clean them up completely, preserve the developer's real `config/async.settings.php`, and fail cleanly when a fixture cannot be created.
+
 ## [2.0.5] – 2026-04-10
 
 ### Features


### PR DESCRIPTION
### Motivation
- Make the unreleased changelog explicitly note that async-settings tests now isolate their fixtures from a developer's real `config/async.settings.php`, and that temporary fixtures are cleaned up and surface explicit failures when a fixture cannot be created.

### Description
- Add a short `### Tests` entry under `## [Unreleased]` documenting that async settings tests load fixtures from temporary files via `LOTGD_ASYNC_SETTINGS_FILE`, preserve the local `config/async.settings.php`, and fail cleanly when a temporary fixture cannot be produced.
- Phrase the entry as a single user-oriented line that collectively summarizes the related test fixes.

### Testing
- Ran formatting and sanity checks (`git diff --check`) and they passed with no whitespace/formatting errors.
- Verified the changelog entry covers the test-fix commits added since the previous changelog update and that the local repository is in a clean state after the change.
- Committed the updated `CHANGELOG.md` successfully and left the working tree clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9e536f91e883299926c43dbf0e0fa1)