### PR TITLE
feat(diagnostics): one screen that answers "is everything still running?"

### DIFF
--- a/diagnostics.php
+++ b/diagnostics.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+use Lotgd\Diagnostics;
+use Lotgd\GameLog;
+use Lotgd\Http;
+use Lotgd\Nav;
+use Lotgd\Nav\SuperuserNav;
+use Lotgd\Output;
+use Lotgd\Page\Footer;
+use Lotgd\Page\Header;
+use Lotgd\Sanitize;
+use Lotgd\SuAccess;
+use Lotgd\Translator;
+
+// translator ready
+// addnews ready
+// mail ready
+
+if (!defined('DIAGNOSTICS_TEST')) {
+    require_once __DIR__ . "/common.php";
+}
+
+if (!isset($output)) {
+    $output = Output::getInstance();
+}
+
+Translator::getInstance()->setSchema("diagnostics");
+
+// Stricter than the other operational pages, which use SU_EDIT_CONFIG: this one
+// puts their contents plus IP addresses plus environment detail on one screen.
+SuAccess::check(SU_MEGAUSER);
+
+$hours = Diagnostics::normalizeHours(Http::get('hours'));
+$severity = Diagnostics::normalizeSeverity(Http::get('severity'));
+$severityParam = $severity === null ? '' : '&severity=' . urlencode($severity);
+
+Header::pageHeader("Diagnostics");
+SuperuserNav::render();
+
+/**
+ * Register every link this page offers.
+ *
+ * ForcedNavigation compares the incoming URI against the allowed list built by
+ * the previous render, so a window or filter that is not registered here sends
+ * the operator to badnav.php instead. The query strings must be built exactly
+ * as the links will request them.
+ */
+Nav::add("Operations");
+Nav::add("Refresh", "diagnostics.php?hours=$hours$severityParam");
+
+Nav::add("Time window");
+foreach (Diagnostics::WINDOWS as $windowOption) {
+    Nav::add(
+        Diagnostics::windowLabel($windowOption),
+        "diagnostics.php?hours=$windowOption$severityParam"
+    );
+}
+
+Nav::add("Severity");
+Nav::add("All severities", "diagnostics.php?hours=$hours");
+foreach ([GameLog::SEVERITY_INFO, GameLog::SEVERITY_WARNING, GameLog::SEVERITY_ERROR, GameLog::SEVERITY_DEBUG] as $severityOption) {
+    Nav::add(
+        "Severity: " . ucfirst($severityOption),
+        "diagnostics.php?hours=$hours&severity=" . urlencode($severityOption)
+    );
+}
+
+Nav::add("Related");
+Nav::add("Gamelog Viewer", "gamelog.php");
+Nav::add("Debug Analysis", "debug.php");
+Nav::add("View Log Files", "logviewer.php");
+
+Output::addHeadMarkup(
+    "<style>"
+    . ".diagnostics details{margin:0 0 6px 0;}"
+    . ".diagnostics summary{cursor:pointer;font-weight:bold;}"
+    . ".diagnostics table{margin-top:4px;}"
+    . "</style>"
+);
+
+/**
+ * Render a table of already-formatted rows.
+ *
+ * Every cell goes through outputNotl() without the privileged flag, so
+ * appoencode() escapes HTML while leaving the game's colour codes intact --
+ * the same treatment gamelog.php gives its messages.
+ *
+ * The function_exists guard is there because this page is pulled in with
+ * require by its tests.
+ */
+if (!function_exists('diagnosticsTable')) {
+    /**
+     * @param list<string>       $headers
+     * @param list<list<string>> $rows
+     */
+    function diagnosticsTable(array $headers, array $rows): void
+    {
+        $output = Output::getInstance();
+
+        if ($rows === []) {
+            $output->output("`7Nothing in this window.`0`n");
+
+            return;
+        }
+
+        $output->rawOutput("<table border='0' cellpadding='2' cellspacing='1'><tr class='trhead'>");
+        foreach ($headers as $header) {
+            $output->rawOutput("<td>");
+            $output->outputNotl($header);
+            $output->rawOutput("</td>");
+        }
+        $output->rawOutput("</tr>");
+
+        $alternate = true;
+        foreach ($rows as $row) {
+            $alternate = !$alternate;
+            $output->rawOutput("<tr class='" . ($alternate ? 'trdark' : 'trlight') . "'>");
+            foreach ($row as $cell) {
+                $output->rawOutput("<td valign='top'>");
+                $output->outputNotl($cell);
+                $output->rawOutput("</td>");
+            }
+            $output->rawOutput("</tr>");
+        }
+        $output->rawOutput("</table>");
+    }
+}
+
+if (!function_exists('diagnosticsStatusColour')) {
+    function diagnosticsStatusColour(string $status): string
+    {
+        return match ($status) {
+            'error' => '`4',
+            'warn' => '`$',
+            'unknown' => '`7',
+            default => '`@',
+        };
+    }
+}
+
+if (!function_exists('diagnosticsSeverityColour')) {
+    function diagnosticsSeverityColour(string $severity): string
+    {
+        return match ($severity) {
+            GameLog::SEVERITY_ERROR => '`4',
+            GameLog::SEVERITY_WARNING => '`$',
+            GameLog::SEVERITY_DEBUG => '`#',
+            default => '`@',
+        };
+    }
+}
+
+$diagnostics = new Diagnostics();
+$counts = $diagnostics->counts($hours);
+
+$output->rawOutput("<div class='diagnostics'>");
+$output->outputNotl(
+    "`n`b`&%s`0`b `7(%s)`0`n`n",
+    Diagnostics::windowLabel($hours),
+    $severity === null ? 'all severities' : 'severity: ' . $severity
+);
+
+// ---------------------------------------------------------------- snapshot --
+$output->outputNotl("`b`^Runtime`0`b`n");
+foreach ($diagnostics->runtime() as $group => $entries) {
+    $rows = [];
+    foreach ($entries as $entry) {
+        $rows[] = [
+            "`7" . Sanitize::sanitize($entry['label']) . "`0",
+            diagnosticsStatusColour($entry['status']) . Sanitize::sanitize($entry['value']) . "`0",
+        ];
+    }
+    $output->outputNotl("`n`b%s`b`n", Sanitize::sanitize((string) $group));
+    diagnosticsTable(['Item', 'Value'], $rows);
+}
+
+// ---------------------------------------------------------------- timeline --
+$timeline = $diagnostics->timeline($hours, Diagnostics::ROW_LIMIT);
+$output->outputNotl("`n`n`b`^Timeline`0`b `7(security events, warnings, errors and failed logins)`0`n");
+$timelineRows = [];
+foreach ($timeline as $event) {
+    $timelineRows[] = [
+        "`v" . Sanitize::sanitize($event['at']) . "`0",
+        diagnosticsSeverityColour($event['severity']) . strtoupper(Sanitize::sanitize($event['severity'])) . "`0",
+        "`7" . Sanitize::sanitize($event['source']) . '/' . Sanitize::sanitize($event['category']) . "`0",
+        Sanitize::sanitize($event['actor']),
+        Sanitize::sanitize($event['text']),
+    ];
+}
+diagnosticsTable(['When', 'Severity', 'Source', 'Who', 'What'], $timelineRows);
+
+// ----------------------------------------------------------------- gamelog --
+$gameLogRows = [];
+foreach ($diagnostics->gameLog($hours, $severity, Diagnostics::ROW_LIMIT) as $row) {
+    $rowSeverity = strtolower((string) ($row['severity'] ?? GameLog::SEVERITY_INFO));
+    $gameLogRows[] = [
+        "`v" . Sanitize::sanitize((string) $row['date']) . "`0",
+        diagnosticsSeverityColour($rowSeverity) . strtoupper(Sanitize::sanitize($rowSeverity)) . "`0",
+        "`7" . Sanitize::sanitize((string) $row['category']) . "`0",
+        ((int) ($row['who'] ?? 0) === 0) ? "`7System`0" : Sanitize::sanitize((string) ($row['name'] ?? '')),
+        Sanitize::sanitize((string) $row['message']),
+    ];
+}
+$output->rawOutput("<details open><summary>");
+$output->outputNotl(
+    "Game log `7(showing %s of %s)`0",
+    (string) count($gameLogRows),
+    (string) ($counts['gamelog'] ?? 0)
+);
+$output->rawOutput("</summary>");
+diagnosticsTable(['When', 'Severity', 'Category', 'Who', 'Message'], $gameLogRows);
+$output->rawOutput("</details>");
+
+// ----------------------------------------------------------------- faillog --
+$failLogRows = [];
+foreach ($diagnostics->failLog($hours, Diagnostics::ROW_LIMIT) as $row) {
+    $privileged = (int) ($row['superuser'] ?? 0) > 0;
+    $failLogRows[] = [
+        "`v" . Sanitize::sanitize((string) $row['date']) . "`0",
+        Sanitize::sanitize((string) ($row['ip'] ?? '')),
+        Sanitize::sanitize((string) ($row['login'] ?? '')),
+        Sanitize::sanitize((string) ($row['name'] ?? '')),
+        $privileged ? "`4yes`0" : "`7no`0",
+    ];
+}
+$output->rawOutput("<details><summary>");
+$output->outputNotl(
+    "Failed logins `7(showing %s of %s)`0",
+    (string) count($failLogRows),
+    (string) ($counts['faillog'] ?? 0)
+);
+$output->rawOutput("</summary>");
+diagnosticsTable(['When', 'IP', 'Login attempted', 'Account', 'Privileged'], $failLogRows);
+$output->output("`7The submitted form data is deliberately not read or shown: it contains the password that was tried.`0`n");
+$output->rawOutput("</details>");
+
+// ---------------------------------------------------------------- debuglog --
+$debugLogRows = [];
+foreach ($diagnostics->debugLog($hours, Diagnostics::ROW_LIMIT) as $row) {
+    $debugLogRows[] = [
+        "`v" . Sanitize::sanitize((string) $row['date']) . "`0",
+        Sanitize::sanitize((string) ($row['actorname'] ?? '')),
+        Sanitize::sanitize((string) ($row['targetname'] ?? '')),
+        "`7" . Sanitize::sanitize((string) ($row['field'] ?? '')) . "`0",
+        Sanitize::sanitize((string) ($row['value'] ?? '')),
+        Sanitize::sanitize((string) $row['message']),
+    ];
+}
+$output->rawOutput("<details><summary>");
+$output->outputNotl(
+    "Character audit trail `7(showing %s of %s)`0",
+    (string) count($debugLogRows),
+    (string) ($counts['debuglog'] ?? 0)
+);
+$output->rawOutput("</summary>");
+diagnosticsTable(['When', 'Actor', 'Target', 'Field', 'Value', 'Message'], $debugLogRows);
+$output->output("`7Entries with a field are consolidated per day: a later event updates the existing row and moves its timestamp forward, so a timestamp here is the most recent activity rather than the first.`0`n");
+$output->rawOutput("</details>");
+
+// --------------------------------------------------------------- profiling --
+$output->rawOutput("<details><summary>");
+$output->outputNotl("Runtimes `7(%s samples in window)`0", (string) ($counts['debug'] ?? 0));
+$output->rawOutput("</summary>");
+
+if (($counts['debug'] ?? 0) === 0) {
+    $output->output("`7No runtime samples. These are only collected while DEBUG mode is on.`0`n");
+} else {
+    foreach (['pagegentime' => 'Pages', 'hooktime' => 'Module hooks'] as $type => $label) {
+        $profileRows = [];
+        foreach ($diagnostics->profiling($hours, $type, 30) as $row) {
+            $profileRows[] = [
+                "`7" . Sanitize::sanitize((string) $row['category']) . "`0",
+                Sanitize::sanitize((string) $row['subcategory']),
+                (string) round((float) $row['total'], 3),
+                (string) round((float) $row['mean'], 4),
+                (string) (int) $row['hits'],
+            ];
+        }
+        $output->outputNotl("`n`b%s`b`n", $label);
+        diagnosticsTable(['Category', 'Name', 'Total s', 'Average s', 'Hits'], $profileRows);
+    }
+}
+$output->rawOutput("</details>");
+
+$output->rawOutput("</div>");
+
+Footer::pageFooter();

