### PR TITLE
fix: honor severity-specific error suppression

### DIFF
--- a/src/Lotgd/ErrorHandler.php
+++ b/src/Lotgd/ErrorHandler.php
@@ -105,8 +105,10 @@ class ErrorHandler
         global $session;
         static $inErrorHandler = 0;
 
-        if (! error_reporting()) {
-            return; // @ operator used
+        // Modern PHP may retain a nonzero restricted mask inside an @-suppressed operation,
+        // so suppression must be checked against the severity currently being handled.
+        if ((error_reporting() & $errno) === 0) {
+            return;
         }
         $settings = Settings::hasInstance() ? Settings::getInstance() : null;
         $output   = Output::getInstance();

--- a/tests/ErrorHandlerNoticeDebugTest.php
+++ b/tests/ErrorHandlerNoticeDebugTest.php
@@ -11,10 +11,13 @@ use PHPUnit\Framework\TestCase;
 
 final class ErrorHandlerNoticeDebugTest extends TestCase
 {
+    private int $originalErrorReporting;
+
     protected function setUp(): void
     {
         global $settings, $session, $output;
 
+        $this->originalErrorReporting = error_reporting(E_ALL);
         $settings = new DummySettings([
             'show_notices' => 1,
         ]);
@@ -35,6 +38,7 @@ final class ErrorHandlerNoticeDebugTest extends TestCase
 
     protected function tearDown(): void
     {
+        error_reporting($this->originalErrorReporting);
         unset($GLOBALS['settings'], $GLOBALS['session'], $GLOBALS['output']);
     }
 

--- a/tests/ErrorHandlerReentrancyTest.php
+++ b/tests/ErrorHandlerReentrancyTest.php
@@ -11,11 +11,13 @@ namespace Lotgd\Tests {
     final class ErrorHandlerReentrancyTest extends TestCase
     {
         private $originalOutput;
+        private int $originalErrorReporting;
 
         protected function setUp(): void
         {
             global $settings;
 
+            $this->originalErrorReporting = error_reporting(E_ALL);
             $settings = new DummySettings([
                 // Reentrancy fallback output is only shown when detailed error
                 // display is permitted for the current context. That is the
@@ -38,6 +40,7 @@ namespace Lotgd\Tests {
 
         protected function tearDown(): void
         {
+            error_reporting($this->originalErrorReporting);
             Output::setInstance($this->originalOutput);
             unset($GLOBALS['settings']);
         }

--- a/tests/ErrorHandlerSuppressionTest.php
+++ b/tests/ErrorHandlerSuppressionTest.php
@@ -5,17 +5,18 @@ declare(strict_types=1);
 namespace Lotgd\Tests;
 
 use Lotgd\ErrorHandler;
+use Lotgd\Output;
 use Lotgd\Tests\Stubs\DummySettings;
 use Lotgd\Tests\Stubs\PHPMailer;
 use PHPUnit\Framework\TestCase;
 
-final class ErrorHandlerWarningNotifyTest extends TestCase
+final class ErrorHandlerSuppressionTest extends TestCase
 {
     private int $originalErrorReporting;
 
     protected function setUp(): void
     {
-        global $settings, $mail_sent_count, $output, $last_subject, $session;
+        global $mail_sent_count, $last_subject, $output, $session, $settings;
 
         $this->originalErrorReporting = error_reporting(E_ALL);
         $mail_sent_count = 0;
@@ -32,30 +33,42 @@ final class ErrorHandlerWarningNotifyTest extends TestCase
             ],
         ];
 
-        // Ensure the PHPMailer stub is loaded so Mail::send uses it
         new PHPMailer();
 
-        // Provide minimal output handler for debug()
         $output = new class {
             public function appoencode($data, $priv)
             {
                 return $data;
             }
         };
+
+        Output::getInstance()->resetOutput();
+        $_SERVER['HTTP_HOST'] = 'example.com';
+        set_error_handler([ErrorHandler::class, 'handleError']);
     }
 
     protected function tearDown(): void
     {
+        restore_error_handler();
         error_reporting($this->originalErrorReporting);
+        Output::getInstance()->resetOutput();
+        unset($GLOBALS['mail_sent_count'], $GLOBALS['last_subject'], $GLOBALS['output']);
+        unset($GLOBALS['session'], $GLOBALS['settings']);
     }
 
-    public function testWarningNotificationIsSent(): void
+    public function testSuppressedWarningIsNeitherDisplayedNorEmailed(): void
     {
-        $_SERVER['HTTP_HOST'] = 'example.com';
-        ob_start();
-        ErrorHandler::handleError(E_WARNING, 'Test warning', 'file.php', 42);
-        ob_end_clean();
+        @trigger_error('Suppressed warning', E_USER_WARNING);
 
+        $this->assertSame('', Output::getInstance()->getRawOutput());
+        $this->assertSame(0, $GLOBALS['mail_sent_count']);
+    }
+
+    public function testUnsuppressedWarningUsesNormalDisplayAndNotificationHandling(): void
+    {
+        trigger_error('Unsuppressed warning', E_USER_WARNING);
+
+        $this->assertStringContainsString('Unsuppressed warning', Output::getInstance()->getRawOutput());
         $this->assertSame(1, $GLOBALS['mail_sent_count']);
         $this->assertSame('LotGD Warning on example.com', $GLOBALS['last_subject']);
     }

--- a/tests/ErrorHandlerWarningNotifyTest.php
+++ b/tests/ErrorHandlerWarningNotifyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lotgd\Tests;
 
 use Lotgd\ErrorHandler;
+use Lotgd\Output;
 use Lotgd\Tests\Stubs\DummySettings;
 use Lotgd\Tests\Stubs\PHPMailer;
 use PHPUnit\Framework\TestCase;
@@ -42,10 +43,14 @@ final class ErrorHandlerWarningNotifyTest extends TestCase
                 return $data;
             }
         };
+
+        // PHPUnit's global backup does not reset static singleton state.
+        Output::getInstance()->resetOutput();
     }
 
     protected function tearDown(): void
     {
+        Output::getInstance()->resetOutput();
         error_reporting($this->originalErrorReporting);
     }
 


### PR DESCRIPTION
### Motivation
- Modern PHP can expose a nonzero, restricted error-reporting mask inside an `@`-suppressed operation, so the previous `error_reporting()` zero-check could misinterpret suppression state and handle suppressed errors incorrectly.
- The handler must therefore decide suppression per-severity so `@` really silences the intended severity while leaving other severities handled normally.

### Description
- Replace the blanket `if (! error_reporting()) { return; }` check in `Lotgd\ErrorHandler::handleError()` with a severity-aware test `if ((error_reporting() & $errno) === 0) { return; }` and add an inline comment explaining why this is required for modern PHP.
- Add `tests/ErrorHandlerSuppressionTest.php` with focused assertions that an `@`-suppressed `E_USER_WARNING` produces no debug output and no notification while an identical unsuppressed warning is displayed and emailed.
- Make existing direct-handler tests deterministic by explicitly setting and restoring `error_reporting()` in `tests/ErrorHandlerWarningNotifyTest.php`, `tests/ErrorHandlerNoticeDebugTest.php`, and `tests/ErrorHandlerReentrancyTest.php`.
- Leave `src/Lotgd/DataCache.php` unchanged as requested.

### Testing
- Ran `php -l` on the modified files (`src/Lotgd/ErrorHandler.php`, all new/changed tests) with no syntax errors reported.
- Executed focused PHPUnit runs including `vendor/bin/phpunit -c phpunit.xml tests/ErrorHandlerSuppressionTest.php` and the group of handler tests which passed (focused runs: 5 tests, 11 assertions; suppression tests: 2 tests, 5 assertions) with the new behavior verified.
- Ran the full test suite via `composer --no-plugins test`, which completed successfully (1,055 tests) while reporting existing warnings/deprecations/notices that are unrelated to this change.
- Ran static checks (`composer --no-plugins static`) and `git diff --check`, both completed without introducing new blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa23dda53f88329b3743195666ef940)