### PR TITLE
test: let the sprintfTranslate recorder hear what can actually be raised

### DIFF
--- a/tests/Translator/SprintfTranslateTest.php
+++ b/tests/Translator/SprintfTranslateTest.php
@@ -14,12 +14,18 @@ use PHPUnit\Framework\TestCase;
 /**
  * sprintfTranslate() formats strings whose placeholders come from a translation
  * file and whose arguments come from the calling page. The two can disagree --
- * a translator adds a placeholder, a caller drops an argument -- and plain
- * sprintf() answers that with a warning and, historically, a broken page. The
- * contract is that it pads or drops silently instead.
+ * a translator adds a placeholder, a caller drops an argument -- and under
+ * PHP 8 plain vsprintf() answers that by throwing a ValueError, which
+ * historically meant a broken page. The contract here is that it pads or drops
+ * silently instead.
  *
- * Every case therefore checks the result *and* that nothing was raised, which
- * is why each one runs through the warning recorder below.
+ * Every case therefore checks the result *and* that nothing was raised on the
+ * way, which is why each one runs through the recorder below. The recorder
+ * takes E_ALL on purpose: this code path raises nothing of its own -- it never
+ * calls trigger_error() -- so anything that does show up comes from PHP itself
+ * and would be E_WARNING, never E_USER_WARNING. A recorder scoped to the latter
+ * listens for a class of message that cannot occur here, which makes the
+ * assertion read as a guarantee while proving nothing.
  *
  * Runs in its own process: this class define()s process-global constants, and a
  * constant cannot be undefined. Without isolation the first test to run here
@@ -57,7 +63,7 @@ final class SprintfTranslateTest extends TestCase
             $warnings[] = [$errno, $errstr];
 
             return true;
-        }, E_USER_WARNING);
+        }, E_ALL);
 
         try {
             $result = Translator::sprintfTranslate($format, ...$args);
@@ -66,7 +72,7 @@ final class SprintfTranslateTest extends TestCase
         }
 
         self::assertSame($expected, $result);
-        self::assertSame([], $warnings, 'sprintfTranslate() must not raise on a format/argument mismatch');
+        self::assertSame([], $warnings, 'sprintfTranslate() must not raise anything on a format/argument mismatch');
     }
 
     /**

--- a/tests/Translator/SprintfTranslateTest.php
+++ b/tests/Translator/SprintfTranslateTest.php
@@ -22,9 +22,10 @@ use PHPUnit\Framework\TestCase;
  * Every case therefore checks the result *and* that nothing was raised on the
  * way, which is why each one runs through the recorder below. The recorder
  * takes E_ALL on purpose: this code path raises nothing of its own -- it never
- * calls trigger_error() -- so anything that does show up comes from PHP itself
- * and would be E_WARNING, never E_USER_WARNING. A recorder scoped to the latter
- * listens for a class of message that cannot occur here, which makes the
+ * calls trigger_error() -- so whatever does show up comes from PHP, at
+ * whichever level PHP chooses, and the point is to hear all of them rather
+ * than to predict which. A recorder scoped to E_USER_WARNING, as this one was,
+ * listens for the one level this path cannot produce, which makes the
  * assertion read as a guarantee while proving nothing.
  *
  * Runs in its own process: this class define()s process-global constants, and a
@@ -58,9 +59,9 @@ final class SprintfTranslateTest extends TestCase
     #[DataProvider('formatProvider')]
     public function testFormatsWithoutRaisingAnything(string $format, array $args, string $expected): void
     {
-        $warnings = [];
-        set_error_handler(static function (int $errno, string $errstr) use (&$warnings): bool {
-            $warnings[] = [$errno, $errstr];
+        $raised = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$raised): bool {
+            $raised[] = [$errno, $errstr];
 
             return true;
         }, E_ALL);
@@ -72,7 +73,7 @@ final class SprintfTranslateTest extends TestCase
         }
 
         self::assertSame($expected, $result);
-        self::assertSame([], $warnings, 'sprintfTranslate() must not raise anything on a format/argument mismatch');
+        self::assertSame([], $raised, 'sprintfTranslate() must not raise anything on a format/argument mismatch');
     }
 
     /**


### PR DESCRIPTION
## Summary

- [x] Provide a clear, concise summary of the change.
- [x] Link related discussions or provide necessary context.

The last finding from Copilot's second review of #1522, which landed after that PR was merged. It arrived in the review body rather than as a thread, so it is not among the five resolved there.

`tests/Translator/SprintfTranslateTest.php` recorded warnings with the handler scoped to `E_USER_WARNING`. `Translator::sprintfTranslate()` never calls `trigger_error()`, so it cannot raise that at all: under PHP 8 `vsprintf()` throws a `ValueError` on a format/argument mismatch — which the method catches and pads around — and anything else would come from PHP itself as `E_WARNING`. The recorder was listening for a class of message this code path cannot produce, so `assertSame([], $warnings)` read as a guarantee while proving nothing.

Takes `E_ALL` now, matching `tests/ErrorHandler/NotificationSubjectTest.php`, which got this right in the same PR.

The docblock carried the assumption that produced the narrow mask — it claimed plain `sprintf()` answers a mismatch "with a warning". It says `ValueError` now.

### Verified by mutation

Injecting a `trigger_error()` into `sprintfTranslate()` fails all eight cases:

| Injected level | Old mask (`E_USER_WARNING`) | New mask (`E_ALL`) |
|---|---|---|
| `E_USER_WARNING` | would have caught it | 8 failures |
| `E_USER_DEPRECATED` | **would have missed it** | 8 failures |

The second row is the point: the widening is not cosmetic.

### Checked the siblings, and they are not the same bug

- `tests/Modules/Hooks/ModuleHookValidationTest.php:80` uses `E_USER_WARNING` — **correct here**, because the code under test really does call `trigger_error(..., E_USER_WARNING)` at `src/Lotgd/Modules.php:590` and `:620`.
- `tests/OutputNotlArrayArgumentTest.php:56` uses `E_WARNING`. Unverified, and outside this change's scope — noted for the follow-up rather than widening this PR.

## Issue Links

- [ ] Resolves #[ISSUE]
- [ ] Related to #[ISSUE]

Follow-up to #1522 (merged).

## Testing Commands

Confirm you ran the required checks locally:

- [x] `composer test`
- [x] `php -l` (on all modified PHP files)
- [x] `composer static`

```
composer test                                              OK — 1122 tests, 5335 assertions
vendor/bin/phpunit --order-by=reverse                      OK — same 5335 assertions
vendor/bin/phpunit --order-by=random --random-order-seed=1234   OK
composer static                                            [OK] No errors
php -l tests/Translator/SprintfTranslateTest.php           clean
```

## Documentation Updates

- [x] Documentation not required; behaviour is unchanged.
- [ ] Documentation updated (e.g., README, in-code docs).
- [ ] Behaviour changed and I updated `UPGRADING.md` and/or `docs/Deprecations.md` as appropriate.

Test-only change; the `CHANGELOG.md` entry from #1522 already covers this work.

## Additional Notes

- [x] Tests or migrations added when needed.
- [x] Changes keep the diff minimal and focused.
- [x] I reviewed the AGENTS.md guidelines before submitting this PR.
- [x] I reviewed the CONTRIBUTING.md checklist before submitting this PR.

One file, 13 insertions, 7 deletions. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014VckBn1RJoNDZNxk4daywc

---
_Generated by [Claude Code](https://claude.ai/code/session_014VckBn1RJoNDZNxk4daywc)_