--- a/diagnostics.php
+++ b/diagnostics.php
@@ -83,9 +83,10 @@ Output::addHeadMarkup(
 /**
  * Render a table of already-formatted rows.
  *
- * Every cell goes through outputNotl() without the privileged flag, so
- * appoencode() escapes HTML while leaving the game's colour codes intact --
- * the same treatment gamelog.php gives its messages.
+ * Headers are source strings and are translated here in the `diagnostics`
+ * namespace; the cells are log data and go through outputNotl() without the
+ * privileged flag, so appoencode() escapes HTML while leaving the game's colour
+ * codes intact -- the same treatment gamelog.php gives its messages.
  *
  * The function_exists guard is there because this page is pulled in with
  * require by its tests.
@@ -108,7 +109,7 @@ if (!function_exists('diagnosticsTable')) {
         $output->rawOutput("<table border='0' cellpadding='2' cellspacing='1'><tr class='trhead'>");
         foreach ($headers as $header) {
             $output->rawOutput("<td>");
-            $output->outputNotl($header);
+            $output->outputNotl((string) Translator::translate($header, 'diagnostics'));
             $output->rawOutput("</td>");
         }
         $output->rawOutput("</tr>");
@@ -153,7 +154,7 @@ if (!function_exists('diagnosticsSeverityColour')) {
 }
 
 $diagnostics = new Diagnostics();
-$counts = $diagnostics->counts($hours);
+$counts = $diagnostics->counts($hours, $severity);
 
 $output->rawOutput("<div class='diagnostics'>");
 $output->outputNotl(
@@ -163,22 +164,44 @@ $output->outputNotl(
 );
 
 // ---------------------------------------------------------------- snapshot --
-$output->outputNotl("`b`^Runtime`0`b`n");
+$output->outputNotl("`b`^%s`0`b`n", (string) Translator::translate('Runtime', 'diagnostics'));
 foreach ($diagnostics->runtime() as $group => $entries) {
     $rows = [];
     foreach ($entries as $entry) {
+        // The class hands out source strings and their arguments rather than
+        // finished sentences, so the whole sentence stays one translatable unit
+        // instead of being concatenated around the data. A row marked as data
+        // (a version, a path, a number) is passed through untouched.
+        if ($entry['args'] !== []) {
+            // The page's schema is already `diagnostics` (set at the top), and
+            // sprintfTranslate() reads the active namespace -- its schema form
+            // takes a `true, '<schema>'` prefix, not a bare namespace argument.
+            $value = (string) Translator::sprintfTranslate(
+                $entry['value'],
+                ...array_map(static fn ($arg): string => Sanitize::sanitize((string) $arg), $entry['args'])
+            );
+        } elseif ($entry['translate']) {
+            $value = (string) Translator::translate($entry['value'], 'diagnostics');
+        } else {
+            $value = Sanitize::sanitize($entry['value']);
+        }
+
         $rows[] = [
-            "`7" . Sanitize::sanitize($entry['label']) . "`0",
-            diagnosticsStatusColour($entry['status']) . Sanitize::sanitize($entry['value']) . "`0",
+            "`7" . Sanitize::sanitize((string) Translator::translate($entry['label'], 'diagnostics')) . "`0",
+            diagnosticsStatusColour($entry['status']) . Sanitize::sanitize($value) . "`0",
         ];
     }
-    $output->outputNotl("`n`b%s`b`n", Sanitize::sanitize((string) $group));
+    $output->outputNotl("`n`b%s`b`n", Sanitize::sanitize((string) Translator::translate((string) $group, 'diagnostics')));
     diagnosticsTable(['Item', 'Value'], $rows);
 }
 
 // ---------------------------------------------------------------- timeline --
 $timeline = $diagnostics->timeline($hours, Diagnostics::ROW_LIMIT);
-$output->outputNotl("`n`n`b`^Timeline`0`b `7(security events, warnings, errors and failed logins)`0`n");
+$output->outputNotl(
+    "`n`n`b`^%s`0`b `7(%s)`0`n",
+    (string) Translator::translate('Timeline', 'diagnostics'),
+    (string) Translator::translate('security events, warnings, errors and failed logins', 'diagnostics')
+);
 $timelineRows = [];
 foreach ($timeline as $event) {
     $timelineRows[] = [
@@ -205,9 +228,11 @@ foreach ($diagnostics->gameLog($hours, $severity, Diagnostics::ROW_LIMIT) as $ro
 }
 $output->rawOutput("<details open><summary>");
 $output->outputNotl(
-    "Game log `7(showing %s of %s)`0",
-    (string) count($gameLogRows),
-    (string) ($counts['gamelog'] ?? 0)
+    (string) Translator::sprintfTranslate(
+        'Game log `7(showing %s of %s)`0',
+        (string) count($gameLogRows),
+        (string) ($counts['gamelog'] ?? 0)
+    )
 );
 $output->rawOutput("</summary>");
 diagnosticsTable(['When', 'Severity', 'Category', 'Who', 'Message'], $gameLogRows);
@@ -227,9 +252,11 @@ foreach ($diagnostics->failLog($hours, Diagnostics::ROW_LIMIT) as $row) {
 }
 $output->rawOutput("<details><summary>");
 $output->outputNotl(
-    "Failed logins `7(showing %s of %s)`0",
-    (string) count($failLogRows),
-    (string) ($counts['faillog'] ?? 0)
+    (string) Translator::sprintfTranslate(
+        'Failed logins `7(showing %s of %s)`0',
+        (string) count($failLogRows),
+        (string) ($counts['faillog'] ?? 0)
+    )
 );
 $output->rawOutput("</summary>");
 diagnosticsTable(['When', 'IP', 'Login attempted', 'Account', 'Privileged'], $failLogRows);
@@ -250,9 +277,11 @@ foreach ($diagnostics->debugLog($hours, Diagnostics::ROW_LIMIT) as $row) {
 }
 $output->rawOutput("<details><summary>");
 $output->outputNotl(
-    "Character audit trail `7(showing %s of %s)`0",
-    (string) count($debugLogRows),
-    (string) ($counts['debuglog'] ?? 0)
+    (string) Translator::sprintfTranslate(
+        'Character audit trail `7(showing %s of %s)`0',
+        (string) count($debugLogRows),
+        (string) ($counts['debuglog'] ?? 0)
+    )
 );
 $output->rawOutput("</summary>");
 diagnosticsTable(['When', 'Actor', 'Target', 'Field', 'Value', 'Message'], $debugLogRows);
@@ -261,7 +290,12 @@ $output->rawOutput("</details>");
 
 // --------------------------------------------------------------- profiling --
 $output->rawOutput("<details><summary>");
-$output->outputNotl("Runtimes `7(%s samples in window)`0", (string) ($counts['debug'] ?? 0));
+$output->outputNotl(
+    (string) Translator::sprintfTranslate(
+        'Runtimes `7(%s samples in window)`0',
+        (string) ($counts['debug'] ?? 0)
+    )
+);
 $output->rawOutput("</summary>");
 
 if (($counts['debug'] ?? 0) === 0) {
@@ -278,7 +312,7 @@ if (($counts['debug'] ?? 0) === 0) {
                 (string) (int) $row['hits'],
             ];
         }
-        $output->outputNotl("`n`b%s`b`n", $label);
+        $output->outputNotl("`n`b%s`b`n", (string) Translator::translate($label, 'diagnostics'));
         diagnosticsTable(['Category', 'Name', 'Total s', 'Average s', 'Hits'], $profileRows);
     }
 }

--- a/docs/AdminGuide.md
+++ b/docs/AdminGuide.md
@@ -95,10 +95,12 @@ It is strictly read-only: it changes nothing, offers no buttons, and does not re
 a time window from the navigation (one hour up to thirty days, twenty-four hours by default) and
 the page shows:
 
-- a **runtime snapshot** — game and schema version and whether they agree, PHP and database
-  versions, missing PHP extensions, how many players are online, when the last new day and the
-  last maintenance run happened, the configured retention for each log, and whether `debug` mode
-  or `show_error_details` is switched on;
+- a **runtime snapshot** — game and schema version, PHP and database versions, missing PHP
+  extensions, how many players are online, when the last new day and the last maintenance run
+  happened, the configured retention for each log, and whether `debug` mode or
+  `show_error_details` is switched on. The two versions are reference information rather than a
+  check: when they differ the game serves "Upgrade Needed" instead of any page, so reaching this
+  one already means they match;
 - a **timeline** merging the events worth noticing across sources: security events, anything
   logged as a warning or an error, and failed logins;
 - **collapsible sections** per source with the detail — game log, failed logins, the character

--- a/docs/AdminGuide.md
+++ b/docs/AdminGuide.md
@@ -67,7 +67,10 @@ The game keeps several logs, and which one to open depends on what you are looki
 | **PHP error log** | Technical faults, plus a copy of every security event. On Docker this is the container log (`docker compose logs web`). | Container/web server log |
 | **`logs/bootstrap.log`** | Failures too early for the game to handle them — a broken `common.php`, a cron that could not start. | `logviewer.php` |
 | **`debug` table** | Page and hook runtimes, collected only while the `debug` setting is on. | `debug.php` |
-| **`faillog` table** | Every failed login attempt, kept for `expirefaillog` days. Individual attempts are also written to the PHP error log; the automatic ban that follows repeated failures is copied into the Game Log's `security` category, which is the one to watch. | — |
+| **`faillog` table** | Every failed login attempt, kept for `expirefaillog` days. Individual attempts are also written to the PHP error log; the automatic ban that follows repeated failures is copied into the Game Log's `security` category, which is the one to watch. | `diagnostics.php` |
+
+All of the above, for a chosen time window, are also pulled together on one screen by
+**`diagnostics.php`** — see below.
 
 Security events appear in **both** the Game Log and the PHP error log, and both carry the same
 `diag=` correlation id, so a line in the container log can be matched to the row an administrator
@@ -80,6 +83,38 @@ automatic ban that follows repeated failures, not each guess.
 > nothing more. To show error messages, file paths and backtraces to visitors who are not
 > megausers you must enable `show_error_details` separately, and you should leave it off on a live
 > server.
+
+## The diagnostics page
+
+`diagnostics.php`, reachable from the Superuser Grotto under **Diagnostics**, answers "is
+everything still running?" on one screen. It requires `SU_MEGAUSER` — stricter than the other
+operational pages, because it puts their contents together with IP addresses and environment
+detail in one place.
+
+It is strictly read-only: it changes nothing, offers no buttons, and does not refresh itself. Pick
+a time window from the navigation (one hour up to thirty days, twenty-four hours by default) and
+the page shows:
+
+- a **runtime snapshot** — game and schema version and whether they agree, PHP and database
+  versions, missing PHP extensions, how many players are online, when the last new day and the
+  last maintenance run happened, the configured retention for each log, and whether `debug` mode
+  or `show_error_details` is switched on;
+- a **timeline** merging the events worth noticing across sources: security events, anything
+  logged as a warning or an error, and failed logins;
+- **collapsible sections** per source with the detail — game log, failed logins, the character
+  audit trail (read from both `debuglog` and `debuglog_archive`, because the new day routine moves
+  the live table into the archive), and the collected runtimes.
+
+Two things it deliberately does **not** show:
+
+- **The submitted form data of a failed login.** The `faillog` table stores the whole POST body,
+  which contains the password that was tried. That column is never read.
+- **The PHP error log itself.** In the Docker image `error_log` points at `/dev/stderr`, which is
+  write-only, so nothing in PHP can read it back. The page names the destination and tells you
+  where to look instead. This is why the async diagnostics (`Jaxon csrf`, rate-limit and
+  bad-request lines) and individual failed-login records do not appear there: use
+  `docker compose logs web`. Failed logins are still visible on the page through the `faillog`
+  table.
 
 > ⚠️ **Security reminder:** `cron.php` must never be reachable over HTTP. Depending on the
 > `register_argc_argv` setting, a web request can supply the execution bitmask through the query

--- a/src/Lotgd/Diagnostics.php
+++ b/src/Lotgd/Diagnostics.php
@@ -244,14 +244,13 @@ class Diagnostics
      *
      * @return array<string,int>
      */
-    public function counts(int $hours): array
+    public function counts(int $hours, ?string $severity = null): array
     {
         $since = self::since($hours);
         $connection = Database::getDoctrineConnection();
         $counts = [];
 
         $sources = [
-            'gamelog' => [Database::prefix('gamelog'), 'date'],
             'faillog' => [Database::prefix('faillog'), 'date'],
             'debug' => [Database::prefix('debug'), 'date'],
         ];
@@ -259,6 +258,33 @@ class Diagnostics
         foreach ($sources as $key => [$table, $column]) {
             $counts[$key] = (int) $connection->fetchOne(
                 "SELECT COUNT(*) FROM {$table} WHERE {$column} > :since",
+                ['since' => $since],
+                ['since' => ParameterType::STRING]
+            );
+        }
+
+        // The game log count carries the same severity filter as the listing,
+        // or the section reads "showing 5 of 1000" when only five rows match.
+        $gamelog = Database::prefix('gamelog');
+        $params = ['since' => $since];
+        $types = ['since' => ParameterType::STRING];
+        $severityClause = '';
+        if ($severity !== null) {
+            $severityClause = ' AND severity = :severity';
+            $params['severity'] = $severity;
+            $types['severity'] = ParameterType::STRING;
+        }
+
+        try {
+            $counts['gamelog'] = (int) $connection->fetchOne(
+                "SELECT COUNT(*) FROM {$gamelog} WHERE date > :since" . $severityClause,
+                $params,
+                $types
+            );
+        } catch (\Throwable $exception) {
+            // No severity column: the unfiltered count is the only one available.
+            $counts['gamelog'] = (int) $connection->fetchOne(
+                "SELECT COUNT(*) FROM {$gamelog} WHERE date > :since",
                 ['since' => $since],
                 ['since' => ParameterType::STRING]
             );
@@ -280,6 +306,63 @@ class Diagnostics
     }
 
     /**
+     * Game log entries worth putting on the timeline, newest first.
+     *
+     * The restriction has to be in the statement rather than applied to the
+     * rows afterwards. Ordinary bookkeeping is the bulk of this table -- the
+     * comment cleanup alone writes nine maintenance rows per run, and every
+     * settings change and module install adds one -- so a plain "newest N"
+     * query followed by a filter in PHP drops every warning, error and security
+     * event behind the first N routine rows. On a busy server that is all of
+     * them, which is exactly what this timeline exists to prevent.
+     *
+     * @return list<array<string,mixed>>
+     */
+    private function notableGameLog(int $hours, int $limit): array
+    {
+        $gamelog = Database::prefix('gamelog');
+        $accounts = Database::prefix('accounts');
+        $since = self::since($hours);
+        $columns = "g.logid, g.date, g.category, g.severity, g.message, g.who, a.name AS name";
+        $from = " FROM {$gamelog} g LEFT JOIN {$accounts} a ON g.who = a.acctid";
+
+        $sql = "SELECT {$columns}" . $from
+            . " WHERE g.date > :since"
+            . " AND (g.category = :security OR g.severity IN (:warning, :error))"
+            . " ORDER BY g.date DESC LIMIT " . $this->cap($limit);
+
+        try {
+            return Database::getDoctrineConnection()->fetchAllAssociative(
+                $sql,
+                [
+                    'since' => $since,
+                    'security' => GameLog::CATEGORY_SECURITY,
+                    'warning' => GameLog::SEVERITY_WARNING,
+                    'error' => GameLog::SEVERITY_ERROR,
+                ],
+                [
+                    'since' => ParameterType::STRING,
+                    'security' => ParameterType::STRING,
+                    'warning' => ParameterType::STRING,
+                    'error' => ParameterType::STRING,
+                ]
+            );
+        } catch (\Throwable $exception) {
+            // Without the severity column the timeline can only be built from
+            // the security category. Narrower, but honest and not fatal.
+            $fallback = "SELECT g.logid, g.date, g.category, g.message, g.who, a.name AS name" . $from
+                . " WHERE g.date > :since AND g.category = :security"
+                . " ORDER BY g.date DESC LIMIT " . $this->cap($limit);
+
+            return Database::getDoctrineConnection()->fetchAllAssociative(
+                $fallback,
+                ['since' => $since, 'security' => GameLog::CATEGORY_SECURITY],
+                ['since' => ParameterType::STRING, 'security' => ParameterType::STRING]
+            );
+        }
+    }
+
+    /**
      * One chronological stream of the events worth noticing.
      *
      * Fed by exactly two sources: game log entries that are security events or
@@ -293,15 +376,9 @@ class Diagnostics
     {
         $events = [];
 
-        foreach ($this->gameLog($hours, null, $limit) as $row) {
+        foreach ($this->notableGameLog($hours, $limit) as $row) {
             $severity = strtolower((string) ($row['severity'] ?? GameLog::SEVERITY_INFO));
             $category = (string) ($row['category'] ?? '');
-            $isSecurity = $category === GameLog::CATEGORY_SECURITY;
-            $isTrouble = in_array($severity, [GameLog::SEVERITY_WARNING, GameLog::SEVERITY_ERROR], true);
-
-            if (! $isSecurity && ! $isTrouble) {
-                continue;
-            }
 
             $events[] = [
                 'at' => (string) $row['date'],
@@ -347,7 +424,7 @@ class Diagnostics
      * only job is to describe the current state is a poor place for that to
      * happen.
      *
-     * @return array<string,list<array{label:string,value:string,status:string}>>
+     * @return array<string,list<array{label:string,value:string,args:list<string|int>,translate:bool,status:string}>>
      */
     public function runtime(): array
     {
@@ -364,25 +441,30 @@ class Diagnostics
     /**
      * @param array<string,mixed> $settings
      *
-     * @return list<array{label:string,value:string,status:string}>
+     * @return list<array{label:string,value:string,args:list<string|int>,translate:bool,status:string}>
      */
     private function versionRows(array $settings): array
     {
         $code = Page::getInstance()->getLogdVersion();
         $schema = (string) ($settings['installer_version'] ?? '');
         $rows = [
-            $this->row('Game version', $code),
+            $this->row('Game version', $code, 'ok', [], false),
+            // Reference only, deliberately without a warning state. When the two
+            // disagree, common.php:484 renders "Upgrade Needed" and its footer
+            // calls exit(), so this page is never reached -- a mismatch cannot be
+            // reported from here, and pretending otherwise would advertise a
+            // check that cannot fire.
+            $schema === ''
+                ? $this->row('Schema version', 'unknown')
+                : $this->row('Schema version', $schema, 'ok', [], false),
             $this->row(
-                'Schema version',
-                $schema === '' ? 'unknown' : $schema,
-                // A mismatch is a finding in itself: common.php diverts to the
-                // installer when these disagree.
-                ($schema !== '' && $schema === $code) ? 'ok' : 'warn'
+                'Version check',
+                'the game refuses to start while these differ, so reaching this page means they match'
             ),
         ];
 
         try {
-            $rows[] = $this->row('Database server', Database::getServerVersion());
+            $rows[] = $this->row('Database server', Database::getServerVersion(), 'ok', [], false);
         } catch (\Throwable $exception) {
             $rows[] = $this->row('Database server', 'unknown', 'unknown');
         }
@@ -390,7 +472,7 @@ class Diagnostics
         // Read the cache the core news page fills; never trigger a fetch here.
         $release = DataCache::getInstance()->datacache('github_release_latest', 86400);
         if (is_array($release) && isset($release['tag_name'])) {
-            $rows[] = $this->row('Latest upstream release', (string) $release['tag_name']);
+            $rows[] = $this->row('Latest upstream release', (string) $release['tag_name'], 'ok', [], false);
         } else {
             $rows[] = $this->row('Latest upstream release', 'not cached', 'unknown');
         }
@@ -399,7 +481,7 @@ class Diagnostics
     }
 
     /**
-     * @return list<array{label:string,value:string,status:string}>
+     * @return list<array{label:string,value:string,args:list<string|int>,translate:bool,status:string}>
      */
     private function environmentRows(): array
     {
@@ -411,21 +493,19 @@ class Diagnostics
         }
 
         return [
-            $this->row('PHP version', PHP_VERSION),
-            $this->row(
-                'Missing extensions',
-                $missing === [] ? 'none' : implode(', ', $missing),
-                $missing === [] ? 'ok' : 'error'
-            ),
-            $this->row('memory_limit', (string) ini_get('memory_limit')),
-            $this->row('max_execution_time', (string) ini_get('max_execution_time')),
+            $this->row('PHP version', PHP_VERSION, 'ok', [], false),
+            $missing === []
+                ? $this->row('Missing extensions', 'none')
+                : $this->row('Missing extensions', implode(', ', $missing), 'error', [], false),
+            $this->row('memory_limit', (string) ini_get('memory_limit'), 'ok', [], false),
+            $this->row('max_execution_time', (string) ini_get('max_execution_time'), 'ok', [], false),
         ];
     }
 
     /**
      * @param array<string,mixed> $settings
      *
-     * @return list<array{label:string,value:string,status:string}>
+     * @return list<array{label:string,value:string,args:list<string|int>,translate:bool,status:string}>
      */
     private function maintenanceRows(array $settings): array
     {
@@ -434,15 +514,16 @@ class Diagnostics
         $online = (int) ($settings['OnlineCount'] ?? 0);
         $onlineLast = (int) ($settings['OnlineCountLast'] ?? 0);
         $maxOnline = (int) ($settings['maxonline'] ?? 0);
-        $rows[] = $this->row(
-            'Players online',
-            sprintf(
-                '%d%s (%s)',
-                $online,
-                $maxOnline > 0 ? ' of ' . $maxOnline : '',
-                $onlineLast > 0 ? $this->ageLabel(time() - $onlineLast) . ' old' : 'never counted'
-            )
-        );
+        if ($onlineLast <= 0) {
+            $rows[] = $maxOnline > 0
+                ? $this->row('Players online', '%s of %s, never counted', 'ok', [$online, $maxOnline])
+                : $this->row('Players online', '%s, never counted', 'ok', [$online]);
+        } else {
+            $age = $this->ageLabel(time() - $onlineLast);
+            $rows[] = $maxOnline > 0
+                ? $this->row('Players online', '%s of %s, counted %s ago', 'ok', [$online, $maxOnline, $age])
+                : $this->row('Players online', '%s, counted %s ago', 'ok', [$online, $age]);
+        }
 
         // Written before the work runs, and also bumped by a player-triggered
         // new day, so it only means "cron ran" when newdaycron is on. It is
@@ -453,12 +534,20 @@ class Diagnostics
             $rows[] = $this->row('Last new day', 'never', 'warn');
         } else {
             $age = time() - (int) strtotime($semaphore . ' +0000');
-            $rows[] = $this->row(
-                'Last new day',
-                $semaphore . ' UTC (' . $this->ageLabel($age) . ' ago)'
-                    . ($cronEnabled ? '' : ' -- newdaycron is off, so this may be player-triggered'),
-                $age > 26 * 3600 ? 'warn' : 'ok'
-            );
+            $status = $age > 26 * 3600 ? 'warn' : 'ok';
+            $rows[] = $cronEnabled
+                ? $this->row(
+                    'Last new day',
+                    '%s UTC, %s ago',
+                    $status,
+                    [$semaphore, $this->ageLabel($age)]
+                )
+                : $this->row(
+                    'Last new day',
+                    '%s UTC, %s ago; newdaycron is off, so this may be player-triggered',
+                    $status,
+                    [$semaphore, $this->ageLabel($age)]
+                );
         }
 
         // The better completion signal: these rows are written after the work,
@@ -470,8 +559,9 @@ class Diagnostics
             $age = time() - (int) strtotime($lastMaintenance);
             $rows[] = $this->row(
                 'Last maintenance run',
-                $lastMaintenance . ' (' . $this->ageLabel($age) . ' ago)',
-                $age > 26 * 3600 ? 'warn' : 'ok'
+                '%s, %s ago',
+                $age > 26 * 3600 ? 'warn' : 'ok',
+                [$lastMaintenance, $this->ageLabel($age)]
             );
         }
 
@@ -481,52 +571,79 @@ class Diagnostics
     /**
      * @param array<string,mixed> $settings
      *
-     * @return list<array{label:string,value:string,status:string}>
+     * @return list<array{label:string,value:string,args:list<string|int>,translate:bool,status:string}>
      */
     private function loggingRows(array $settings): array
     {
         $target = (string) ini_get('error_log');
         $readable = $target !== '' && is_file($target) && is_readable($target);
         $rows = [
-            $this->row(
-                'PHP error log',
-                $target === ''
-                    ? 'the web server log'
-                    : $target . ($readable ? '' : ' -- not readable from PHP, use the container log'),
-                $readable ? 'ok' : 'unknown'
-            ),
+            $this->errorLogRow($target, $readable),
         ];
 
         $debugMode = (int) ($settings['debug'] ?? 0) === 1;
-        $rows[] = $this->row(
-            'DEBUG mode',
-            $debugMode ? 'on -- runtimes are being collected' : 'off -- no runtimes are collected',
-            $debugMode ? 'warn' : 'ok'
-        );
+        $rows[] = $debugMode
+            ? $this->row('DEBUG mode', 'on; runtimes are being collected', 'warn')
+            : $this->row('DEBUG mode', 'off; no runtimes are collected');
 
         // The one setting on this page that is a live risk rather than a fact.
         $detailsPublic = (int) ($settings['show_error_details'] ?? 0) === 1;
-        $rows[] = $this->row(
-            'Public error details',
-            $detailsPublic
-                ? 'ON -- every visitor sees messages, paths and backtraces'
-                : 'off',
-            $detailsPublic ? 'error' : 'ok'
-        );
+        $rows[] = $detailsPublic
+            ? $this->row(
+                'Public error details',
+                'ON; every visitor sees messages, paths and backtraces',
+                'error'
+            )
+            : $this->row('Public error details', 'off');
 
         foreach (
             [
-                'expiregamelog' => 'Game log retention',
-                'expiredebuglog' => 'Debug log retention',
-                'expirefaillog' => 'Fail log retention',
-                'expiredebug' => 'DEBUG runtime retention',
-            ] as $key => $label
+                'expiregamelog' => ['Game log retention', 30],
+                'expiredebuglog' => ['Debug log retention', 18],
+                'expirefaillog' => ['Fail log retention', 1],
+                'expiredebug' => ['DEBUG runtime retention', 7],
+            ] as $key => [$label, $default]
         ) {
-            $days = (int) ($settings[$key] ?? 0);
-            $rows[] = $this->row($label, $days > 0 ? $days . ' days' : 'kept indefinitely');
+            // The defaults mirror the ones Newday passes to getSetting() when it
+            // cleans up (Newday.php:87-89, 143-144, 188-189, 206-207). A key that
+            // has not been materialised yet is still governed by them, so
+            // reporting "indefinitely" would describe a retention that is not the
+            // one in force. Read here without persisting; the pages that use a
+            // setting are where a default belongs in the table.
+            $days = (int) ($settings[$key] ?? $default);
+            $rows[] = $days > 0
+                ? $this->row($label, '%s days', 'ok', [$days])
+                : $this->row($label, 'kept indefinitely');
         }
 
         return $rows;
+    }
+
+    /**
+     * Where PHP's error log goes, and whether this page could read it.
+     *
+     * In the container image the destination is /dev/stderr, which is
+     * write-only, so the honest answer is the destination plus where to look
+     * instead -- not an attempt to open it.
+     *
+     * @return array{label:string,value:string,args:list<string|int>,translate:bool,status:string}
+     */
+    private function errorLogRow(string $target, bool $readable): array
+    {
+        if ($target === '') {
+            return $this->row('PHP error log', 'the web server log', 'unknown');
+        }
+
+        if ($readable) {
+            return $this->row('PHP error log', '%s', 'ok', [$target]);
+        }
+
+        return $this->row(
+            'PHP error log',
+            '%s; not readable from PHP, use the container log',
+            'unknown',
+            [$target]
+        );
     }
 
     /**
@@ -600,9 +717,36 @@ class Diagnostics
     /**
      * @return array{label:string,value:string,status:string}
      */
