### PR TITLE
test: cover the three places where value changes hands

### DIFF
--- a/tests/Buffs/ActivateBuffsTest.php
+++ b/tests/Buffs/ActivateBuffsTest.php
@@ -177,9 +177,10 @@ final class ActivateBuffsTest extends TestCase
      */
     public function testTheTagDoesNotGateTheModifiers(): void
     {
+        // The second activate() replaces the whole 'blessing' entry, so the
+        // 'used' marker the first run set is gone and the two calls do not
+        // interfere. No fixture reset is needed between them.
         $onOffense = $this->activate(['blessing' => ['atkmod' => 2.0]], 'offense');
-
-        $this->setUp();
         $onDefense = $this->activate(['blessing' => ['atkmod' => 2.0]], 'defense');
 
         self::assertSame(2.0, $onOffense['atkmod']);

--- a/tests/Buffs/ActivateBuffsTest.php
+++ b/tests/Buffs/ActivateBuffsTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Buffs;
+
+use Lotgd\Buffs;
+use Lotgd\Output;
+use Lotgd\Template;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Buffs::activateBuffs() reduces the player's active buffs to the set of
+ * modifiers a combat round is fought with. Its only existing test was a smoke
+ * test that checked nothing threw.
+ *
+ * The property worth pinning is that modifiers *multiply*. Two buffs that each
+ * halve incoming damage leave it at a quarter, not a half, and that is where
+ * stacking exploits live -- a change from *= to = would look harmless and would
+ * quietly rebalance every fight in the game.
+ */
+final class ActivateBuffsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $session, $badguy, $count;
+
+        // A round message goes through Substitute, which reads the fighters'
+        // names and gear off both sides. A thinner fixture still passes but
+        // adds undefined-key warnings to every run.
+        $session = [
+            'user' => [
+                'maxhitpoints' => 100,
+                'hitpoints' => 100,
+                'name' => 'Hero',
+                'weapon' => 'Sword',
+                'armor' => 'Mail',
+                'sex' => 0,
+            ],
+            'bufflist' => [],
+        ];
+        $badguy = [
+            'istarget' => false,
+            'creaturename' => 'Goblin',
+            'creatureweapon' => 'Club',
+        ];
+        $count = 0;
+        Template::getInstance()->setTemplate([]);
+    }
+
+    protected function tearDown(): void
+    {
+        global $session, $badguy, $count;
+
+        unset($session, $badguy, $count);
+        Template::getInstance()->setTemplate([]);
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $buffs
+     * @return array<string, mixed>
+     */
+    private function activate(array $buffs, string $tag = 'offense'): array
+    {
+        global $session;
+
+        foreach ($buffs as $name => $buff) {
+            $session['bufflist'][$name] = $buff + ['schema' => false];
+        }
+
+        return Buffs::activateBuffs($tag);
+    }
+
+    public function testTwoBuffsOfTheSameKindMultiply(): void
+    {
+        $result = $this->activate([
+            'blessing' => ['atkmod' => 1.5],
+            'fervour' => ['atkmod' => 2.0],
+        ]);
+
+        self::assertSame(3.0, $result['atkmod'], '1.5 and 2.0 stack to 3.0, they do not replace');
+    }
+
+    public function testEachModifierAccumulatesIndependently(): void
+    {
+        $result = $this->activate([
+            'ward' => ['defmod' => 2.0, 'badguyatkmod' => 0.5],
+            'curse' => ['badguydmgmod' => 0.25, 'dmgmod' => 3.0],
+        ]);
+
+        self::assertSame(2.0, $result['defmod']);
+        self::assertSame(0.5, $result['badguyatkmod']);
+        self::assertSame(0.25, $result['badguydmgmod']);
+        self::assertSame(3.0, $result['dmgmod']);
+        self::assertSame(1, $result['atkmod'], 'an untouched modifier stays neutral, and stays an int until something multiplies it');
+    }
+
+    /**
+     * An aura extends the player's attack, defence and damage modifiers to
+     * their companions; a buff without one leaves the companions at 1.
+     */
+    public function testAnAuraExtendsTheModifierToCompanions(): void
+    {
+        $withAura = $this->activate([
+            'banner' => ['atkmod' => 2.0, 'defmod' => 3.0, 'dmgmod' => 4.0, 'aura' => true],
+        ]);
+
+        self::assertSame(2.0, $withAura['compatkmod']);
+        self::assertSame(3.0, $withAura['compdefmod']);
+        self::assertSame(4.0, $withAura['compdmgmod']);
+    }
+
+    public function testWithoutAnAuraTheCompanionsAreUnaffected(): void
+    {
+        $result = $this->activate([
+            'selfish' => ['atkmod' => 2.0, 'defmod' => 3.0, 'dmgmod' => 4.0],
+        ]);
+
+        self::assertSame(2.0, $result['atkmod'], 'positive control: the player does get it');
+        self::assertSame(1, $result['compatkmod']);
+        self::assertSame(1, $result['compdefmod']);
+        self::assertSame(1, $result['compdmgmod']);
+    }
+
+    public function testASuspendedBuffContributesNothing(): void
+    {
+        $result = $this->activate([
+            'active' => ['atkmod' => 2.0],
+            'paused' => ['atkmod' => 5.0, 'suspended' => true],
+        ]);
+
+        self::assertSame(2.0, $result['atkmod'], 'only the active buff counts');
+    }
+
+    public function testInvulnerabilityLatchesOn(): void
+    {
+        $result = $this->activate([
+            'mortal' => ['atkmod' => 2.0],
+            'shielded' => ['invulnerable' => 1],
+        ]);
+
+        self::assertSame(1, $result['invulnerable']);
+    }
+
+    public function testAnUnsetInvulnerabilityLeavesTheDefaultAlone(): void
+    {
+        $result = $this->activate(['plain' => ['atkmod' => 2.0]]);
+
+        self::assertSame(0, $result['invulnerable']);
+    }
+
+    /**
+     * Lifetaps and damage shields are collected whole rather than reduced to a
+     * number, because the round applies each one separately.
+     */
+    public function testLifetapsAndDamageShieldsAreCollected(): void
+    {
+        $result = $this->activate([
+            'leech' => ['lifetap' => 0.5],
+            'thorns' => ['damageshield' => 3],
+        ]);
+
+        self::assertCount(1, $result['lifetap']);
+        self::assertSame(0.5, $result['lifetap'][0]['lifetap']);
+        self::assertCount(1, $result['dmgshield']);
+        self::assertSame(3, $result['dmgshield'][0]['damageshield']);
+    }
+
+    /**
+     * The tag decides which buffs announce themselves, not which ones count.
+     *
+     * This is the least obvious thing in the method: the $activate flag built
+     * from the tag guards only the round message and the 'used' marker, while
+     * the modifier arithmetic below it runs for every buff that is not
+     * suspended. A reader expecting 'defense' to exclude an attack buff would
+     * be wrong, so it is worth a case of its own.
+     */
+    public function testTheTagDoesNotGateTheModifiers(): void
+    {
+        $onOffense = $this->activate(['blessing' => ['atkmod' => 2.0]], 'offense');
+
+        $this->setUp();
+        $onDefense = $this->activate(['blessing' => ['atkmod' => 2.0]], 'defense');
+
+        self::assertSame(2.0, $onOffense['atkmod']);
+        self::assertSame(2.0, $onDefense['atkmod'], 'the attack modifier applies on defence too');
+    }
+
+    /**
+     * A buff that has announced itself is marked used, so the same round
+     * message cannot be printed twice.
+     */
+    public function testAnActivatedBuffIsMarkedUsed(): void
+    {
+        global $session;
+
+        $this->activate(['blessing' => ['atkmod' => 2.0, 'roundmsg' => 'The blessing holds.']], 'offense');
+
+        self::assertSame(1, $session['bufflist']['blessing']['used']);
+        self::assertStringContainsString('The blessing holds.', Output::getInstance()->getRawOutput());
+    }
+
+    public function testABuffAlreadyMarkedUsedDoesNotAnnounceItselfAgain(): void
+    {
+        $this->activate([
+            'blessing' => ['atkmod' => 2.0, 'roundmsg' => 'The blessing holds.', 'used' => 1],
+        ], 'offense');
+
+        self::assertStringNotContainsString('The blessing holds.', Output::getInstance()->getRawOutput());
+    }
+}