-    private function row(string $label, string $value, string $status = 'ok'): array
-    {
-        return ['label' => $label, 'value' => $value, 'status' => $status];
+    /**
+     * Build one snapshot row.
+     *
+     * The label and the value are source strings for the translator, not
+     * finished output: the page translates them in the `diagnostics` namespace
+     * before rendering. Anything that varies -- a version, a count, a path, a
+     * timestamp -- goes into `args` as a positional `%s` so the sentence stays
+     * one translatable unit instead of being concatenated around the data.
+     *
+     * `translate: false` marks a value that is pure data and has no business in
+     * the translation table.
+     *
+     * @param list<string|int> $args
+     *
+     * @return array{label:string,value:string,args:list<string|int>,translate:bool,status:string}
+     */
+    private function row(
+        string $label,
+        string $value,
+        string $status = 'ok',
+        array $args = [],
+        bool $translate = true
+    ): array {
+        return [
+            'label' => $label,
+            'value' => $value,
+            'args' => $args,
+            'translate' => $translate,
+            'status' => $status,
+        ];
     }
 
     /**

--- a/src/Lotgd/Diagnostics.php
+++ b/src/Lotgd/Diagnostics.php
@@ -1,0 +1,628 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Read side of the log subsystem, for the megauser diagnostics page.
+ *
+ * Every log in this game already has a writer, and since the logging
+ * consolidation each kind of message has one place it belongs. Reading them
+ * back was still spread over five pages, and three sources had no reader at
+ * all: the faillog table, the server's runtime state, and the question of
+ * whether the code and the schema are the same version.
+ *
+ * This class answers "is everything still running?" from the sources that can
+ * actually be read. It is deliberately read-only: nothing here writes, and
+ * {@see self::runtime()} goes out of its way to keep it that way.
+ */
+
+namespace Lotgd;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\ParameterType;
+use Lotgd\MySQL\Database;
+
+class Diagnostics
+{
+    /** Time windows the page offers, in hours. */
+    public const WINDOWS = [1, 6, 24, 72, 168, 720];
+
+    public const DEFAULT_HOURS = 24;
+
+    /** Per-source row cap, so one page view cannot run away on a busy server. */
+    public const ROW_LIMIT = 200;
+
+    /**
+     * Extensions the runtime is expected to carry.
+     *
+     * Mirrors the list the container readiness probe checks
+     * ({@see docker/health/ready.php}); that file lives outside the autoloaded
+     * tree, so the list is repeated rather than imported.
+     *
+     * @var list<string>
+     */
+    private const EXPECTED_EXTENSIONS = ['gd', 'mbstring', 'mysqli', 'Zend OPcache', 'pdo', 'pdo_mysql', 'zip'];
+
+    /**
+     * Clamp a requested window to one this page offers.
+     *
+     * This is the input validation boundary for the whole page: anything that
+     * is not exactly one of the offered windows becomes the default, so no
+     * caller-supplied value ever reaches a query as anything but a bound
+     * timestamp derived from here.
+     */
+    public static function normalizeHours(mixed $raw): int
+    {
+        if (! is_scalar($raw)) {
+            return self::DEFAULT_HOURS;
+        }
+
+        $hours = (int) $raw;
+
+        return in_array($hours, self::WINDOWS, true) ? $hours : self::DEFAULT_HOURS;
+    }
+
+    /**
+     * Clamp a requested severity to the game log's vocabulary, or null for "all".
+     */
+    public static function normalizeSeverity(mixed $raw): ?string
+    {
+        if (! is_string($raw) || $raw === '') {
+            return null;
+        }
+
+        $severity = strtolower($raw);
+        $allowed = [
+            GameLog::SEVERITY_INFO,
+            GameLog::SEVERITY_WARNING,
+            GameLog::SEVERITY_ERROR,
+            GameLog::SEVERITY_DEBUG,
+        ];
+
+        return in_array($severity, $allowed, true) ? $severity : null;
+    }
+
+    /**
+     * Start of the window as a comparable timestamp.
+     */
+    public static function since(int $hours): string
+    {
+        return date('Y-m-d H:i:s', strtotime('-' . self::normalizeHours($hours) . ' hours'));
+    }
+
+    /**
+     * Human label for a window, for navigation entries and headings.
+     */
+    public static function windowLabel(int $hours): string
+    {
+        return match ($hours) {
+            1 => 'Last hour',
+            6 => 'Last 6 hours',
+            24 => 'Last 24 hours',
+            72 => 'Last 3 days',
+            168 => 'Last 7 days',
+            720 => 'Last 30 days',
+            default => sprintf('Last %d hours', $hours),
+        };
+    }
+
+    /**
+     * Game log entries in the window, newest first.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function gameLog(int $hours, ?string $severity, int $limit): array
+    {
+        $gamelog = Database::prefix('gamelog');
+        $accounts = Database::prefix('accounts');
+        $params = ['since' => self::since($hours)];
+        $types = ['since' => ParameterType::STRING];
+
+        $severityClause = '';
+        if ($severity !== null) {
+            $severityClause = ' AND g.severity = :severity';
+            $params['severity'] = $severity;
+            $types['severity'] = ParameterType::STRING;
+        }
+
+        $sql = "SELECT g.logid, g.date, g.category, g.severity, g.message, g.who, a.name AS name"
+            . " FROM {$gamelog} g LEFT JOIN {$accounts} a ON g.who = a.acctid"
+            . " WHERE g.date > :since" . $severityClause
+            . " ORDER BY g.date DESC LIMIT " . $this->cap($limit);
+
+        try {
+            return Database::getDoctrineConnection()->fetchAllAssociative($sql, $params, $types);
+        } catch (\Throwable $exception) {
+            // `severity` arrived with a migration, and every query above names
+            // it -- in the SELECT list even when no filter was asked for. An
+            // installation that has not run that migration must still get a
+            // usable page rather than a fatal, so fall back to the shape that
+            // predates the column, whether or not a filter was requested.
+            $fallback = "SELECT g.logid, g.date, g.category, g.message, g.who, a.name AS name"
+                . " FROM {$gamelog} g LEFT JOIN {$accounts} a ON g.who = a.acctid"
+                . " WHERE g.date > :since"
+                . " ORDER BY g.date DESC LIMIT " . $this->cap($limit);
+
+            return Database::getDoctrineConnection()->fetchAllAssociative(
+                $fallback,
+                ['since' => $params['since']],
+                ['since' => ParameterType::STRING]
+            );
+        }
+    }
+
+    /**
+     * Character audit entries in the window, across both debug log tables.
+     *
+     * The new day routine moves the entire contents of `debuglog` into
+     * `debuglog_archive` every time it runs, with a cutoff of "now". Reading
+     * only the live table would therefore lose everything written before the
+     * last new day, which for a 24 hour window is most of it.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function debugLog(int $hours, int $limit): array
+    {
+        $live = Database::prefix('debuglog');
+        $archive = Database::prefix('debuglog_archive');
+        $since = self::since($hours);
+
+        // Two placeholder names for one value: a repeated named placeholder is
+        // not safe with PDO unless emulated prepares are on.
+        $sql = "SELECT id, date, actor, target, message, field, value, 'live' AS origin"
+            . " FROM {$live} WHERE date > :since_live"
+            . " UNION ALL"
+            . " SELECT id, date, actor, target, message, field, value, 'archive' AS origin"
+            . " FROM {$archive} WHERE date > :since_archive"
+            . " ORDER BY date DESC LIMIT " . $this->cap($limit);
+
+        $rows = Database::getDoctrineConnection()->fetchAllAssociative(
+            $sql,
+            ['since_live' => $since, 'since_archive' => $since],
+            ['since_live' => ParameterType::STRING, 'since_archive' => ParameterType::STRING]
+        );
+
+        return $this->attachAccountNames($rows, ['actor', 'target']);
+    }
+
+    /**
+     * Failed login attempts in the window.
+     *
+     * The column list is explicit and `post` is not in it, deliberately: that
+     * column holds a serialize() of the whole POST body of a failed login, so
+     * it contains submitted passwords. It is never selected, never rendered and
+     * never passed on -- not even to a megauser. DiagnosticsFaillogPostRegressionTest
+     * holds that line.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function failLog(int $hours, int $limit): array
+    {
+        $faillog = Database::prefix('faillog');
+        $accounts = Database::prefix('accounts');
+
+        $sql = "SELECT f.eventid, f.date, f.ip, f.acctid, a.name AS name, a.login AS login, a.superuser AS superuser"
+            . " FROM {$faillog} f LEFT JOIN {$accounts} a ON f.acctid = a.acctid"
+            . " WHERE f.date > :since"
+            . " ORDER BY f.date DESC LIMIT " . $this->cap($limit);
+
+        return Database::getDoctrineConnection()->fetchAllAssociative(
+            $sql,
+            ['since' => self::since($hours)],
+            ['since' => ParameterType::STRING]
+        );
+    }
+
+    /**
+     * Aggregated runtime samples from the profiling table.
+     *
+     * @param string $type Either `pagegentime` or `hooktime`.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function profiling(int $hours, string $type, int $limit): array
+    {
+        $debug = Database::prefix('debug');
+
+        // ORDER BY is a constant here on purpose: debug.php interpolates a
+        // request value into its ORDER BY, and that is not a pattern to copy.
+        $sql = "SELECT type, category, subcategory, COUNT(id) AS hits,"
+            . " SUM(value + 0) AS total, AVG(value + 0) AS mean"
+            . " FROM {$debug} WHERE date > :since AND type = :type"
+            . " GROUP BY type, category, subcategory"
+            . " ORDER BY total DESC LIMIT " . $this->cap($limit);
+
+        return Database::getDoctrineConnection()->fetchAllAssociative(
+            $sql,
+            ['since' => self::since($hours), 'type' => $type],
+            ['since' => ParameterType::STRING, 'type' => ParameterType::STRING]
+        );
+    }
+
+    /**
+     * Row counts per source, so the page can say "showing 200 of 4312".
+     *
+     * @return array<string,int>
+     */
+    public function counts(int $hours): array
+    {
+        $since = self::since($hours);
+        $connection = Database::getDoctrineConnection();
+        $counts = [];
+
+        $sources = [
+            'gamelog' => [Database::prefix('gamelog'), 'date'],
+            'faillog' => [Database::prefix('faillog'), 'date'],
+            'debug' => [Database::prefix('debug'), 'date'],
+        ];
+
+        foreach ($sources as $key => [$table, $column]) {
+            $counts[$key] = (int) $connection->fetchOne(
+                "SELECT COUNT(*) FROM {$table} WHERE {$column} > :since",
+                ['since' => $since],
+                ['since' => ParameterType::STRING]
+            );
+        }
+
+        // Both halves of the character audit trail, for the same reason the
+        // reader above reads both.
+        $counts['debuglog'] = (int) $connection->fetchOne(
+            'SELECT COUNT(*) FROM ' . Database::prefix('debuglog') . ' WHERE date > :since',
+            ['since' => $since],
+            ['since' => ParameterType::STRING]
+        ) + (int) $connection->fetchOne(
+            'SELECT COUNT(*) FROM ' . Database::prefix('debuglog_archive') . ' WHERE date > :since',
+            ['since' => $since],
+            ['since' => ParameterType::STRING]
+        );
+
+        return $counts;
+    }
+
+    /**
+     * One chronological stream of the events worth noticing.
+     *
+     * Fed by exactly two sources: game log entries that are security events or
+     * carry a warning/error severity, and failed logins. The character audit
+     * trail and the profiling samples are deliberately left out -- they are
+     * high volume and would bury the signal.
+     *
+     * @return list<array{at:string,source:string,severity:string,category:string,actor:string,text:string}>
+     */
+    public function timeline(int $hours, int $limit): array
+    {
+        $events = [];
+
+        foreach ($this->gameLog($hours, null, $limit) as $row) {
+            $severity = strtolower((string) ($row['severity'] ?? GameLog::SEVERITY_INFO));
+            $category = (string) ($row['category'] ?? '');
+            $isSecurity = $category === GameLog::CATEGORY_SECURITY;
+            $isTrouble = in_array($severity, [GameLog::SEVERITY_WARNING, GameLog::SEVERITY_ERROR], true);
+
+            if (! $isSecurity && ! $isTrouble) {
+                continue;
+            }
+
+            $events[] = [
+                'at' => (string) $row['date'],
+                'source' => 'gamelog',
+                'severity' => $severity,
+                'category' => $category,
+                'actor' => (string) ($row['name'] ?? ''),
+                'text' => (string) $row['message'],
+            ];
+        }
+
+        foreach ($this->failLog($hours, $limit) as $row) {
+            $who = (string) ($row['login'] ?? '');
+            $events[] = [
+                'at' => (string) $row['date'],
+                'source' => 'faillog',
+                'severity' => GameLog::SEVERITY_WARNING,
+                'category' => 'login',
+                'actor' => (string) ($row['name'] ?? ''),
+                'text' => sprintf(
+                    'Failed login from %s%s',
+                    (string) ($row['ip'] ?? 'unknown'),
+                    $who === '' ? '' : ' for account ' . $who
+                ),
+            ];
+        }
+
+        usort($events, static fn (array $a, array $b): int => strcmp($b['at'], $a['at']));
+
+        return array_slice($events, 0, $this->cap($limit));
+    }
+
+    /**
+     * The runtime snapshot: version, environment, cron and configuration state.
+     *
+     * The settings map is taken once through getArray() rather than key by key.
+     * Roughly twenty values are reported here, so one read beats twenty, and
+     * every row in the snapshot then describes the same moment.
+     *
+     * It also keeps the page from being the thing that materialises what it
+     * reports on: getSetting() stores the default when a key is missing, which
+     * is how a fresh installation fills its settings table, but a page whose
+     * only job is to describe the current state is a poor place for that to
+     * happen.
+     *
+     * @return array<string,list<array{label:string,value:string,status:string}>>
+     */
+    public function runtime(): array
+    {
+        $settings = Settings::hasInstance() ? Settings::getInstance()->getArray() : [];
+
+        return [
+            'Version' => $this->versionRows($settings),
+            'Environment' => $this->environmentRows(),
+            'Maintenance' => $this->maintenanceRows($settings),
+            'Logging' => $this->loggingRows($settings),
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $settings
+     *
+     * @return list<array{label:string,value:string,status:string}>
+     */
+    private function versionRows(array $settings): array
+    {
+        $code = Page::getInstance()->getLogdVersion();
+        $schema = (string) ($settings['installer_version'] ?? '');
+        $rows = [
+            $this->row('Game version', $code),
+            $this->row(
+                'Schema version',
+                $schema === '' ? 'unknown' : $schema,
+                // A mismatch is a finding in itself: common.php diverts to the
+                // installer when these disagree.
+                ($schema !== '' && $schema === $code) ? 'ok' : 'warn'
+            ),
+        ];
+
+        try {
+            $rows[] = $this->row('Database server', Database::getServerVersion());
+        } catch (\Throwable $exception) {
+            $rows[] = $this->row('Database server', 'unknown', 'unknown');
+        }
+
+        // Read the cache the core news page fills; never trigger a fetch here.
+        $release = DataCache::getInstance()->datacache('github_release_latest', 86400);
+        if (is_array($release) && isset($release['tag_name'])) {
+            $rows[] = $this->row('Latest upstream release', (string) $release['tag_name']);
+        } else {
+            $rows[] = $this->row('Latest upstream release', 'not cached', 'unknown');
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return list<array{label:string,value:string,status:string}>
+     */
+    private function environmentRows(): array
+    {
+        $missing = [];
+        foreach (self::EXPECTED_EXTENSIONS as $extension) {
+            if (! extension_loaded($extension)) {
+                $missing[] = $extension;
+            }
+        }
+
+        return [
+            $this->row('PHP version', PHP_VERSION),
+            $this->row(
+                'Missing extensions',
+                $missing === [] ? 'none' : implode(', ', $missing),
+                $missing === [] ? 'ok' : 'error'
+            ),
+            $this->row('memory_limit', (string) ini_get('memory_limit')),
+            $this->row('max_execution_time', (string) ini_get('max_execution_time')),
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $settings
+     *
+     * @return list<array{label:string,value:string,status:string}>
+     */
+    private function maintenanceRows(array $settings): array
+    {
+        $rows = [];
+
+        $online = (int) ($settings['OnlineCount'] ?? 0);
+        $onlineLast = (int) ($settings['OnlineCountLast'] ?? 0);
+        $maxOnline = (int) ($settings['maxonline'] ?? 0);
+        $rows[] = $this->row(
+            'Players online',
+            sprintf(
+                '%d%s (%s)',
+                $online,
+                $maxOnline > 0 ? ' of ' . $maxOnline : '',
+                $onlineLast > 0 ? $this->ageLabel(time() - $onlineLast) . ' old' : 'never counted'
+            )
+        );
+
+        // Written before the work runs, and also bumped by a player-triggered
+        // new day, so it only means "cron ran" when newdaycron is on. It is
+        // stored with gmdate(), so it has to be read back as UTC.
+        $semaphore = (string) ($settings['newdaySemaphore'] ?? '');
+        $cronEnabled = (int) ($settings['newdaycron'] ?? 0) === 1;
+        if ($semaphore === '') {
+            $rows[] = $this->row('Last new day', 'never', 'warn');
+        } else {
+            $age = time() - (int) strtotime($semaphore . ' +0000');
+            $rows[] = $this->row(
+                'Last new day',
+                $semaphore . ' UTC (' . $this->ageLabel($age) . ' ago)'
+                    . ($cronEnabled ? '' : ' -- newdaycron is off, so this may be player-triggered'),
+                $age > 26 * 3600 ? 'warn' : 'ok'
+            );
+        }
+
+        // The better completion signal: these rows are written after the work,
+        // unlike newdaySemaphore and lastdboptimize which are set before it.
+        $lastMaintenance = $this->lastMaintenanceRun();
+        if ($lastMaintenance === null) {
+            $rows[] = $this->row('Last maintenance run', 'no record in the game log', 'warn');
+        } else {
+            $age = time() - (int) strtotime($lastMaintenance);
+            $rows[] = $this->row(
+                'Last maintenance run',
+                $lastMaintenance . ' (' . $this->ageLabel($age) . ' ago)',
+                $age > 26 * 3600 ? 'warn' : 'ok'
+            );
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string,mixed> $settings
+     *
+     * @return list<array{label:string,value:string,status:string}>
+     */
+    private function loggingRows(array $settings): array
+    {
+        $target = (string) ini_get('error_log');
+        $readable = $target !== '' && is_file($target) && is_readable($target);
+        $rows = [
+            $this->row(
+                'PHP error log',
+                $target === ''
+                    ? 'the web server log'
+                    : $target . ($readable ? '' : ' -- not readable from PHP, use the container log'),
+                $readable ? 'ok' : 'unknown'
+            ),
+        ];
+
+        $debugMode = (int) ($settings['debug'] ?? 0) === 1;
+        $rows[] = $this->row(
+            'DEBUG mode',
+            $debugMode ? 'on -- runtimes are being collected' : 'off -- no runtimes are collected',
+            $debugMode ? 'warn' : 'ok'
+        );
+
+        // The one setting on this page that is a live risk rather than a fact.
+        $detailsPublic = (int) ($settings['show_error_details'] ?? 0) === 1;
+        $rows[] = $this->row(
+            'Public error details',
+            $detailsPublic
+                ? 'ON -- every visitor sees messages, paths and backtraces'
+                : 'off',
+            $detailsPublic ? 'error' : 'ok'
+        );
+
+        foreach (
+            [
+                'expiregamelog' => 'Game log retention',
+                'expiredebuglog' => 'Debug log retention',
+                'expirefaillog' => 'Fail log retention',
+                'expiredebug' => 'DEBUG runtime retention',
+            ] as $key => $label
+        ) {
+            $days = (int) ($settings[$key] ?? 0);
+            $rows[] = $this->row($label, $days > 0 ? $days . ' days' : 'kept indefinitely');
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Newest maintenance entry in the game log, or null when there is none.
+     */
+    private function lastMaintenanceRun(): ?string
+    {
+        $value = Database::getDoctrineConnection()->fetchOne(
+            'SELECT MAX(date) FROM ' . Database::prefix('gamelog') . ' WHERE category = :category',
+            ['category' => GameLog::CATEGORY_MAINTENANCE],
+            ['category' => ParameterType::STRING]
+        );
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    /**
+     * Resolve account ids in the given columns to display names.
+     *
+     * Done in one follow-up query rather than by joining inside each half of a
+     * UNION: joining there is what forced the CAST(... AS CHAR) workarounds in
+     * the existing debug log viewer.
+     *
+     * @param list<array<string,mixed>> $rows
+     * @param list<string>              $columns
+     *
+     * @return list<array<string,mixed>>
+     */
+    private function attachAccountNames(array $rows, array $columns): array
+    {
+        $ids = [];
+        foreach ($rows as $row) {
+            foreach ($columns as $column) {
+                $id = (int) ($row[$column] ?? 0);
+                if ($id > 0) {
+                    $ids[$id] = true;
+                }
+            }
+        }
+
+        $names = [];
+        if ($ids !== []) {
+            $found = Database::getDoctrineConnection()->fetchAllAssociative(
+                'SELECT acctid, name FROM ' . Database::prefix('accounts') . ' WHERE acctid IN (:ids)',
+                ['ids' => array_keys($ids)],
+                ['ids' => ArrayParameterType::INTEGER]
+            );
+            foreach ($found as $account) {
+                $names[(int) $account['acctid']] = (string) $account['name'];
+            }
+        }
+
+        foreach ($rows as $index => $row) {
+            foreach ($columns as $column) {
+                $id = (int) ($row[$column] ?? 0);
+                $rows[$index][$column . 'name'] = $names[$id] ?? '';
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Keep a caller-supplied limit inside something a page view can render.
+     */
+    private function cap(int $limit): int
+    {
+        return max(1, min($limit, self::ROW_LIMIT));
+    }
+
+    /**
+     * @return array{label:string,value:string,status:string}
+     */
+    private function row(string $label, string $value, string $status = 'ok'): array
+    {
+        return ['label' => $label, 'value' => $value, 'status' => $status];
+    }
+
+    /**
+     * Render a duration in seconds as a short human label.
+     */
+    private function ageLabel(int $seconds): string
+    {
+        if ($seconds < 0) {
+            return 'in the future';
+        }
+        if ($seconds < 90) {
+            return $seconds . 's';
+        }
+        if ($seconds < 5400) {
+            return round($seconds / 60) . 'm';
+        }
+        if ($seconds < 172800) {
+            return round($seconds / 3600) . 'h';
+        }
+
+        return round($seconds / 86400) . 'd';
+    }
+}

--- a/superuser.php
+++ b/superuser.php
@@ -188,6 +188,9 @@ if ($session['user']['superuser'] & SU_EDIT_CONFIG) {
 if ($session['user']['superuser'] & SU_EDIT_CONFIG) {
                     Nav::add('L?View Log Files', 'logviewer.php');
 }
+if ($session['user']['superuser'] & SU_MEGAUSER) {
+    Nav::add('Y?Diagnostics', 'diagnostics.php');
+}
 
 Nav::add("Module Configurations");
 

--- a/tests/DiagnosticsPageTest.php
+++ b/tests/DiagnosticsPageTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Diagnostics;
+use Lotgd\Settings;
+use Lotgd\Tests\Stubs\Database;
+use Lotgd\Tests\Stubs\DummySettings;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+final class DiagnosticsPageTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $diagnostics_output, $diagnostics_navs, $diagnostics_su_checks, $session;
+
+        $diagnostics_output = '';
+        $diagnostics_navs = [];
+        $diagnostics_su_checks = [];
+        $session = ['user' => ['acctid' => 1, 'superuser' => SU_MEGAUSER]];
+
+        if (!class_exists('\\Lotgd\\SuAccess', false)) {
+            eval('namespace Lotgd; class SuAccess { public static function check(int $level): void { global $diagnostics_su_checks, $diagnostics_output; $diagnostics_su_checks[] = ["level" => $level, "output_so_far" => $diagnostics_output]; } }');
+        }
+        if (!class_exists('\\Lotgd\\Nav\\SuperuserNav', false)) {
+            eval('namespace Lotgd\\Nav; class SuperuserNav { public static function render(): void {} }');
+        }
+        if (!class_exists('\\Lotgd\\Nav', false)) {
+            eval('namespace Lotgd; class Nav { public static function add($text, $link = false): void { global $diagnostics_navs; $diagnostics_navs[] = [$text, $link]; } }');
+        }
+        if (!class_exists('\\Lotgd\\Page\\Header', false)) {
+            eval('namespace Lotgd\\Page; class Header { public static function pageHeader(...$args): void {} }');
+        }
+        if (!class_exists('\\Lotgd\\Page\\Footer', false)) {
+            eval('namespace Lotgd\\Page; class Footer { public static function pageFooter(...$args): void {} }');
+        }
+        if (!class_exists('\\Lotgd\\Http', false)) {
+            eval('namespace Lotgd; class Http { public static function get(string $name) { return $_GET[$name] ?? false; } }');
+        }
+        if (!class_exists('\\Lotgd\\Output', false)) {
+            // Carries the members the page and Sanitize actually use.
+            eval('namespace Lotgd; class Output {
+                public static function getInstance() { return new self(); }
+                public static function addHeadMarkup(string $markup): void {}
+                public function getColormapEscaped(): string { return "1234567890!@#\\$%^&*()"; }
+                public function rawOutput(string $in): void { global $diagnostics_output; $diagnostics_output .= $in; }
+                public function outputNotl(...$args): void { global $diagnostics_output; $format = (string) array_shift($args); $diagnostics_output .= $args === [] ? $format : vsprintf($format, $args); }
+                public function output(...$args): void { $this->outputNotl(...$args); }
+            }');
+        }
+        if (!class_exists('\\Lotgd\\Translator', false)) {
+            eval('namespace Lotgd; class Translator { public static function getInstance() { return new self(); } public function setSchema(?string $s = null): void {} }');
+        }
+        if (!class_exists('\\Lotgd\\Page', false)) {
+            eval('namespace Lotgd; class Page { public static function getInstance() { return new self(); } public function getLogdVersion(): string { return "2.0.6 +nb Edition"; } }');
+        }
+
+        Settings::setInstance(new DummySettings([
+            'installer_version' => '2.0.6 +nb Edition',
+            'expiregamelog' => 30,
+            'expiredebuglog' => 18,
+            'expirefaillog' => 1,
+            'expiredebug' => 7,
+        ]));
+
+        Database::$queries = [];
+        Database::$mockResults = [];
+        Database::$tablePrefix = '';
+        Database::resetDoctrineConnection();
+
+        if (!defined('DB_CHOSEN')) {
+            define('DB_CHOSEN', false);
+        }
+        $_GET = [];
+    }
+
+    protected function tearDown(): void
+    {
+        Settings::setInstance(null);
+        Database::resetDoctrineConnection();
+        $_GET = [];
+        unset($GLOBALS['session']);
+        parent::tearDown();
+    }
+
+    private function renderPage(): string
+    {
+        if (!defined('DIAGNOSTICS_TEST')) {
+            define('DIAGNOSTICS_TEST', true);
+        }
+
+        require __DIR__ . '/../diagnostics.php';
+
+        global $diagnostics_output;
+
+        return (string) $diagnostics_output;
+    }
+
+    /**
+     * The gate has to run before anything is written, or a refused visitor has
+     * already been handed part of the page.
+     */
+    public function testTheMegauserGateRunsBeforeAnyOutput(): void
+    {
+        $this->renderPage();
+
+        global $diagnostics_su_checks;
+        self::assertCount(1, $diagnostics_su_checks);
+        self::assertSame(SU_MEGAUSER, $diagnostics_su_checks[0]['level']);
+        self::assertSame('', $diagnostics_su_checks[0]['output_so_far']);
+    }
+
+    /**
+     * ForcedNavigation refuses a URI that the previous render did not register,
+     * so an offered window that is not in the navigation sends the operator to
+     * badnav.php instead of showing the data.
+     */
+    public function testEveryOfferedWindowIsRegisteredWithTheNavigation(): void
+    {
+        $this->renderPage();
+
+        global $diagnostics_navs;
+        $links = array_filter(array_column($diagnostics_navs, 1));
+
+        foreach (Diagnostics::WINDOWS as $hours) {
+            self::assertContains(
+                "diagnostics.php?hours=$hours",
+                $links,
+                "the $hours hour window must be reachable"
+            );
+        }
+    }
+
+    public function testTheSeverityFiltersAndRefreshAreRegisteredToo(): void
+    {
+        $this->renderPage();
+
+        global $diagnostics_navs;
+        $links = array_filter(array_column($diagnostics_navs, 1));
+
+        self::assertContains('diagnostics.php?hours=24', $links);
+        foreach (['info', 'warning', 'error', 'debug'] as $severity) {
+            self::assertContains("diagnostics.php?hours=24&severity=$severity", $links);
+        }
+    }
+
+    /**
+     * A window the page does not offer must not produce links it never
+     * registered, or the next click lands on badnav.php.
+     */
+    public function testAnUnofferedWindowFallsBackAndStillLinksConsistently(): void
+    {
+        $_GET['hours'] = '999999';
+
+        $this->renderPage();
+
+        global $diagnostics_navs;
+        $links = array_filter(array_column($diagnostics_navs, 1));
+
+        self::assertContains('diagnostics.php?hours=24', $links);
+        foreach ($links as $link) {
+            self::assertStringNotContainsString('999999', (string) $link);
+        }
+    }
+
+    public function testThePageNamesItsSections(): void
+    {
+        $output = $this->renderPage();
+
+        self::assertStringContainsString('Runtime', $output);
+        self::assertStringContainsString('Timeline', $output);
+        self::assertStringContainsString('Game log', $output);
+        self::assertStringContainsString('Failed logins', $output);
+        self::assertStringContainsString('Character audit trail', $output);
+    }
+}

--- a/tests/DiagnosticsPageTest.php
+++ b/tests/DiagnosticsPageTest.php
@@ -20,11 +20,12 @@ final class DiagnosticsPageTest extends TestCase
 {
     protected function setUp(): void
     {
-        global $diagnostics_output, $diagnostics_navs, $diagnostics_su_checks, $session;
+        global $diagnostics_output, $diagnostics_navs, $diagnostics_su_checks, $diagnostics_translated, $session;
 
         $diagnostics_output = '';
         $diagnostics_navs = [];
         $diagnostics_su_checks = [];
+        $diagnostics_translated = [];
         $session = ['user' => ['acctid' => 1, 'superuser' => SU_MEGAUSER]];
 
         if (!class_exists('\\Lotgd\\SuAccess', false)) {
@@ -57,7 +58,14 @@ final class DiagnosticsPageTest extends TestCase
             }');
         }
         if (!class_exists('\\Lotgd\\Translator', false)) {
-            eval('namespace Lotgd; class Translator { public static function getInstance() { return new self(); } public function setSchema(?string $s = null): void {} }');
+            // Records what was handed to it so a test can assert that the static
+            // labels go through the translator instead of straight to output.
+            eval('namespace Lotgd; class Translator {
+                public static function getInstance() { return new self(); }
+                public function setSchema(?string $s = null): void {}
+                public static function translate($in, $namespace = false) { global $diagnostics_translated; $diagnostics_translated[] = (string) $in; return $in; }
+                public static function sprintfTranslate(...$args) { global $diagnostics_translated; $format = (string) array_shift($args); $diagnostics_translated[] = $format; return $args === [] ? $format : vsprintf($format, $args); }
+            }');
         }
         if (!class_exists('\\Lotgd\\Page', false)) {
             eval('namespace Lotgd; class Page { public static function getInstance() { return new self(); } public function getLogdVersion(): string { return "2.0.6 +nb Edition"; } }');
@@ -168,6 +176,37 @@ final class DiagnosticsPageTest extends TestCase
         self::assertContains('diagnostics.php?hours=24', $links);
         foreach ($links as $link) {
             self::assertStringNotContainsString('999999', (string) $link);
+        }
+    }
+
+    /**
+     * AGENTS.md asks for Translator on new user-facing strings. The table
+     * headers and the snapshot labels are static text, so they have to pass
+     * through it -- only the log data itself goes out untranslated.
+     */
+    public function testStaticHeadersAndLabelsGoThroughTheTranslator(): void
+    {
+        $this->renderPage();
+
+        global $diagnostics_translated;
+
+        // The log tables are empty in this fixture and an empty table renders no
+        // header row, so the assertion uses the runtime block: it always has
+        // rows, and its headers go through the same diagnosticsTable() path as
+        // every other table's.
+        $expected = [
+            'Runtime',                                   // section title
+            'Item', 'Value',                             // table headers
+            'Version', 'Environment', 'Maintenance', 'Logging', // group titles
+            'Game version', 'PHP version', 'DEBUG mode', // row labels
+        ];
+
+        foreach ($expected as $label) {
+            self::assertContains(
+                $label,
+                $diagnostics_translated,
+                sprintf('the static label "%s" must be translated', $label)
+            );
         }
     }
 

--- a/tests/DiagnosticsTest.php
+++ b/tests/DiagnosticsTest.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests;
+
+use Lotgd\Diagnostics;
+use Lotgd\GameLog;
+use Lotgd\Settings;
+use Lotgd\Tests\Stubs\Database;
+use Lotgd\Tests\Stubs\DummySettings;
+use PHPUnit\Framework\TestCase;
+
+final class DiagnosticsTest extends TestCase
+{
+    private Diagnostics $diagnostics;
+
+    protected function setUp(): void
+    {
+        class_exists(Database::class);
+        Database::$queries = [];
+        Database::$mockResults = [];
+        Database::$tablePrefix = '';
+        Database::resetDoctrineConnection();
+
+        $this->diagnostics = new Diagnostics();
+    }
+
+    protected function tearDown(): void
+    {
+        Database::$queries = [];
+        Database::$mockResults = [];
+        Database::resetDoctrineConnection();
+        Settings::setInstance(null);
+    }
+
+    /**
+     * @return list<array{sql:string,params:array,types:array}>
+     */
+    private function statements(): array
+    {
+        return Database::getDoctrineConnection()->fetchAllLog;
+    }
+
+    // ------------------------------------------------------ input boundary --
+
+    public function testAnAbsentWindowFallsBackToTheDefault(): void
+    {
+        $this->assertSame(Diagnostics::DEFAULT_HOURS, Diagnostics::normalizeHours(false));
+        $this->assertSame(Diagnostics::DEFAULT_HOURS, Diagnostics::normalizeHours(null));
+        $this->assertSame(Diagnostics::DEFAULT_HOURS, Diagnostics::normalizeHours([]));
+    }
+
+    public function testEveryOfferedWindowIsAccepted(): void
+    {
+        foreach (Diagnostics::WINDOWS as $hours) {
+            $this->assertSame($hours, Diagnostics::normalizeHours($hours));
+            $this->assertSame($hours, Diagnostics::normalizeHours((string) $hours));
+        }
+    }
+
+    /**
+     * A window that is not on the list is not clamped to the nearest one, it is
+     * replaced: the set of windows is also the set of links the page registers
+     * with the navigation, and an unregistered URI is refused before it gets here.
+     */
+    public function testAnUnofferedWindowIsReplacedByTheDefault(): void
+    {
+        foreach (['0', '-5', '999999', '23', 'nonsense', '24; DROP TABLE', '1e3'] as $raw) {
+            $this->assertSame(
+                Diagnostics::DEFAULT_HOURS,
+                Diagnostics::normalizeHours($raw),
+                sprintf('%s should not be accepted as a window', var_export($raw, true))
+            );
+        }
+    }
+
+    public function testOnlyTheGameLogVocabularyIsAcceptedAsSeverity(): void
+    {
+        $this->assertSame('warning', Diagnostics::normalizeSeverity('warning'));
+        $this->assertSame('error', Diagnostics::normalizeSeverity('ERROR'));
+        $this->assertNull(Diagnostics::normalizeSeverity('critical'));
+        $this->assertNull(Diagnostics::normalizeSeverity(''));
+        $this->assertNull(Diagnostics::normalizeSeverity(false));
+        $this->assertNull(Diagnostics::normalizeSeverity(['warning']));
+    }
+
+    // -------------------------------------------------------------- queries --
+
+    public function testTheWindowIsBoundRatherThanInterpolated(): void
+    {
+        $this->diagnostics->gameLog(24, null, 50);
+
+        $statement = $this->statements()[0] ?? null;
+        $this->assertNotNull($statement);
+        $this->assertStringContainsString('g.date > :since', $statement['sql']);
+        $this->assertArrayHasKey('since', $statement['params']);
+        $this->assertStringNotContainsString($statement['params']['since'], $statement['sql']);
+    }
+
+    public function testTheSeverityFilterIsOmittedEntirelyWhenNoneIsRequested(): void
+    {
+        $this->diagnostics->gameLog(24, null, 50);
+
+        $statement = $this->statements()[0];
+        $this->assertStringNotContainsString(':severity', $statement['sql']);
+        $this->assertArrayNotHasKey('severity', $statement['params']);
+    }
+
+    public function testTheSeverityFilterIsBoundWhenRequested(): void
+    {
+        $this->diagnostics->gameLog(24, GameLog::SEVERITY_ERROR, 50);
+
+        $statement = $this->statements()[0];
+        $this->assertStringContainsString('g.severity = :severity', $statement['sql']);
+        $this->assertSame('error', $statement['params']['severity']);
+    }
+
+    /**
+     * The new day routine empties debuglog into debuglog_archive with a cutoff
+     * of "now", so reading only the live table loses everything written before
+     * the last new day -- which for a 24 hour window is most of it.
+     */
+    public function testTheCharacterAuditTrailIsReadFromBothTables(): void
+    {
+        $this->diagnostics->debugLog(24, 50);
+
+        $statement = $this->statements()[0];
+        $this->assertStringContainsString('FROM debuglog ', $statement['sql']);
+        $this->assertStringContainsString('FROM debuglog_archive ', $statement['sql']);
+        $this->assertStringContainsString('UNION ALL', $statement['sql']);
+    }
+
+    /**
+     * A named placeholder repeated in one statement is not safe with PDO unless
+     * emulated prepares are on, so the two halves get their own names.
+     */
+    public function testTheUnionUsesOnePlaceholderPerHalf(): void
+    {
+        $this->diagnostics->debugLog(24, 50);
+
+        $statement = $this->statements()[0];
+        $this->assertStringContainsString(':since_live', $statement['sql']);
+        $this->assertStringContainsString(':since_archive', $statement['sql']);
+        $this->assertSame(
+            $statement['params']['since_live'],
+            $statement['params']['since_archive'],
+            'both halves must cover the same window'
+        );
+    }
+
+    public function testTheRowLimitIsCappedRegardlessOfWhatIsAskedFor(): void
+    {
+        $this->diagnostics->gameLog(24, null, 100000);
+
+        $this->assertStringContainsString(
+            'LIMIT ' . Diagnostics::ROW_LIMIT,
+            $this->statements()[0]['sql']
+        );
+    }
+
+    public function testProfilingOrdersByAConstantAndBindsItsType(): void
+    {
+        $this->diagnostics->profiling(24, 'hooktime', 30);
+
+        $statement = $this->statements()[0];
+        $this->assertStringContainsString('type = :type', $statement['sql']);
+        $this->assertSame('hooktime', $statement['params']['type']);
+        $this->assertStringContainsString('ORDER BY total DESC', $statement['sql']);
+    }
+
+    /**
+     * `severity` arrived with a migration and every query names it, in the
+     * SELECT list even when no filter was asked for. An installation that has
+     * not run that migration must still get a usable page, so the fallback has
+     * to apply whether or not a filter was requested -- it once only applied
+     * when one was, which left the unfiltered view empty on exactly the
+     * installations that needed it most.
+     */
+    public function testAMissingSeverityColumnFallsBackWithAndWithoutAFilter(): void
+    {
+        foreach ([null, 'error'] as $severity) {
+            Database::resetDoctrineConnection();
+            $connection = Database::getDoctrineConnection();
+            $connection->throwOnceOnFetchAll = true;
+
+            $this->diagnostics->gameLog(24, $severity, 50);
+
+            $statements = $connection->fetchAllLog;
+            $last = end($statements);
+            self::assertIsArray($last);
+            self::assertStringNotContainsString(
+                'severity',
+                $last['sql'],
+                'the fallback query must not name the column that is missing'
+            );
+            self::assertStringContainsString('g.date > :since', $last['sql']);
+        }
+    }
+
+    // ------------------------------------------------------------- timeline --
+
+    /**
+     * The timeline exists to answer "what went wrong"; ordinary informational
+     * bookkeeping would bury that.
+     */
+    public function testTheTimelineKeepsSecurityAndTroubleAndDropsRoutineEntries(): void
+    {
+        Database::$mockResults = [
+            [
+                ['logid' => 1, 'date' => '2026-09-09 10:00:00', 'category' => 'maintenance', 'severity' => 'info', 'message' => 'Deleted 5 rows', 'who' => 0, 'name' => null],
+                ['logid' => 2, 'date' => '2026-09-09 11:00:00', 'category' => 'security', 'severity' => 'info', 'message' => 'Superuser page access denied', 'who' => 7, 'name' => 'Admin'],
+                ['logid' => 3, 'date' => '2026-09-09 12:00:00', 'category' => 'expiration', 'severity' => 'error', 'message' => 'Failed to delete account 1', 'who' => 0, 'name' => null],
+            ],
+            [
+                ['eventid' => 1, 'date' => '2026-09-09 11:30:00', 'ip' => '203.0.113.7', 'acctid' => 7, 'name' => 'Admin', 'login' => 'admin', 'superuser' => 1],
+            ],
+        ];
+
+        $timeline = $this->diagnostics->timeline(24, 50);
+
+        $texts = array_column($timeline, 'text');
+        $this->assertCount(3, $timeline);
+        $this->assertContains('Superuser page access denied', $texts, 'a security event is kept even at info severity');
+        $this->assertContains('Failed to delete account 1', $texts, 'an error is kept whatever its category');
+        $this->assertNotContains('Deleted 5 rows', $texts, 'routine maintenance must not reach the timeline');
+    }
+
+    public function testTheTimelineIsSortedNewestFirst(): void
+    {
+        Database::$mockResults = [
+            [
+                ['logid' => 1, 'date' => '2026-09-09 10:00:00', 'category' => 'security', 'severity' => 'warning', 'message' => 'older', 'who' => 0, 'name' => null],
+                ['logid' => 2, 'date' => '2026-09-09 12:00:00', 'category' => 'security', 'severity' => 'warning', 'message' => 'newer', 'who' => 0, 'name' => null],
+            ],
+            [
+                ['eventid' => 1, 'date' => '2026-09-09 11:00:00', 'ip' => '203.0.113.7', 'acctid' => 0, 'name' => null, 'login' => null, 'superuser' => 0],
+            ],
+        ];
+
+        $timeline = $this->diagnostics->timeline(24, 50);
+
+        $this->assertSame('newer', $timeline[0]['text']);
+        $this->assertStringContainsString('203.0.113.7', $timeline[1]['text']);
+        $this->assertSame('older', $timeline[2]['text']);
+    }
+
+    // -------------------------------------------------------------- runtime --
+
+    /**
+     * The snapshot reports around twenty settings, so it takes the map once
+     * instead of asking key by key: one read rather than twenty, and every row
+     * then describes the same moment.
+     *
+     * Pinning it also keeps a later refactor from turning a page that only
+     * describes the current state into one that writes the defaults it finds
+     * missing -- getSetting() does that by design, and it is how a fresh
+     * installation fills its settings table, but it belongs on the pages that
+     * use a setting rather than on the one that merely reports it.
+     */
+    public function testTheSnapshotReadsTheSettingsMapOnceInsteadOfKeyByKey(): void
+    {
+        Settings::setInstance(new class (['installer_version' => '2.0.6 +nb Edition']) extends DummySettings {
+            /**
+             * `usedatacache` and `datacachepath` are exempt for a plain reason:
+             * getSetting() answers them from dbconnect.php, not from the
+             * settings table, so getArray() can never supply them and the
+             * accessor is the only way to read them.
+             */
+            public function getSetting(string|int $settingname, mixed $default = false): mixed
+            {
+                if (in_array($settingname, ['usedatacache', 'datacachepath'], true)) {
+                    return parent::getSetting($settingname, $default);
+                }
+
+                throw new \LogicException(sprintf(
+                    'runtime() read "%s" key by key; take the settings map once through getArray().',
+                    (string) $settingname
+                ));
+            }
+        });
+
+        $snapshot = $this->diagnostics->runtime();
+
+        $this->assertArrayHasKey('Version', $snapshot);
+        $this->assertArrayHasKey('Logging', $snapshot);
+    }
+
+    public function testAnUnavailableDatabaseVersionIsReportedRatherThanThrown(): void
+    {
+        Settings::setInstance(new DummySettings([]));
+        Database::resetDoctrineConnection();
+
+        $snapshot = $this->diagnostics->runtime();
+
+        $labels = array_column($snapshot['Version'], 'label');
+        $this->assertContains('Database server', $labels);
+    }
+
+    /**
+     * The setting that publishes backtraces to every visitor is the one thing on
+     * this page that is a live risk rather than a fact, so it has to stand out.
+     */
+    public function testPublicErrorDetailsAreFlaggedAsAnError(): void
+    {
+        Settings::setInstance(new DummySettings(['show_error_details' => 1]));
+
+        $rows = $this->diagnostics->runtime()['Logging'];
+        $flagged = null;
+        foreach ($rows as $row) {
+            if ($row['label'] === 'Public error details') {
+                $flagged = $row;
+            }
+        }
+
+        $this->assertNotNull($flagged);
+        $this->assertSame('error', $flagged['status']);
+    }
+
+    public function testPublicErrorDetailsAreQuietWhenOff(): void
+    {
+        Settings::setInstance(new DummySettings(['show_error_details' => 0]));
+
+        foreach ($this->diagnostics->runtime()['Logging'] as $row) {
+            if ($row['label'] === 'Public error details') {
+                $this->assertSame('ok', $row['status']);
+            }
+        }
+    }
+}

--- a/tests/DiagnosticsTest.php
+++ b/tests/DiagnosticsTest.php
@@ -201,29 +201,65 @@ final class DiagnosticsTest extends TestCase
     // ------------------------------------------------------------- timeline --
 
     /**
-     * The timeline exists to answer "what went wrong"; ordinary informational
-     * bookkeeping would bury that.
+     * The restriction must live in the statement, not in a filter applied to
+     * the rows afterwards.
+     *
+     * Routine bookkeeping is the bulk of the game log, so fetching the newest N
+     * rows and filtering them in PHP drops every warning, error and security
+     * event that sits behind the first N routine rows -- on a busy server, all
+     * of them. It was written that way once; this is the guard against it
+     * coming back.
      */
-    public function testTheTimelineKeepsSecurityAndTroubleAndDropsRoutineEntries(): void
+    public function testTheTimelineRestrictsInSqlRatherThanAfterTheRowCap(): void
+    {
+        $this->diagnostics->timeline(24, 50);
+
+        $statement = $this->statements()[0] ?? null;
+        $this->assertNotNull($statement);
+        $this->assertStringContainsString('g.category = :security', $statement['sql']);
+        $this->assertStringContainsString('g.severity IN (:warning, :error)', $statement['sql']);
+        $this->assertSame('security', $statement['params']['security']);
+        $this->assertSame('warning', $statement['params']['warning']);
+        $this->assertSame('error', $statement['params']['error']);
+    }
+
+    /**
+     * Without the severity column the timeline narrows to the security category
+     * rather than failing outright.
+     */
+    public function testTheTimelineFallsBackToTheSecurityCategoryAlone(): void
+    {
+        $connection = Database::getDoctrineConnection();
+        $connection->throwOnceOnFetchAll = true;
+
+        $this->diagnostics->timeline(24, 50);
+
+        $statements = $connection->fetchAllLog;
+        $this->assertStringNotContainsString('severity', $statements[1]['sql']);
+        $this->assertStringContainsString('g.category = :security', $statements[1]['sql']);
+    }
+
+    /**
+     * Rows the query returns are normalised into the common shape, and a
+     * security event keeps its own severity rather than being relabelled.
+     */
+    public function testNotableRowsAreNormalisedIntoTheCommonShape(): void
     {
         Database::$mockResults = [
             [
-                ['logid' => 1, 'date' => '2026-09-09 10:00:00', 'category' => 'maintenance', 'severity' => 'info', 'message' => 'Deleted 5 rows', 'who' => 0, 'name' => null],
                 ['logid' => 2, 'date' => '2026-09-09 11:00:00', 'category' => 'security', 'severity' => 'info', 'message' => 'Superuser page access denied', 'who' => 7, 'name' => 'Admin'],
-                ['logid' => 3, 'date' => '2026-09-09 12:00:00', 'category' => 'expiration', 'severity' => 'error', 'message' => 'Failed to delete account 1', 'who' => 0, 'name' => null],
             ],
-            [
-                ['eventid' => 1, 'date' => '2026-09-09 11:30:00', 'ip' => '203.0.113.7', 'acctid' => 7, 'name' => 'Admin', 'login' => 'admin', 'superuser' => 1],
-            ],
+            [],
         ];
 
         $timeline = $this->diagnostics->timeline(24, 50);
 
-        $texts = array_column($timeline, 'text');
-        $this->assertCount(3, $timeline);
-        $this->assertContains('Superuser page access denied', $texts, 'a security event is kept even at info severity');
-        $this->assertContains('Failed to delete account 1', $texts, 'an error is kept whatever its category');
-        $this->assertNotContains('Deleted 5 rows', $texts, 'routine maintenance must not reach the timeline');
+        $this->assertCount(1, $timeline);
+        $this->assertSame('gamelog', $timeline[0]['source']);
+        $this->assertSame('security', $timeline[0]['category']);
+        $this->assertSame('info', $timeline[0]['severity']);
+        $this->assertSame('Admin', $timeline[0]['actor']);
+        $this->assertSame('Superuser page access denied', $timeline[0]['text']);
     }
 
     public function testTheTimelineIsSortedNewestFirst(): void
@@ -245,7 +281,100 @@ final class DiagnosticsTest extends TestCase
         $this->assertSame('older', $timeline[2]['text']);
     }
 
+    // --------------------------------------------------------------- counts --
+
+    /**
+     * A filtered listing next to an unfiltered total reads as "showing 5 of
+     * 1000" when only five rows match, which is worse than no number at all.
+     */
+    public function testTheGameLogCountCarriesTheSeverityFilter(): void
+    {
+        $this->diagnostics->counts(24, GameLog::SEVERITY_ERROR);
+
+        $gamelogCount = null;
+        foreach ($this->statements() as $statement) {
+            if (str_contains($statement['sql'], 'FROM gamelog')) {
+                $gamelogCount = $statement;
+            }
+        }
+
+        $this->assertNotNull($gamelogCount);
+        $this->assertStringContainsString('severity = :severity', $gamelogCount['sql']);
+        $this->assertSame('error', $gamelogCount['params']['severity']);
+    }
+
+    public function testTheGameLogCountIsUnfilteredWhenNoSeverityIsChosen(): void
+    {
+        $this->diagnostics->counts(24, null);
+
+        foreach ($this->statements() as $statement) {
+            if (str_contains($statement['sql'], 'FROM gamelog')) {
+                $this->assertStringNotContainsString(':severity', $statement['sql']);
+            }
+        }
+    }
+
     // -------------------------------------------------------------- runtime --
+
+    /**
+     * Newday applies its own defaults when a retention key has not been
+     * materialised, so reporting "kept indefinitely" for an absent key would
+     * describe a retention that is not the one in force. Reading the settings
+     * map means the defaults have to be mirrored here rather than arriving with
+     * the value.
+     */
+    public function testAbsentRetentionKeysReportTheDefaultsNewdayApplies(): void
+    {
+        Settings::setInstance(new DummySettings([]));
+
+        $rows = [];
+        foreach ($this->diagnostics->runtime()['Logging'] as $row) {
+            $rows[$row['label']] = $row;
+        }
+
+        // The value is a translatable template and the number is an argument,
+        // so the assertion is on the number rather than on the formatting.
+        foreach (
+            [
+                'Game log retention' => 30,
+                'Debug log retention' => 18,
+                'Fail log retention' => 1,
+                'DEBUG runtime retention' => 7,
+            ] as $label => $expected
+        ) {
+            $this->assertSame('%s days', $rows[$label]['value'] ?? null, $label);
+            $this->assertSame([$expected], $rows[$label]['args'] ?? null, $label);
+        }
+    }
+
+    public function testAnExplicitZeroRetentionStillMeansIndefinitely(): void
+    {
+        Settings::setInstance(new DummySettings(['expiregamelog' => 0]));
+
+        foreach ($this->diagnostics->runtime()['Logging'] as $row) {
+            if ($row['label'] === 'Game log retention') {
+                $this->assertSame('kept indefinitely', $row['value']);
+            }
+        }
+    }
+
+    /**
+     * common.php:484 renders "Upgrade Needed" and its footer exits when the
+     * code and schema versions differ, so this page is unreachable in exactly
+     * that case. The row is reference information; it must never claim to be a
+     * check that caught something.
+     */
+    public function testTheSchemaVersionRowNeverCarriesAWarning(): void
+    {
+        Settings::setInstance(new DummySettings(['installer_version' => 'something else entirely']));
+
+        foreach ($this->diagnostics->runtime()['Version'] as $row) {
+            if ($row['label'] === 'Schema version') {
+                $this->assertSame('ok', $row['status']);
+                $this->assertSame('something else entirely', $row['value']);
+            }
+        }
+    }
 
     /**
      * The snapshot reports around twenty settings, so it takes the map once

--- a/tests/Security/DiagnosticsFaillogPostRegressionTest.php
+++ b/tests/Security/DiagnosticsFaillogPostRegressionTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Security;
+
+use Lotgd\Diagnostics;
+use Lotgd\Tests\Stubs\Database;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The failed-login viewer must never read the submitted form data.
+ *
+ * `faillog.post` holds a serialize() of the entire POST body of a failed login
+ * attempt, so it contains the password that was tried. Until this page existed
+ * nothing read the table back at all, which is why the column was never a
+ * problem; a viewer makes it one.
+ *
+ * Two independent guards, because either alone can be defeated: the statement
+ * the collector actually issues, and the source of both the collector and the
+ * page. A `SELECT *` would slip past a source check while still fetching the
+ * column, and an explicit list could be widened without anyone noticing in the
+ * generated SQL.
+ */
+final class DiagnosticsFaillogPostRegressionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        class_exists(Database::class);
+        Database::$queries = [];
+        Database::$mockResults = [];
+        Database::$tablePrefix = '';
+        Database::resetDoctrineConnection();
+    }
+
+    protected function tearDown(): void
+    {
+        Database::$queries = [];
+        Database::resetDoctrineConnection();
+        parent::tearDown();
+    }
+
+    public function testTheFailedLoginQueryNeverAsksForTheSubmittedPost(): void
+    {
+        (new Diagnostics())->failLog(24, 50);
+
+        $statement = Database::getDoctrineConnection()->fetchAllLog[0] ?? null;
+        self::assertNotNull($statement, 'expected the failed-login query to be issued');
+
+        $sql = (string) $statement['sql'];
+        self::assertStringContainsString('FROM faillog', $sql);
+        self::assertStringNotContainsString('post', $sql);
+        self::assertStringNotContainsString('*', $sql, 'an explicit column list is what keeps post out');
+    }
+
+    public function testTheTimelineDoesNotReachForItEither(): void
+    {
+        Database::$mockResults = [
+            [],
+            [
+                [
+                    'eventid' => 1,
+                    'date' => '2026-09-09 11:30:00',
+                    'ip' => '203.0.113.7',
+                    'acctid' => 7,
+                    'name' => 'Admin',
+                    'login' => 'admin',
+                    'superuser' => 1,
+                ],
+            ],
+        ];
+
+        $timeline = (new Diagnostics())->timeline(24, 50);
+
+        self::assertCount(1, $timeline);
+        self::assertStringContainsString('203.0.113.7', $timeline[0]['text']);
+
+        foreach (Database::getDoctrineConnection()->fetchAllLog as $statement) {
+            self::assertStringNotContainsString('post', (string) $statement['sql']);
+        }
+    }
+
+    public function testNeitherTheCollectorNorThePageSelectsTheColumn(): void
+    {
+        $root = dirname(__DIR__, 2);
+
+        foreach (['/src/Lotgd/Diagnostics.php', '/diagnostics.php'] as $file) {
+            $source = (string) file_get_contents($root . $file);
+
+            // Strip comments so the prose explaining *why* the column is avoided
+            // does not itself trip the check.
+            $code = '';
+            foreach (token_get_all($source) as $token) {
+                if (is_array($token) && in_array($token[0], [T_COMMENT, T_DOC_COMMENT], true)) {
+                    continue;
+                }
+                $code .= is_array($token) ? $token[1] : $token;
+            }
+
+            self::assertStringNotContainsString(
+                'post',
+                $code,
+                $file . ' must not name the faillog post column anywhere in its code'
+            );
+        }
+    }
+}

--- a/tests/Stubs/DoctrineBootstrap.php
+++ b/tests/Stubs/DoctrineBootstrap.php
@@ -85,6 +85,8 @@ class DoctrineConnection
     public array $lastExecuteStatementTypes = [];
     public array $executeQueryParams = [];
     public array $executeQueryTypes = [];
+    /** When true, the next fetchAllAssociative() throws instead of returning rows. */
+    public bool $throwOnceOnFetchAll = false;
 
     private function makeResult(array $rows): DoctrineResult
     {
@@ -301,6 +303,15 @@ class DoctrineConnection
             'params' => $params,
             'types'  => $types,
         ];
+
+        // Lets a test exercise a degradation path -- a query against a column an
+        // unmigrated installation does not have, for instance. The statement is
+        // still logged above, so the assertion can see what was attempted.
+        if ($this->throwOnceOnFetchAll) {
+            $this->throwOnceOnFetchAll = false;
+
+            throw new \RuntimeException('simulated query failure');
+        }
 
         if (!empty(Database::$mockResults)) {
             $rows = array_shift(Database::$mockResults);


### PR DESCRIPTION
## Summary

The logging consolidation in #1519 unified the **write** side. Reading it back is still spread over five pages — `gamelog.php`, `debug.php`, `user.php?op=debuglog`, `logviewer.php`, `stats.php` — and three things have no reader at all: the `faillog` table (commented in `login.php` as *"nothing reads it back: there is no viewer for it"*), the server's runtime state, and the retention actually in force.

`diagnostics.php` answers **"is everything still running?"** on one screen. Reachable from the Superuser Grotto, `SU_MEGAUSER` only, strictly read-only, no auto-refresh.

For a chosen window (one hour to thirty days, 24 h by default):

- a **runtime snapshot** — game and schema version, PHP and database versions, missing extensions, players online, when the last new day and the last maintenance run happened, the retention in force per log, and whether `debug` mode or `show_error_details` is on;
- a **merged timeline** of the events worth noticing: security events, anything at warning or error severity, and failed logins;
- **collapsible sections** per source: game log, failed logins, character audit trail, collected runtimes.

Deliberately a first, small version: one new class, one new page, **no schema change**. The extensions left out are listed at the bottom.

## Two things the page will not show

**The submitted form data of a failed login.** `faillog.post` holds a `serialize()` of the entire POST body, so it contains the password that was tried. It is never selected. Two independent guards, because either alone can be defeated: the statement actually issued, and the source of both the class and the page *with comments stripped*, so the prose explaining the rule cannot satisfy the check. Verified by adding `f.post` back locally — all three cases fail.

**The PHP error log.** `docker/php/production.ini:6` and `development.ini:6` both set `error_log = /dev/stderr`, which is write-only. The page reports the destination and points at `docker compose logs web`. That is also why the async diagnostics (`Jaxon csrf`, rate-limit, bad-request) and individual failed-login records do not appear here — they are `error_log`-only by design. Failed logins remain visible through the `faillog` table.

## Two details the data forced

- **The character audit trail is read from `debuglog` *and* `debuglog_archive`.** `Newday::commentCleanup()` moves the live table into the archive with a cutoff of `now` on every new day, so reading only the live table loses most of a 24-hour window. Each half of the `UNION` gets its own placeholder name — a repeated named placeholder is not safe with PDO unless emulated prepares are on. Account names come from one follow-up `IN (:ids)` query rather than a join inside each half; joining there is what forced the `CAST(... AS CHAR)` workarounds in `pages/user/user_debuglog.php`.
- **`gamelog.severity` arrived with a migration** and every query names it — in the `SELECT` list even when no filter was asked for. My first version only fell back to the pre-migration shape when a filter *was* requested, which would have left the main view empty on exactly the unmigrated installations that need it. Fixed, and pinned by a test using a `throwOnceOnFetchAll` seam in the Doctrine stub.

## Review round (18a6285)

Five findings, all correct, all addressed. Two of them mattered:

- **The timeline hid the events it exists to surface** (P1). It fetched the newest 200 game log rows and filtered them in PHP. Routine bookkeeping is the bulk of that table — the comment cleanup alone writes nine maintenance rows per run — so every warning, error and security event behind those 200 rows never reached the timeline. On a busy server, all of them. The restriction is in the statement now, with the category and both severities bound; without the severity column it narrows to the security category rather than failing.
- **Static labels bypassed the translator** (P1). Table headers, section titles and snapshot labels stayed English on a localised installation. They are translated at the render boundary now, and the snapshot rows that mix prose with data no longer arrive as finished sentences: the class hands out a source string plus positional `%s` arguments (AGENTS.md:100), so each sentence stays one translatable unit instead of being concatenated around a timestamp. `Translator` stays out of `Diagnostics` on purpose — a lookup mid-collection would add statements to the log the collector tests assert on.
- **The schema version row could never report its own condition** (P2). When the code and schema versions differ, `common.php:484` renders "Upgrade Needed" and its footer exits, so this page is unreachable in exactly that case. Rather than adding a bypass of that guard — a bad trade on the page with the widest data exposure here — the two versions are reference information now, with a row saying why. Corrected in the admin guide and above.
- **The game log count ignored the severity filter** (P2), so a filtered listing beside an unfiltered total read "showing 5 of 1000". It carries the filter now.
- **Retention rows reported "kept indefinitely"** for any key not yet materialised (P2), though `Newday` applies 30/18/1/7 days regardless. That is the cost of reading the settings map instead of asking key by key: no default arrives with the value. Those defaults are mirrored now, without persisting them.

Each fix with a behavioural guarantee was checked by restoring the defect locally and confirming the new test fails.

## Issue Links

- Not applicable; follow-up to #1519 rather than a filed issue.

## Testing Commands

- [x] `composer test` — 1053 tests, 5148 assertions, all pass (baseline 1019; +34 new). Warning/deprecation counts unchanged from `master`.
- [x] `php -l` on every changed PHP file
- [x] `composer static` — PHPStan clean, `qa:http-wrappers` and `qa:sql-addslashes` pass
- [x] `php scripts/check-sql-value-interpolation.php --changed-since=origin/master` — passes over 7 changed files
- [x] `phpcs` compared per file against `master`: no new violations (the one reported finding is identical in the neighbouring `GameLog.php` / `SecurityLog.php`)

Tests: `tests/DiagnosticsTest.php` (25 cases — window and severity validation, bound parameters, both audit tables, the severity fallback, SQL-side timeline restriction, filtered counts, retention defaults, the settings read), `tests/DiagnosticsPageTest.php` (6 cases — the gate runs before any output, every offered window and severity is registered with the navigation, static labels go through the translator), `tests/Security/DiagnosticsFaillogPostRegressionTest.php` (3 cases — the `post` guards).

## Documentation Updates

- [x] `docs/AdminGuide.md`: the "Where each kind of message goes" table points at the new page, and a new section describes it, both things it will not show, and the corrected version-check wording.
- [x] `UPGRADING.md` untouched on purpose: a new read-only page, no behaviour change to anything existing, no schema change.

## Additional Notes

- [x] Tests added; no migration needed.
- [x] `AGENTS.md` and `CONTRIBUTING.md` reviewed.
- `tests/Stubs/DoctrineBootstrap.php` gains an 11-line `throwOnceOnFetchAll` seam so a test can exercise a query failing against a column an unmigrated installation does not have. The statement is still logged, so the assertion can see what was attempted.

### Security review note

- **Input validation boundary:** only `hours` and `severity` from `Http::get()`. `Diagnostics::normalizeHours()` and `normalizeSeverity()` are the sole place that happens; both compare against fixed allow-lists (`hours` additionally `(int)`-cast), and an unoffered value is *replaced* by the default rather than clamped, so no caller-supplied value reaches a query as anything but a bound timestamp derived from the allow-list.
- **CSRF coverage:** not required — the page changes no state. No writes, no buttons, no form.
- **Authorization:** `SuAccess::check(SU_MEGAUSER)` before any output, pinned by a test asserting nothing has been written when the gate runs. Stricter than the `SU_EDIT_CONFIG` used by the other operational pages, because this one puts their contents together with IP addresses and environment detail in one place.
- **Prepared statements:** every query bound, no `addslashes`, no interpolated values; `ORDER BY` is a constant and `LIMIT` is capped at 200 per source. `debug.php` interpolates a request value into its `ORDER BY` — that pattern is deliberately not copied.
- **Deliberately not shown:** `faillog.post` (see above) and `accounts.emailaddress` — personal data with no diagnostic value.
- **Shown and justified:** IP, login and display name, account id. Without them an administrator cannot act on an incident; access is limited to megausers.
- **Output encoding:** every value passes `Sanitize::sanitize()` and then `outputNotl()` without the privileged flag, so `appoencode()` escapes HTML.
- **Availability:** about eleven queries per view, all against indexed date columns except `gamelog`, whose only index is the composite `(category, date)`. With 30-day retention that partial scan is acceptable for a manually opened admin page; an index on `gamelog(date)` is a separate small change if it proves worth it.

## Deliberately left for later

Each is easy to add once the page has been used in anger: an index on `gamelog(date)`; a tail of the file logs (`logviewer.php` already shows them, so this only links there); datacache statistics and the async configuration (both readable — the async config files are plain `return [...]` files, loadable without the loader's `extract()` and `trigger_error` side effects); a module inventory including drift between `filemoddate` and the real file mtime; a ban overview and top errors by frequency.

Making the async diagnostic stream queryable would need a new sink. A rotating file is the workable route; database rows are not, since that would reverse the decision in #1519 that an unauthenticated caller must not be able to drive one row per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Z9E42yiuXp4X46x8ascjd