--- a/tests/Newday/DragonPointRecalcTest.php
+++ b/tests/Newday/DragonPointRecalcTest.php
@@ -75,7 +75,10 @@ final class DragonPointRecalcTest extends TestCase
     /**
      * Post a spend and run the recalculation.
      *
-     * @param array<string, string> $spend
+     * Keyed by array-key rather than string: the section-title entries in the
+     * label list carry integer keys, and a field naming one is posted as such.
+     *
+     * @param array<array-key, string> $spend
      */
     private function spend(array $spend, int $dkills, int &$dp): void
     {
@@ -184,13 +187,20 @@ final class DragonPointRecalcTest extends TestCase
     /**
      * The section titles in the label list are not spendable types, and a post
      * naming one must not become a point.
+     *
+     * The field to post is the numeric 0, not the label text. The title entries
+     * are written into the array without an explicit key, so they get the next
+     * integer -- and dragonPointRecalc() reads the POST by key, via
+     * Http::post($type). Posting 'General Stuff,title' would name a field the
+     * method never looks at, which would leave the assertions below passing for
+     * the wrong reason.
      */
     public function testPostingAgainstASectionTitleIsIgnored(): void
     {
         global $session;
 
         $dp = 0;
-        $this->spend(['hp' => '2', 'General Stuff,title' => '5'], dkills: 2, dp: $dp);
+        $this->spend(['hp' => '2', 0 => '5'], dkills: 2, dp: $dp);
 
         self::assertSame(2, $dp, 'only the two hitpoint points count');
         self::assertSame(110, $session['user']['maxhitpoints']);

--- a/tests/Newday/DragonPointRecalcTest.php
+++ b/tests/Newday/DragonPointRecalcTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Newday;
+
+use Lotgd\Newday;
+use Lotgd\Output;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Newday::dragonPointRecalc() spends dragon points on permanent stats, from
+ * numbers the player posts. Nothing about that is reversible and nothing about
+ * it was tested.
+ *
+ * Two conditions stand between the form and the grant:
+ *
+ *     if ($pdktotal == $dkills - $dp && !$pdkneg) {
+ *
+ * The first is bookkeeping -- spend exactly what you have. The second is the
+ * one that matters: without it, posting hp=10 together with at=-9 sums to 1
+ * while asking for ten points' worth of hitpoints. A sum check alone cannot
+ * tell the difference, which is why both halves need a case of their own.
+ */
+final class DragonPointRecalcTest extends TestCase
+{
+    /**
+     * The labels newday.php passes in.
+     *
+     * The entries carrying a comma are section titles rather than spendable
+     * types, and dragonPointRecalc() skips them. They are kept here because
+     * their presence is part of what the method has to cope with.
+     *
+     * @var array<int|string, string>
+     */
+    private const LABELS = [
+        'General Stuff,title',
+        'hp' => 'Max Hitpoints + 5',
+        'ff' => 'Forest Fights + 1',
+        'Attributes,title',
+        'str' => 'Strength +1',
+        'dex' => 'Dexterity +1',
+        'con' => 'Constitution +1',
+        'int' => 'Intelligence +1',
+        'wis' => 'Wisdom +1',
+        'at' => 'Attack + 1',
+        'de' => 'Defense + 1',
+    ];
+
+    private const BASE_STATS = [
+        'maxhitpoints' => 100,
+        'attack' => 10,
+        'defense' => 10,
+        'strength' => 20,
+        'dexterity' => 21,
+        'intelligence' => 22,
+        'constitution' => 23,
+        'wisdom' => 24,
+    ];
+
+    protected function setUp(): void
+    {
+        global $session;
+
+        $_POST = [];
+        $session = ['user' => self::BASE_STATS + ['dragonpoints' => []]];
+    }
+
+    protected function tearDown(): void
+    {
+        $_POST = [];
+    }
+
+    /**
+     * Post a spend and run the recalculation.
+     *
+     * @param array<string, string> $spend
+     */
+    private function spend(array $spend, int $dkills, int &$dp): void
+    {
+        $_POST = $spend;
+        Newday::dragonPointRecalc(self::LABELS, $dkills, $dp);
+    }
+
+    /**
+     * @return array<string, int|float>
+     */
+    private static function stats(): array
+    {
+        global $session;
+
+        return array_intersect_key($session['user'], self::BASE_STATS);
+    }
+
+    public function testASpendThatAddsUpGrantsTheStats(): void
+    {
+        global $session;
+
+        $dp = 0;
+        $this->spend(['hp' => '2', 'str' => '1', 'wis' => '1'], dkills: 4, dp: $dp);
+
+        self::assertSame(4, $dp, 'the points are now spent');
+        self::assertSame(110, $session['user']['maxhitpoints'], 'five hitpoints per point');
+        self::assertSame(21, $session['user']['strength']);
+        self::assertSame(25, $session['user']['wisdom']);
+        self::assertSame(10, $session['user']['attack'], 'untouched types do not move');
+    }
+
+    /**
+     * The spend is recorded per point, not per type, because the list is what
+     * a later newday reads back to know what was bought.
+     */
+    public function testEachPointIsRecordedSeparately(): void
+    {
+        global $session;
+
+        $dp = 0;
+        $this->spend(['hp' => '2', 'ff' => '1'], dkills: 3, dp: $dp);
+
+        self::assertSame(['hp', 'hp', 'ff'], $session['user']['dragonpoints']);
+    }
+
+    /**
+     * Forest fights are spendable and countable but grant no stat here -- the
+     * record in dragonpoints is the whole effect.
+     */
+    public function testForestFightsCountWithoutChangingAStat(): void
+    {
+        $dp = 0;
+        $this->spend(['ff' => '2'], dkills: 2, dp: $dp);
+
+        self::assertSame(2, $dp);
+        self::assertSame(self::BASE_STATS, self::stats());
+    }
+
+    /**
+     * A rejected spend must change nothing at all.
+     *
+     * Asserting only on the error message would let a partial grant through,
+     * which is the failure that would actually matter.
+     *
+     * @param array<string, string> $spend
+     */
+    #[DataProvider('rejectedSpendProvider')]
+    public function testARejectedSpendGrantsNothing(array $spend, int $dkills): void
+    {
+        global $session;
+
+        $dp = 0;
+        $this->spend($spend, $dkills, $dp);
+
+        self::assertSame(0, $dp, 'no point may be marked spent');
+        self::assertSame(self::BASE_STATS, self::stats(), 'no stat may move');
+        self::assertSame([], $session['user']['dragonpoints'], 'nothing may be recorded');
+        self::assertStringContainsString(
+            'spend the correct total amount',
+            Output::getInstance()->getRawOutput(),
+            'and the player is told'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: array<string, string>, 1: int}>
+     */
+    public static function rejectedSpendProvider(): array
+    {
+        return [
+            'spending more than is available' => [['hp' => '5'], 2],
+            'spending less than is available' => [['hp' => '1'], 4],
+            'spending nothing at all' => [[], 2],
+
+            // The exploit the negative check exists for: these sum to exactly
+            // the points available, so the total check passes on its own.
+            'a negative offsetting a larger positive' => [['hp' => '10', 'at' => '-9'], 1],
+            'a negative offset across three types' => [['hp' => '8', 'str' => '2', 'de' => '-8'], 2],
+
+            // A negative on its own does not add up either, but it must be
+            // refused for being negative rather than by luck of the sum.
+            'a bare negative' => [['hp' => '-2'], -2],
+        ];
+    }
+
+    /**
+     * The section titles in the label list are not spendable types, and a post
+     * naming one must not become a point.
+     */
+    public function testPostingAgainstASectionTitleIsIgnored(): void
+    {
+        global $session;
+
+        $dp = 0;
+        $this->spend(['hp' => '2', 'General Stuff,title' => '5'], dkills: 2, dp: $dp);
+
+        self::assertSame(2, $dp, 'only the two hitpoint points count');
+        self::assertSame(110, $session['user']['maxhitpoints']);
+        self::assertSame(['hp', 'hp'], $session['user']['dragonpoints']);
+    }
+
+    /**
+     * Points already spent are subtracted before the total is checked, so a
+     * player returning with some of their dragon kills already committed can
+     * only spend the remainder.
+     */
+    public function testOnlyTheUnspentRemainderMayBeSpent(): void
+    {
+        global $session;
+
+        $session['user']['dragonpoints'] = ['hp', 'hp'];
+        $dp = 2;
+        $this->spend(['str' => '1'], dkills: 3, dp: $dp);
+
+        self::assertSame(3, $dp);
+        self::assertSame(21, $session['user']['strength']);
+    }
+}

--- a/tests/Pvp/VictoryTest.php
+++ b/tests/Pvp/VictoryTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotgd\Tests\Pvp;
+
+use Doctrine\DBAL\ParameterType;
+use Lotgd\MySQL\Database as CoreDatabase;
+use Lotgd\Output;
+use Lotgd\Pvp;
+use Lotgd\Settings;
+use Lotgd\Tests\Stubs\Database;
+use Lotgd\Tests\Stubs\DummySettings;
+use Lotgd\Tests\Stubs\PHPMailer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pvp::victory() moves gold and experience from one player's account to
+ * another's, and until now nothing checked the arithmetic that decides how
+ * much. The formulas below were read out of src/Lotgd/Pvp.php and then
+ * confirmed against the running code, so each expected number here is the one
+ * the game actually produces today -- these cases pin current behaviour, they
+ * do not assert what the balance ought to be.
+ *
+ * The one case that is a rule rather than a formula is the cap: an attacker
+ * cannot take more gold than the defender owns. Without it PvP mints money.
+ *
+ * The expectations are floats on purpose. victory() builds both awards with
+ * round(), which returns a float in PHP, so a win leaves gold and experience
+ * as floats in the session. That is what the code does today; asserting ints
+ * here would mean writing a test that the game fails.
+ */
+final class VictoryTest extends TestCase
+{
+    private const ATTACKER = 1;
+    private const DEFENDER = 2;
+
+    /**
+     * @param array<string, mixed> $settings
+     * @param array<string, mixed> $attacker
+     */
+    private function runVictory(
+        int $defenderGold,
+        array $badguy = [],
+        array $settings = [],
+        array $attacker = []
+    ): void {
+        global $session;
+
+        new PHPMailer();
+
+        Settings::setInstance(new DummySettings($settings + [
+            'pvpattgain' => 10,
+            'pvpdeflose' => 5,
+            'pvphardlimit' => 0,
+            'usedatacache' => 0,
+        ]));
+
+        $session = ['user' => $attacker + [
+            'acctid' => self::ATTACKER,
+            'name' => 'Attacker',
+            'level' => 5,
+            'sex' => 0,
+            'gold' => 0,
+            'experience' => 0,
+            'weapon' => 'Sword',
+            'hitpoints' => 20,
+        ]];
+
+        CoreDatabase::resetDoctrineConnection();
+        // The gold the defender actually has, as victory() reads it back before
+        // deciding how much can be taken.
+        Database::$mockResults = [[['gold' => $defenderGold]]];
+
+        Pvp::victory($badguy + [
+            'acctid' => self::DEFENDER,
+            'creaturename' => 'Defender',
+            'creaturelevel' => 6,
+            'creaturegold' => 300,
+            'creatureexp' => 2000,
+            'playerstarthp' => 40,
+            'fightstartdate' => 1700000000,
+        ], 'the field');
+    }
+
+    /**
+     * The UPDATE that takes the loss from the defender.
+     *
+     * @return array{sql: string, params: array<string, mixed>, types: array<string, mixed>}
+     */
+    private static function defenderUpdate(): array
+    {
+        $statements = array_values(array_filter(
+            CoreDatabase::getDoctrineConnection()->executeStatements,
+            static fn (array $statement): bool => str_contains($statement['sql'], 'UPDATE ' . CoreDatabase::prefix('accounts'))
+        ));
+
+        self::assertCount(1, $statements, 'the defender should be updated exactly once');
+
+        return $statements[0];
+    }
+
+    /**
+     * An attacker must not be able to take gold the defender does not have.
+     *
+     * victory() re-reads the defender's balance and caps the prize at it. The
+     * cap is the only thing standing between PvP and a money press: creaturegold
+     * comes from the fight setup, not from the defender's current purse.
+     */
+    public function testTheprizeIsCappedAtTheGoldTheDefenderActuallyHas(): void
+    {
+        global $session;
+
+        // Defender carries 50; the fight offered 300.
+        $this->runVictory(defenderGold: 50);
+
+        // round(10 * 6 * log(50)) -- computed from 50, not from 300.
+        self::assertSame(235.0, $session['user']['gold']);
+        self::assertSame(50, self::defenderUpdate()['params']['creaturegold_for_subtract']);
+    }
+
+    public function testTheFullPrizeIsPaidWhenTheDefenderCanCoverIt(): void
+    {
+        global $session;
+
+        $this->runVictory(defenderGold: 500);
+
+        // round(10 * 6 * log(300))
+        self::assertSame(342.0, $session['user']['gold']);
+        self::assertSame(300, self::defenderUpdate()['params']['creaturegold_for_subtract']);
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     */
+    #[DataProvider('experienceProvider')]
+    public function testExperienceAwarded(int $attackerLevel, int $defenderLevel, array $settings, float $expected): void
+    {
+        global $session;
+
+        $this->runVictory(
+            defenderGold: 500,
+            badguy: ['creaturelevel' => $defenderLevel],
+            settings: $settings,
+            attacker: ['level' => $attackerLevel]
+        );
+
+        self::assertSame($expected, $session['user']['experience']);
+    }
+
+    /**
+     * @return array<string, array{0: int, 1: int, 2: array<string, mixed>, 3: float}>
+     */
+    public static function experienceProvider(): array
+    {
+        // base = round(pvpattgain% of creatureexp 2000) = 200, then scaled by
+        // 1 + 0.1 * (defender level - attacker level).
+        return [
+            'even fight pays the base award' => [6, 6, [], 200.0],
+            'punching up pays a bonus' => [5, 6, [], 220.0],
+            'punching further up pays more' => [3, 6, [], 260.0],
+            'punching down is penalised' => [8, 6, [], 160.0],
+            'the hard limit caps the award' => [6, 6, ['pvphardlimit' => 1, 'pvphardlimitamount' => 50], 50.0],
+            'the cap is ignored while the limit is off' => [6, 6, ['pvphardlimitamount' => 50], 200.0],
+            'a higher attack gain pays more' => [6, 6, ['pvpattgain' => 25], 500.0],
+        ];
+    }
+
+    /**
+     * At the level cap there is nothing left to gain, and victory() says so
+     * rather than silently paying nothing: three separate branches zero the
+     * gold and the experience.
+     */
+    public function testTheLevelCapEarnsNeitherGoldNorExperience(): void
+    {
+        global $session;
+
+        $this->runVictory(defenderGold: 500, attacker: ['level' => 15]);
+
+        // Gold is zeroed by a literal assignment and stays an int; the
+        // experience still runs through round() on its way to zero and comes
+        // out a float. Which is the clearest evidence of where the floats in
+        // the other cases come from.
+        self::assertSame(0, $session['user']['gold']);
+        self::assertSame(0.0, $session['user']['experience']);
+        self::assertStringContainsString(
+            'sufficient accolade',
+            Output::getInstance()->getRawOutput(),
+            'the player is told why there is no reward'
+        );
+    }
+
+    /**
+     * The defender is left dead, poorer and less experienced -- and every value
+     * in that statement is bound, not interpolated.
+     */
+    public function testTheDefenderLosesGoldAndExperienceAndIsMarkedDead(): void
+    {
+        $this->runVictory(defenderGold: 500);
+
+        $update = self::defenderUpdate();
+
+        self::assertStringContainsString('alive = 0', $update['sql']);
+        self::assertSame(self::DEFENDER, $update['params']['acctid']);
+        self::assertSame(ParameterType::INTEGER, $update['types']['acctid']);
+
+        // pvpdeflose is 5%, of creatureexp 2000.
+        self::assertSame(100, $update['params']['lostexp_for_subtract']);
+
+        foreach ($update['types'] as $name => $type) {
+            self::assertSame(ParameterType::INTEGER, $type, "{$name} must be bound as an integer");
+        }
+        self::assertStringNotContainsString('300', $update['sql'], 'amounts belong in the parameters');
+    }
+
+    /**
+     * Experience cannot go negative: the statement floors it at zero rather
+     * than subtracting past it.
+     */
+    public function testTheDefendersExperienceIsFlooredAtZero(): void
+    {
+        $this->runVictory(defenderGold: 500);
+
+        self::assertStringContainsString(
+            'experience = IF(experience >= :lostexp_for_check, experience - :lostexp_for_subtract, 0)',
+            self::defenderUpdate()['sql']
+        );
+    }
+}

--- a/tests/Pvp/VictoryTest.php
+++ b/tests/Pvp/VictoryTest.php
@@ -108,7 +108,7 @@ final class VictoryTest extends TestCase
      * cap is the only thing standing between PvP and a money press: creaturegold
      * comes from the fight setup, not from the defender's current purse.
      */
-    public function testTheprizeIsCappedAtTheGoldTheDefenderActuallyHas(): void
+    public function testThePrizeIsCappedAtTheGoldTheDefenderActuallyHas(): void
     {
         global $session;
 


### PR DESCRIPTION
## Summary

- [x] Provide a clear, concise summary of the change.
- [x] Link related discussions or provide necessary context.

The coverage half of the test-suite audit. #1522, #1523 and #1524 fixed how the suite tests; this starts fixing *what* it tests.

The audit's third finding was that **coverage is inverse to stakes**. `ErrorHandler` had 23 test files. A grep across the whole suite for `Pvp::`, `dragonPointSpend`, `goldinbank`, `rollDamage` and `seenmaster` returned nothing — the gold and experience transfer between player accounts, permanent stat purchases, and combat damage had no behavioural tests at all.

This covers the three gaps that need **no production change**: the code already sits testable in `src/`. **No production file is touched in this PR** — 3 new test files, 657 insertions, 0 deletions.

### Why these three

Each moves something permanent, and two of them have a guard where a missing check turns directly into a player advantage.

**`Pvp::victory()`** — 543 LOC, zero tests. The rule worth having a test for is the cap: victory() re-reads the defender's balance and limits the prize to it, because `creaturegold` comes from the fight setup rather than from the defender's current purse. Without that line an attacker is paid for gold the defender never had — a money press rather than a transfer.

Also covered: the experience award across seven combinations (even fight, punching up, punching down, the hard limit on and off, a raised attack gain), the level cap earning nothing at all, and the UPDATE that takes the loss — every value bound rather than interpolated, experience floored at zero, defender marked dead.

**`Newday::dragonPointRecalc()`** — 49 LOC, zero tests, and irreversible: it grants permanent stats from numbers the player posts. Two conditions stand between the form and the grant:

```php
if ($pdktotal == $dkills - $dp && !$pdkneg) {
```

The second is the one that matters. Posting `hp=10` alongside `at=-9` sums to 1 while asking for ten points' worth of hitpoints, and **a total check alone cannot tell that from an honest spend of one point.** Three provider rows cover it.

Every rejection case asserts that no point was marked spent, no stat moved and nothing was recorded — not merely that the error message appeared. A test checking only the message would pass on a partial grant, which is the failure that would actually matter.

**`Buffs::activateBuffs()`** — 278 LOC, one smoke test that asserted nothing threw. Modifiers *multiply*: two buffs that each double the attack leave it at four times, not two. A change from `*=` to `=` would look harmless in review and would quietly rebalance every fight in the game.

### Verified by mutation, not just by being green

A new test that only confirms what the code already does is worth nothing, and a green run cannot tell you which kind you wrote. Every file was checked against deliberate breakage, each restored afterwards and confirmed clean with `git diff --stat`:

| Mutation | Result |
|---|---|
| remove the `min()` gold cap | Pvp: 1 failure, the cap case |
| make the hard experience limit never apply | Pvp: 1 failure |
| bind `acctid` as a string instead of an integer | Pvp: 1 failure |
| strike `!$pdkneg` from the guard | Dragon points: **3 failures**, all exploit rows |
| change the hitpoint multiplier from 5 to 1 | Dragon points: 2 failures |
| stop skipping the section-title labels | Dragon points: whole file errors |
| turn `*=` into `=` for `atkmod` | Buffs: 1 failure, the stacking case |
| count suspended buffs | Buffs: 1 failure |
| apply the aura unconditionally | Buffs: 1 failure |

### What these tests claim, and what they do not

The PvP arithmetic was read out of the source and then confirmed against the running code, so **every expected number is the one the game produces today**. These cases pin current behaviour; they do not assert that the balance is right. Where a case states a rule rather than a formula — the gold cap, the negative guard — the comment says so.

Three observations recorded rather than fixed, since this branch does not touch production code:

- **A PvP win leaves gold and experience as floats in the session**, because both awards are built with `round()`. The level-cap path shows where that comes from: it zeroes gold by literal assignment and the value stays an `int`, while the experience still passes through `round()` and comes out `0.0`. The tests assert what the code does.
- **The tag in `activateBuffs()` does not gate the modifiers.** The `$activate` flag built from `roundstart`/`offense`/`defense` guards only the round message and the `used` marker; the modifier arithmetic below runs for every buff that is not suspended. A reader expecting `defense` to exclude an attack buff would be wrong, so it is asserted rather than assumed.
- The gold cap is computed from a `SELECT` and applied in a separate `UPDATE`, so the statement keeps a defensive `IF` for the case where the balance changed in between.

Not covered: the regen branch of `activateBuffs()`, which reaches into `$badguy` and the companion list and wants a fixture of its own. Named rather than half-done.

## Issue Links

- [ ] Resolves #[ISSUE]
- [ ] Related to #[ISSUE]

Continues #1522, #1523, #1524 (all merged).

## Testing Commands

Confirm you ran the required checks locally:

- [x] `composer test`
- [x] `php -l` (on all modified PHP files)
- [x] `composer static`

```
composer test                                              OK — 1156 tests, 5456 assertions
vendor/bin/phpunit --order-by=reverse                      OK — same 5456 assertions
vendor/bin/phpunit --order-by=random --random-order-seed=1234   OK
vendor/bin/phpunit --order-by=random --random-order-seed=4321   OK
composer static                                            [OK] No errors
vendor/bin/phpcs .                                         646 findings (unchanged from master)
php -l on every changed PHP file                           clean
```

From master's 1,122 tests and 5,363 assertions: **+34 tests, +93 assertions**. The suite's warning count is unchanged at 17 — the combat fixtures are filled in far enough that a rendered round message raises nothing.

## Documentation Updates

- [x] Documentation not required; behaviour is unchanged.
- [ ] Documentation updated (e.g., README, in-code docs).
- [ ] Behaviour changed and I updated `UPGRADING.md` and/or `docs/Deprecations.md` as appropriate.

Test-only; nothing an operator or player can observe changes.

## Additional Notes

- [x] Tests or migrations added when needed.
- [x] Changes keep the diff minimal and focused.
- [x] I reviewed the AGENTS.md guidelines before submitting this PR.
- [x] I reviewed the CONTRIBUTING.md checklist before submitting this PR.

Three commits, one subsystem each.

**Reviewing this.** The diff is almost entirely new assertions, so the question for each is whether it states the game's rule correctly — not whether it passes. The two worth the most attention are the gold cap in `VictoryTest` and the negative-value rows in `DragonPointRecalcTest`; if either describes the intended rule wrongly, say so and I will change the test rather than the code.

**Still outstanding:** the four Etappe-3 targets that need a refactor first — extracting the bank economy from `bank.php:145–240`, giving `Battle::rollDamage()` a signature that does not read ten globals, the level-up block in `train.php:216–229`, and replacing `LoginQuerySecurityTest` with a behavioural test. Plus the ~18 test files that still read production source as text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014VckBn1RJoNDZNxk4daywc

---
_Generated by [Claude Code](https://claude.ai/code/session_014VckBn1RJoNDZNxk4daywc)_